### PR TITLE
fix: War-room users not being invited — wrong HTTP method for Slack email lookup

### DIFF
--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -299,17 +299,26 @@ export async function createIncidentWarRoom(incidentId: string): Promise<WarRoom
         }
       }
 
-      // Parallel email lookups for better performance
+      // Parallel email lookups using GET-based findSlackUserByEmail
+      // (slackApiCall sends POST+JSON which causes `invalid_arguments` for users.lookupByEmail)
       const lookupResults = await Promise.allSettled(
         Array.from(emailsToInvite).map(async (email) => {
-          const lookupResult = await slackApiCall('users.lookupByEmail', botToken, { email });
+          const lookupResult = await findSlackUserByEmail(botToken, email.trim().toLowerCase());
           if (lookupResult.ok && (lookupResult as any).user?.id) { // eslint-disable-line @typescript-eslint/no-explicit-any
             return (lookupResult as any).user.id as string; // eslint-disable-line @typescript-eslint/no-explicit-any
           }
+          const lookupErr = lookupResult.error || 'User not found in Slack workspace';
           logger.warn('[ChatOps] Could not find Slack user by email', {
             email,
-            error: lookupResult.error || 'User not found in Slack workspace',
+            error: lookupErr,
           });
+          // Log to incident timeline for visibility
+          await prisma.incidentEvent.create({
+            data: {
+              incidentId,
+              message: `War-room: Could not invite user (${email}) — ${lookupErr === 'users_not_found' ? 'email not found in Slack workspace' : lookupErr}`,
+            },
+          }).catch(() => {});
           return null;
         })
       );


### PR DESCRIPTION
## Bug Found

**Server log error:**
```
[ChatOps] Could not find Slack user by email
email: dushyantrahangdale5@gmail.com
error: invalid_arguments
```

## Root Cause

`createIncidentWarRoom()` was calling `slackApiCall('users.lookupByEmail', ...)` which sends a **POST request with JSON body**. But Slack's `users.lookupByEmail` requires a **GET request with query parameters** — sending POST+JSON returns `invalid_arguments`.

This caused **every single user invite to silently fail**, so war-room channels were created but nobody was added to them.

## Fix

- Use the existing `findSlackUserByEmail()` function (which correctly uses HTTP GET with query params) instead of the generic `slackApiCall()`
- Add incident timeline events when user invite lookups fail, so failures are visible in the UI instead of being silently swallowed

## Files Changed

- `src/lib/chatops/war-room.ts` — Line 305: replaced `slackApiCall` → `findSlackUserByEmail`, added timeline events on failure