### PR TITLE
fix(docs): resolve 404 relative links across v1.1 documentation index pages

### DIFF
--- a/docs/v1.1/administration/README.md
+++ b/docs/v1.1/administration/README.md
@@ -26,11 +26,11 @@ This section covers the administrative configuration of OpsKnight, including not
 
 | Topic                              | Description                                 | Why It Matters                 |
 | ---------------------------------- | ------------------------------------------- | ------------------------------ |
-| [Notifications](./notifications)   | Configure Email, SMS, Push, WhatsApp, Slack | Ensure alerts reach responders |
-| [Authentication](./authentication) | Local auth, SSO/OIDC, user management       | Secure access control          |
-| [Custom Fields](./custom-fields)   | Add metadata fields to incidents            | Track additional information   |
-| [Data Retention](./data-retention) | Configure cleanup policies                  | Manage storage and compliance  |
-| [Audit Logs](./audit-logs)         | Track security-relevant events              | Compliance and troubleshooting |
+| [Notifications](./administration/notifications)   | Configure Email, SMS, Push, WhatsApp, Slack | Ensure alerts reach responders |
+| [Authentication](./administration/authentication) | Local auth, SSO/OIDC, user management       | Secure access control          |
+| [Custom Fields](./administration/custom-fields)   | Add metadata fields to incidents            | Track additional information   |
+| [Data Retention](./administration/data-retention) | Configure cleanup policies                  | Manage storage and compliance  |
+| [Audit Logs](./administration/audit-logs)         | Track security-relevant events              | Compliance and troubleshooting |
 
 ---
 

--- a/docs/v1.1/api/README.md
+++ b/docs/v1.1/api/README.md
@@ -14,8 +14,8 @@ The OpsKnight API lets you programmatically manage incidents, integrate monitori
 
 | Endpoint                     | Description                             | Common Use Cases              |
 | ---------------------------- | --------------------------------------- | ----------------------------- |
-| [Events API](./events)       | Trigger, acknowledge, resolve incidents | Monitoring integrations       |
-| [Incidents API](./incidents) | List, create, update incidents          | Custom dashboards, automation |
+| [Events API](./api/events)       | Trigger, acknowledge, resolve incidents | Monitoring integrations       |
+| [Incidents API](./api/incidents) | List, create, update incidents          | Custom dashboards, automation |
 | Services API                 | Manage services                         | Service catalog automation    |
 | Schedules API                | Query on-call schedules                 | Who's on-call integrations    |
 | Users API                    | Manage users                            | User provisioning             |

--- a/docs/v1.1/core-concepts/README.md
+++ b/docs/v1.1/core-concepts/README.md
@@ -66,18 +66,18 @@ OpsKnight is built around a simple but powerful model: **Alerts become Incidents
 
 | Concept                                      | What It Is                              | Why It Matters                            |
 | -------------------------------------------- | --------------------------------------- | ----------------------------------------- |
