### PR TITLE
fix(slack): await decrypt in getSlackBotToken for valid authentication token

### DIFF
--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -61,7 +61,7 @@ export async function getSlackBotToken(serviceId?: string): Promise<string | nul
     if (service?.slackIntegration?.enabled && service.slackIntegration.botToken) {
       // Decrypt token
       try {
-        return decrypt(service.slackIntegration.botToken);
+        return await decrypt(service.slackIntegration.botToken);
       } catch (error) {
         logger.error('[Slack] Failed to decrypt token', { serviceId, error });
       }
@@ -78,7 +78,7 @@ export async function getSlackBotToken(serviceId?: string): Promise<string | nul
 
   if (globalIntegration?.botToken) {
     try {
-      return decrypt(globalIntegration.botToken);
+      return await decrypt(globalIntegration.botToken);
     } catch (error) {
       logger.error('[Slack] Failed to decrypt global token', { error });
     }


### PR DESCRIPTION
## Summary of Fix

This PR fixes a critical token decryption bug in `getSlackBotToken()`:

### 🐛 Problem
- `decrypt()` in `@/lib/encryption` is an `async` function returning `Promise<string>`.
- Inside `getSlackBotToken()`, `return decrypt(...)` was called **without `await`**.
- In compiled production JS, callers received an unresolved `Promise` object instead of the decrypted token string (`xoxb-...`).
- When sending Slack API requests, HTTP headers contained `Authorization: Bearer [object Promise]`, causing Slack API to reject all requests (`conversations.setTopic`, `users.lookupByEmail`, `conversations.invite`, `chat.postMessage`) with **`invalid_auth`**.

### 🛠️ Fix
- Added `await` to `decrypt()` calls in `getSlackBotToken()`, ensuring valid string tokens are passed to Slack API endpoints.