### PR TITLE
feat(chatops): /incident postmortem slash command

### DIFF
--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -150,6 +150,7 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
               '`/incident resolve [summary]` — Resolve with optional summary',
               '`/incident note <message>` — Add an incident note',
               '`/incident who` — Show who is on-call',
+              '`/incident postmortem` — Create a postmortem draft from timeline & notes',
               '`/incident help` — Show this help message',
             ].join('\n'),
           },
@@ -408,6 +409,99 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
         return {
           response_type: 'ephemeral',
           text: '⚠️ Failed to query on-call information.',
+        };
+      }
+    }
+
+    case 'postmortem': {
+      try {
+        const appUrl = (await import('@/lib/env-validation')).getBaseUrl();
+        const existingPostmortem = await prisma.postmortem.findUnique({
+          where: { incidentId: incident.id },
+          select: { id: true, title: true, status: true },
+        });
+
+        if (existingPostmortem) {
+          const postmortemUrl = `${appUrl}/postmortems/${existingPostmortem.id}`;
+          return {
+            response_type: 'in_channel',
+            text: `📄 *Postmortem Draft Already Exists*\nTitle: *${existingPostmortem.title}* (${existingPostmortem.status})\n🔗 Edit Postmortem: ${postmortemUrl}`,
+          };
+        }
+
+        // Resolve author
+        let authorUserId: string | undefined;
+        if (botToken) {
+          const opsUser = await resolveOpsKnightUser(
+            user_id,
+            botToken,
+            incident.assigneeId,
+            payload.user_name
+          );
+          authorUserId = opsUser?.id;
+        }
+
+        const defaultAuthor = authorUserId
+          ? authorUserId
+          : (await prisma.user.findFirst({ select: { id: true } }))?.id;
+
+        if (!defaultAuthor) {
+          return {
+            response_type: 'ephemeral',
+            text: '⚠️ Could not resolve author for postmortem.',
+          };
+        }
+
+        // Fetch incident notes and events for timeline
+        const notes = await prisma.incidentNote.findMany({
+          where: { incidentId: incident.id },
+          include: { user: { select: { name: true } } },
+          orderBy: { createdAt: 'asc' },
+        });
+
+        const events = await prisma.incidentEvent.findMany({
+          where: { incidentId: incident.id },
+          orderBy: { createdAt: 'asc' },
+        });
+
+        const timelineEntries = [
+          ...events.map(e => ({ time: e.createdAt, text: e.message, type: 'event' })),
+          ...notes.map(n => ({ time: n.createdAt, text: `[${n.user.name}]: ${n.content}`, type: 'note' })),
+        ].sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
+
+        const newPostmortem = await prisma.postmortem.create({
+          data: {
+            incidentId: incident.id,
+            title: `Postmortem: ${incident.title}`,
+            summary: `Automated postmortem draft generated from Slack war-room #${payload.channel_name}`,
+            impact: { service: incident.service.name, urgency: incident.urgency },
+            rootCause: 'TBD — Generated from Slack War Room',
+            resolution: `Resolved via ChatOps by @${payload.user_name}`,
+            lessons: 'Timeline and notes captured from Slack war-room channel.',
+            timeline: timelineEntries as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+            createdById: defaultAuthor,
+            status: 'DRAFT',
+          },
+        });
+
+        await prisma.incidentEvent.create({
+          data: {
+            incidentId: incident.id,
+            message: `Postmortem draft generated via Slack ChatOps by @${payload.user_name}`,
+          },
+        });
+
+        const editUrl = `${appUrl}/postmortems/${newPostmortem.id}`;
+
+        return {
+          response_type: 'in_channel',
+          text: `📄 *Postmortem Draft Created!*\n*Title:* ${newPostmortem.title}\n*Timeline Events Captured:* ${timelineEntries.length}\n🔗 *Edit & Publish:* ${editUrl}`,
+        };
+      } catch (pmErr) {
+        logger.error('[ChatOps] Failed to create postmortem via slash command', { error: pmErr });
+        return {
+          response_type: 'ephemeral',
+          text: '⚠️ Failed to generate postmortem draft.',
         };
       }
     }

--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -469,6 +469,14 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
           ...notes.map(n => ({ time: n.createdAt, text: `[${n.user.name}]: ${n.content}`, type: 'note' })),
         ].sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
 
+        const actionItemsFromNotes = notes
+          .filter(n => /todo:|action item:|fix:|followup:/i.test(n.content))
+          .map(n => ({
+            title: n.content.replace(/^(todo:|action item:|fix:|followup:)\s*/i, '').trim(),
+            status: 'OPEN',
+            priority: 'MEDIUM',
+          }));
+
         const newPostmortem = await prisma.postmortem.create({
           data: {
             incidentId: incident.id,
@@ -479,6 +487,7 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
             resolution: `Resolved via ChatOps by @${payload.user_name}`,
             lessons: 'Timeline and notes captured from Slack war-room channel.',
             timeline: timelineEntries as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+            actionItems: actionItemsFromNotes as any, // eslint-disable-line @typescript-eslint/no-explicit-any
             createdById: defaultAuthor,
             status: 'DRAFT',
           },


### PR DESCRIPTION
## Feature Overview

- Adds `/incident postmortem` command to Slack war rooms.
- Auto-extracts incident events and notes into a structured timeline.
- Creates an OpsKnight `Postmortem` draft linked to the incident.
- Responds in Slack with a direct link to the postmortem editor.

## Files Changed
- `src/lib/chatops/slash-commands.ts` — added `case 'postmortem'` & updated help text