### PR TITLE
fix(chatops): Export slackApiCall function to fix build failures on main

### DIFF
--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -88,7 +88,7 @@ export function generateBridgeUrl(
 /**
  * Call a Slack API method with bot token authentication
  */
-async function slackApiCall(
+export async function slackApiCall(
   method: string,
   botToken: string,
   body: Record<string, unknown>


### PR DESCRIPTION
## Summary of Fix

Resolves the TypeScript compilation failure on `main` by exporting `slackApiCall` from `src/lib/chatops/war-room.ts` (`Property 'slackApiCall' does not exist on type 'typeof import("@/lib/chatops/war-room")'`).

Please review and merge when ready.