### PR TITLE
fix(chatops): request reaction/history scopes and surface Slack lookup errors

### DIFF
--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -102,27 +102,40 @@ export async function POST(request: NextRequest) {
         let reactorEmail: string | undefined;
 
         try {
-          const historyUrl = `https://slack.com/api/conversations.history?channel=${channelId}&latest=${messageTs}&oldest=${messageTs}&inclusive=true&limit=1`;
+          // Pass inclusive=true and limit=10 to reliably locate messageTs in Slack channel history
+          const historyUrl = `https://slack.com/api/conversations.history?channel=${channelId}&latest=${messageTs}&inclusive=true&limit=10`;
           const historyRes = await retryFetch(historyUrl, {
             headers: { Authorization: `Bearer ${botToken}` },
           });
           const historyData = await historyRes.json();
 
-          if (historyData.ok && historyData.messages?.[0]?.text) {
-            messageText = historyData.messages[0].text;
+          const foundMsg = historyData.ok
+            ? historyData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || historyData.messages?.[0]
+            : null;
+
+          if (foundMsg?.text) {
+            messageText = foundMsg.text;
           } else {
             // Fallback to conversations.replies for thread replies
-            const repliesUrl = `https://slack.com/api/conversations.replies?channel=${channelId}&ts=${messageTs}&limit=1`;
+            const repliesUrl = `https://slack.com/api/conversations.replies?channel=${channelId}&ts=${messageTs}&limit=5`;
             const repliesRes = await retryFetch(repliesUrl, {
               headers: { Authorization: `Bearer ${botToken}` },
             });
             const repliesData = await repliesRes.json();
-            if (repliesData.ok && repliesData.messages?.[0]?.text) {
-              messageText = repliesData.messages[0].text;
+            const foundReply = repliesData.ok
+              ? repliesData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || repliesData.messages?.[0]
+              : null;
+            if (foundReply?.text) {
+              messageText = foundReply.text;
             }
           }
         } catch (err) {
           logger.warn('[Slack Events] Failed to fetch message text', { error: err });
+        }
+
+        // Guaranteed fallback so note is never skipped
+        if (!messageText) {
+          messageText = (event as { text?: string }).text || 'Pinned message from Slack war-room channel';
         }
 
         // Fetch reactor user info from Slack

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -41,10 +41,15 @@ function verifySlackSignature(
       .update(sigBaseString)
       .digest('hex');
 
-  return crypto.timingSafeEqual(
-    Buffer.from(computedSignature),
-    Buffer.from(signature)
-  );
+  // timingSafeEqual throws on length mismatch — treat a malformed signature as invalid
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(computedSignature),
+      Buffer.from(signature)
+    );
+  } catch {
+    return false;
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -101,6 +106,10 @@ export async function POST(request: NextRequest) {
         let authorName = 'Slack User';
         let reactorEmail: string | undefined;
 
+        // Slack API error from history/replies, retained so a failed lookup is explained
+        // rather than silently degrading to placeholder note text
+        let lookupError: string | undefined;
+
         try {
           // Pass inclusive=true and limit=10 to reliably locate messageTs in Slack channel history
           const historyUrl = `https://slack.com/api/conversations.history?channel=${channelId}&latest=${messageTs}&inclusive=true&limit=10`;
@@ -108,6 +117,10 @@ export async function POST(request: NextRequest) {
             headers: { Authorization: `Bearer ${botToken}` },
           });
           const historyData = await historyRes.json();
+
+          if (!historyData.ok) {
+            lookupError = historyData.error || 'unknown_error';
+          }
 
           const foundMsg = historyData.ok
             ? historyData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || historyData.messages?.[0]
@@ -122,6 +135,9 @@ export async function POST(request: NextRequest) {
               headers: { Authorization: `Bearer ${botToken}` },
             });
             const repliesData = await repliesRes.json();
+            if (!repliesData.ok) {
+              lookupError = lookupError || repliesData.error || 'unknown_error';
+            }
             const foundReply = repliesData.ok
               ? repliesData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || repliesData.messages?.[0]
               : null;
@@ -130,12 +146,32 @@ export async function POST(request: NextRequest) {
             }
           }
         } catch (err) {
+          lookupError = err instanceof Error ? err.message : String(err);
           logger.warn('[Slack Events] Failed to fetch message text', { error: err });
         }
 
         // Guaranteed fallback so note is never skipped
         if (!messageText) {
-          messageText = (event as { text?: string }).text || 'Pinned message from Slack war-room channel';
+          if (lookupError) {
+            logger.warn('[Slack Events] Could not read pinned message text', {
+              incidentId: incident.id,
+              channelId,
+              messageTs,
+              error: lookupError,
+              hint:
+                lookupError === 'missing_scope'
+                  ? "Slack app is missing the 'channels:history' (or 'groups:history' for private channels) scope. Re-authorize Slack in Settings > Slack."
+                  : undefined,
+            });
+          }
+
+          messageText =
+            (event as { text?: string }).text ||
+            (lookupError === 'missing_scope'
+              ? "(message text unavailable — Slack app is missing the 'channels:history' scope; re-authorize Slack in Settings > Slack)"
+              : lookupError
+                ? `(message text unavailable — Slack API error: ${lookupError})`
+                : 'Pinned message from Slack war-room channel');
         }
 
         // Fetch reactor user info from Slack

--- a/src/app/api/slack/oauth/route.ts
+++ b/src/app/api/slack/oauth/route.ts
@@ -101,10 +101,13 @@ export async function GET(request: NextRequest) {
       'channels:read',
       'channels:join',
       'channels:manage',
+      'channels:history', // Read pinned message text for emoji reaction timeline sync
       'groups:read',
       'groups:write',
+      'groups:history', // Same, for private war-room channels
       'im:read',
       'mpim:read',
+      'reactions:read', // Receive reaction_added events (:pushpin: -> incident timeline)
       'users:read',
       'users:read.email',
     ].join(',');

--- a/src/lib/__tests__/timezone.test.ts
+++ b/src/lib/__tests__/timezone.test.ts
@@ -27,4 +27,32 @@ describe('timezone helpers', () => {
     expect(formatDateKeyInTimeZone(start, timeZone)).toBe(dateKey);
     expect(formatDateKeyInTimeZone(nextStart, timeZone)).toBe('2024-03-11');
   });
+
+  // Regression: getTimeZoneOffsetMs used `hour12: false`, which resolves to the
+  // h24 hour cycle on Node 20's ICU and reports midnight as hour "24". That
+  // rolled Date.UTC into the next day and produced a 24h offset error, so
+  // start-of-day in a zero-offset zone landed a full day early — on Node 20
+  // only. Node 22 defaults to h23 and was unaffected, so the two runtimes
+  // silently disagreed about who was on call.
+  it('resolves start of day in zero-offset zones without a day shift', () => {
+    for (const timeZone of ['UTC', 'Europe/London', 'Africa/Abidjan']) {
+      const start = startOfDayFromDateKey('2026-08-16', timeZone);
+      expect(formatDateKeyInTimeZone(start, timeZone)).toBe('2026-08-16');
+    }
+  });
+
+  it('keeps start of day at midnight across a range of zones and dates', () => {
+    const zones = ['UTC', 'Asia/Kolkata', 'America/New_York', 'Australia/Sydney', 'Europe/London'];
+    const dateKeys = ['2026-01-01', '2026-03-29', '2026-08-16', '2026-11-01', '2026-12-31'];
+
+    for (const timeZone of zones) {
+      for (const dateKey of dateKeys) {
+        const start = startOfDayFromDateKey(dateKey, timeZone);
+        expect(formatDateKeyInTimeZone(start, timeZone)).toBe(dateKey);
+
+        const nextStart = startOfNextDayFromDateKey(dateKey, timeZone);
+        expect(formatDateKeyInTimeZone(nextStart, timeZone)).toBe(addDaysToDateKey(dateKey, 1));
+      }
+    }
+  });
 });

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -289,7 +289,12 @@ function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      hour12: false,
+      // hourCycle h23 keeps midnight as hour 00. `hour12: false` alone is not
+      // enough: on Node 20's ICU, en-US resolves to the h24 cycle and formats
+      // midnight as hour "24", which rolls Date.UTC below into the next day and
+      // yields a 24h offset error. Node 22 defaults to h23, so this diverged by
+      // runtime — see the %24 guard for the same reason.
+      hourCycle: 'h23',
     });
     const parts = formatter.formatToParts(date);
     const partMap: Record<string, string> = {};
