### PR TITLE
chore(docker): remove Watchtower auto-update from production compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,25 +61,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - opsknight-network
     command: >
       sh -c "./docker-entrypoint.sh"
-
-  watchtower:
-    image: containrrr/watchtower:latest
-    container_name: opsknight_watchtower
-    restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - WATCHTOWER_LABEL_ENABLE=true
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_POLL_INTERVAL=60
-    networks:
-      - opsknight-network
 
 volumes:
   opsknight_postgres_data:

--- a/src/lib/__tests__/timezone.test.ts
+++ b/src/lib/__tests__/timezone.test.ts
@@ -27,4 +27,32 @@ describe('timezone helpers', () => {
     expect(formatDateKeyInTimeZone(start, timeZone)).toBe(dateKey);
     expect(formatDateKeyInTimeZone(nextStart, timeZone)).toBe('2024-03-11');
   });
+
+  // Regression: getTimeZoneOffsetMs used `hour12: false`, which resolves to the
+  // h24 hour cycle on Node 20's ICU and reports midnight as hour "24". That
+  // rolled Date.UTC into the next day and produced a 24h offset error, so
+  // start-of-day in a zero-offset zone landed a full day early — on Node 20
+  // only. Node 22 defaults to h23 and was unaffected, so the two runtimes
+  // silently disagreed about who was on call.
+  it('resolves start of day in zero-offset zones without a day shift', () => {
+    for (const timeZone of ['UTC', 'Europe/London', 'Africa/Abidjan']) {
+      const start = startOfDayFromDateKey('2026-08-16', timeZone);
+      expect(formatDateKeyInTimeZone(start, timeZone)).toBe('2026-08-16');
+    }
+  });
+
+  it('keeps start of day at midnight across a range of zones and dates', () => {
+    const zones = ['UTC', 'Asia/Kolkata', 'America/New_York', 'Australia/Sydney', 'Europe/London'];
+    const dateKeys = ['2026-01-01', '2026-03-29', '2026-08-16', '2026-11-01', '2026-12-31'];
+
+    for (const timeZone of zones) {
+      for (const dateKey of dateKeys) {
+        const start = startOfDayFromDateKey(dateKey, timeZone);
+        expect(formatDateKeyInTimeZone(start, timeZone)).toBe(dateKey);
+
+        const nextStart = startOfNextDayFromDateKey(dateKey, timeZone);
+        expect(formatDateKeyInTimeZone(nextStart, timeZone)).toBe(addDaysToDateKey(dateKey, 1));
+      }
+    }
+  });
 });

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -289,7 +289,12 @@ function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      hour12: false,
+      // hourCycle h23 keeps midnight as hour 00. `hour12: false` alone is not
+      // enough: on Node 20's ICU, en-US resolves to the h24 cycle and formats
+      // midnight as hour "24", which rolls Date.UTC below into the next day and
+      // yields a 24h offset error. Node 22 defaults to h23, so this diverged by
+      // runtime — see the %24 guard for the same reason.
+      hourCycle: 'h23',
     });
     const parts = formatter.formatToParts(date);
     const partMap: Record<string, string> = {};
@@ -302,7 +307,8 @@ function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
       Number(partMap.year),
       Number(partMap.month) - 1,
       Number(partMap.day),
-      Number(partMap.hour),
+      // Defensive: any ICU build that still reports "24" for midnight
+      Number(partMap.hour) % 24,
       Number(partMap.minute),
       Number(partMap.second)
     );

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -133,46 +133,89 @@ describe('Notification System Tests', () => {
     });
   });
 