-| [Dashboard](./dashboard)                     | Command center for real-time visibility | See the forest, not just the trees        |
-| [Services](./services)                       | Systems you monitor with ownership      | Alerts need context and routing           |
-| [Incidents](./incidents)                     | Actionable work items from alerts       | Track resolution from trigger to close    |
-| [Escalation Policies](./escalation-policies) | Who gets notified and when              | Ensure issues never fall through cracks   |
-| [Schedules](./schedules)                     | On-call rotations and shifts            | Fair distribution of on-call duty         |
-| [Teams](./teams)                             | User groups with shared responsibility  | Organize people and permissions           |
-| [Users](./users)                             | Individuals with roles and preferences  | Authentication and personalization        |
-| [Analytics](./analytics)                     | Metrics, SLAs, and trends               | Measure and improve performance           |
-| [Postmortems](./postmortems)                 | Incident retrospectives                 | Learn from failures                       |
-| [Status Pages](./status-page)                | Public service health communication     | Transparency with customers               |
-| [Integrations](./integrations)               | Connections to monitoring tools         | Route alerts from your stack              |
-| [Scalability](./scalability)                 | Capacity targets and tuning             | Understand scale limits and optimizations |
+| [Dashboard](./core-concepts/dashboard)                     | Command center for real-time visibility | See the forest, not just the trees        |
+| [Services](./core-concepts/services)                       | Systems you monitor with ownership      | Alerts need context and routing           |
+| [Incidents](./core-concepts/incidents)                     | Actionable work items from alerts       | Track resolution from trigger to close    |
+| [Escalation Policies](./core-concepts/escalation-policies) | Who gets notified and when              | Ensure issues never fall through cracks   |
+| [Schedules](./core-concepts/schedules)                     | On-call rotations and shifts            | Fair distribution of on-call duty         |
+| [Teams](./core-concepts/teams)                             | User groups with shared responsibility  | Organize people and permissions           |
+| [Users](./core-concepts/users)                             | Individuals with roles and preferences  | Authentication and personalization        |
+| [Analytics](./core-concepts/analytics)                     | Metrics, SLAs, and trends               | Measure and improve performance           |
+| [Postmortems](./core-concepts/postmortems)                 | Incident retrospectives                 | Learn from failures                       |
+| [Status Pages](./core-concepts/status-page)                | Public service health communication     | Transparency with customers               |
+| [Integrations](./core-concepts/integrations)               | Connections to monitoring tools         | Route alerts from your stack              |
+| [Scalability](./core-concepts/scalability)                 | Capacity targets and tuning             | Understand scale limits and optimizations |
 
 ---
 

--- a/docs/v1.1/deployment/README.md
+++ b/docs/v1.1/deployment/README.md
@@ -14,10 +14,10 @@ This section covers production deployment of OpsKnight. Choose the deployment me
 
 | Method                     | Best For                  | Complexity | HA Support |
 | -------------------------- | ------------------------- | ---------- | ---------- |
-| [Docker Compose](./docker) | Small teams, dev/staging  | Low        | No         |
-| [Kubernetes](./kubernetes) | Production, enterprise    | Medium     | Yes        |
-| [Helm](./helm)             | Templated K8s deployments | Medium     | Yes        |
-| [Mobile PWA](./mobile-pwa) | Mobile access             | N/A        | N/A        |
+| [Docker Compose](./deployment/docker) | Small teams, dev/staging  | Low        | No         |
+| [Kubernetes](./deployment/kubernetes) | Production, enterprise    | Medium     | Yes        |
+| [Helm](./deployment/helm)             | Templated K8s deployments | Medium     | Yes        |
+| [Mobile PWA](./deployment/mobile-pwa) | Mobile access             | N/A        | N/A        |
 
 ---
 

--- a/docs/v1.1/getting-started/README.md
+++ b/docs/v1.1/getting-started/README.md
@@ -17,9 +17,9 @@ This section will take you from zero to a fully operational incident management 
 
 | Guide                            | What You'll Accomplish                                    |
 | -------------------------------- | --------------------------------------------------------- |
-| [Installation](./installation)   | Get OpsKnight running with Docker, Kubernetes, or locally |
-| [Configuration](./configuration) | Understand environment variables and system settings      |
-| [First Steps](./first-steps)     | Create your first service, incident, and on-call schedule |
+| [Installation](./getting-started/installation)   | Get OpsKnight running with Docker, Kubernetes, or locally |
+| [Configuration](./getting-started/configuration) | Understand environment variables and system settings      |
+| [First Steps](./getting-started/first-steps)     | Create your first service, incident, and on-call schedule |
 
 ---
 
@@ -99,7 +99,7 @@ Once OpsKnight is running, you'll want to:
 4. **Configure Notifications** — Set up Email, SMS, Slack, or Push notifications
 5. **Connect Integrations** — Route alerts from Datadog, Prometheus, or other tools
 
-The [First Steps Guide](./first-steps) walks you through all of these in detail.
+The [First Steps Guide](./getting-started/first-steps) walks you through all of these in detail.
 
 ---
 
