### PR TITLE
feat(slack): Simplify Slack Cards, Fix Single Incident Web Console Archiving, and Remove Slash Postmortem

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -220,7 +220,7 @@ export async function updateIncidentStatus(id: string, status: IncidentStatus) {
   if (status === 'RESOLVED') {
     try {
       const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-      archiveWarRoomChannel(id).catch(err =>
+      await archiveWarRoomChannel(id).catch(err =>
         logger.error('ChatOps war-room archive failed', { component: 'incidents-actions', error: err, incidentId: id })
       );
     } catch (e) {

--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -144,11 +144,10 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
           text: {
             type: 'mrkdwn',
             text: [
-              '`/incident ack` — Acknowledge this incident',
-              '`/incident resolve [summary]` — Resolve with optional summary',
-              '`/incident note <message>` — Add an incident note',
+              '`/incident ack` — Acknowledge incident',
+              '`/incident resolve [summary]` — Resolve incident with notes',
+              '`/incident note <message>` — Add a note to incident timeline',
               '`/incident who` — Show who is on-call',
-              '`/incident postmortem` — Create a postmortem draft from timeline & notes',
               '`/incident help` — Show this help message',
             ].join('\n'),
           },
@@ -407,108 +406,6 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
         return {
           response_type: 'ephemeral',
           text: '⚠️ Failed to query on-call information.',
-        };
-      }
-    }
-
-    case 'postmortem': {
-      try {
-        const appUrl = (await import('@/lib/env-validation')).getBaseUrl();
-        const existingPostmortem = await prisma.postmortem.findUnique({
-          where: { incidentId: incident.id },
-          select: { id: true, title: true, status: true },
-        });
-
-        if (existingPostmortem) {
-          const postmortemUrl = `${appUrl}/postmortems/${incident.id}`;
-          return {
-            response_type: 'in_channel',
-            text: `📄 *Postmortem Draft Exists*\nTitle: *${existingPostmortem.title}* (${existingPostmortem.status})\n🔗 *Edit & Publish:* ${postmortemUrl}`,
-          };
-        }
-
-        // Resolve author
-        let authorUserId: string | undefined;
-        if (botToken) {
-          const opsUser = await resolveOpsKnightUser(
-            user_id,
-            botToken,
-            incident.assigneeId,
-            payload.user_name
-          );
-          authorUserId = opsUser?.id;
-        }
-
-        const defaultAuthor = authorUserId
-          ? authorUserId
-          : (await prisma.user.findFirst({ select: { id: true } }))?.id;
-
-        if (!defaultAuthor) {
-          return {
-            response_type: 'ephemeral',
-            text: '⚠️ Could not resolve author for postmortem.',
-          };
-        }
-
-        // Fetch incident notes and events for timeline
-        const notes = await prisma.incidentNote.findMany({
-          where: { incidentId: incident.id },
-          include: { user: { select: { name: true } } },
-          orderBy: { createdAt: 'asc' },
-        });
-
-        const events = await prisma.incidentEvent.findMany({
-          where: { incidentId: incident.id },
-          orderBy: { createdAt: 'asc' },
-        });
-
-        const timelineEntries = [
-          ...events.map(e => ({ time: e.createdAt, text: e.message, type: 'event' })),
-          ...notes.map(n => ({ time: n.createdAt, text: `[${n.user.name}]: ${n.content}`, type: 'note' })),
-        ].sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
-
-        const actionItemsFromNotes = notes
-          .filter(n => /todo:|action item:|fix:|followup:/i.test(n.content))
-          .map(n => ({
-            title: n.content.replace(/^(todo:|action item:|fix:|followup:)\s*/i, '').trim(),
-            status: 'OPEN',
-            priority: 'MEDIUM',
-          }));
-
-        const newPostmortem = await prisma.postmortem.create({
-          data: {
-            incidentId: incident.id,
-            title: `Postmortem: ${incident.title}`,
-            summary: `Automated postmortem draft generated from Slack war-room #${payload.channel_name}`,
-            impact: { service: incident.service.name, urgency: incident.urgency },
-            rootCause: 'TBD — Generated from Slack War Room',
-            resolution: `Resolved via ChatOps by @${payload.user_name}`,
-            lessons: 'Timeline and notes captured from Slack war-room channel.',
-            timeline: timelineEntries as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-            actionItems: actionItemsFromNotes as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-            createdById: defaultAuthor,
-            status: 'DRAFT',
-          },
-        });
-
-        await prisma.incidentEvent.create({
-          data: {
-            incidentId: incident.id,
-            message: `Postmortem draft generated via Slack ChatOps by @${payload.user_name}`,
-          },
-        });
-
-        const editUrl = `${appUrl}/postmortems/${incident.id}`;
-
-        return {
-          response_type: 'in_channel',
-          text: `📄 *Postmortem Draft Created!*\n*Title:* ${newPostmortem.title}\n*Timeline Events Captured:* ${timelineEntries.length}\n🔗 *Edit & Publish:* ${editUrl}`,
-        };
-      } catch (pmErr) {
-        logger.error('[ChatOps] Failed to create postmortem via slash command', { error: pmErr });
-        return {
-          response_type: 'ephemeral',
-          text: '⚠️ Failed to generate postmortem draft.',
         };
       }
     }

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -701,10 +701,9 @@ export async function postWarRoomWelcomeCard(
       text: {
         type: 'mrkdwn',
         text: [
-          '*⚡ War Room Power Features:*',
-          '• 🔘 *1-Click Action Buttons*: Use *Acknowledge*, *Assign to Me*, or *Resolve* on the card above.',
+          '*⚡ War Room Features:*',
+          '• 🔍 *View Details Button*: Click *View Details ↗* on the card above to manage in OpsKnight Console.',
           '• 📌 *Emoji Reaction Sync*: React to ANY message with 📌 (`:pushpin:`) or 📝 (`:memo:`) to auto-save to the incident timeline!',
-          '• 📄 *Auto Postmortem*: Type `/incident postmortem` to generate a pre-filled Postmortem draft.',
         ].join('\n'),
       },
     },
@@ -718,7 +717,6 @@ export async function postWarRoomWelcomeCard(
           '`/incident resolve [summary]` — Resolve incident with notes',
           '`/incident note <message>` — Save a note to the timeline',
           '`/incident who` — View current on-call responders',
-          '`/incident postmortem` — Create postmortem draft',
         ].join('\n'),
       },
     },
