### PR TITLE
fix(chatops): update war-room topic and auto-invite team/user on incident reassignment

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -895,10 +895,11 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
       });
     });
 
-    // ChatOps: Sync unassignment to war-room
+    // ChatOps: Sync unassignment & update topic in war-room
     try {
-      const { postWarRoomUpdate } = await import('@/lib/chatops/war-room');
+      const { postWarRoomUpdate, updateWarRoomTopic } = await import('@/lib/chatops/war-room');
       postWarRoomUpdate(incidentId, '👤 *Incident unassigned*').catch(() => {});
+      updateWarRoomTopic(incidentId).catch(() => {});
     } catch {} // Best-effort
 
     revalidatePath(`/incidents/${incidentId}`);
@@ -982,11 +983,13 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
       });
     } // Continue even if notifications fail
 
-    // ChatOps: Sync team assignment to war-room
+    // ChatOps: Sync team assignment, auto-invite members & update topic in war-room
     try {
-      const { postWarRoomUpdate } = await import('@/lib/chatops/war-room');
+      const { postWarRoomUpdate, inviteTeamToWarRoom, updateWarRoomTopic } = await import('@/lib/chatops/war-room');
       const teamRecord = await prisma.team.findUnique({ where: { id: teamId }, select: { name: true } });
       postWarRoomUpdate(incidentId, `👥 *Incident assigned to team: ${teamRecord?.name || 'Unknown'}*`).catch(() => {});
+      inviteTeamToWarRoom(incidentId, teamId).catch(() => {});
+      updateWarRoomTopic(incidentId).catch(() => {});
     } catch {} // Best-effort
 
     revalidatePath(`/incidents/${incidentId}`);
@@ -1028,11 +1031,13 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
       logger.error('Failed to send reassignment notification', { error, incidentId });
     }
 
