### PR TITLE
fix(oncall): correct 24h offset error that pages the whole schedule on Node 20

### DIFF
--- a/src/lib/__tests__/timezone.test.ts
+++ b/src/lib/__tests__/timezone.test.ts
@@ -27,4 +27,32 @@ describe('timezone helpers', () => {
     expect(formatDateKeyInTimeZone(start, timeZone)).toBe(dateKey);
     expect(formatDateKeyInTimeZone(nextStart, timeZone)).toBe('2024-03-11');
   });
+
+  // Regression: getTimeZoneOffsetMs used `hour12: false`, which resolves to the
+  // h24 hour cycle on Node 20's ICU and reports midnight as hour "24". That
+  // rolled Date.UTC into the next day and produced a 24h offset error, so
+  // start-of-day in a zero-offset zone landed a full day early — on Node 20
+  // only. Node 22 defaults to h23 and was unaffected, so the two runtimes
+  // silently disagreed about who was on call.
+  it('resolves start of day in zero-offset zones without a day shift', () => {
+    for (const timeZone of ['UTC', 'Europe/London', 'Africa/Abidjan']) {
+      const start = startOfDayFromDateKey('2026-08-16', timeZone);
+      expect(formatDateKeyInTimeZone(start, timeZone)).toBe('2026-08-16');
+    }
+  });
+
+  it('keeps start of day at midnight across a range of zones and dates', () => {
+    const zones = ['UTC', 'Asia/Kolkata', 'America/New_York', 'Australia/Sydney', 'Europe/London'];
+    const dateKeys = ['2026-01-01', '2026-03-29', '2026-08-16', '2026-11-01', '2026-12-31'];
+
+    for (const timeZone of zones) {
+      for (const dateKey of dateKeys) {
+        const start = startOfDayFromDateKey(dateKey, timeZone);
+        expect(formatDateKeyInTimeZone(start, timeZone)).toBe(dateKey);
+
+        const nextStart = startOfNextDayFromDateKey(dateKey, timeZone);
+        expect(formatDateKeyInTimeZone(nextStart, timeZone)).toBe(addDaysToDateKey(dateKey, 1));
+      }
+    }
+  });
 });

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -289,7 +289,12 @@ function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      hour12: false,
+      // hourCycle h23 keeps midnight as hour 00. `hour12: false` alone is not
+      // enough: on Node 20's ICU, en-US resolves to the h24 cycle and formats
+      // midnight as hour "24", which rolls Date.UTC below into the next day and
+      // yields a 24h offset error. Node 22 defaults to h23, so this diverged by
+      // runtime — see the %24 guard for the same reason.
+      hourCycle: 'h23',
     });
     const parts = formatter.formatToParts(date);
     const partMap: Record<string, string> = {};
@@ -302,7 +307,8 @@ function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
       Number(partMap.year),
       Number(partMap.month) - 1,
       Number(partMap.day),
-      Number(partMap.hour),
+      // Defensive: any ICU build that still reports "24" for midnight
+      Number(partMap.hour) % 24,
       Number(partMap.minute),
       Number(partMap.second)
     );

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -133,46 +133,89 @@ describe('Notification System Tests', () => {
     });
   });
 
