### PR TITLE
fix(chatops): case-insensitive email matching for Slack user resolution in slash commands

### DIFF
--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -45,12 +45,18 @@ async function resolveOpsKnightUser(slackUserId: string, botToken: string) {
     );
 
     const data = await response.json();
-    if (!data.ok || !data.user?.profile?.email) {
+    const slackEmail = data.user?.profile?.email?.trim();
+    if (!data.ok || !slackEmail) {
       return null;
     }
 
     const user = await prisma.user.findFirst({
-      where: { email: data.user.profile.email },
+      where: {
+        email: {
+          equals: slackEmail,
+          mode: 'insensitive',
+        },
+      },
       select: { id: true, name: true, email: true },
     });
 


### PR DESCRIPTION
## Summary of Fix

This PR ensures case-insensitive email matching when mapping Slack users to OpsKnight database accounts:

### 🐛 Problem
- `resolveOpsKnightUser` performed exact string matching on `email: data.user.profile.email`.
- Differences in trailing whitespace or casing (e.g. `Dushyant...` vs `dushyant...`) caused `/incident note` to fail with `Could not find your OpsKnight account`.

### 🛠️ Fix
- Updated `resolveOpsKnightUser` in `src/lib/chatops/slash-commands.ts` to perform trimmed, case-insensitive email lookup (`mode: 'insensitive'`).