@@ -119,7 +119,7 @@ NEXTAUTH_SECRET=your-32-character-secret-key-here
 APP_URL=http://localhost:3000
 ```
 
-See the [Configuration Guide](./configuration) for the complete reference.
+See the [Configuration Guide](./getting-started/configuration) for the complete reference.
 
 ---
 
@@ -184,9 +184,9 @@ docker compose up -d
 
 Ready to continue? Here's your path:
 
-1. **[Installation Guide](./installation)** — Detailed installation for all deployment methods
-2. **[Configuration Reference](./configuration)** — Complete environment variable documentation
-3. **[First Steps](./first-steps)** — Create your first service and incident
+1. **[Installation Guide](./getting-started/installation)** — Detailed installation for all deployment methods
+2. **[Configuration Reference](./getting-started/configuration)** — Complete environment variable documentation
+3. **[First Steps](./getting-started/first-steps)** — Create your first service and incident
 
 ---
 

--- a/docs/v1.1/security/README.md
+++ b/docs/v1.1/security/README.md
@@ -12,8 +12,8 @@ This section covers identity management, data encryption, and secure operations 
 
 | Guide                          | Description                                                           |
 | ------------------------------ | --------------------------------------------------------------------- |
-| [OIDC SSO Setup](./oidc-setup) | Configure single sign-on with Google, Okta, Azure, and more           |
-| [Encryption](./encryption)     | How secrets are encrypted at rest and how to configure the master key |
+| [OIDC SSO Setup](./security/oidc-setup) | Configure single sign-on with Google, Okta, Azure, and more           |
+| [Encryption](./security/encryption)     | How secrets are encrypted at rest and how to configure the master key |
 
 ## Key Concepts
 

--- a/docs/website/v1.1/administration/README.md
+++ b/docs/website/v1.1/administration/README.md
@@ -26,11 +26,11 @@ This section covers the administrative configuration of OpsKnight, including not
 
 | Topic                              | Description                                 | Why It Matters                 |
 | ---------------------------------- | ------------------------------------------- | ------------------------------ |
-| [Notifications](./notifications)   | Configure Email, SMS, Push, WhatsApp, Slack | Ensure alerts reach responders |
-| [Authentication](./authentication) | Local auth, SSO/OIDC, user management       | Secure access control          |
-| [Custom Fields](./custom-fields)   | Add metadata fields to incidents            | Track additional information   |
-| [Data Retention](./data-retention) | Configure cleanup policies                  | Manage storage and compliance  |
-| [Audit Logs](./audit-logs)         | Track security-relevant events              | Compliance and troubleshooting |
+| [Notifications](./administration/notifications)   | Configure Email, SMS, Push, WhatsApp, Slack | Ensure alerts reach responders |
+| [Authentication](./administration/authentication) | Local auth, SSO/OIDC, user management       | Secure access control          |
+| [Custom Fields](./administration/custom-fields)   | Add metadata fields to incidents            | Track additional information   |
+| [Data Retention](./administration/data-retention) | Configure cleanup policies                  | Manage storage and compliance  |
+| [Audit Logs](./administration/audit-logs)         | Track security-relevant events              | Compliance and troubleshooting |
 
 ---
 

--- a/docs/website/v1.1/api/README.md
+++ b/docs/website/v1.1/api/README.md
@@ -14,8 +14,8 @@ The OpsKnight API lets you programmatically manage incidents, integrate monitori
 
 | Endpoint                     | Description                             | Common Use Cases              |
 | ---------------------------- | --------------------------------------- | ----------------------------- |
-| [Events API](./events)       | Trigger, acknowledge, resolve incidents | Monitoring integrations       |
-| [Incidents API](./incidents) | List, create, update incidents          | Custom dashboards, automation |
+| [Events API](./api/events)       | Trigger, acknowledge, resolve incidents | Monitoring integrations       |
+| [Incidents API](./api/incidents) | List, create, update incidents          | Custom dashboards, automation |
 | Services API                 | Manage services                         | Service catalog automation    |
 | Schedules API                | Query on-call schedules                 | Who's on-call integrations    |
 | Users API                    | Manage users                            | User provisioning             |

--- a/docs/website/v1.1/core-concepts/README.md
+++ b/docs/website/v1.1/core-concepts/README.md
@@ -66,18 +66,18 @@ OpsKnight is built around a simple but powerful model: **Alerts become Incidents
 
 | Concept                                      | What It Is                              | Why It Matters                            |
 | -------------------------------------------- | --------------------------------------- | ----------------------------------------- |
-| [Dashboard](./dashboard)                     | Command center for real-time visibility | See the forest, not just the trees        |
-| [Services](./services)                       | Systems you monitor with ownership      | Alerts need context and routing           |
-| [Incidents](./incidents)                     | Actionable work items from alerts       | Track resolution from trigger to close    |
-| [Escalation Policies](./escalation-policies) | Who gets notified and when              | Ensure issues never fall through cracks   |
-| [Schedules](./schedules)                     | On-call rotations and shifts            | Fair distribution of on-call duty         |
-| [Teams](./teams)                             | User groups with shared responsibility  | Organize people and permissions           |
-| [Users](./users)                             | Individuals with roles and preferences  | Authentication and personalization        |
-| [Analytics](./analytics)                     | Metrics, SLAs, and trends               | Measure and improve performance           |
-| [Postmortems](./postmortems)                 | Incident retrospectives                 | Learn from failures                       |
-| [Status Pages](./status-page)                | Public service health communication     | Transparency with customers               |
-| [Integrations](./integrations)               | Connections to monitoring tools         | Route alerts from your stack              |
-| [Scalability](./scalability)                 | Capacity targets and tuning             | Understand scale limits and optimizations |
+| [Dashboard](./core-concepts/dashboard)                     | Command center for real-time visibility | See the forest, not just the trees        |
+| [Services](./core-concepts/services)                       | Systems you monitor with ownership      | Alerts need context and routing           |
+| [Incidents](./core-concepts/incidents)                     | Actionable work items from alerts       | Track resolution from trigger to close    |
+| [Escalation Policies](./core-concepts/escalation-policies) | Who gets notified and when              | Ensure issues never fall through cracks   |
+| [Schedules](./core-concepts/schedules)                     | On-call rotations and shifts            | Fair distribution of on-call duty         |
+| [Teams](./core-concepts/teams)                             | User groups with shared responsibility  | Organize people and permissions           |
+| [Users](./core-concepts/users)                             | Individuals with roles and preferences  | Authentication and personalization        |
+| [Analytics](./core-concepts/analytics)                     | Metrics, SLAs, and trends               | Measure and improve performance           |
+| [Postmortems](./core-concepts/postmortems)                 | Incident retrospectives                 | Learn from failures                       |
+| [Status Pages](./core-concepts/status-page)                | Public service health communication     | Transparency with customers               |
+| [Integrations](./core-concepts/integrations)               | Connections to monitoring tools         | Route alerts from your stack              |
+| [Scalability](./core-concepts/scalability)                 | Capacity targets and tuning             | Understand scale limits and optimizations |
 
 ---
 

--- a/docs/website/v1.1/deployment/README.md
+++ b/docs/website/v1.1/deployment/README.md
@@ -14,10 +14,10 @@ This section covers production deployment of OpsKnight. Choose the deployment me
 
 | Method                     | Best For                  | Complexity | HA Support |
 | -------------------------- | ------------------------- | ---------- | ---------- |
-| [Docker Compose](./docker) | Small teams, dev/staging  | Low        | No         |
-| [Kubernetes](./kubernetes) | Production, enterprise    | Medium     | Yes        |
-| [Helm](./helm)             | Templated K8s deployments | Medium     | Yes        |
-| [Mobile PWA](./mobile-pwa) | Mobile access             | N/A        | N/A        |
+| [Docker Compose](./deployment/docker) | Small teams, dev/staging  | Low        | No         |
+| [Kubernetes](./deployment/kubernetes) | Production, enterprise    | Medium     | Yes        |
+| [Helm](./deployment/helm)             | Templated K8s deployments | Medium     | Yes        |
+| [Mobile PWA](./deployment/mobile-pwa) | Mobile access             | N/A        | N/A        |
 
 ---
 

--- a/docs/website/v1.1/getting-started/README.md
+++ b/docs/website/v1.1/getting-started/README.md
@@ -17,9 +17,9 @@ This section will take you from zero to a fully operational incident management 
 
 | Guide                            | What You'll Accomplish                                    |
 | -------------------------------- | --------------------------------------------------------- |
-| [Installation](./installation)   | Get OpsKnight running with Docker, Kubernetes, or locally |
-| [Configuration](./configuration) | Understand environment variables and system settings      |
-| [First Steps](./first-steps)     | Create your first service, incident, and on-call schedule |
+| [Installation](./getting-started/installation)   | Get OpsKnight running with Docker, Kubernetes, or locally |
+| [Configuration](./getting-started/configuration) | Understand environment variables and system settings      |
+| [First Steps](./getting-started/first-steps)     | Create your first service, incident, and on-call schedule |
 
 ---
 
@@ -99,7 +99,7 @@ Once OpsKnight is running, you'll want to:
 4. **Configure Notifications** — Set up Email, SMS, Slack, or Push notifications
 5. **Connect Integrations** — Route alerts from Datadog, Prometheus, or other tools
 
-The [First Steps Guide](./first-steps) walks you through all of these in detail.
+The [First Steps Guide](./getting-started/first-steps) walks you through all of these in detail.
 
 ---
 
@@ -119,7 +119,7 @@ NEXTAUTH_SECRET=your-32-character-secret-key-here
 APP_URL=http://localhost:3000
 ```
 