@@ -727,7 +725,7 @@ export async function postWarRoomWelcomeCard(
   await slackApiCall('chat.postMessage', botToken, {
     channel: channelId,
     blocks,
-    text: '👋 Welcome to your Incident War Room! Use 1-click buttons, 📌 emoji pins, or /incident slash commands.',
+    text: '👋 Welcome to your Incident War Room! Use 📌 emoji pins or /incident slash commands.',
   }).catch(err => logger.warn('[ChatOps] Failed to post welcome card', { error: err }));
 }
 

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -306,62 +306,17 @@ function buildSlackBlocks(
 
   // Action Buttons
   if (includeInteractiveButtons) {
-    const elements = [];
-
-    // Ack button (only for triggered)
-    if (eventType === 'triggered') {
-      elements.push({
+    const elements = [
+      {
         type: 'button',
         text: {
           type: 'plain_text',
-          text: '👀 Acknowledge',
+          text: '🔍 View Details ↗',
           emoji: true,
         },
-        style: 'primary',
-        value: JSON.stringify({ action: 'ack', incidentId: incident.id }),
-        action_id: 'ack_incident',
-      });
-    }
-
-    // Assign to Me button (for non-resolved)
-    if (eventType !== 'resolved') {
-      elements.push({
-        type: 'button',
-        text: {
-          type: 'plain_text',
-          text: '🙋 Assign to Me',
-          emoji: true,
-        },
-        value: JSON.stringify({ action: 'assign_me', incidentId: incident.id }),
-        action_id: 'assign_me_incident',
-      });
-    }
-
-    // Resolve button (only for acked or triggered)
-    if (eventType !== 'resolved') {
-      elements.push({
-        type: 'button',
-        text: {
-          type: 'plain_text',
-          text: '✅ Resolve',
-          emoji: true,
-        },
-        style: eventType === 'acknowledged' ? 'primary' : undefined,
-        value: JSON.stringify({ action: 'resolve', incidentId: incident.id }),
-        action_id: 'resolve_incident',
-      });
-    }
-
-    // View Incident Button (Always present)
-    elements.push({
-      type: 'button',
-      text: {
-        type: 'plain_text',
-        text: 'View Details ↗', // Arrow for external link feel
-        emoji: true,
+        url: incidentUrl,
       },
-      url: incidentUrl,
-    });
+    ];
 
     blocks.push({
       type: 'divider',
@@ -369,7 +324,7 @@ function buildSlackBlocks(
 
     blocks.push({
       type: 'actions',
-      elements: elements,
+      elements: elements as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     });
   } else {
     // If no interactive buttons, at least provide the View Link


### PR DESCRIPTION
## Summary of Changes

1. **Slack Cards Simplification:** Removed `Acknowledge`, `Assign to Me`, and `Resolve` interactive buttons from Slack incident cards. Kept only the **`🔍 View Details ↗`** button for opening the incident in the OpsKnight Web Console.
2. **Single Incident Web Console Archiving Fix:** Added `await` to `archiveWarRoomChannel(id)` inside `updateIncidentStatus()` in `src/app/(app)/incidents/actions.ts`. Single incident resolution from the Web Console now reliably archives the Slack war room channel every time.
3. **Removed Slash Postmortem:** Removed `/incident postmortem` command from `slash-commands.ts` and updated war room welcome card.