### PR TITLE
feat(chatops): Emoji Reaction Timeline Sync (:pushpin: -> Incident Timeline)

### DIFF
--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -95,9 +95,10 @@ export async function POST(request: NextRequest) {
           return NextResponse.json({ ok: true });
         }
 
-        // Fetch original message text from Slack history
+        // Fetch original message text from Slack history (or thread replies)
         let messageText = '';
         let authorName = 'Slack User';
+        let reactorEmail: string | undefined;
 
         try {
           const historyUrl = `https://slack.com/api/conversations.history?channel=${channelId}&latest=${messageTs}&inclusive=true&limit=1`;
@@ -106,8 +107,18 @@ export async function POST(request: NextRequest) {
           });
           const historyData = await historyRes.json();
 
-          if (historyData.ok && historyData.messages?.[0]) {
-            messageText = historyData.messages[0].text || '';
+          if (historyData.ok && historyData.messages?.[0]?.text) {
+            messageText = historyData.messages[0].text;
+          } else {
+            // Fallback to conversations.replies for thread replies
+            const repliesUrl = `https://slack.com/api/conversations.replies?channel=${channelId}&ts=${messageTs}&limit=1`;
+            const repliesRes = await retryFetch(repliesUrl, {
+              headers: { Authorization: `Bearer ${botToken}` },
+            });
+            const repliesData = await repliesRes.json();
+            if (repliesData.ok && repliesData.messages?.[0]?.text) {
+              messageText = repliesData.messages[0].text;
+            }
           }
         } catch (err) {
           logger.warn('[Slack Events] Failed to fetch message text', { error: err });
@@ -122,18 +133,28 @@ export async function POST(request: NextRequest) {
           const userData = await userRes.json();
           if (userData.ok && userData.user) {
             authorName = userData.user.profile?.real_name || userData.user.name || slackUserId;
+            reactorEmail = userData.user.profile?.email?.trim();
           }
         } catch (err) {
           logger.warn('[Slack Events] Failed to fetch reactor info', { error: err });
         }
 
         if (messageText) {
-          // Resolve to OpsKnight user or fallback to assignee
-          const userByEmail = await prisma.user.findFirst({
-            where: { name: { contains: authorName, mode: 'insensitive' } },
-            select: { id: true },
-          });
-          const noteUserId = userByEmail?.id || incident.assigneeId;
+          // Resolve to OpsKnight user by email first, then name, then fallback to assignee
+          let resolvedUser: { id: string } | null = null;
+          if (reactorEmail) {
+            resolvedUser = await prisma.user.findFirst({
+              where: { email: { equals: reactorEmail, mode: 'insensitive' } },
+              select: { id: true },
+            });
+          }
+          if (!resolvedUser && authorName) {
+            resolvedUser = await prisma.user.findFirst({
+              where: { name: { contains: authorName, mode: 'insensitive' } },
+              select: { id: true },
+            });
+          }
+          const noteUserId = resolvedUser?.id || incident.assigneeId;
 
           if (noteUserId) {
             await prisma.incidentNote.create({

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -1,0 +1,184 @@
+/**
+ * Slack Event Subscriptions API
+ * Listens for Slack events such as `reaction_added` (:pushpin:, :memo:)
+ * and automatically captures pinned messages into the OpsKnight incident timeline.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import { getSlackBotToken } from '@/lib/slack';
+import { retryFetch } from '@/lib/retry';
+import crypto from 'crypto';
+
+const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
+
+const PIN_EMOJIS = new Set(['pushpin', 'round_pushpin', 'memo', 'star', 'bookmark']);
+
+/**
+ * Verify Slack request signature
+ */
+function verifySlackSignature(
+  body: string,
+  signature: string,
+  timestamp: string
+): boolean {
+  if (!SLACK_SIGNING_SECRET) {
+    return true; // Allow in dev if no secret configured
+  }
+
+  const currentTime = Math.floor(Date.now() / 1000);
+  const requestTime = parseInt(timestamp, 10);
+  if (Math.abs(currentTime - requestTime) > 300) {
+    return false;
+  }
+
+  const sigBaseString = `v0:${timestamp}:${body}`;
+  const computedSignature =
+    'v0=' +
+    crypto
+      .createHmac('sha256', SLACK_SIGNING_SECRET)
+      .update(sigBaseString)
+      .digest('hex');
+
+  return crypto.timingSafeEqual(
+    Buffer.from(computedSignature),
+    Buffer.from(signature)
+  );
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const rawBody = await request.text();
+    const signature = request.headers.get('x-slack-signature') || '';
+    const timestamp = request.headers.get('x-slack-request-timestamp') || '';
+
+    // Verify signature
+    if (!verifySlackSignature(rawBody, signature, timestamp)) {
+      logger.warn('[Slack Events] Invalid signature');
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+
+    const payload = JSON.parse(rawBody);
+
+    // 1. Handle Slack URL Verification Challenge
+    if (payload.type === 'url_verification') {
+      return NextResponse.json({ challenge: payload.challenge });
+    }
+
+    // 2. Handle Event Callbacks
+    if (payload.type === 'event_callback' && payload.event) {
+      const event = payload.event;
+
+      // Reaction Added (📌 Emoji Reaction Sync)
+      if (event.type === 'reaction_added' && PIN_EMOJIS.has(event.reaction)) {
+        const channelId = event.item?.channel;
+        const messageTs = event.item?.ts;
+        const slackUserId = event.user;
+
+        if (!channelId || !messageTs) {
+          return NextResponse.json({ ok: true });
+        }
+
+        // Find incident linked to this channel
+        const incident = await prisma.incident.findFirst({
+          where: { slackChannelId: channelId },
+          select: { id: true, title: true, serviceId: true, assigneeId: true },
+        });
+
+        if (!incident) {
+          return NextResponse.json({ ok: true }); // Not a war-room channel
+        }
+
+        const botToken = await getSlackBotToken(incident.serviceId);
+        if (!botToken) {
+          return NextResponse.json({ ok: true });
+        }
+
+        // Fetch original message text from Slack history
+        let messageText = '';
+        let authorName = 'Slack User';
+
+        try {
+          const historyUrl = `https://slack.com/api/conversations.history?channel=${channelId}&latest=${messageTs}&inclusive=true&limit=1`;
+          const historyRes = await retryFetch(historyUrl, {
+            headers: { Authorization: `Bearer ${botToken}` },
+          });
+          const historyData = await historyRes.json();
+
+          if (historyData.ok && historyData.messages?.[0]) {
+            messageText = historyData.messages[0].text || '';
+          }
+        } catch (err) {
+          logger.warn('[Slack Events] Failed to fetch message text', { error: err });
+        }
+
+        // Fetch reactor user info from Slack
+        try {
+          const userUrl = `https://slack.com/api/users.info?user=${slackUserId}`;
+          const userRes = await retryFetch(userUrl, {
+            headers: { Authorization: `Bearer ${botToken}` },
+          });
+          const userData = await userRes.json();
+          if (userData.ok && userData.user) {
+            authorName = userData.user.profile?.real_name || userData.user.name || slackUserId;
+          }
+        } catch (err) {
+          logger.warn('[Slack Events] Failed to fetch reactor info', { error: err });
+        }
+
+        if (messageText) {
+          // Resolve to OpsKnight user or fallback to assignee
+          const userByEmail = await prisma.user.findFirst({
+            where: { name: { contains: authorName, mode: 'insensitive' } },
+            select: { id: true },
+          });
+          const noteUserId = userByEmail?.id || incident.assigneeId;
+
+          if (noteUserId) {
+            await prisma.incidentNote.create({
+              data: {
+                incidentId: incident.id,
+                userId: noteUserId,
+                content: `📌 [Slack Pin by ${authorName}]: ${messageText}`,
+              },
+            });
+          }
+
+          // Create timeline event
+          await prisma.incidentEvent.create({
+            data: {
+              incidentId: incident.id,
+              message: `Message pinned to timeline via 📌 emoji by @${authorName}`,
+            },
+          });
+
+          // Post confirmation thread reply in Slack
+          await retryFetch('https://slack.com/api/chat.postMessage', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${botToken}`,
+            },
+            body: JSON.stringify({
+              channel: channelId,
+              thread_ts: messageTs,
+              text: `📌 *Pinned to OpsKnight Incident Timeline!*`,
+            }),
+          }).catch(() => {});
+
+          logger.info('[Slack Events] Pinned message synced to timeline', {
+            incidentId: incident.id,
+            authorName,
+          });
+        }
+      }
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const err = error instanceof Error ? error.message : String(error);
+    logger.error('[Slack Events] Event handler error', { error: err });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Feature Overview

- Adds `POST /api/slack/events` to process Slack Event Subscriptions.
- Reacting to any Slack message in a war room channel with 📌 (`:pushpin:`), 📝 (`:memo:`), or ⭐ (`:star:`) automatically:
  1. Fetches the pinned message content and author.
  2. Creates an `IncidentNote` and `IncidentEvent` in OpsKnight.
  3. Replies in thread to confirm pin (`📌 Pinned to OpsKnight Incident Timeline!`).

## Files Changed
- `src/app/api/slack/events/route.ts` — new Slack Event Subscriptions receiver