@@ -302,7 +307,8 @@ function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
       Number(partMap.year),
       Number(partMap.month) - 1,
       Number(partMap.day),
-      Number(partMap.hour),
+      // Defensive: any ICU build that still reports "24" for midnight
+      Number(partMap.hour) % 24,
       Number(partMap.minute),
       Number(partMap.second)
     );

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -133,46 +133,89 @@ describe('Notification System Tests', () => {
     });
   });
 
-  describe('Schedule Escalation - Multiple On-Call Users', () => {
-    it('should return all active on-call users from all layers', async () => {
-      const user1Id = 'user-1';
-      const user2Id = 'user-2';
-      const scheduleId = 'sched-1';
+  describe('Schedule Escalation - Overlapping Layer Precedence', () => {
+    // Overlapping layers are priority-resolved to a single on-call user by
+    // getFinalScheduleBlocks: the highest-priority layer wins, ties broken on
+    // lexical layerId. This assertion previously expected every layer's users
+    // to be paged, which stopped being true when priority resolution landed.
+    const scheduleId = 'sched-1';
+    const user1Id = 'user-1';
+    const user2Id = 'user-2';
 
-      (vi.mocked(prisma.user.create) as any).mockImplementation(({ data }: any) =>
-        Promise.resolve({ id: data.email === 'user1@example.com' ? user1Id : user2Id, ...data })
+    const scheduleWithLayers = (layer1Priority?: number, layer2Priority?: number) => ({
+      id: scheduleId,
+      name: 'Test Schedule',
+      timeZone: 'UTC',
+      layers: [
+        {
+          id: 'layer-1',
+          name: 'Layer 1',
+          start: new Date('2024-01-01'),
+          rotationLengthHours: 24,
+          priority: layer1Priority,
+          users: [{ userId: user1Id, position: 0, user: { name: 'User 1' } }],
+        },
+        {
+          id: 'layer-2',
+          name: 'Layer 2',
+          start: new Date('2024-01-01'),
+          rotationLengthHours: 24,
+          priority: layer2Priority,
+          users: [{ userId: user2Id, position: 0, user: { name: 'User 2' } }],
+        },
+      ],
+      overrides: [],
+    });
+
+    it('should page a single user when equal-priority layers overlap', async () => {
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(
+        scheduleWithLayers() as any // eslint-disable-line @typescript-eslint/no-explicit-any
       );
 
-      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue({
-        id: scheduleId,
-        name: 'Test Schedule',
-        timeZone: 'UTC',
-        layers: [
-          {
-            id: 'layer-1',
-            name: 'Layer 1',
-            start: new Date('2024-01-01'),
-            rotationLengthHours: 24,
-            users: [{ userId: user1Id, position: 0, user: { name: 'User 1' } }],
-          },
-          {
-            id: 'layer-2',
-            name: 'Layer 2',
-            start: new Date('2024-01-01'),
-            rotationLengthHours: 24,
-            users: [{ userId: user2Id, position: 0, user: { name: 'User 2' } }],
-          },
-        ],
-        overrides: [],
-      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-      // Mock resolveEscalationTarget internal logic dependencies if necessary
-      // Actually resolveEscalationTarget probably uses several prisma calls.
       const users = await resolveEscalationTarget('SCHEDULE', scheduleId, new Date());
 
-      expect(users.length).toBeGreaterThanOrEqual(1);
-      expect(users).toContain(user1Id);
-      expect(users).toContain(user2Id);
+      // Tie on priority resolves to the lexically-first layerId ('layer-1')
+      expect(users).toEqual([user1Id]);
+    });
+
+    it('should page the higher-priority layer when layers overlap', async () => {
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(
+        scheduleWithLayers(0, 10) as any // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+
+      const users = await resolveEscalationTarget('SCHEDULE', scheduleId, new Date());
+
+      expect(users).toEqual([user2Id]);
+    });
+
+    it('should page every override user when overrides are active', async () => {
+      const now = new Date();
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue({
+        ...scheduleWithLayers(),
+        overrides: [
+          {
+            id: 'ovr-1',
+            userId: user1Id,
+            user: { name: 'User 1' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
+          {
+            id: 'ovr-2',
+            userId: user2Id,
+            user: { name: 'User 2' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
+        ],
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const users = await resolveEscalationTarget('SCHEDULE', scheduleId, now);
+
+      // Overrides replace the rotation outright, so both are paged
+      expect(users).toEqual(expect.arrayContaining([user1Id, user2Id]));
     });
   });
 


### PR DESCRIPTION
## Problem

Emoji reaction sync (📌 → incident timeline) needs Slack scopes that the OAuth flow **never requested**:

| Scope | Needed for |
|---|---|
| `reactions:read` | Receiving `reaction_added` events at all |
| `channels:history` | Reading the reacted-to message via `conversations.history` / `.replies` |
| `groups:history` | Same, for private channels |

Without them `conversations.history` returns `ok: false` with `missing_scope` — and the events handler **never read `historyData.error`**. Every pin silently degraded to generic placeholder note text with no indication of why, so the failure was invisible.

## Change

- Add `reactions:read`, `channels:history`, `groups:history` to the OAuth scope list
- Capture and log the Slack API error from `conversations.history` / `conversations.replies`, with an explicit re-authorize hint on `missing_scope`
- Put the reason **in the note body** when text is unavailable, instead of a placeholder that reads like a successful pin
- Guard `timingSafeEqual` against length mismatch so a malformed signature is rejected as `401` rather than throwing into the `500` handler

## ⚠️ Requires re-authorization

Scope changes only take effect after **re-authorizing Slack in Settings → Slack**. Existing installs keep failing until they do.

This also means the earlier commit on this branch (widening the `conversations.history` lookup window) may not be what actually fixes pins — worth confirming `historyData.error` against a real workspace, since `missing_scope` would have produced the same symptom.

Slack **Event Subscriptions** must also be configured to point at `/api/slack/events`; that is currently undocumented (docs PR #264 was closed unmerged).

## Verification

Full unit suite: 127 files, 1003 passed, 0 failed.

> Includes a cherry-pick of the #276 test fix so this branch could pass the pre-push hook. That commit disappears from the diff once #276 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)