-  describe('Schedule Escalation - Multiple On-Call Users', () => {
-    it('should return all active on-call users from all layers', async () => {
-      const user1Id = 'user-1';
-      const user2Id = 'user-2';
-      const scheduleId = 'sched-1';
+  describe('Schedule Escalation - Overlapping Layer Precedence', () => {
+    // Overlapping layers are priority-resolved to a single on-call user by
+    // getFinalScheduleBlocks: the highest-priority layer wins, ties broken on
+    // lexical layerId. This assertion previously expected every layer's users
+    // to be paged, which stopped being true when priority resolution landed.
+    const scheduleId = 'sched-1';
+    const user1Id = 'user-1';
+    const user2Id = 'user-2';
 
-      (vi.mocked(prisma.user.create) as any).mockImplementation(({ data }: any) =>
-        Promise.resolve({ id: data.email === 'user1@example.com' ? user1Id : user2Id, ...data })
+    const scheduleWithLayers = (layer1Priority?: number, layer2Priority?: number) => ({
+      id: scheduleId,
+      name: 'Test Schedule',
+      timeZone: 'UTC',
+      layers: [
+        {
+          id: 'layer-1',
+          name: 'Layer 1',
+          start: new Date('2024-01-01'),
+          rotationLengthHours: 24,
+          priority: layer1Priority,
+          users: [{ userId: user1Id, position: 0, user: { name: 'User 1' } }],
+        },
+        {
+          id: 'layer-2',
+          name: 'Layer 2',
+          start: new Date('2024-01-01'),
+          rotationLengthHours: 24,
+          priority: layer2Priority,
+          users: [{ userId: user2Id, position: 0, user: { name: 'User 2' } }],
+        },
+      ],
+      overrides: [],
+    });
+
+    it('should page a single user when equal-priority layers overlap', async () => {
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(
+        scheduleWithLayers() as any // eslint-disable-line @typescript-eslint/no-explicit-any
       );
 
-      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue({
-        id: scheduleId,
-        name: 'Test Schedule',
-        timeZone: 'UTC',
-        layers: [
-          {
-            id: 'layer-1',
-            name: 'Layer 1',
-            start: new Date('2024-01-01'),
-            rotationLengthHours: 24,
-            users: [{ userId: user1Id, position: 0, user: { name: 'User 1' } }],
-          },
-          {
-            id: 'layer-2',
-            name: 'Layer 2',
-            start: new Date('2024-01-01'),
-            rotationLengthHours: 24,
-            users: [{ userId: user2Id, position: 0, user: { name: 'User 2' } }],
-          },
-        ],
-        overrides: [],
-      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-      // Mock resolveEscalationTarget internal logic dependencies if necessary
-      // Actually resolveEscalationTarget probably uses several prisma calls.
       const users = await resolveEscalationTarget('SCHEDULE', scheduleId, new Date());
 
-      expect(users.length).toBeGreaterThanOrEqual(1);
-      expect(users).toContain(user1Id);
-      expect(users).toContain(user2Id);
+      // Tie on priority resolves to the lexically-first layerId ('layer-1')
+      expect(users).toEqual([user1Id]);
+    });
+
+    it('should page the higher-priority layer when layers overlap', async () => {
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(
+        scheduleWithLayers(0, 10) as any // eslint-disable-line @typescript-eslint/no-explicit-any
+      );
+
+      const users = await resolveEscalationTarget('SCHEDULE', scheduleId, new Date());
+
+      expect(users).toEqual([user2Id]);
+    });
+
+    it('should page every override user when overrides are active', async () => {
+      const now = new Date();
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue({
+        ...scheduleWithLayers(),
+        overrides: [
+          {
+            id: 'ovr-1',
+            userId: user1Id,
+            user: { name: 'User 1' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
+          {
+            id: 'ovr-2',
+            userId: user2Id,
+            user: { name: 'User 2' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
+        ],
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const users = await resolveEscalationTarget('SCHEDULE', scheduleId, now);
+
+      // Overrides replace the rotation outright, so both are paged
+      expect(users).toEqual(expect.arrayContaining([user1Id, user2Id]));
     });
   });
 


### PR DESCRIPTION
## Change

Removes Watchtower from `docker-compose.yml`.

It polled every 60s and auto-pulled `ghcr.io/dushyant-rahangdale/opsknight:latest`, silently replacing the running production container on any upstream push. Production image rollout should be a deliberate action, not a background poll.

Removed:
- the `watchtower` service (`containrrr/watchtower:latest`, docker.sock mounted, `WATCHTOWER_POLL_INTERVAL=60`)
- the now-meaningless `com.centurylinklabs.watchtower.enable=true` label on the app service

No other references remain anywhere in the repo.

## Why it was not moved to `docker-compose.dev.yml`

The dev app is **built locally** from `Dockerfile.dev` rather than pulled from a registry. Watchtower only updates containers running pulled images, so it would have nothing to track there — the config would be inert. Removing outright rather than relocating.

## ⚠️ Follow-up worth considering

`docker-compose.yml` still pins the app to `:latest`:

```yaml
image: ghcr.io/dushyant-rahangdale/opsknight:latest
```

Watchtower is gone, so nothing updates it *on its own* any more — but any `docker compose pull` or container recreate will still pick up whatever `:latest` points at. If the goal is fully deliberate version control, pinning to a release tag (e.g. `:v1.1.0`) would complete it. Left alone here since the comment marks this as the Test Channel and choosing the tag is your call.

> Includes a cherry-pick of the #276 test fix so this branch could pass the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)