### PR TITLE
fix(chatops): sync status updates and channel topic on acknowledge and button clicks

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -228,10 +228,10 @@ export async function updateIncidentStatus(id: string, status: IncidentStatus) {
     }
   }
 
-  // ChatOps: Sync status changes to war-room (best-effort)
+  // ChatOps: Sync status changes & update topic in war-room (best-effort)
   if (status !== 'RESOLVED') {
     try {
-      const { postWarRoomUpdate } = await import('@/lib/chatops/war-room');
+      const { postWarRoomUpdate, updateWarRoomTopic } = await import('@/lib/chatops/war-room');
       const statusEmoji: Record<string, string> = {
         ACKNOWLEDGED: '👀',
         OPEN: '🔄',
@@ -241,6 +241,7 @@ export async function updateIncidentStatus(id: string, status: IncidentStatus) {
       postWarRoomUpdate(id, `${statusEmoji[status] || '📋'} *Status updated to ${status}*`).catch(err =>
         logger.error('ChatOps status sync failed', { component: 'incidents-actions', error: err, incidentId: id })
       );
+      updateWarRoomTopic(id, status).catch(() => {});
     } catch (e) {
       logger.error('Failed to load chatops/war-room', { error: e });
     }

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -131,11 +131,17 @@ export async function POST(request: NextRequest) {
                 );
             }
 
-            // Update incident
-            await prisma.incident.update({
-                where: { id: incidentId },
-                data: updateData
-            });
+            // Update incident via standard server action for full lifecycle side-effects
+            try {
+                const { updateIncidentStatus } = await import('@/app/(app)/incidents/actions');
+                await updateIncidentStatus(incidentId, actionType === 'ack' ? 'ACKNOWLEDGED' : 'RESOLVED');
+            } catch (err) {
+                logger.error('[Slack] Failed to update incident status via actions API', { incidentId, error: err });
+                await prisma.incident.update({
+                    where: { id: incidentId },
+                    data: updateData
+                });
+            }
 
             // Create incident event
             await prisma.incidentEvent.create({

--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -152,6 +152,16 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
         slackUser: payload.user_name,
       });
 
+      // Update channel topic to ACKNOWLEDGED
+      try {
+        const { updateWarRoomTopic } = await import('@/lib/chatops/war-room');
+        updateWarRoomTopic(incident.id, 'ACKNOWLEDGED').catch(err =>
+          logger.warn('[ChatOps] Failed to update topic on ack', { error: err })
+        );
+      } catch (e) {
+        logger.warn('[ChatOps] Failed to load war-room module', { error: e });
+      }
+
       return {
         response_type: 'in_channel',
         text: `👀 *Incident Acknowledged* by <@${user_id}>\n_${incident.title}_`,

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -451,3 +451,37 @@ export async function archiveWarRoomChannel(
     return { success: false, error: err };
   }
 }
+
+/**
+ * Update the Slack war-room channel topic when incident status or metadata changes
+ */
+export async function updateWarRoomTopic(
+  incidentId: string,
+  newStatus?: string
+): Promise<void> {
+  try {
+    const incident = await prisma.incident.findUnique({
+      where: { id: incidentId },
+      select: { title: true, urgency: true, status: true, slackChannelId: true, serviceId: true },
+    });
+
+    if (!incident?.slackChannelId) return;
+
+    const botToken = await getSlackBotToken(incident.serviceId);
+    if (!botToken) return;
+
+    const appUrl = getBaseUrl();
+    const dashboardUrl = `${appUrl}/incidents/${incidentId}`;
+    const displayStatus = newStatus || incident.status;
+    const statusIcon = displayStatus === 'ACKNOWLEDGED' ? '👀' : displayStatus === 'RESOLVED' ? '✅' : '🚨';
+    const topic = `${statusIcon} ${incident.title} | ${displayStatus} | ${incident.urgency} | ${dashboardUrl}`;
+
+    await slackApiCall('conversations.setTopic', botToken, {
+      channel: incident.slackChannelId,
+      topic: topic.slice(0, 250),
+    }).catch(() => {});
+  } catch (err) {
+    logger.warn('[ChatOps] Failed to update war-room topic', { incidentId, error: err });
+  }
+}
+


### PR DESCRIPTION
## Summary of Fixes

This PR fixes status synchronization and topic updates when incidents are acknowledged or updated in Slack or Web UI:

### 1. Real-Time Slack Channel Topic Updates
- **Added `updateWarRoomTopic(incidentId, newStatus)`**: Automatically updates the Slack war-room channel topic to `👀 {Title} | ACKNOWLEDGED | HIGH | {Link}` whenever an incident is acknowledged or updated.

### 2. Interactive Slack Button Clicks (`/api/slack/actions`)
- **Updated `/api/slack/actions/route.ts`**: Clicking the 'Acknowledge' or 'Resolve' button on Slack Block Cards now triggers `updateIncidentStatus()`, executing all lifecycle side-effects (canceling pending escalation jobs, updating SLA timers, updating channel topic, posting status updates, and archiving channel on resolve).

### 3. Slash Command Acknowledge Sync (`/incident ack`)
- **Updated `/incident ack`**: Acknowledging via slash command now updates the Slack channel topic in real time.