### PR TITLE
fix(slack): verify signatures fail-closed, block SSRF via response_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,19 @@ NEXTAUTH_SECRET="dev-secret-key-for-development-only"
 # ENCRYPTION_KEY="your-64-char-hex-key-here"
 
 # ----------------------------------------------------
+# SLACK
+# ----------------------------------------------------
+# Signing secret used to verify that inbound requests to /api/slack/* genuinely
+# came from Slack (slash commands, interactive buttons, event subscriptions).
+# Found at api.slack.com/apps > your app > Basic Information > Signing Secret.
+#
+# Required: Yes, unless Slack was connected via OAuth — in that case the secret
+# is stored encrypted on the integration record and used automatically.
+# Verification fails closed: with no secret from either source, every inbound
+# Slack request is rejected with 401.
+# SLACK_SIGNING_SECRET="your-slack-signing-secret"
+
+# ----------------------------------------------------
 # APPLICATION URL (Client-Side)
 # ----------------------------------------------------
 # Public-facing application URL (used in emails, SMS, push notifications, and client-side logic)

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -6,320 +6,297 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import crypto from 'crypto';
-
-const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
-
-/**
- * Verify Slack request signature
- */
-function verifySlackSignature(
-    body: string,
-    signature: string,
-    timestamp: string
-): boolean {
-    if (!SLACK_SIGNING_SECRET) {
-        logger.warn('[Slack] No signing secret configured, skipping verification');
-        return true; // Allow in development if no secret configured
-    }
-
-    // Check timestamp (prevent replay attacks)
-    const currentTime = Math.floor(Date.now() / 1000);
-    const requestTime = parseInt(timestamp, 10);
-    if (Math.abs(currentTime - requestTime) > 300) {
-        // Request is older than 5 minutes
-        return false;
-    }
-
-    // Create signature
-    const sigBaseString = `v0:${timestamp}:${body}`;
-    const computedSignature = 'v0=' + crypto
-        .createHmac('sha256', SLACK_SIGNING_SECRET)
-        .update(sigBaseString)
-        .digest('hex');
-
-    // Timing-safe comparison — throws on length mismatch, so a malformed
-    // signature must be treated as invalid rather than crashing the handler
-    try {
-        return crypto.timingSafeEqual(
-            Buffer.from(computedSignature),
-            Buffer.from(signature)
-        );
-    } catch {
-        return false;
-    }
-}
+import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.text();
-        const signature = request.headers.get('x-slack-signature') || '';
-        const timestamp = request.headers.get('x-slack-request-timestamp') || '';
+  try {
+    const body = await request.text();
+    const signature = request.headers.get('x-slack-signature') || '';
+    const timestamp = request.headers.get('x-slack-request-timestamp') || '';
 
-        // Verify signature
-        if (!verifySlackSignature(body, signature, timestamp)) {
-            logger.warn('[Slack] Invalid signature', { signature, timestamp });
-            return NextResponse.json(
-                { error: 'Invalid signature' },
-                { status: 401 }
-            );
-        }
-
-        let payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-        if (body.startsWith('payload=')) {
-            const params = new URLSearchParams(body);
-            payload = JSON.parse(params.get('payload') || '{}');
-        } else {
-            try {
-                payload = JSON.parse(body);
-            } catch {
-                const params = new URLSearchParams(body);
-                payload = JSON.parse(params.get('payload') || '{}');
-            }
-        }
-
-        // Handle URL verification (for Slack app setup)
-        if (payload.type === 'url_verification') {
-            return NextResponse.json({ challenge: payload.challenge });
-        }
-
-        // Handle interactive button clicks
-        if (payload.type === 'block_actions') {
-            const action = payload.actions?.[0];
-            if (!action) {
-                return NextResponse.json({ error: 'No action found' }, { status: 400 });
-            }
-
-            const actionValue = JSON.parse(action.value || '{}');
-            const { action: actionType, incidentId } = actionValue;
-            const slackUserId = payload.user?.id;
-            const slackUserName = payload.user?.name || payload.user?.username;
-
-            if (!incidentId || !actionType) {
-                return NextResponse.json(
-                    { error: 'Invalid action data' },
-                    { status: 400 }
-                );
-            }
-
-            // Get incident
-            const incident = await prisma.incident.findUnique({
-                where: { id: incidentId }
-            });
-
-            if (!incident) {
-                return NextResponse.json(
-                    { error: 'Incident not found' },
-                    { status: 404 }
-                );
-            }
-
-            let responseMessage = '';
-
-            if (actionType === 'ack') {
-                if (incident.status === 'OPEN') {
-                    await prisma.incident.update({
-                        where: { id: incidentId },
-                        data: {
-                            status: 'ACKNOWLEDGED',
-                            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-                            // Acknowledging must stop the escalation chain, exactly as
-                            // `/incident ack` does — otherwise the button changes the
-                            // status label while OpsKnight keeps paging the next step.
-                            escalationStatus: 'COMPLETED',
-                            nextEscalationAt: null,
-                        }
-                    });
-                    responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
-                } else {
-                    return NextResponse.json({
-                        text: `ℹ️ Incident is already ${incident.status.toLowerCase()}`
-                    });
-                }
-            } else if (actionType === 'resolve') {
-                if (incident.status !== 'RESOLVED') {
-                    await prisma.incident.update({
-                        where: { id: incidentId },
-                        data: {
-                            status: 'RESOLVED',
-                            resolvedAt: incident.resolvedAt ?? new Date(),
-                            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-                            escalationStatus: 'COMPLETED',
-                            nextEscalationAt: null,
-                        }
-                    });
-                    responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
-
-                    // Auto-generate Postmortem draft & archive war-room channel
-                    const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-                    archiveWarRoomChannel(incidentId).catch(err => {
-                        logger.error('[Slack Actions] War-room channel archive failed', { error: err, incidentId });
-                    });
-                } else {
-                    return NextResponse.json({
-                        text: 'ℹ️ Incident is already resolved'
-                    });
-                }
-            } else if (actionType === 'assign_me') {
-                if (slackUserId) {
-                    try {
-                        const { getSlackBotToken } = await import('@/lib/slack');
-                        const { updateWarRoomTopic, slackApiCall } = await import('@/lib/chatops/war-room');
-                        const botToken = await getSlackBotToken(incident.serviceId);
-
-                        // Direct invite Slack user into channel via slackUserId
-                        if (botToken && incident.slackChannelId) {
-                            await slackApiCall('conversations.invite', botToken, {
-                                channel: incident.slackChannelId,
-                                users: slackUserId,
-                            }).catch(() => {});
-                        }
-                        
-                        let targetUser: { id: string; name: string } | null = null;
-
-                        // 1. Try to fetch Slack user info via HTTP GET
-                        if (botToken) {
-                            try {
-                                const userRes = await fetch(`https://slack.com/api/users.info?user=${slackUserId}`, {
-                                    method: 'GET',
-                                    headers: {
-                                        Authorization: `Bearer ${botToken}`,
-                                    },
-                                });
-                                const userData = await userRes.json();
-                                const email = userData.user?.profile?.email?.trim();
-                                const realName = userData.user?.profile?.real_name || userData.user?.name;
-
-                                if (email) {
-                                    targetUser = await prisma.user.findFirst({
-                                        where: { email: { equals: email, mode: 'insensitive' } },
-                                        select: { id: true, name: true }
-                                    });
-                                }
-
-                                if (!targetUser && realName) {
-                                    targetUser = await prisma.user.findFirst({
-                                        where: {
-                                            OR: [
-                                                { name: { equals: realName, mode: 'insensitive' } },
-                                                { name: { contains: realName, mode: 'insensitive' } },
-                                            ]
-                                        },
-                                        select: { id: true, name: true }
-                                    });
-                                }
-                            } catch (e) {
-                                logger.warn('[Slack] Failed to fetch Slack user info for assign_me', { error: e });
-                            }
-                        }
-
-                        // 2. Fall back to matching on the Slack username
-                        if (!targetUser && slackUserName) {
-                            targetUser = await prisma.user.findFirst({
-                                where: {
-                                    OR: [
-                                        { name: { equals: slackUserName, mode: 'insensitive' } },
-                                        { name: { contains: slackUserName, mode: 'insensitive' } },
-                                    ]
-                                },
-                                select: { id: true, name: true }
-                            });
-                        }
-
-                        // No "first active user" fallback: assigning the incident to an
-                        // arbitrary person is worse than not assigning it. Fail loudly
-                        // and tell the clicker how to make resolution work.
-                        if (!targetUser) {
-                            logger.warn('[Slack] assign_me could not resolve Slack user to an OpsKnight account', {
-                                slackUserId,
-                                slackUserName,
-                                incidentId,
-                            });
-                            return NextResponse.json({
-                                response_type: 'ephemeral',
-                                text: '⚠️ Could not match your Slack account to an OpsKnight user, so the incident was left unchanged. Make sure your Slack email matches your OpsKnight account email, then try again.',
-                            });
-                        }
-
-                        await prisma.incident.update({
-                            where: { id: incidentId },
-                            data: { assigneeId: targetUser.id }
-                        });
-                        updateWarRoomTopic(incidentId).catch(() => {});
-                        responseMessage = `🙋 Incident assigned to *${targetUser.name}* (<@${slackUserId}>)`;
-                    } catch (err) {
-                        logger.warn('[Slack] Assign to Me failed', { error: err, incidentId });
-                        return NextResponse.json({
-                            response_type: 'ephemeral',
-                            text: '⚠️ Could not assign this incident. Please try again, or assign it from the OpsKnight incident page.',
-                        });
-                    }
-                } else {
-                    return NextResponse.json({
-                        response_type: 'ephemeral',
-                        text: '⚠️ Could not identify your Slack user, so the incident was left unchanged.',
-                    });
-                }
-            } else {
-                return NextResponse.json(
-                    { error: 'Unknown action' },
-                    { status: 400 }
-                );
-            }
-
-            // Create incident event
-            await prisma.incidentEvent.create({
-                data: {
-                    incidentId,
-                    message: `${responseMessage} (1-Click Slack Button)`
-                }
-            }).catch(() => {});
-
-            // Post notification directly into Slack channel & response_url
-            try {
-                const { getSlackBotToken } = await import('@/lib/slack');
-                const { slackApiCall } = await import('@/lib/chatops/war-room');
-                const botToken = await getSlackBotToken(incident.serviceId);
-
-                if (botToken && incident.slackChannelId) {
-                    await slackApiCall('chat.postMessage', botToken, {
-                        channel: incident.slackChannelId,
-                        text: responseMessage,
-                    }).catch(() => {});
-                }
-
-                if (payload.response_url) {
-                    await fetch(payload.response_url, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                            text: responseMessage,
-                            response_type: 'in_channel',
-                        }),
-                    }).catch(() => {});
-                }
-            } catch (notifyErr) {
-                logger.warn('[Slack] Failed to dispatch action response message', { error: notifyErr });
-            }
-
-            return NextResponse.json({
-                text: responseMessage,
-                response_type: 'in_channel',
-            });
-        }
-
-        return NextResponse.json({ ok: true });
-    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-        logger.error('[Slack] Actions API error', {
-            error: error.message,
-            stack: error.stack
-        });
-        return NextResponse.json(
-            { error: 'Internal server error' },
-            { status: 500 }
-        );
+    // Verify signature
+    const verification = await verifySlackSignature(body, signature, timestamp);
+    if (!verification.valid) {
+      logger.warn('[Slack] Rejected unverified request', { reason: verification.reason });
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
+
+    let payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    if (body.startsWith('payload=')) {
+      const params = new URLSearchParams(body);
+      payload = JSON.parse(params.get('payload') || '{}');
+    } else {
+      try {
+        payload = JSON.parse(body);
+      } catch {
+        const params = new URLSearchParams(body);
+        payload = JSON.parse(params.get('payload') || '{}');
+      }
+    }
+
+    // Handle URL verification (for Slack app setup)
+    if (payload.type === 'url_verification') {
+      return NextResponse.json({ challenge: payload.challenge });
+    }
+
+    // Handle interactive button clicks
+    if (payload.type === 'block_actions') {
+      const action = payload.actions?.[0];
+      if (!action) {
+        return NextResponse.json({ error: 'No action found' }, { status: 400 });
+      }
+
+      const actionValue = JSON.parse(action.value || '{}');
+      const { action: actionType, incidentId } = actionValue;
+      const slackUserId = payload.user?.id;
+      const slackUserName = payload.user?.name || payload.user?.username;
+
+      if (!incidentId || !actionType) {
+        return NextResponse.json({ error: 'Invalid action data' }, { status: 400 });
+      }
+
+      // Get incident
+      const incident = await prisma.incident.findUnique({
+        where: { id: incidentId },
+      });
+
+      if (!incident) {
+        return NextResponse.json({ error: 'Incident not found' }, { status: 404 });
+      }
+
+      let responseMessage = '';
+      // Mirrors the event the equivalent web console action notifies with
+      let notifyEventType: 'acknowledged' | 'resolved' | 'updated' | null = null;
+
+      if (actionType === 'ack') {
+        if (incident.status === 'OPEN') {
+          await prisma.incident.update({
+            where: { id: incidentId },
+            data: {
+              status: 'ACKNOWLEDGED',
+              acknowledgedAt: incident.acknowledgedAt ?? new Date(),
+              // Acknowledging must stop the escalation chain, exactly as
+              // `/incident ack` does — otherwise the button changes the
+              // status label while OpsKnight keeps paging the next step.
+              escalationStatus: 'COMPLETED',
+              nextEscalationAt: null,
+            },
+          });
+          responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
+          notifyEventType = 'acknowledged';
+        } else {
+          return NextResponse.json({
+            text: `ℹ️ Incident is already ${incident.status.toLowerCase()}`,
+          });
+        }
+      } else if (actionType === 'resolve') {
+        if (incident.status !== 'RESOLVED') {
+          await prisma.incident.update({
+            where: { id: incidentId },
+            data: {
+              status: 'RESOLVED',
+              resolvedAt: incident.resolvedAt ?? new Date(),
+              acknowledgedAt: incident.acknowledgedAt ?? new Date(),
+              escalationStatus: 'COMPLETED',
+              nextEscalationAt: null,
+            },
+          });
+          responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
+          notifyEventType = 'resolved';
+
+          // Auto-generate Postmortem draft & archive war-room channel
+          const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
+          archiveWarRoomChannel(incidentId).catch(err => {
+            logger.error('[Slack Actions] War-room channel archive failed', {
+              error: err,
+              incidentId,
+            });
+          });
+        } else {
+          return NextResponse.json({
+            text: 'ℹ️ Incident is already resolved',
+          });
+        }
+      } else if (actionType === 'assign_me') {
+        if (slackUserId) {
+          try {
+            const { getSlackBotToken } = await import('@/lib/slack');
+            const { updateWarRoomTopic, slackApiCall } = await import('@/lib/chatops/war-room');
+            const botToken = await getSlackBotToken(incident.serviceId);
+
+            // Direct invite Slack user into channel via slackUserId
+            if (botToken && incident.slackChannelId) {
+              await slackApiCall('conversations.invite', botToken, {
+                channel: incident.slackChannelId,
+                users: slackUserId,
+              }).catch(() => {});
+            }
+
+            let targetUser: { id: string; name: string } | null = null;
+
+            // 1. Try to fetch Slack user info via HTTP GET
+            if (botToken) {
+              try {
+                const userRes = await fetch(
+                  `https://slack.com/api/users.info?user=${slackUserId}`,
+                  {
+                    method: 'GET',
+                    headers: {
+                      Authorization: `Bearer ${botToken}`,
+                    },
+                  }
+                );
+                const userData = await userRes.json();
+                const email = userData.user?.profile?.email?.trim();
+                const realName = userData.user?.profile?.real_name || userData.user?.name;
+
+                if (email) {
+                  targetUser = await prisma.user.findFirst({
+                    where: { email: { equals: email, mode: 'insensitive' } },
+                    select: { id: true, name: true },
+                  });
+                }
+
+                if (!targetUser && realName) {
+                  targetUser = await prisma.user.findFirst({
+                    where: {
+                      OR: [
+                        { name: { equals: realName, mode: 'insensitive' } },
+                        { name: { contains: realName, mode: 'insensitive' } },
+                      ],
+                    },
+                    select: { id: true, name: true },
+                  });
+                }
+              } catch (e) {
+                logger.warn('[Slack] Failed to fetch Slack user info for assign_me', { error: e });
+              }
+            }
+
+            // 2. Fall back to matching on the Slack username
+            if (!targetUser && slackUserName) {
+              targetUser = await prisma.user.findFirst({
+                where: {
+                  OR: [
+                    { name: { equals: slackUserName, mode: 'insensitive' } },
+                    { name: { contains: slackUserName, mode: 'insensitive' } },
+                  ],
+                },
+                select: { id: true, name: true },
+              });
+            }
+
+            // No "first active user" fallback: assigning the incident to an
+            // arbitrary person is worse than not assigning it. Fail loudly
+            // and tell the clicker how to make resolution work.
+            if (!targetUser) {
+              logger.warn(
+                '[Slack] assign_me could not resolve Slack user to an OpsKnight account',
+                {
+                  slackUserId,
+                  slackUserName,
+                  incidentId,
+                }
+              );
+              return NextResponse.json({
+                response_type: 'ephemeral',
+                text: '⚠️ Could not match your Slack account to an OpsKnight user, so the incident was left unchanged. Make sure your Slack email matches your OpsKnight account email, then try again.',
+              });
+            }
+
+            await prisma.incident.update({
+              where: { id: incidentId },
+              data: { assigneeId: targetUser.id },
+            });
+            updateWarRoomTopic(incidentId).catch(() => {});
+            responseMessage = `🙋 Incident assigned to *${targetUser.name}* (<@${slackUserId}>)`;
+            notifyEventType = 'updated';
+          } catch (err) {
+            logger.warn('[Slack] Assign to Me failed', { error: err, incidentId });
+            return NextResponse.json({
+              response_type: 'ephemeral',
+              text: '⚠️ Could not assign this incident. Please try again, or assign it from the OpsKnight incident page.',
+            });
+          }
+        } else {
+          return NextResponse.json({
+            response_type: 'ephemeral',
+            text: '⚠️ Could not identify your Slack user, so the incident was left unchanged.',
+          });
+        }
+      } else {
+        return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+      }
+
+      // Create incident event
+      await prisma.incidentEvent
+        .create({
+          data: {
+            incidentId,
+            message: `${responseMessage} (1-Click Slack Button)`,
+          },
+        })
+        .catch(() => {});
+
+      // Notify the same way the web console does. These handlers write to
+      // Prisma directly, so without this a Slack button silently skips the
+      // notification the equivalent UI action always sends.
+      // Fire-and-forget: Slack times the interaction out after 3s.
+      if (notifyEventType) {
+        import('@/lib/user-notifications')
+          .then(({ sendIncidentNotifications }) =>
+            sendIncidentNotifications(incidentId, notifyEventType)
+          )
+          .catch(err =>
+            logger.error('[Slack] Failed to send notifications for button action', {
+              error: err instanceof Error ? err.message : String(err),
+              incidentId,
+              actionType,
+            })
+          );
+      }
+
+      // Post notification directly into Slack channel & response_url
+      try {
+        const { getSlackBotToken } = await import('@/lib/slack');
+        const { slackApiCall } = await import('@/lib/chatops/war-room');
+        const botToken = await getSlackBotToken(incident.serviceId);
+
+        if (botToken && incident.slackChannelId) {
+          await slackApiCall('chat.postMessage', botToken, {
+            channel: incident.slackChannelId,
+            text: responseMessage,
+          }).catch(() => {});
+        }
+
+        // Attacker-controlled input — only ever POST back to Slack's own host
+        if (isTrustedSlackResponseUrl(payload.response_url)) {
+          await fetch(payload.response_url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              text: responseMessage,
+              response_type: 'in_channel',
+            }),
+          }).catch(() => {});
+        }
+      } catch (notifyErr) {
+        logger.warn('[Slack] Failed to dispatch action response message', { error: notifyErr });
+      }
+
+      return NextResponse.json({
+        text: responseMessage,
+        response_type: 'in_channel',
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
+    logger.error('[Slack] Actions API error', {
+      error: error.message,
+      stack: error.stack,
+    });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }
-
-
-

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
+import { verifySlackSignature, toSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
   try {
@@ -269,9 +269,10 @@ export async function POST(request: NextRequest) {
           }).catch(() => {});
         }
 
-        // Attacker-controlled input — only ever POST back to Slack's own host
-        if (isTrustedSlackResponseUrl(payload.response_url)) {
-          await fetch(payload.response_url, {
+        // Rebuilt against a literal origin, so this can only ever reach Slack
+        const slackResponseUrl = toSlackResponseUrl(payload.response_url);
+        if (slackResponseUrl) {
+          await fetch(slackResponseUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -292,7 +293,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true });
   } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
     logger.error('[Slack] Actions API error', {
       error: error.message,
       stack: error.stack,

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { handleSlashCommand } from '@/lib/chatops/slash-commands';
-import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
+import { verifySlackSignature, toSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
   try {
@@ -37,11 +37,12 @@ export async function POST(request: NextRequest) {
 
     if ('timeout' in raceResult && raceResult.timeout) {
       // Processing taking longer than 1.5s -> finish in background and post to response_url
-      const responseUrl = payload.response_url;
+      // Rebuilt against a literal origin, so this can only ever reach Slack
+      const responseUrl = toSlackResponseUrl(payload.response_url);
       handlePromise
         .then(async result => {
           // Attacker-controlled input — only ever POST back to Slack's own host
-          if (isTrustedSlackResponseUrl(responseUrl) && result) {
+          if (responseUrl && result) {
             try {
               await fetch(responseUrl, {
                 method: 'POST',
@@ -68,7 +69,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(await handlePromise);
   } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
     logger.error('[Slack] Commands API error', {
       error: error.message,
       stack: error.stack,

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -1,111 +1,82 @@
 import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'crypto';
 import { logger } from '@/lib/logger';
 import { handleSlashCommand } from '@/lib/chatops/slash-commands';
-
-const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
-
-function verifySlackSignature(body: string, signature: string, timestamp: string): boolean {
-    if (!SLACK_SIGNING_SECRET) {
-        logger.warn('[Slack] No signing secret configured, skipping verification');
-        return true;
-    }
-
-    const currentTime = Math.floor(Date.now() / 1000);
-    const requestTime = parseInt(timestamp, 10);
-    if (Math.abs(currentTime - requestTime) > 300) {
-        return false;
-    }
-
-    const sigBaseString = `v0:${timestamp}:${body}`;
-    const computedSignature = 'v0=' + crypto
-        .createHmac('sha256', SLACK_SIGNING_SECRET)
-        .update(sigBaseString)
-        .digest('hex');
-
-    try {
-        return crypto.timingSafeEqual(
-            Buffer.from(computedSignature),
-            Buffer.from(signature)
-        );
-    } catch {
-        return false;
-    }
-}
+import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.text();
-        const signature = request.headers.get('x-slack-signature') || '';
-        const timestamp = request.headers.get('x-slack-request-timestamp') || '';
+  try {
+    const body = await request.text();
+    const signature = request.headers.get('x-slack-signature') || '';
+    const timestamp = request.headers.get('x-slack-request-timestamp') || '';
 
-        if (!verifySlackSignature(body, signature, timestamp)) {
-            logger.warn('[Slack] Invalid signature for slash command', { signature, timestamp });
-            return NextResponse.json(
-                { error: 'Invalid signature' },
-                { status: 401 }
-            );
-        }
-
-        const params = new URLSearchParams(body);
-        
-        const payload = {
-            command: params.get('command') || '',
-            text: params.get('text') || '',
-            channel_id: params.get('channel_id') || '',
-            channel_name: params.get('channel_name') || '',
-            user_id: params.get('user_id') || '',
-            user_name: params.get('user_name') || '',
-            team_id: params.get('team_id') || '',
-            response_url: params.get('response_url') || '',
-        };
-
-        const handlePromise = handleSlashCommand(payload);
-        const timeoutPromise = new Promise<{ timeout: true }>(resolve =>
-            setTimeout(() => resolve({ timeout: true }), 1500)
-        );
-
-        const raceResult = await Promise.race([handlePromise, timeoutPromise]);
-
-        if ('timeout' in raceResult && raceResult.timeout) {
-            // Processing taking longer than 1.5s -> finish in background and post to response_url
-            const responseUrl = payload.response_url;
-            handlePromise
-                .then(async result => {
-                    if (responseUrl && result) {
-                        try {
-                            await fetch(responseUrl, {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify(result),
-                            });
-                        } catch (err) {
-                            logger.error('[Slack] Failed to post async command response to response_url', { error: err });
-                        }
-                    }
-                })
-                .catch(err => {
-                    logger.error('[Slack] Error in async slash command processing', { error: err });
-                });
-
-            // Return immediate HTTP 200 to Slack within 1.5s to prevent 3000ms operation_timeout
-            return NextResponse.json({
-                response_type: 'ephemeral',
-                text: '⚙️ Processing `/incident` command...',
-            });
-        }
-
-        return NextResponse.json(await handlePromise);
-
-    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-        logger.error('[Slack] Commands API error', {
-            error: error.message,
-            stack: error.stack
-        });
-        
-        return NextResponse.json({
-            response_type: 'ephemeral',
-            text: 'An error occurred while processing your command.'
-        });
+    const verification = await verifySlackSignature(body, signature, timestamp);
+    if (!verification.valid) {
+      logger.warn('[Slack] Rejected unverified slash command', { reason: verification.reason });
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
+
+    const params = new URLSearchParams(body);
+
+    const payload = {
+      command: params.get('command') || '',
+      text: params.get('text') || '',
+      channel_id: params.get('channel_id') || '',
+      channel_name: params.get('channel_name') || '',
+      user_id: params.get('user_id') || '',
+      user_name: params.get('user_name') || '',
+      team_id: params.get('team_id') || '',
+      response_url: params.get('response_url') || '',
+    };
+
+    const handlePromise = handleSlashCommand(payload);
+    const timeoutPromise = new Promise<{ timeout: true }>(resolve =>
+      setTimeout(() => resolve({ timeout: true }), 1500)
+    );
+
+    const raceResult = await Promise.race([handlePromise, timeoutPromise]);
+
+    if ('timeout' in raceResult && raceResult.timeout) {
+      // Processing taking longer than 1.5s -> finish in background and post to response_url
+      const responseUrl = payload.response_url;
+      handlePromise
+        .then(async result => {
+          // Attacker-controlled input — only ever POST back to Slack's own host
+          if (isTrustedSlackResponseUrl(responseUrl) && result) {
+            try {
+              await fetch(responseUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(result),
+              });
+            } catch (err) {
+              logger.error('[Slack] Failed to post async command response to response_url', {
+                error: err,
+              });
+            }
+          }
+        })
+        .catch(err => {
+          logger.error('[Slack] Error in async slash command processing', { error: err });
+        });
+
+      // Return immediate HTTP 200 to Slack within 1.5s to prevent 3000ms operation_timeout
+      return NextResponse.json({
+        response_type: 'ephemeral',
+        text: '⚙️ Processing `/incident` command...',
+      });
+    }
+
+    return NextResponse.json(await handlePromise);
+  } catch (error: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
+    logger.error('[Slack] Commands API error', {
+      error: error.message,
+      stack: error.stack,
+    });
+
+    return NextResponse.json({
+      response_type: 'ephemeral',
+      text: 'An error occurred while processing your command.',
+    });
+  }
 }

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -9,48 +9,18 @@ import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { getSlackBotToken } from '@/lib/slack';
 import { retryFetch } from '@/lib/retry';
-import crypto from 'crypto';
+import { verifySlackSignature } from '@/lib/slack-signature';
 
-const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
-
-const PIN_EMOJIS = new Set(['pushpin', 'round_pushpin', 'memo', 'star', 'bookmark', 'pin', 'push_pin', 'note']);
-
-/**
- * Verify Slack request signature
- */
-function verifySlackSignature(
-  body: string,
-  signature: string,
-  timestamp: string
-): boolean {
-  if (!SLACK_SIGNING_SECRET) {
-    return true; // Allow in dev if no secret configured
-  }
-
-  const currentTime = Math.floor(Date.now() / 1000);
-  const requestTime = parseInt(timestamp, 10);
-  if (Math.abs(currentTime - requestTime) > 300) {
-    return false;
-  }
-
-  const sigBaseString = `v0:${timestamp}:${body}`;
-  const computedSignature =
-    'v0=' +
-    crypto
-      .createHmac('sha256', SLACK_SIGNING_SECRET)
-      .update(sigBaseString)
-      .digest('hex');
-
-  // timingSafeEqual throws on length mismatch — treat a malformed signature as invalid
-  try {
-    return crypto.timingSafeEqual(
-      Buffer.from(computedSignature),
-      Buffer.from(signature)
-    );
-  } catch {
-    return false;
-  }
-}
+const PIN_EMOJIS = new Set([
+  'pushpin',
+  'round_pushpin',
+  'memo',
+  'star',
+  'bookmark',
+  'pin',
+  'push_pin',
+  'note',
+]);
 
 export async function POST(request: NextRequest) {
   try {
@@ -59,8 +29,9 @@ export async function POST(request: NextRequest) {
     const timestamp = request.headers.get('x-slack-request-timestamp') || '';
 
     // Verify signature
-    if (!verifySlackSignature(rawBody, signature, timestamp)) {
-      logger.warn('[Slack Events] Invalid signature');
+    const verification = await verifySlackSignature(rawBody, signature, timestamp);
+    if (!verification.valid) {
+      logger.warn('[Slack Events] Rejected unverified request', { reason: verification.reason });
       return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
 
@@ -123,7 +94,9 @@ export async function POST(request: NextRequest) {
           }
 
           const foundMsg = historyData.ok
-            ? historyData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || historyData.messages?.[0]
+            ? historyData.messages?.find(
+                (m: { ts: string; text?: string }) => m.ts === messageTs
+              ) || historyData.messages?.[0]
             : null;
 
           if (foundMsg?.text) {
@@ -139,7 +112,9 @@ export async function POST(request: NextRequest) {
               lookupError = lookupError || repliesData.error || 'unknown_error';
             }
             const foundReply = repliesData.ok
-              ? repliesData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || repliesData.messages?.[0]
+              ? repliesData.messages?.find(
+                  (m: { ts: string; text?: string }) => m.ts === messageTs
+                ) || repliesData.messages?.[0]
               : null;
             if (foundReply?.text) {
               messageText = foundReply.text;

--- a/src/lib/slack-signature.ts
+++ b/src/lib/slack-signature.ts
@@ -1,0 +1,142 @@
+/**
+ * Slack request signature verification.
+ *
+ * The signing secret is resolved from SLACK_SIGNING_SECRET first, then from the
+ * encrypted `signingSecret` stored on the Slack integration record. The database
+ * fallback matters: OAuth-installed workspaces persist the secret there, so an
+ * env-only lookup silently found nothing and every request went unverified.
+ *
+ * Verification fails closed. When no secret can be resolved, requests are
+ * rejected rather than trusted — an unverified `/api/slack/*` endpoint lets
+ * anyone who can reach the URL acknowledge, resolve and reassign incidents.
+ */
+
+import crypto from 'crypto';
+import prisma from './prisma';
+import { logger } from './logger';
+import { decrypt } from './encryption';
+
+/** Slack rejects its own replays past 5 minutes; mirror that here. */
+const MAX_TIMESTAMP_SKEW_SECONDS = 300;
+
+/** Short TTL so a re-install is picked up quickly without a DB read per event. */
+const SECRET_CACHE_TTL_MS = 60_000;
+
+let cachedSecret: { value: string; expiresAt: number } | null = null;
+
+/** Test seam — clears the memoised secret. */
+export function resetSigningSecretCache(): void {
+  cachedSecret = null;
+}
+
+/**
+ * Resolve the Slack signing secret, preferring the environment variable and
+ * falling back to the encrypted secret on the enabled Slack integration.
+ * Returns null when neither source yields a usable secret.
+ */
+export async function getSlackSigningSecret(): Promise<string | null> {
+  const fromEnv = process.env.SLACK_SIGNING_SECRET?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  if (cachedSecret && cachedSecret.expiresAt > Date.now()) {
+    return cachedSecret.value;
+  }
+
+  try {
+    const integration = await prisma.slackIntegration.findFirst({
+      where: { enabled: true, NOT: { signingSecret: null } },
+      orderBy: { updatedAt: 'desc' },
+      select: { signingSecret: true },
+    });
+
+    if (!integration?.signingSecret) {
+      return null;
+    }
+
+    const decrypted = (await decrypt(integration.signingSecret)).trim();
+    if (!decrypted) {
+      return null;
+    }
+
+    cachedSecret = { value: decrypted, expiresAt: Date.now() + SECRET_CACHE_TTL_MS };
+    return decrypted;
+  } catch (error) {
+    logger.error('[Slack] Failed to load signing secret from integration', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Slack delivers interactive payloads with a `response_url` the app may POST
+ * back to. It arrives in the request body, so it is attacker-controlled input:
+ * fetching it unchecked is a server-side request forgery primitive that can be
+ * aimed at internal services or the cloud metadata endpoint.
+ *
+ * Slack only ever issues these on hooks.slack.com over HTTPS.
+ */
+const TRUSTED_RESPONSE_HOSTS = new Set(['hooks.slack.com']);
+
+export function isTrustedSlackResponseUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || !value) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && TRUSTED_RESPONSE_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export type SignatureFailure = 'no_secret' | 'missing_headers' | 'stale_timestamp' | 'mismatch';
+
+export type SignatureResult = { valid: true } | { valid: false; reason: SignatureFailure };
+
+/**
+ * Verify an inbound Slack request signature against the raw request body.
+ */
+export async function verifySlackSignature(
+  body: string,
+  signature: string,
+  timestamp: string
+): Promise<SignatureResult> {
+  const secret = await getSlackSigningSecret();
+
+  if (!secret) {
+    logger.error(
+      '[Slack] Rejecting request: no signing secret configured. Set SLACK_SIGNING_SECRET, ' +
+        'or store it on the Slack integration by reconnecting Slack in Settings > Slack.'
+    );
+    return { valid: false, reason: 'no_secret' };
+  }
+
+  if (!signature || !timestamp) {
+    return { valid: false, reason: 'missing_headers' };
+  }
+
+  const requestTime = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(requestTime)) {
+    return { valid: false, reason: 'missing_headers' };
+  }
+
+  const skew = Math.abs(Math.floor(Date.now() / 1000) - requestTime);
+  if (skew > MAX_TIMESTAMP_SKEW_SECONDS) {
+    return { valid: false, reason: 'stale_timestamp' };
+  }
+
+  const computed =
+    'v0=' + crypto.createHmac('sha256', secret).update(`v0:${timestamp}:${body}`).digest('hex');
+
+  try {
+    // timingSafeEqual throws on length mismatch — a malformed signature is invalid, not an error
+    const matches = crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(signature));
+    return matches ? { valid: true } : { valid: false, reason: 'mismatch' };
+  } catch {
+    return { valid: false, reason: 'mismatch' };
+  }
+}

--- a/src/lib/slack-signature.ts
+++ b/src/lib/slack-signature.ts
@@ -78,19 +78,42 @@ export async function getSlackSigningSecret(): Promise<string | null> {
  *
  * Slack only ever issues these on hooks.slack.com over HTTPS.
  */
-const TRUSTED_RESPONSE_HOSTS = new Set(['hooks.slack.com']);
+const SLACK_RESPONSE_ORIGIN = 'https://hooks.slack.com';
 
 export function isTrustedSlackResponseUrl(value: unknown): value is string {
+  return toSlackResponseUrl(value) !== null;
+}
+
+/**
+ * Validate a `response_url` and rebuild it against a literal origin.
+ *
+ * Returning a reconstructed URL rather than the caller's string is deliberate:
+ * the host is a compile-time constant, so no attacker-controlled value can
+ * influence which server is contacted, only the path beneath Slack's own host.
+ * A boolean-only guard leaves the tainted string flowing into fetch(), which is
+ * both weaker and unprovable to static analysis.
+ *
+ * Returns null when the value is not an HTTPS Slack hooks URL.
+ */
+export function toSlackResponseUrl(value: unknown): string | null {
   if (typeof value !== 'string' || !value) {
-    return false;
+    return null;
   }
 
+  let parsed: URL;
   try {
-    const url = new URL(value);
-    return url.protocol === 'https:' && TRUSTED_RESPONSE_HOSTS.has(url.hostname);
+    parsed = new URL(value);
   } catch {
-    return false;
+    return null;
   }
+
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'hooks.slack.com') {
+    return null;
+  }
+
+  // URL.pathname is always normalised and leading-slashed, so concatenating it
+  // onto the literal origin cannot escape the host.
+  return `${SLACK_RESPONSE_ORIGIN}${parsed.pathname}${parsed.search}`;
 }
 
 export type SignatureFailure = 'no_secret' | 'missing_headers' | 'stale_timestamp' | 'mismatch';

--- a/tests/lib/slack-signature.test.ts
+++ b/tests/lib/slack-signature.test.ts
@@ -7,6 +7,7 @@ import {
   getSlackSigningSecret,
   resetSigningSecretCache,
   isTrustedSlackResponseUrl,
+  toSlackResponseUrl,
 } from '@/lib/slack-signature';
 
 vi.mock('@/lib/prisma', () => ({
@@ -168,6 +169,17 @@ describe('Slack signature verification', () => {
     // server-side request forgery primitive (CodeQL js/request-forgery).
     it('accepts Slack response URLs', () => {
       expect(isTrustedSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc')).toBe(true);
+    });
+
+    it('rebuilds the URL against a literal Slack origin', () => {
+      // The returned host is a constant, so no input can redirect the request.
+      expect(toSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc?x=1')).toBe(
+        'https://hooks.slack.com/actions/T1/2/abc?x=1'
+      );
+      expect(toSlackResponseUrl('https://hooks.slack.com/a/../../b')).toBe(
+        'https://hooks.slack.com/b'
+      );
+      expect(toSlackResponseUrl('https://attacker.example.com/x')).toBeNull();
     });
 
     it('rejects internal and metadata targets', () => {

--- a/tests/lib/slack-signature.test.ts
+++ b/tests/lib/slack-signature.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import crypto from 'crypto';
+import prisma from '@/lib/prisma';
+import { decrypt } from '@/lib/encryption';
+import {
+  verifySlackSignature,
+  getSlackSigningSecret,
+  resetSigningSecretCache,
+  isTrustedSlackResponseUrl,
+} from '@/lib/slack-signature';
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    slackIntegration: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/encryption', () => ({
+  decrypt: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const SECRET = 'test-signing-secret';
+const BODY = 'payload=%7B%22type%22%3A%22block_actions%22%7D';
+
+function sign(body: string, timestamp: string, secret: string): string {
+  return (
+    'v0=' + crypto.createHmac('sha256', secret).update(`v0:${timestamp}:${body}`).digest('hex')
+  );
+}
+
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+describe('Slack signature verification', () => {
+  const originalSecret = process.env.SLACK_SIGNING_SECRET;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSigningSecretCache();
+    delete process.env.SLACK_SIGNING_SECRET;
+    vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue(null as any);
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.SLACK_SIGNING_SECRET;
+    } else {
+      process.env.SLACK_SIGNING_SECRET = originalSecret;
+    }
+  });
+
+  describe('secret resolution', () => {
+    it('prefers the environment variable', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+
+      await expect(getSlackSigningSecret()).resolves.toBe(SECRET);
+      expect(prisma.slackIntegration.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the encrypted secret on the Slack integration', async () => {
+      // OAuth-installed workspaces persist the secret here, so an env-only
+      // lookup found nothing and every request went unverified.
+      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+        signingSecret: 'encrypted_blob',
+      } as any);
+      vi.mocked(decrypt).mockResolvedValue(SECRET);
+
+      await expect(getSlackSigningSecret()).resolves.toBe(SECRET);
+      expect(decrypt).toHaveBeenCalledWith('encrypted_blob');
+    });
+
+    it('returns null when decryption fails rather than throwing', async () => {
+      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+        signingSecret: 'corrupt',
+      } as any);
+      vi.mocked(decrypt).mockRejectedValue(new Error('bad key'));
+
+      await expect(getSlackSigningSecret()).resolves.toBeNull();
+    });
+
+    it('returns null when no source has a secret', async () => {
+      await expect(getSlackSigningSecret()).resolves.toBeNull();
+    });
+  });
+
+  describe('verification', () => {
+    it('fails closed when no secret is configured', async () => {
+      const ts = String(nowSeconds());
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+
+      expect(result).toEqual({ valid: false, reason: 'no_secret' });
+    });
+
+    it('accepts a correctly signed request', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('accepts a request signed with the secret from the database', async () => {
+      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+        signingSecret: 'encrypted_blob',
+      } as any);
+      vi.mocked(decrypt).mockResolvedValue(SECRET);
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('rejects a signature made with a different secret', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, 'attacker-secret'), ts);
+      expect(result).toEqual({ valid: false, reason: 'mismatch' });
+    });
+
+    it('rejects a tampered body', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+      const signature = sign(BODY, ts, SECRET);
+
+      const result = await verifySlackSignature(BODY + '&extra=1', signature, ts);
+      expect(result).toEqual({ valid: false, reason: 'mismatch' });
+    });
+
+    it('rejects a replayed request older than five minutes', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds() - 601);
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+      expect(result).toEqual({ valid: false, reason: 'stale_timestamp' });
+    });
+
+    it('rejects a request whose signature was made for a different body length', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET).slice(0, 20), ts);
+      expect(result).toEqual({ valid: false, reason: 'mismatch' });
+    });
+
+    it('rejects missing headers without throwing on length mismatch', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+
+      await expect(verifySlackSignature(BODY, '', '')).resolves.toEqual({
+        valid: false,
+        reason: 'missing_headers',
+      });
+
+      const ts = String(nowSeconds());
+      await expect(verifySlackSignature(BODY, 'v0=short', ts)).resolves.toEqual({
+        valid: false,
+        reason: 'mismatch',
+      });
+    });
+  });
+
+  describe('response_url trust check', () => {
+    // response_url arrives in the request body, so fetching it unchecked is a
+    // server-side request forgery primitive (CodeQL js/request-forgery).
+    it('accepts Slack response URLs', () => {
+      expect(isTrustedSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc')).toBe(true);
+    });
+
+    it('rejects internal and metadata targets', () => {
+      const hostile = [
+        'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+        'http://localhost:3000/api/admin',
+        'http://127.0.0.1/',
+        'https://attacker.example.com/collect',
+        // Lookalike hosts that a naive substring check would accept
+        'https://hooks.slack.com.attacker.example.com/x',
+        'https://attacker.example.com/?q=hooks.slack.com',
+        // Right host, wrong scheme
+        'http://hooks.slack.com/actions/T1/2/abc',
+      ];
+
+      for (const url of hostile) {
+        expect(isTrustedSlackResponseUrl(url), url).toBe(false);
+      }
+    });
+
+    it('rejects absent or malformed values', () => {
+      for (const value of [undefined, null, '', 'not-a-url', 42, {}]) {
+        expect(isTrustedSlackResponseUrl(value)).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Three fixes, all confirmed against the running test server.

## 1. Signature verification was effectively off 🔴

All three `/api/slack/*` routes read only `process.env.SLACK_SIGNING_SECRET` and returned `true` when it was unset — trusting every unsigned request.

Confirmed on the test server:

```
$ docker exec opsknight sh -c '[ -n "$SLACK_SIGNING_SECRET" ] && echo SET || echo UNSET'
UNSET

$ curl -o /dev/null -w "%{http_code}" -X POST -d '{}' http://localhost:3000/api/slack/events
200
```

Anyone who could reach those URLs could acknowledge, resolve and reassign incidents.

**The secret was there all along.** OAuth installs persist it encrypted on `SlackIntegration.signingSecret` — verified present on the test server as a `v2` envelope. Nothing ever read it.

- New `src/lib/slack-signature.ts` resolves the secret from the env var, then the encrypted integration record, memoised for 60s
- **Fails closed**: no secret means `401`, never "trust everything"
- One shared implementation replaces three near-identical copies

## 2. Critical SSRF via `response_url` 🔴

CodeQL `js/request-forgery`, surfaced on #280. `payload.response_url` arrives in the request body and was fetched unvalidated — so combined with #1, an unsigned request could make the server POST to any host, including `169.254.169.254` for EC2 instance credentials.

Now restricted to HTTPS on `hooks.slack.com`. The commands route had the same hole. Tests cover metadata/localhost targets and lookalike hosts like `hooks.slack.com.attacker.example.com`.

## 3. Slack buttons never sent notifications

Reported from the test server: *"assign to me got assigned but didn't trigger notification."*

`ack`, `resolve` and `assign_me` write to Prisma directly, so unlike the equivalent web console actions they never called `sendIncidentNotifications` — [actions.ts:1028](src/app/(app)/incidents/actions.ts#L1028) does for reassignment. Same class as the escalation bug fixed in #278: the button path bypasses the lifecycle the UI path runs.

Each action now dispatches the same event the web path does (`acknowledged` / `resolved` / `updated`), fire-and-forget to stay inside Slack's 3s interaction timeout.

## Deploy safety

Failing closed only works if the stored secret decrypts. Verified on the test server that `signingSecret` is a `v2` envelope encrypted with the same key by the same function as `botToken` — and `botToken` demonstrably decrypts today, since the buttons work. **This will not lock the existing integration out.**

Also documents `SLACK_SIGNING_SECRET` in `.env.example`, which never mentioned it.

## Verification

`tsc --noEmit` clean. Full suite with CI flags: **128 files, 1026 passed**, on Node 20 and Node 22. 15 new tests covering secret resolution, fail-closed behaviour, replay/tamper rejection, and the SSRF allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)