### PR TITLE
fix(slack): Standardize users.info API call to HTTP GET

### DIFF
--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -44,14 +44,12 @@ async function resolveOpsKnightUser(
 
     if (botToken) {
       const response = await retryFetch(
-        'https://slack.com/api/users.info',
+        `https://slack.com/api/users.info?user=${encodeURIComponent(slackUserId)}`,
         {
-          method: 'POST',
+          method: 'GET',
           headers: {
-            'Content-Type': 'application/json',
             Authorization: `Bearer ${botToken}`,
           },
-          body: JSON.stringify({ user: slackUserId }),
         },
         { maxAttempts: 2, initialDelayMs: 300 }
       );


### PR DESCRIPTION
## Slack Web API Standards Compliance

Standardizes `users.info` in `resolveOpsKnightUser()` from `POST` with JSON body to `GET` with query parameters (`https://slack.com/api/users.info?user=...`), matching official Slack Web API documentation specifications for user lookup endpoints.

## Files Changed
- `src/lib/chatops/slash-commands.ts` — switched `users.info` call to HTTP GET