### PR TITLE
fix(chatops): await war-room creation & sync assignee for instant UI update and auto-invite

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -800,10 +800,10 @@ export async function createIncident(formData: FormData) {
     });
   }
 
-  // ChatOps: Auto-create war-room for qualifying incidents (best-effort, non-blocking)
+  // ChatOps: Auto-create war-room for qualifying incidents (best-effort)
   try {
     const { createIncidentWarRoom } = await import('@/lib/chatops/war-room');
-    createIncidentWarRoom(incident.id).catch(err => {
+    await createIncidentWarRoom(incident.id).catch(err => {
       logger.error('ChatOps war-room creation failed', {
         component: 'incidents-actions',
         error: err instanceof Error ? err.message : String(err),

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -230,9 +230,14 @@ export async function createIncidentWarRoom(incidentId: string): Promise<WarRoom
         }
       }
 
-      // Add the current assignee
-      if (incident.assigneeId) {
-        userIdsToInvite.add(incident.assigneeId);
+      // Add the current assignee (re-query latest from DB in case escalation just assigned it)
+      const latestIncidentAssignee = await prisma.incident.findUnique({
+        where: { id: incidentId },
+        select: { assigneeId: true },
+      });
+      const activeAssigneeId = latestIncidentAssignee?.assigneeId || incident.assigneeId;
+      if (activeAssigneeId) {
+        userIdsToInvite.add(activeAssigneeId);
       }
 
       const emailsToInvite = new Set<string>();


### PR DESCRIPTION
## Summary of Fixes

This PR fixes two critical timing issues in the ChatOps War-Room flow:

### 1. Instant UI Display (No Refresh Needed)
- **Problem**: In `createIncident()`, `createIncidentWarRoom(incident.id)` was called without `await`. As a result, the server redirected the client to `/incidents/[id]` before the Slack API channel creation and database update finished. On initial page load, `slackChannelId` was `null` until the page was manually refreshed.
- **Fix**: Added `await createIncidentWarRoom(incident.id)` inside `createIncident()`. The Slack channel and DB record are fully created BEFORE the page redirect, so the UI card displays the active war-room link immediately on first load.

### 2. Auto-Invite Assigned User (`dushyant5`)
- **Problem**: When `createIncidentWarRoom` ran in the background concurrently with `executeEscalation`, `incident.assigneeId` was still `null` when the incident record was initially queried. The assigned user was skipped during auto-invitation.
- **Fix**: Updated `createIncidentWarRoom` to re-query the latest `assigneeId` from the database immediately before resolving emails, ensuring the newly assigned user is always included in `userIdsToInvite`.