### PR TITLE
fix(chatops): remove SLACK_HUDDLE option from video bridge dropdown

### DIFF
--- a/src/components/settings/ChatOpsSettingsPage.tsx
+++ b/src/components/settings/ChatOpsSettingsPage.tsx
@@ -39,7 +39,6 @@ const PRIORITY_OPTIONS = [
 const VIDEO_BRIDGE_OPTIONS = [
   { value: 'NONE', label: 'None' },
   { value: 'JITSI', label: 'Jitsi Meet' },
-  { value: 'SLACK_HUDDLE', label: 'Slack Channel Huddle 🎧' },
   { value: 'ZOOM', label: 'Zoom' },
   { value: 'GOOGLE_MEET', label: 'Google Meet' },
 ];

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -51,12 +51,6 @@ export function generateBridgeUrl(
   }
 
   switch (provider) {
-    case 'SLACK_HUDDLE':
-      if (slackChannelId) {
-        return `https://slack.com/app_redirect?channel=${slackChannelId}&huddle=1`;
-      }
-      return `https://slack.com/app_redirect?huddle=1`;
-
     case 'JITSI':
       return formattedUrl || `https://meet.jit.si/opsknight-inc-${incidentId.slice(-8)}`;
 

--- a/tests/lib/chatops-war-room.test.ts
+++ b/tests/lib/chatops-war-room.test.ts
@@ -57,10 +57,6 @@ describe('ChatOps War-Room Engine', () => {
       expect(url).toBe('https://meet.jit.si/opsknight-inc-12345678');
     });
 
-    it('should generate Slack Huddle URL with channel redirect', () => {
-      const url = generateBridgeUrl('inc-12345678', 'SLACK_HUDDLE', null, 'C0BP67E0KK8');
-      expect(url).toBe('https://slack.com/app_redirect?channel=C0BP67E0KK8&huddle=1');
-    });
 
     it('should return null for NONE provider', () => {
       const url = generateBridgeUrl('inc-12345678', 'NONE');


### PR DESCRIPTION
## Summary of Removal

This PR removes `SLACK_HUDDLE` from the Video Bridge options to keep Video Bridge integrations clean, predictable, and 100% functional:

### 🛠️ Changes
1. **Settings UI**: Removed `SLACK_HUDDLE` from `VIDEO_BRIDGE_OPTIONS` in `src/components/settings/ChatOpsSettingsPage.tsx`.
2. **ChatOps Engine**: Removed `SLACK_HUDDLE` case in `src/lib/chatops/war-room.ts`.
3. **Supported Options**: **Jitsi Meet** (Instant 1-click), **Zoom**, **Google Meet**, and **None**.