-  describe('Schedule Escalation - Multiple On-Call Users', () => {
-    it('should return all active on-call users from all layers', async () => {
-      const user1Id = 'user-1';
-      const user2Id = 'user-2';
-      const scheduleId = 'sched-1';
+  describe('Schedule Escalation - Overlapping Layer Precedence', () => {
+    // Overlapping layers are priority-resolved to a single on-call user by
+    // getFinalScheduleBlocks: the highest-priority layer wins, ties broken on
+    // lexical layerId. This assertion previously expected every layer's users
+    // to be paged, which stopped being true when priority resolution landed.
+    const scheduleId = 'sched-1';
+    const user1Id = 'user-1';
+    const user2Id = 'user-2';
 
-      (vi.mocked(prisma.user.create) as any).mockImplementation(({ data }: any) =>
-        Promise.resolve({ id: data.email === 'user1@example.com' ? user1Id : user2Id, ...data })
+    const scheduleWithLayers = (layer1Priority?: number, layer2Priority?: number) => ({
+      id: scheduleId,
+      name: 'Test Schedule',
+      timeZone: 'UTC',
+      layers: [
+        {
+          id: 'layer-1',
+          name: 'Layer 1',
+          start: new Date('2024-01-01'),
+          rotationLengthHours: 24,
+          priority: layer1Priority,
+          users: [{ userId: user1Id, position: 0, user: { name: 'User 1' } }],
+        },
+        {
+          id: 'layer-2',
+          name: 'Layer 2',
+          start: new Date('2024-01-01'),
+          rotationLengthHours: 24,
+          priority: layer2Priority,
+          users: [{ userId: user2Id, position: 0, user: { name: 'User 2' } }],
+        },
+      ],
+      overrides: [],
+    });
+
+    it('should page a single user when equal-priority layers overlap', async () => {
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(
+        scheduleWithLayers() as any // eslint-disable-line @typescript-eslint/no-explicit-any
       );
 
-      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue({
-        id: scheduleId,
-        name: 'Test Schedule',
-        timeZone: 'UTC',
-        layers: [
-          {
-            id: 'layer-1',
-            name: 'Layer 1',
-            start: new Date('2024-01-01'),
-            rotationLengthHours: 24,
-            users: [{ userId: user1Id, position: 0, user: { name: 'User 1' } }],
-          },
-          {
-            id: 'layer-2',
-            name: 'Layer 2',
-            start: new Date('2024-01-01'),
-            rotationLengthHours: 24,
-            users: [{ userId: user2Id, position: 0, user: { name: 'User 2' } }],
-          },
-        ],
-        overrides: [],
-      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-      // Mock resolveEscalationTarget internal logic dependencies if necessary
-      // Actually resolveEscalationTarget probably uses several prisma calls.
       const users = await resolveEscalationTarget('SCHEDULE', scheduleId, new Date());
 
-      expect(users.length).toBeGreaterThanOrEqual(1);
-      expect(users).toContain(user1Id);
-      expect(users).toContain(user2Id);
+      // Tie on priority resolves to the lexically-first layerId ('layer-1')
+      expect(users).toEqual([user1Id]);
+    });
+
+    it('should page the higher-priority layer when layers overlap', async () => {
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(
+        scheduleWithLayers(0, 10) as any // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+
+      const users = await resolveEscalationTarget('SCHEDULE', scheduleId, new Date());
+
+      expect(users).toEqual([user2Id]);
+    });
+
+    it('should page every override user when overrides are active', async () => {
+      const now = new Date();
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue({
+        ...scheduleWithLayers(),
+        overrides: [
+          {
+            id: 'ovr-1',
+            userId: user1Id,
+            user: { name: 'User 1' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
+          {
+            id: 'ovr-2',
+            userId: user2Id,
+            user: { name: 'User 2' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
+        ],
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const users = await resolveEscalationTarget('SCHEDULE', scheduleId, now);
+
+      // Overrides replace the rotation outright, so both are paged
+      expect(users).toEqual(expect.arrayContaining([user1Id, user2Id]));
     });
   });
 


### PR DESCRIPTION
> **This PR changed substantially after CI came back red.** It was opened as a test-only correction. Investigating the CI failure showed the test was not the problem — it was reporting a real production bug. Details below.

## The bug

`getTimeZoneOffsetMs` built its `Intl.DateTimeFormat` with `hour12: false`. On **Node 20's ICU** that resolves to the **h24** hour cycle, which formats midnight as hour `"24"` rather than `"00"`. The subsequent `Date.UTC(..., 24, ...)` rolls into the next day, so the computed offset is out by **+24h** and `startOfDayFromDateKey` lands a full day early.

It only triggers when the instant is local midnight in the target zone — which is exactly what `startOfDayFromDateKey` always asks for — so it hits **zero-offset zones**: `UTC`, `Europe/London` (winter), `Africa/Abidjan`.

`parseDateTimeInTimeZone('2026-08-16T00:00', tz)`:

| Timezone | Node 22 | Node 20 |
|---|---|---|
| `Asia/Kolkata` | Aug 16 00:00 | Aug 16 00:00 ✅ |
| `America/New_York` | Aug 16 00:00 | Aug 16 00:00 ✅ |
| **`UTC`** | Aug 16 00:00 | **Aug 15 00:00** ❌ |

## Why it matters

`getOnCallUsersForSchedule` derives its block window from `startOfDayInTimeZone`. With the window shifted to the previous day, **no block covers "now"**, the active-block filter returns empty, and the function falls through to its safety net:

> *"if no active block was found (e.g. schedule gaps or data issues), return all unique users in the schedule so escalation still reaches someone instead of failing silently."*

So a **UTC schedule pages every member of the schedule instead of the one person actually on call.**

**Production runs `node:20-alpine`** (all three Dockerfile stages), so this is live. Node 22 defaults to `h23` and is unaffected — which is why the same code produced different on-call answers in CI, in local development, and in production.

## Fix

- Set `hourCycle: 'h23'` explicitly rather than relying on `hour12`
- Normalise the parsed hour with `% 24` as a defensive guard for any ICU build that still reports `"24"`

## Also included

The on-call escalation test that was already red on `main`. It asserted that overlapping layers page **every** layer's users — which is what the roster fallback happened to return *because of this bug*. It was encoding the buggy behaviour, which is why it passed on Node 20 CI and failed on Node 22 locally.

Replaced with three tests covering the semantics `getFinalScheduleBlocks` actually implements:

| Case | Expectation |
|---|---|
| Equal-priority layers overlap | Resolves to the lexically-first `layerId` |
| One layer has higher priority | Higher-priority layer wins |
| Active overrides | Overrides replace the rotation and page every override user |

Plus regression tests for the timezone helper: zero-offset zones, and a zone × date matrix across DST boundaries.

## Verification

Full unit suite run with the CI flags (`--no-file-parallelism --maxWorkers=1`) on **both** runtimes:

| Runtime | Result |
|---|---|
| Node 20.20.2 (matches CI + production) | 127 files, 1005 passed, 0 failed |
| Node 22.23.2 | 127 files, 1005 passed, 0 failed |

Before the fix, Node 20 failed both precedence tests with `['user-1','user-2']` — the roster fallback — while Node 22 passed.

## Worth considering separately

The roster fallback turned a date bug into "page everyone" with no signal. It is defensible as a safety net, but it currently fires silently — a `logger.warn` there would have surfaced this long ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)