### PR TITLE
fix(chatops): sanitize Zoom URLs with automatic /j/ join path insertion

### DIFF
--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -36,35 +36,53 @@ function slugify(name: string, maxLen: number = 40): string {
 export function generateBridgeUrl(
   incidentId: string,
   provider: string,
-  customTemplate?: string | null,
-  slackChannelId?: string | null
+  customTemplate?: string | null
 ): string | null {
   if (!provider || provider === 'NONE') {
     return null;
   }
 
-  // Format custom URL template if provided
-  let formattedUrl = customTemplate ? customTemplate.replace(/\{incidentId\}/g, incidentId).trim() : null;
+  const shortId = incidentId.slice(-8);
 
-  if (formattedUrl && !/^https?:\/\//i.test(formattedUrl)) {
-    formattedUrl = `https://${formattedUrl}`;
+  // Format custom URL template if provided
+  let formattedUrl: string | null = null;
+  if (customTemplate && customTemplate.trim()) {
+    let urlStr = customTemplate.trim();
+    if (!/^https?:\/\//i.test(urlStr)) {
+      urlStr = `https://${urlStr}`;
+    }
+
+    if (urlStr.includes('{incidentId}')) {
+      // If Zoom URL template lacks /j/ or /my/ path, insert /j/
+      if (/zoom\.us\/(?!j\/|my\/)/i.test(urlStr)) {
+        urlStr = urlStr.replace(/zoom\.us\//i, 'zoom.us/j/');
+      }
+      formattedUrl = urlStr.replace(/\{incidentId\}/g, incidentId);
+    } else {
+      // If user entered a base domain like https://us04web.zoom.us or https://zoom.us/
+      if (/zoom\.us\/?$/i.test(urlStr)) {
+        formattedUrl = `${urlStr.replace(/\/$/, '')}/j/opsknight-inc-${shortId}`;
+      } else {
+        formattedUrl = urlStr;
+      }
+    }
   }
 
   switch (provider) {
     case 'JITSI':
-      return formattedUrl || `https://meet.jit.si/opsknight-inc-${incidentId.slice(-8)}`;
+      return formattedUrl || `https://meet.jit.si/opsknight-inc-${shortId}`;
 
     case 'ZOOM':
       if (formattedUrl) {
         return formattedUrl;
       }
-      return `https://zoom.us/j/opsknight-inc-${incidentId.slice(-8)}`;
+      return `https://zoom.us/j/opsknight-inc-${shortId}`;
 
     case 'GOOGLE_MEET':
       if (formattedUrl) {
         return formattedUrl;
       }
-      return `https://meet.google.com/lookup/opsknight-inc-${incidentId.slice(-8)}`;
+      return `https://meet.google.com/lookup/opsknight-inc-${shortId}`;
 
     default:
       if (formattedUrl) {

--- a/tests/lib/chatops-war-room.test.ts
+++ b/tests/lib/chatops-war-room.test.ts
@@ -67,6 +67,9 @@ describe('ChatOps War-Room Engine', () => {
       const customUrl = generateBridgeUrl('inc-9999', 'ZOOM', 'https://zoom.us/j/1234567890');
       expect(customUrl).toBe('https://zoom.us/j/1234567890');
 
+      const baseDomainUrl = generateBridgeUrl('inc-12345678', 'ZOOM', 'https://us04web.zoom.us/');
+      expect(baseDomainUrl).toBe('https://us04web.zoom.us/j/opsknight-inc-12345678');
+
       const fallbackUrl = generateBridgeUrl('inc-12345678', 'ZOOM');
       expect(fallbackUrl).toBe('https://zoom.us/j/opsknight-inc-12345678');
     });


### PR DESCRIPTION
## Summary of Fix

This PR fixes invalid Zoom meeting join URLs (which previously returned Zoom 404 `Uh oh!` pages):

### 🐛 Problem
- When an admin saved a base Zoom domain (e.g. `https://us04web.zoom.us/`), OpsKnight appended the incident ID directly to the root path (`https://us04web.zoom.us/cmklfe09e003...`).
- Zoom does not support meeting IDs at the root domain level, resulting in Zoom 404 `Uh oh!` pages.

### 🛠️ Fix
1. **Automatic `/j/` Join Path Insertion**:
   - If a base Zoom domain is provided (e.g. `https://us04web.zoom.us/`), OpsKnight automatically appends the required `/j/` meeting route (`https://us04web.zoom.us/j/opsknight-inc-XXXX`).
   - If `{incidentId}` is used in a Zoom template without `/j/`, it automatically inserts `/j/` (`https://us04web.zoom.us/j/{incidentId}`).
2. **Static Meeting Link Support**:
   - Explicit meeting links (e.g. `https://us04web.zoom.us/j/1234567890` or `https://myorg.zoom.us/my/warroom`) are preserved as-is.