-See the [Configuration Guide](./configuration) for the complete reference.
+See the [Configuration Guide](./getting-started/configuration) for the complete reference.
 
 ---
 
@@ -184,9 +184,9 @@ docker compose up -d
 
 Ready to continue? Here's your path:
 
-1. **[Installation Guide](./installation)** — Detailed installation for all deployment methods
-2. **[Configuration Reference](./configuration)** — Complete environment variable documentation
-3. **[First Steps](./first-steps)** — Create your first service and incident
+1. **[Installation Guide](./getting-started/installation)** — Detailed installation for all deployment methods
+2. **[Configuration Reference](./getting-started/configuration)** — Complete environment variable documentation
+3. **[First Steps](./getting-started/first-steps)** — Create your first service and incident
 
 ---
 

--- a/docs/website/v1.1/security/README.md
+++ b/docs/website/v1.1/security/README.md
@@ -12,8 +12,8 @@ This section covers identity management, data encryption, and secure operations 
 
 | Guide                          | Description                                                           |
 | ------------------------------ | --------------------------------------------------------------------- |
-| [OIDC SSO Setup](./oidc-setup) | Configure single sign-on with Google, Okta, Azure, and more           |
-| [Encryption](./encryption)     | How secrets are encrypted at rest and how to configure the master key |
+| [OIDC SSO Setup](./security/oidc-setup) | Configure single sign-on with Google, Okta, Azure, and more           |
+| [Encryption](./security/encryption)     | How secrets are encrypted at rest and how to configure the master key |
 
 ## Key Concepts
 


### PR DESCRIPTION
Fixes #237

## Summary of Fixes
This PR fixes broken relative links across the v1.1 documentation pages.

### 🐛 Problem
Section index  files (such as , , , , , ) used un-scoped relative links (e.g. `[First Steps](./first-steps)`, `[Services](./services)`, `[Notifications](./notifications)`).

When accessed at URLs like `https://opsknight.com/docs/v1.1/getting-started` without a trailing slash, standard browser URL resolution mapped `./first-steps` to `/docs/v1.1/first-steps`, resulting in **404 Not Found** errors.

### 🛠️ Solution
- Updated all relative links in section `README.md` files across `docs/v1.1/` and `docs/website/v1.1/` to include explicit directory prefixes (e.g. `./getting-started/first-steps`, `./core-concepts/services`, `./administration/notifications`, `./deployment/docker`, `./security/oidc-setup`, `./api/events`).
- Ensures clean, 404-free navigation across all documentation paths.