-    // ChatOps: Sync user assignment to war-room
+    // ChatOps: Sync user assignment, auto-invite user & update topic in war-room
     try {
-      const { postWarRoomUpdate } = await import('@/lib/chatops/war-room');
+      const { postWarRoomUpdate, inviteUserToWarRoom, updateWarRoomTopic } = await import('@/lib/chatops/war-room');
       const assignee = await prisma.user.findUnique({ where: { id: assigneeId }, select: { name: true } });
       postWarRoomUpdate(incidentId, `👤 *Incident reassigned to ${assignee?.name || 'Unknown'}*`).catch(() => {});
+      inviteUserToWarRoom(incidentId, assigneeId).catch(() => {});
+      updateWarRoomTopic(incidentId).catch(() => {});
     } catch {} // Best-effort
 
     revalidatePath(`/incidents/${incidentId}`);

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -467,7 +467,15 @@ export async function updateWarRoomTopic(
   try {
     const incident = await prisma.incident.findUnique({
       where: { id: incidentId },
-      select: { title: true, urgency: true, status: true, slackChannelId: true, serviceId: true },
+      select: {
+        title: true,
+        urgency: true,
+        status: true,
+        slackChannelId: true,
+        serviceId: true,
+        assignee: { select: { name: true } },
+        team: { select: { name: true } },
+      },
     });
 
     if (!incident?.slackChannelId) return;
@@ -479,7 +487,8 @@ export async function updateWarRoomTopic(
     const dashboardUrl = `${appUrl}/incidents/${incidentId}`;
     const displayStatus = newStatus || incident.status;
     const statusIcon = displayStatus === 'ACKNOWLEDGED' ? '👀' : displayStatus === 'RESOLVED' ? '✅' : '🚨';
-    const topic = `${statusIcon} ${incident.title} | ${displayStatus} | ${incident.urgency} | ${dashboardUrl}`;
+    const assigneeText = incident.assignee ? ` | 👤 ${incident.assignee.name}` : incident.team ? ` | 👥 ${incident.team.name}` : '';
+    const topic = `${statusIcon} ${incident.title} | ${displayStatus} | ${incident.urgency}${assigneeText} | ${dashboardUrl}`;
 
     await slackApiCall('conversations.setTopic', botToken, {
       channel: incident.slackChannelId,
@@ -490,3 +499,106 @@ export async function updateWarRoomTopic(
   }
 }
 
+/**
+ * Auto-invite a specific user to an incident's war-room channel
+ */
+export async function inviteUserToWarRoom(
+  incidentId: string,
+  userId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const incident = await prisma.incident.findUnique({
+      where: { id: incidentId },
+      select: { slackChannelId: true, slackChannelName: true, serviceId: true },
+    });
+
+    if (!incident?.slackChannelId) {
+      return { success: false, error: 'No active war-room channel' };
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, name: true, email: true },
+    });
+
+    if (!user?.email) {
+      return { success: false, error: 'User has no email configured' };
+    }
+
+    const botToken = await getSlackBotToken(incident.serviceId);
+    if (!botToken) {
+      return { success: false, error: 'No Slack bot token' };
+    }
+
+    const normalizedEmail = user.email.trim().toLowerCase();
+    const lookupResult = await slackApiCall('users.lookupByEmail', botToken, { email: normalizedEmail });
+
+    if (!lookupResult.ok || !(lookupResult as any).user?.id) { // eslint-disable-line @typescript-eslint/no-explicit-any
+      const lookupErr = lookupResult.error || 'User not found in Slack workspace';
+      const reason =
+        lookupErr === 'user_not_found'
+          ? `Email ${normalizedEmail} not found in Slack workspace`
+          : lookupErr === 'missing_scope'
+          ? `Slack app is missing 'users:read.email' scope`
+          : lookupErr;
+
+      await prisma.incidentEvent.create({
+        data: {
+          incidentId,
+          message: `Slack War-Room: Could not auto-invite ${user.name} (${reason})`,
+        },
+      }).catch(() => {});
+
+      return { success: false, error: reason };
+    }
+
+    const slackUserId = (lookupResult as any).user.id as string; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const inviteResult = await slackApiCall('conversations.invite', botToken, {
+      channel: incident.slackChannelId,
+      users: slackUserId,
+    });
+
+    if (!inviteResult.ok && (inviteResult as any).error !== 'already_in_channel') { // eslint-disable-line @typescript-eslint/no-explicit-any
+      const inviteErr = (inviteResult as any).error || 'Failed to invite user'; // eslint-disable-line @typescript-eslint/no-explicit-any
+      await prisma.incidentEvent.create({
+        data: {
+          incidentId,
+          message: `Slack War-Room: Could not invite ${user.name} to channel #${incident.slackChannelName} (${inviteErr})`,
+        },
+      }).catch(() => {});
+
+      return { success: false, error: inviteErr };
+    }
+
+    return { success: true };
+  } catch (error) {
+    const err = error instanceof Error ? error.message : String(error);
+    logger.error('[ChatOps] Invite user to war-room failed', { incidentId, userId, error: err });
+    return { success: false, error: err };
+  }
+}
+
+/**
+ * Auto-invite all members of a team to an incident's war-room channel
+ */
+export async function inviteTeamToWarRoom(
+  incidentId: string,
+  teamId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const teamMembers = await prisma.teamMember.findMany({
+      where: { teamId },
+      select: { userId: true },
+    });
+
+    for (const member of teamMembers) {
+      await inviteUserToWarRoom(incidentId, member.userId).catch(() => {});
+    }
+
+    return { success: true };
+  } catch (error) {
+    const err = error instanceof Error ? error.message : String(error);
+    logger.error('[ChatOps] Invite team to war-room failed', { incidentId, teamId, error: err });
+    return { success: false, error: err };
+  }
+}


### PR DESCRIPTION
## Summary of Fixes

This PR fixes real-time Slack channel topic updates and member invitations on incident reassignment:

### 1. Channel Topic Assignee Sync (`updateWarRoomTopic`)
- **Added Assignee/Team to Topic**: The Slack channel topic now updates to include the assignee or team name in real time:
  `🚨 {Title} | OPEN | HIGH | 👤 Dushyant 5 | {Dashboard URL}` or `👥 DevOps Team`

### 2. Automatic Team & User Invitations on Reassignment
- **User Reassignment**: Reassigning an incident to a user automatically invites that user to the active Slack war-room channel and updates the channel topic.
- **Team Assignment**: Assigning an incident to a team automatically invites all team members to the active Slack war-room channel (`inviteTeamToWarRoom`) and updates the topic.
- **Unassigning**: Unassigning an incident updates the channel topic to reflect unassigned state.