### PR TITLE
fix(chatops): Fix Postmortem Route URL and Enhance Emoji Reaction Sync

### DIFF
--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -13,7 +13,7 @@ import crypto from 'crypto';
 
 const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
 
-const PIN_EMOJIS = new Set(['pushpin', 'round_pushpin', 'memo', 'star', 'bookmark']);
+const PIN_EMOJIS = new Set(['pushpin', 'round_pushpin', 'memo', 'star', 'bookmark', 'pin', 'push_pin', 'note']);
 
 /**
  * Verify Slack request signature
@@ -69,9 +69,10 @@ export async function POST(request: NextRequest) {
     // 2. Handle Event Callbacks
     if (payload.type === 'event_callback' && payload.event) {
       const event = payload.event;
+      const rawEmoji = (event.reaction || '').split('::')[0];
 
       // Reaction Added (📌 Emoji Reaction Sync)
-      if (event.type === 'reaction_added' && PIN_EMOJIS.has(event.reaction)) {
+      if (event.type === 'reaction_added' && PIN_EMOJIS.has(rawEmoji)) {
         const channelId = event.item?.channel;
         const messageTs = event.item?.ts;
         const slackUserId = event.user;
@@ -101,7 +102,7 @@ export async function POST(request: NextRequest) {
         let reactorEmail: string | undefined;
 
         try {
-          const historyUrl = `https://slack.com/api/conversations.history?channel=${channelId}&latest=${messageTs}&inclusive=true&limit=1`;
+          const historyUrl = `https://slack.com/api/conversations.history?channel=${channelId}&latest=${messageTs}&oldest=${messageTs}&inclusive=true&limit=1`;
           const historyRes = await retryFetch(historyUrl, {
             headers: { Authorization: `Bearer ${botToken}` },
           });

--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -420,10 +420,10 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
         });
 
         if (existingPostmortem) {
-          const postmortemUrl = `${appUrl}/postmortems/${existingPostmortem.id}`;
+          const postmortemUrl = `${appUrl}/postmortems/${incident.id}`;
           return {
             response_type: 'in_channel',
-            text: `📄 *Postmortem Draft Already Exists*\nTitle: *${existingPostmortem.title}* (${existingPostmortem.status})\n🔗 Edit Postmortem: ${postmortemUrl}`,
+            text: `📄 *Postmortem Draft Exists*\nTitle: *${existingPostmortem.title}* (${existingPostmortem.status})\n🔗 *Edit & Publish:* ${postmortemUrl}`,
           };
         }
 
@@ -498,7 +498,7 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
           },
         });
 
-        const editUrl = `${appUrl}/postmortems/${newPostmortem.id}`;
+        const editUrl = `${appUrl}/postmortems/${incident.id}`;
 
         return {
           response_type: 'in_channel',

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -738,7 +738,7 @@ export async function ensurePostmortemDraft(incidentId: string): Promise<string 
 
     const appUrl = getBaseUrl();
     if (existing) {
-      return `${appUrl}/postmortems/${existing.id}`;
+      return `${appUrl}/postmortems/${incidentId}`;
     }
 
     const incident = await prisma.incident.findUnique({
@@ -800,7 +800,7 @@ export async function ensurePostmortemDraft(incidentId: string): Promise<string 
       },
     });
 
-    return `${appUrl}/postmortems/${postmortem.id}`;
+    return `${appUrl}/postmortems/${incidentId}`;
   } catch (err) {
     logger.warn('[ChatOps] Failed to ensure postmortem draft', { incidentId, error: err });
     return null;


### PR DESCRIPTION
## Summary of Fixes

1. **Postmortem URL Fix:** Next.js route parameter is `/postmortems/[incidentId]`. Changed postmortem URL generator from `postmortem.id` to `incident.id`, resolving 404 broken link errors.
2. **Emoji Reaction Sync Fix:**
   - Stripped skin-tone modifiers (`split('::')[0]`).
   - Expanded emoji set to include `pushpin`, `round_pushpin`, `pin`, `push_pin`, `memo`, `note`.
   - Added `oldest=${messageTs}` to Slack `conversations.history` API for 100% exact message retrieval.