### PR TITLE
fix(slack): fail-closed signatures, SSRF guard, button notifications, timeline names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,19 @@ NEXTAUTH_SECRET="dev-secret-key-for-development-only"
 # ENCRYPTION_KEY="your-64-char-hex-key-here"
 
 # ----------------------------------------------------
+# SLACK
+# ----------------------------------------------------
+# Signing secret used to verify that inbound requests to /api/slack/* genuinely
+# came from Slack (slash commands, interactive buttons, event subscriptions).
+# Found at api.slack.com/apps > your app > Basic Information > Signing Secret.
+#
+# Required: Yes, unless Slack was connected via OAuth — in that case the secret
+# is stored encrypted on the integration record and used automatically.
+# Verification fails closed: with no secret from either source, every inbound
+# Slack request is rejected with 401.
+# SLACK_SIGNING_SECRET="your-slack-signing-secret"
+
+# ----------------------------------------------------
 # APPLICATION URL (Client-Side)
 # ----------------------------------------------------
 # Public-facing application URL (used in emails, SMS, push notifications, and client-side logic)

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -6,320 +6,297 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import crypto from 'crypto';
-
-const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
-
-/**
- * Verify Slack request signature
- */
-function verifySlackSignature(
-    body: string,
-    signature: string,
-    timestamp: string
-): boolean {
-    if (!SLACK_SIGNING_SECRET) {
-        logger.warn('[Slack] No signing secret configured, skipping verification');
-        return true; // Allow in development if no secret configured
-    }
-
-    // Check timestamp (prevent replay attacks)
-    const currentTime = Math.floor(Date.now() / 1000);
-    const requestTime = parseInt(timestamp, 10);
-    if (Math.abs(currentTime - requestTime) > 300) {
-        // Request is older than 5 minutes
-        return false;
-    }
-
-    // Create signature
-    const sigBaseString = `v0:${timestamp}:${body}`;
-    const computedSignature = 'v0=' + crypto
-        .createHmac('sha256', SLACK_SIGNING_SECRET)
-        .update(sigBaseString)
-        .digest('hex');
-
-    // Timing-safe comparison — throws on length mismatch, so a malformed
-    // signature must be treated as invalid rather than crashing the handler
-    try {
-        return crypto.timingSafeEqual(
-            Buffer.from(computedSignature),
-            Buffer.from(signature)
-        );
-    } catch {
-        return false;
-    }
-}
+import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.text();
-        const signature = request.headers.get('x-slack-signature') || '';
-        const timestamp = request.headers.get('x-slack-request-timestamp') || '';
+  try {
+    const body = await request.text();
+    const signature = request.headers.get('x-slack-signature') || '';
+    const timestamp = request.headers.get('x-slack-request-timestamp') || '';
 
-        // Verify signature
-        if (!verifySlackSignature(body, signature, timestamp)) {
-            logger.warn('[Slack] Invalid signature', { signature, timestamp });
-            return NextResponse.json(
-                { error: 'Invalid signature' },
-                { status: 401 }
-            );
-        }
-
-        let payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-        if (body.startsWith('payload=')) {
-            const params = new URLSearchParams(body);
-            payload = JSON.parse(params.get('payload') || '{}');
-        } else {
-            try {
-                payload = JSON.parse(body);
-            } catch {
-                const params = new URLSearchParams(body);
-                payload = JSON.parse(params.get('payload') || '{}');
-            }
-        }
-
-        // Handle URL verification (for Slack app setup)
-        if (payload.type === 'url_verification') {
-            return NextResponse.json({ challenge: payload.challenge });
-        }
-
-        // Handle interactive button clicks
-        if (payload.type === 'block_actions') {
-            const action = payload.actions?.[0];
-            if (!action) {
-                return NextResponse.json({ error: 'No action found' }, { status: 400 });
-            }
-
-            const actionValue = JSON.parse(action.value || '{}');
-            const { action: actionType, incidentId } = actionValue;
-            const slackUserId = payload.user?.id;
-            const slackUserName = payload.user?.name || payload.user?.username;
-
-            if (!incidentId || !actionType) {
-                return NextResponse.json(
-                    { error: 'Invalid action data' },
-                    { status: 400 }
-                );
-            }
-
-            // Get incident
-            const incident = await prisma.incident.findUnique({
-                where: { id: incidentId }
-            });
-
-            if (!incident) {
-                return NextResponse.json(
-                    { error: 'Incident not found' },
-                    { status: 404 }
-                );
-            }
-
-            let responseMessage = '';
-
-            if (actionType === 'ack') {
-                if (incident.status === 'OPEN') {
-                    await prisma.incident.update({
-                        where: { id: incidentId },
-                        data: {
-                            status: 'ACKNOWLEDGED',
-                            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-                            // Acknowledging must stop the escalation chain, exactly as
-                            // `/incident ack` does — otherwise the button changes the
-                            // status label while OpsKnight keeps paging the next step.
-                            escalationStatus: 'COMPLETED',
-                            nextEscalationAt: null,
-                        }
-                    });
-                    responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
-                } else {
-                    return NextResponse.json({
-                        text: `ℹ️ Incident is already ${incident.status.toLowerCase()}`
-                    });
-                }
-            } else if (actionType === 'resolve') {
-                if (incident.status !== 'RESOLVED') {
-                    await prisma.incident.update({
-                        where: { id: incidentId },
-                        data: {
-                            status: 'RESOLVED',
-                            resolvedAt: incident.resolvedAt ?? new Date(),
-                            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-                            escalationStatus: 'COMPLETED',
-                            nextEscalationAt: null,
-                        }
-                    });
-                    responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
-
-                    // Auto-generate Postmortem draft & archive war-room channel
-                    const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-                    archiveWarRoomChannel(incidentId).catch(err => {
-                        logger.error('[Slack Actions] War-room channel archive failed', { error: err, incidentId });
-                    });
-                } else {
-                    return NextResponse.json({
-                        text: 'ℹ️ Incident is already resolved'
-                    });
-                }
-            } else if (actionType === 'assign_me') {
-                if (slackUserId) {
-                    try {
-                        const { getSlackBotToken } = await import('@/lib/slack');
-                        const { updateWarRoomTopic, slackApiCall } = await import('@/lib/chatops/war-room');
-                        const botToken = await getSlackBotToken(incident.serviceId);
-
-                        // Direct invite Slack user into channel via slackUserId
-                        if (botToken && incident.slackChannelId) {
-                            await slackApiCall('conversations.invite', botToken, {
-                                channel: incident.slackChannelId,
-                                users: slackUserId,
-                            }).catch(() => {});
-                        }
-                        
-                        let targetUser: { id: string; name: string } | null = null;
-
-                        // 1. Try to fetch Slack user info via HTTP GET
-                        if (botToken) {
-                            try {
-                                const userRes = await fetch(`https://slack.com/api/users.info?user=${slackUserId}`, {
-                                    method: 'GET',
-                                    headers: {
-                                        Authorization: `Bearer ${botToken}`,
-                                    },
-                                });
-                                const userData = await userRes.json();
-                                const email = userData.user?.profile?.email?.trim();
-                                const realName = userData.user?.profile?.real_name || userData.user?.name;
-
-                                if (email) {
-                                    targetUser = await prisma.user.findFirst({
-                                        where: { email: { equals: email, mode: 'insensitive' } },
-                                        select: { id: true, name: true }
-                                    });
-                                }
-
-                                if (!targetUser && realName) {
-                                    targetUser = await prisma.user.findFirst({
-                                        where: {
-                                            OR: [
-                                                { name: { equals: realName, mode: 'insensitive' } },
-                                                { name: { contains: realName, mode: 'insensitive' } },
-                                            ]
-                                        },
-                                        select: { id: true, name: true }
-                                    });
-                                }
-                            } catch (e) {
-                                logger.warn('[Slack] Failed to fetch Slack user info for assign_me', { error: e });
-                            }
-                        }
-
-                        // 2. Fall back to matching on the Slack username
-                        if (!targetUser && slackUserName) {
-                            targetUser = await prisma.user.findFirst({
-                                where: {
-                                    OR: [
-                                        { name: { equals: slackUserName, mode: 'insensitive' } },
-                                        { name: { contains: slackUserName, mode: 'insensitive' } },
-                                    ]
-                                },
-                                select: { id: true, name: true }
-                            });
-                        }
-
-                        // No "first active user" fallback: assigning the incident to an
-                        // arbitrary person is worse than not assigning it. Fail loudly
-                        // and tell the clicker how to make resolution work.
-                        if (!targetUser) {
-                            logger.warn('[Slack] assign_me could not resolve Slack user to an OpsKnight account', {
-                                slackUserId,
-                                slackUserName,
-                                incidentId,
-                            });
-                            return NextResponse.json({
-                                response_type: 'ephemeral',
-                                text: '⚠️ Could not match your Slack account to an OpsKnight user, so the incident was left unchanged. Make sure your Slack email matches your OpsKnight account email, then try again.',
-                            });
-                        }
-
-                        await prisma.incident.update({
-                            where: { id: incidentId },
-                            data: { assigneeId: targetUser.id }
-                        });
-                        updateWarRoomTopic(incidentId).catch(() => {});
-                        responseMessage = `🙋 Incident assigned to *${targetUser.name}* (<@${slackUserId}>)`;
-                    } catch (err) {
-                        logger.warn('[Slack] Assign to Me failed', { error: err, incidentId });
-                        return NextResponse.json({
-                            response_type: 'ephemeral',
-                            text: '⚠️ Could not assign this incident. Please try again, or assign it from the OpsKnight incident page.',
-                        });
-                    }
-                } else {
-                    return NextResponse.json({
-                        response_type: 'ephemeral',
-                        text: '⚠️ Could not identify your Slack user, so the incident was left unchanged.',
-                    });
-                }
-            } else {
-                return NextResponse.json(
-                    { error: 'Unknown action' },
-                    { status: 400 }
-                );
-            }
-
-            // Create incident event
-            await prisma.incidentEvent.create({
-                data: {
-                    incidentId,
-                    message: `${responseMessage} (1-Click Slack Button)`
-                }
-            }).catch(() => {});
-
-            // Post notification directly into Slack channel & response_url
-            try {
-                const { getSlackBotToken } = await import('@/lib/slack');
-                const { slackApiCall } = await import('@/lib/chatops/war-room');
-                const botToken = await getSlackBotToken(incident.serviceId);
-
-                if (botToken && incident.slackChannelId) {
-                    await slackApiCall('chat.postMessage', botToken, {
-                        channel: incident.slackChannelId,
-                        text: responseMessage,
-                    }).catch(() => {});
-                }
-
-                if (payload.response_url) {
-                    await fetch(payload.response_url, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                            text: responseMessage,
-                            response_type: 'in_channel',
-                        }),
-                    }).catch(() => {});
-                }
-            } catch (notifyErr) {
-                logger.warn('[Slack] Failed to dispatch action response message', { error: notifyErr });
-            }
-
-            return NextResponse.json({
-                text: responseMessage,
-                response_type: 'in_channel',
-            });
-        }
-
-        return NextResponse.json({ ok: true });
-    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-        logger.error('[Slack] Actions API error', {
-            error: error.message,
-            stack: error.stack
-        });
-        return NextResponse.json(
-            { error: 'Internal server error' },
-            { status: 500 }
-        );
+    // Verify signature
+    const verification = await verifySlackSignature(body, signature, timestamp);
+    if (!verification.valid) {
+      logger.warn('[Slack] Rejected unverified request', { reason: verification.reason });
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
+
+    let payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    if (body.startsWith('payload=')) {
+      const params = new URLSearchParams(body);
+      payload = JSON.parse(params.get('payload') || '{}');
+    } else {
+      try {
+        payload = JSON.parse(body);
+      } catch {
+        const params = new URLSearchParams(body);
+        payload = JSON.parse(params.get('payload') || '{}');
+      }
+    }
+
+    // Handle URL verification (for Slack app setup)
+    if (payload.type === 'url_verification') {
+      return NextResponse.json({ challenge: payload.challenge });
+    }
+
+    // Handle interactive button clicks
+    if (payload.type === 'block_actions') {
+      const action = payload.actions?.[0];
+      if (!action) {
+        return NextResponse.json({ error: 'No action found' }, { status: 400 });
+      }
+
+      const actionValue = JSON.parse(action.value || '{}');
+      const { action: actionType, incidentId } = actionValue;
+      const slackUserId = payload.user?.id;
+      const slackUserName = payload.user?.name || payload.user?.username;
+
+      if (!incidentId || !actionType) {
+        return NextResponse.json({ error: 'Invalid action data' }, { status: 400 });
+      }
+
+      // Get incident
+      const incident = await prisma.incident.findUnique({
+        where: { id: incidentId },
+      });
+
+      if (!incident) {
+        return NextResponse.json({ error: 'Incident not found' }, { status: 404 });
+      }
+
+      let responseMessage = '';
+      // Mirrors the event the equivalent web console action notifies with
+      let notifyEventType: 'acknowledged' | 'resolved' | 'updated' | null = null;
+
+      if (actionType === 'ack') {
+        if (incident.status === 'OPEN') {
+          await prisma.incident.update({
+            where: { id: incidentId },
+            data: {
+              status: 'ACKNOWLEDGED',
+              acknowledgedAt: incident.acknowledgedAt ?? new Date(),
+              // Acknowledging must stop the escalation chain, exactly as
+              // `/incident ack` does — otherwise the button changes the
+              // status label while OpsKnight keeps paging the next step.
+              escalationStatus: 'COMPLETED',
+              nextEscalationAt: null,
+            },
+          });
+          responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
+          notifyEventType = 'acknowledged';
+        } else {
+          return NextResponse.json({
+            text: `ℹ️ Incident is already ${incident.status.toLowerCase()}`,
+          });
+        }
+      } else if (actionType === 'resolve') {
+        if (incident.status !== 'RESOLVED') {
+          await prisma.incident.update({
+            where: { id: incidentId },
+            data: {
+              status: 'RESOLVED',
+              resolvedAt: incident.resolvedAt ?? new Date(),
+              acknowledgedAt: incident.acknowledgedAt ?? new Date(),
+              escalationStatus: 'COMPLETED',
+              nextEscalationAt: null,
+            },
+          });
+          responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
+          notifyEventType = 'resolved';
+
+          // Auto-generate Postmortem draft & archive war-room channel
+          const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
+          archiveWarRoomChannel(incidentId).catch(err => {
+            logger.error('[Slack Actions] War-room channel archive failed', {
+              error: err,
+              incidentId,
+            });
+          });
+        } else {
+          return NextResponse.json({
+            text: 'ℹ️ Incident is already resolved',
+          });
+        }
+      } else if (actionType === 'assign_me') {
+        if (slackUserId) {
+          try {
+            const { getSlackBotToken } = await import('@/lib/slack');
+            const { updateWarRoomTopic, slackApiCall } = await import('@/lib/chatops/war-room');
+            const botToken = await getSlackBotToken(incident.serviceId);
+
+            // Direct invite Slack user into channel via slackUserId
+            if (botToken && incident.slackChannelId) {
+              await slackApiCall('conversations.invite', botToken, {
+                channel: incident.slackChannelId,
+                users: slackUserId,
+              }).catch(() => {});
+            }
+
+            let targetUser: { id: string; name: string } | null = null;
+
+            // 1. Try to fetch Slack user info via HTTP GET
+            if (botToken) {
+              try {
+                const userRes = await fetch(
+                  `https://slack.com/api/users.info?user=${slackUserId}`,
+                  {
+                    method: 'GET',
+                    headers: {
+                      Authorization: `Bearer ${botToken}`,
+                    },
+                  }
+                );
+                const userData = await userRes.json();
+                const email = userData.user?.profile?.email?.trim();
+                const realName = userData.user?.profile?.real_name || userData.user?.name;
+
+                if (email) {
+                  targetUser = await prisma.user.findFirst({
+                    where: { email: { equals: email, mode: 'insensitive' } },
+                    select: { id: true, name: true },
+                  });
+                }
+
+                if (!targetUser && realName) {
+                  targetUser = await prisma.user.findFirst({
+                    where: {
+                      OR: [
+                        { name: { equals: realName, mode: 'insensitive' } },
+                        { name: { contains: realName, mode: 'insensitive' } },
+                      ],
+                    },
+                    select: { id: true, name: true },
+                  });
+                }
+              } catch (e) {
+                logger.warn('[Slack] Failed to fetch Slack user info for assign_me', { error: e });
+              }
+            }
+
+            // 2. Fall back to matching on the Slack username
+            if (!targetUser && slackUserName) {
+              targetUser = await prisma.user.findFirst({
+                where: {
+                  OR: [
+                    { name: { equals: slackUserName, mode: 'insensitive' } },
+                    { name: { contains: slackUserName, mode: 'insensitive' } },
+                  ],
+                },
+                select: { id: true, name: true },
+              });
+            }
+
+            // No "first active user" fallback: assigning the incident to an
+            // arbitrary person is worse than not assigning it. Fail loudly
+            // and tell the clicker how to make resolution work.
+            if (!targetUser) {
+              logger.warn(
+                '[Slack] assign_me could not resolve Slack user to an OpsKnight account',
+                {
+                  slackUserId,
+                  slackUserName,
+                  incidentId,
+                }
+              );
+              return NextResponse.json({
+                response_type: 'ephemeral',
+                text: '⚠️ Could not match your Slack account to an OpsKnight user, so the incident was left unchanged. Make sure your Slack email matches your OpsKnight account email, then try again.',
+              });
+            }
+
+            await prisma.incident.update({
+              where: { id: incidentId },
+              data: { assigneeId: targetUser.id },
+            });
+            updateWarRoomTopic(incidentId).catch(() => {});
+            responseMessage = `🙋 Incident assigned to *${targetUser.name}* (<@${slackUserId}>)`;
+            notifyEventType = 'updated';
+          } catch (err) {
+            logger.warn('[Slack] Assign to Me failed', { error: err, incidentId });
+            return NextResponse.json({
+              response_type: 'ephemeral',
+              text: '⚠️ Could not assign this incident. Please try again, or assign it from the OpsKnight incident page.',
+            });
+          }
+        } else {
+          return NextResponse.json({
+            response_type: 'ephemeral',
+            text: '⚠️ Could not identify your Slack user, so the incident was left unchanged.',
+          });
+        }
+      } else {
+        return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+      }
+
+      // Create incident event
+      await prisma.incidentEvent
+        .create({
+          data: {
+            incidentId,
+            message: `${responseMessage} (1-Click Slack Button)`,
+          },
+        })
+        .catch(() => {});
+
+      // Notify the same way the web console does. These handlers write to
+      // Prisma directly, so without this a Slack button silently skips the
+      // notification the equivalent UI action always sends.
+      // Fire-and-forget: Slack times the interaction out after 3s.
+      if (notifyEventType) {
+        import('@/lib/user-notifications')
+          .then(({ sendIncidentNotifications }) =>
+            sendIncidentNotifications(incidentId, notifyEventType)
+          )
+          .catch(err =>
+            logger.error('[Slack] Failed to send notifications for button action', {
+              error: err instanceof Error ? err.message : String(err),
+              incidentId,
+              actionType,
+            })
+          );
+      }
+
+      // Post notification directly into Slack channel & response_url
+      try {
+        const { getSlackBotToken } = await import('@/lib/slack');
+        const { slackApiCall } = await import('@/lib/chatops/war-room');
+        const botToken = await getSlackBotToken(incident.serviceId);
+
+        if (botToken && incident.slackChannelId) {
+          await slackApiCall('chat.postMessage', botToken, {
+            channel: incident.slackChannelId,
+            text: responseMessage,
+          }).catch(() => {});
+        }
+
+        // Attacker-controlled input — only ever POST back to Slack's own host
+        if (isTrustedSlackResponseUrl(payload.response_url)) {
+          await fetch(payload.response_url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              text: responseMessage,
+              response_type: 'in_channel',
+            }),
+          }).catch(() => {});
+        }
+      } catch (notifyErr) {
+        logger.warn('[Slack] Failed to dispatch action response message', { error: notifyErr });
+      }
+
+      return NextResponse.json({
+        text: responseMessage,
+        response_type: 'in_channel',
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
+    logger.error('[Slack] Actions API error', {
+      error: error.message,
+      stack: error.stack,
+    });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }
-
-
-

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
+import { verifySlackSignature, toSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
   try {
@@ -269,9 +269,10 @@ export async function POST(request: NextRequest) {
           }).catch(() => {});
         }
 
-        // Attacker-controlled input — only ever POST back to Slack's own host
-        if (isTrustedSlackResponseUrl(payload.response_url)) {
-          await fetch(payload.response_url, {
+        // Rebuilt against a literal origin, so this can only ever reach Slack
+        const slackResponseUrl = toSlackResponseUrl(payload.response_url);
+        if (slackResponseUrl) {
+          await fetch(slackResponseUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -292,7 +293,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true });
   } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
     logger.error('[Slack] Actions API error', {
       error: error.message,
       stack: error.stack,

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -8,6 +8,73 @@ import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { verifySlackSignature, toSlackResponseUrl } from '@/lib/slack-signature';
 
+/**
+ * Resolve the Slack user who pressed a button to an OpsKnight account and a
+ * human-readable name.
+ *
+ * Slack renders `<@U0673U4TWAJ>` as a display name, but the incident timeline
+ * stores raw text — so a mention written for Slack surfaces as the literal user
+ * ID in the web UI. Callers need both forms, so this returns the name to use in
+ * timeline entries while the Slack copy keeps the mention.
+ */
+async function resolveSlackActor(
+  botToken: string | null,
+  slackUserId?: string,
+  slackUserName?: string
+): Promise<{ opsUser: { id: string; name: string } | null; displayName: string }> {
+  let slackRealName: string | undefined;
+  let slackEmail: string | undefined;
+
+  if (botToken && slackUserId) {
+    try {
+      const userRes = await fetch(
+        `https://slack.com/api/users.info?user=${encodeURIComponent(slackUserId)}`,
+        { method: 'GET', headers: { Authorization: `Bearer ${botToken}` } }
+      );
+      const userData = await userRes.json();
+      if (userData.ok && userData.user) {
+        slackEmail = userData.user.profile?.email?.trim();
+        slackRealName = (
+          userData.user.profile?.real_name ||
+          userData.user.real_name ||
+          userData.user.name
+        )?.trim();
+      }
+    } catch (e) {
+      logger.warn('[Slack] Failed to fetch Slack user info', { error: e, slackUserId });
+    }
+  }
+
+  let opsUser: { id: string; name: string } | null = null;
+
+  if (slackEmail) {
+    opsUser = await prisma.user.findFirst({
+      where: { email: { equals: slackEmail, mode: 'insensitive' } },
+      select: { id: true, name: true },
+    });
+  }
+
+  for (const candidate of [slackRealName, slackUserName]) {
+    if (opsUser || !candidate) continue;
+    opsUser = await prisma.user.findFirst({
+      where: {
+        OR: [
+          { name: { equals: candidate, mode: 'insensitive' } },
+          { name: { contains: candidate, mode: 'insensitive' } },
+        ],
+      },
+      select: { id: true, name: true },
+    });
+  }
+
+  // Never falls back to an arbitrary account — an unresolved actor is named
+  // from Slack only, and callers decide whether that is good enough.
+  const displayName =
+    opsUser?.name || slackRealName || slackUserName || slackUserId || 'an unknown user';
+
+  return { opsUser, displayName };
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.text();
@@ -64,7 +131,19 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'Incident not found' }, { status: 404 });
       }
 
+      const { getSlackBotToken } = await import('@/lib/slack');
+      const botToken = await getSlackBotToken(incident.serviceId);
+      const { opsUser: actorUser, displayName: actorName } = await resolveSlackActor(
+        botToken,
+        slackUserId,
+        slackUserName
+      );
+
+      // Two variants of every message: `responseMessage` goes to Slack and keeps
+      // the <@ID> mention; `timelineMessage` is plain text for the incident
+      // timeline, which has no way to render a Slack mention.
       let responseMessage = '';
+      let timelineMessage = '';
       // Mirrors the event the equivalent web console action notifies with
       let notifyEventType: 'acknowledged' | 'resolved' | 'updated' | null = null;
 
@@ -83,6 +162,7 @@ export async function POST(request: NextRequest) {
             },
           });
           responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
+          timelineMessage = `Acknowledged via Slack button by ${actorName}`;
           notifyEventType = 'acknowledged';
         } else {
           return NextResponse.json({
@@ -102,6 +182,7 @@ export async function POST(request: NextRequest) {
             },
           });
           responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
+          timelineMessage = `Resolved via Slack button by ${actorName}`;
           notifyEventType = 'resolved';
 
           // Auto-generate Postmortem draft & archive war-room channel
@@ -120,9 +201,7 @@ export async function POST(request: NextRequest) {
       } else if (actionType === 'assign_me') {
         if (slackUserId) {
           try {
-            const { getSlackBotToken } = await import('@/lib/slack');
             const { updateWarRoomTopic, slackApiCall } = await import('@/lib/chatops/war-room');
-            const botToken = await getSlackBotToken(incident.serviceId);
 
             // Direct invite Slack user into channel via slackUserId
             if (botToken && incident.slackChannelId) {
@@ -132,59 +211,9 @@ export async function POST(request: NextRequest) {
               }).catch(() => {});
             }
 
-            let targetUser: { id: string; name: string } | null = null;
-
-            // 1. Try to fetch Slack user info via HTTP GET
-            if (botToken) {
-              try {
-                const userRes = await fetch(
-                  `https://slack.com/api/users.info?user=${slackUserId}`,
-                  {
-                    method: 'GET',
-                    headers: {
-                      Authorization: `Bearer ${botToken}`,
-                    },
-                  }
-                );
-                const userData = await userRes.json();
-                const email = userData.user?.profile?.email?.trim();
-                const realName = userData.user?.profile?.real_name || userData.user?.name;
-
-                if (email) {
-                  targetUser = await prisma.user.findFirst({
-                    where: { email: { equals: email, mode: 'insensitive' } },
-                    select: { id: true, name: true },
-                  });
-                }
-
-                if (!targetUser && realName) {
-                  targetUser = await prisma.user.findFirst({
-                    where: {
-                      OR: [
-                        { name: { equals: realName, mode: 'insensitive' } },
-                        { name: { contains: realName, mode: 'insensitive' } },
-                      ],
-                    },
-                    select: { id: true, name: true },
-                  });
-                }
-              } catch (e) {
-                logger.warn('[Slack] Failed to fetch Slack user info for assign_me', { error: e });
-              }
-            }
-
-            // 2. Fall back to matching on the Slack username
-            if (!targetUser && slackUserName) {
-              targetUser = await prisma.user.findFirst({
-                where: {
-                  OR: [
-                    { name: { equals: slackUserName, mode: 'insensitive' } },
-                    { name: { contains: slackUserName, mode: 'insensitive' } },
-                  ],
-                },
-                select: { id: true, name: true },
-              });
-            }
+            // Already resolved once above, by email then real name then
+            // username — the same lookup every action type needs.
+            const targetUser = actorUser;
 
             // No "first active user" fallback: assigning the incident to an
             // arbitrary person is worse than not assigning it. Fail loudly
@@ -210,6 +239,7 @@ export async function POST(request: NextRequest) {
             });
             updateWarRoomTopic(incidentId).catch(() => {});
             responseMessage = `🙋 Incident assigned to *${targetUser.name}* (<@${slackUserId}>)`;
+            timelineMessage = `Assigned to ${targetUser.name} via Slack button`;
             notifyEventType = 'updated';
           } catch (err) {
             logger.warn('[Slack] Assign to Me failed', { error: err, incidentId });
@@ -233,7 +263,7 @@ export async function POST(request: NextRequest) {
         .create({
           data: {
             incidentId,
-            message: `${responseMessage} (1-Click Slack Button)`,
+            message: timelineMessage || `${responseMessage} (1-Click Slack Button)`,
           },
         })
         .catch(() => {});
@@ -258,9 +288,7 @@ export async function POST(request: NextRequest) {
 
       // Post notification directly into Slack channel & response_url
       try {
-        const { getSlackBotToken } = await import('@/lib/slack');
         const { slackApiCall } = await import('@/lib/chatops/war-room');
-        const botToken = await getSlackBotToken(incident.serviceId);
 
         if (botToken && incident.slackChannelId) {
           await slackApiCall('chat.postMessage', botToken, {

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { handleSlashCommand } from '@/lib/chatops/slash-commands';
-import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
+import { verifySlackSignature, toSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
   try {
@@ -37,11 +37,12 @@ export async function POST(request: NextRequest) {
 
     if ('timeout' in raceResult && raceResult.timeout) {
       // Processing taking longer than 1.5s -> finish in background and post to response_url
-      const responseUrl = payload.response_url;
+      // Rebuilt against a literal origin, so this can only ever reach Slack
+      const responseUrl = toSlackResponseUrl(payload.response_url);
       handlePromise
         .then(async result => {
           // Attacker-controlled input — only ever POST back to Slack's own host
-          if (isTrustedSlackResponseUrl(responseUrl) && result) {
+          if (responseUrl && result) {
             try {
               await fetch(responseUrl, {
                 method: 'POST',
@@ -68,7 +69,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(await handlePromise);
   } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
     logger.error('[Slack] Commands API error', {
       error: error.message,
       stack: error.stack,

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -1,111 +1,82 @@
 import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'crypto';
 import { logger } from '@/lib/logger';
 import { handleSlashCommand } from '@/lib/chatops/slash-commands';
-
-const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
-
-function verifySlackSignature(body: string, signature: string, timestamp: string): boolean {
-    if (!SLACK_SIGNING_SECRET) {
-        logger.warn('[Slack] No signing secret configured, skipping verification');
-        return true;
-    }
-
-    const currentTime = Math.floor(Date.now() / 1000);
-    const requestTime = parseInt(timestamp, 10);
-    if (Math.abs(currentTime - requestTime) > 300) {
-        return false;
-    }
-
-    const sigBaseString = `v0:${timestamp}:${body}`;
-    const computedSignature = 'v0=' + crypto
-        .createHmac('sha256', SLACK_SIGNING_SECRET)
-        .update(sigBaseString)
-        .digest('hex');
-
-    try {
-        return crypto.timingSafeEqual(
-            Buffer.from(computedSignature),
-            Buffer.from(signature)
-        );
-    } catch {
-        return false;
-    }
-}
+import { verifySlackSignature, isTrustedSlackResponseUrl } from '@/lib/slack-signature';
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.text();
-        const signature = request.headers.get('x-slack-signature') || '';
-        const timestamp = request.headers.get('x-slack-request-timestamp') || '';
+  try {
+    const body = await request.text();
+    const signature = request.headers.get('x-slack-signature') || '';
+    const timestamp = request.headers.get('x-slack-request-timestamp') || '';
 
-        if (!verifySlackSignature(body, signature, timestamp)) {
-            logger.warn('[Slack] Invalid signature for slash command', { signature, timestamp });
-            return NextResponse.json(
-                { error: 'Invalid signature' },
-                { status: 401 }
-            );
-        }
-
-        const params = new URLSearchParams(body);
-        
-        const payload = {
-            command: params.get('command') || '',
-            text: params.get('text') || '',
-            channel_id: params.get('channel_id') || '',
-            channel_name: params.get('channel_name') || '',
-            user_id: params.get('user_id') || '',
-            user_name: params.get('user_name') || '',
-            team_id: params.get('team_id') || '',
-            response_url: params.get('response_url') || '',
-        };
-
-        const handlePromise = handleSlashCommand(payload);
-        const timeoutPromise = new Promise<{ timeout: true }>(resolve =>
-            setTimeout(() => resolve({ timeout: true }), 1500)
-        );
-
-        const raceResult = await Promise.race([handlePromise, timeoutPromise]);
-
-        if ('timeout' in raceResult && raceResult.timeout) {
-            // Processing taking longer than 1.5s -> finish in background and post to response_url
-            const responseUrl = payload.response_url;
-            handlePromise
-                .then(async result => {
-                    if (responseUrl && result) {
-                        try {
-                            await fetch(responseUrl, {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify(result),
-                            });
-                        } catch (err) {
-                            logger.error('[Slack] Failed to post async command response to response_url', { error: err });
-                        }
-                    }
-                })
-                .catch(err => {
-                    logger.error('[Slack] Error in async slash command processing', { error: err });
-                });
-
-            // Return immediate HTTP 200 to Slack within 1.5s to prevent 3000ms operation_timeout
-            return NextResponse.json({
-                response_type: 'ephemeral',
-                text: '⚙️ Processing `/incident` command...',
-            });
-        }
-
-        return NextResponse.json(await handlePromise);
-
-    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-        logger.error('[Slack] Commands API error', {
-            error: error.message,
-            stack: error.stack
-        });
-        
-        return NextResponse.json({
-            response_type: 'ephemeral',
-            text: 'An error occurred while processing your command.'
-        });
+    const verification = await verifySlackSignature(body, signature, timestamp);
+    if (!verification.valid) {
+      logger.warn('[Slack] Rejected unverified slash command', { reason: verification.reason });
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
+
+    const params = new URLSearchParams(body);
+
+    const payload = {
+      command: params.get('command') || '',
+      text: params.get('text') || '',
+      channel_id: params.get('channel_id') || '',
+      channel_name: params.get('channel_name') || '',
+      user_id: params.get('user_id') || '',
+      user_name: params.get('user_name') || '',
+      team_id: params.get('team_id') || '',
+      response_url: params.get('response_url') || '',
+    };
+
+    const handlePromise = handleSlashCommand(payload);
+    const timeoutPromise = new Promise<{ timeout: true }>(resolve =>
+      setTimeout(() => resolve({ timeout: true }), 1500)
+    );
+
+    const raceResult = await Promise.race([handlePromise, timeoutPromise]);
+
+    if ('timeout' in raceResult && raceResult.timeout) {
+      // Processing taking longer than 1.5s -> finish in background and post to response_url
+      const responseUrl = payload.response_url;
+      handlePromise
+        .then(async result => {
+          // Attacker-controlled input — only ever POST back to Slack's own host
+          if (isTrustedSlackResponseUrl(responseUrl) && result) {
+            try {
+              await fetch(responseUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(result),
+              });
+            } catch (err) {
+              logger.error('[Slack] Failed to post async command response to response_url', {
+                error: err,
+              });
+            }
+          }
+        })
+        .catch(err => {
+          logger.error('[Slack] Error in async slash command processing', { error: err });
+        });
+
+      // Return immediate HTTP 200 to Slack within 1.5s to prevent 3000ms operation_timeout
+      return NextResponse.json({
+        response_type: 'ephemeral',
+        text: '⚙️ Processing `/incident` command...',
+      });
+    }
+
+    return NextResponse.json(await handlePromise);
+  } catch (error: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
+    logger.error('[Slack] Commands API error', {
+      error: error.message,
+      stack: error.stack,
+    });
+
+    return NextResponse.json({
+      response_type: 'ephemeral',
+      text: 'An error occurred while processing your command.',
+    });
+  }
 }

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -1,7 +1,7 @@
 /**
  * Slack Event Subscriptions API
  * Listens for Slack events such as `reaction_added` (:pushpin:, :memo:)
- * and automatically captures pinned messages into the OpsKnight incident timeline.
+ * and automatically captures pinned messages as OpsKnight incident notes.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -182,23 +182,27 @@ export async function POST(request: NextRequest) {
           const fallbackUser = await prisma.user.findFirst({ select: { id: true } });
           const noteUserId = resolvedUser?.id || incident.assigneeId || fallbackUser?.id;
 
-          if (noteUserId) {
-            await prisma.incidentNote.create({
-              data: {
-                incidentId: incident.id,
-                userId: noteUserId,
-                content: `📌 [Slack Pin by ${authorName}]: ${messageText}`,
-              },
+          // The note is now the only record of a pin, so a missing author means
+          // the pin captured nothing — say so rather than reporting success.
+          if (!noteUserId) {
+            logger.warn('[Slack Events] No OpsKnight user available to attribute pinned note to', {
+              incidentId: incident.id,
+              authorName,
             });
+            return NextResponse.json({ ok: true });
           }
 
-          // Create timeline event
-          await prisma.incidentEvent.create({
+          await prisma.incidentNote.create({
             data: {
               incidentId: incident.id,
-              message: `Message pinned to timeline via 📌 emoji by @${authorName}`,
+              userId: noteUserId,
+              content: `📌 [Slack Pin by ${authorName}]: ${messageText}`,
             },
           });
+
+          // Deliberately no timeline event: a pin captures the message itself,
+          // which is what the note holds. Emitting an event as well duplicated
+          // every pin across both the notes list and the timeline.
 
           // Post confirmation thread reply in Slack
           await retryFetch('https://slack.com/api/chat.postMessage', {
@@ -210,11 +214,11 @@ export async function POST(request: NextRequest) {
             body: JSON.stringify({
               channel: channelId,
               thread_ts: messageTs,
-              text: `📌 *Pinned to OpsKnight Incident Timeline!*`,
+              text: `📌 *Saved to OpsKnight incident notes.*`,
             }),
           }).catch(() => {});
 
-          logger.info('[Slack Events] Pinned message synced to timeline', {
+          logger.info('[Slack Events] Pinned message saved as incident note', {
             incidentId: incident.id,
             authorName,
           });

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -9,48 +9,18 @@ import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { getSlackBotToken } from '@/lib/slack';
 import { retryFetch } from '@/lib/retry';
-import crypto from 'crypto';
+import { verifySlackSignature } from '@/lib/slack-signature';
 
-const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
-
-const PIN_EMOJIS = new Set(['pushpin', 'round_pushpin', 'memo', 'star', 'bookmark', 'pin', 'push_pin', 'note']);
-
-/**
- * Verify Slack request signature
- */
-function verifySlackSignature(
-  body: string,
-  signature: string,
-  timestamp: string
-): boolean {
-  if (!SLACK_SIGNING_SECRET) {
-    return true; // Allow in dev if no secret configured
-  }
-
-  const currentTime = Math.floor(Date.now() / 1000);
-  const requestTime = parseInt(timestamp, 10);
-  if (Math.abs(currentTime - requestTime) > 300) {
-    return false;
-  }
-
-  const sigBaseString = `v0:${timestamp}:${body}`;
-  const computedSignature =
-    'v0=' +
-    crypto
-      .createHmac('sha256', SLACK_SIGNING_SECRET)
-      .update(sigBaseString)
-      .digest('hex');
-
-  // timingSafeEqual throws on length mismatch — treat a malformed signature as invalid
-  try {
-    return crypto.timingSafeEqual(
-      Buffer.from(computedSignature),
-      Buffer.from(signature)
-    );
-  } catch {
-    return false;
-  }
-}
+const PIN_EMOJIS = new Set([
+  'pushpin',
+  'round_pushpin',
+  'memo',
+  'star',
+  'bookmark',
+  'pin',
+  'push_pin',
+  'note',
+]);
 
 export async function POST(request: NextRequest) {
   try {
@@ -59,8 +29,9 @@ export async function POST(request: NextRequest) {
     const timestamp = request.headers.get('x-slack-request-timestamp') || '';
 
     // Verify signature
-    if (!verifySlackSignature(rawBody, signature, timestamp)) {
-      logger.warn('[Slack Events] Invalid signature');
+    const verification = await verifySlackSignature(rawBody, signature, timestamp);
+    if (!verification.valid) {
+      logger.warn('[Slack Events] Rejected unverified request', { reason: verification.reason });
       return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
 
@@ -123,7 +94,9 @@ export async function POST(request: NextRequest) {
           }
 
           const foundMsg = historyData.ok
-            ? historyData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || historyData.messages?.[0]
+            ? historyData.messages?.find(
+                (m: { ts: string; text?: string }) => m.ts === messageTs
+              ) || historyData.messages?.[0]
             : null;
 
           if (foundMsg?.text) {
@@ -139,7 +112,9 @@ export async function POST(request: NextRequest) {
               lookupError = lookupError || repliesData.error || 'unknown_error';
             }
             const foundReply = repliesData.ok
-              ? repliesData.messages?.find((m: { ts: string; text?: string }) => m.ts === messageTs) || repliesData.messages?.[0]
+              ? repliesData.messages?.find(
+                  (m: { ts: string; text?: string }) => m.ts === messageTs
+                ) || repliesData.messages?.[0]
               : null;
             if (foundReply?.text) {
               messageText = foundReply.text;

--- a/src/lib/slack-signature.ts
+++ b/src/lib/slack-signature.ts
@@ -80,6 +80,9 @@ export async function getSlackSigningSecret(): Promise<string | null> {
  */
 const SLACK_RESPONSE_ORIGIN = 'https://hooks.slack.com';
 
+/** /actions/<team>/<request>/<token> — alphanumeric segments only. */
+const SLACK_RESPONSE_PATH = /^\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+){1,5}$/;
+
 export function isTrustedSlackResponseUrl(value: unknown): value is string {
   return toSlackResponseUrl(value) !== null;
 }
@@ -111,9 +114,17 @@ export function toSlackResponseUrl(value: unknown): string | null {
     return null;
   }
 
-  // URL.pathname is always normalised and leading-slashed, so concatenating it
-  // onto the literal origin cannot escape the host.
-  return `${SLACK_RESPONSE_ORIGIN}${parsed.pathname}${parsed.search}`;
+  // Slack response URLs are /actions/<team>/<request>/<token> — plain
+  // alphanumeric segments. Requiring that shape means nothing from the request
+  // body reaches fetch() except characters matched by this literal pattern, and
+  // the query string is dropped entirely since Slack never sets one.
+  if (!SLACK_RESPONSE_PATH.test(parsed.pathname)) {
+    return null;
+  }
+
+  // Origin is a compile-time constant, so the destination host cannot be
+  // influenced; only the validated path below it varies.
+  return `${SLACK_RESPONSE_ORIGIN}${parsed.pathname}`;
 }
 
 export type SignatureFailure = 'no_secret' | 'missing_headers' | 'stale_timestamp' | 'mismatch';

--- a/src/lib/slack-signature.ts
+++ b/src/lib/slack-signature.ts
@@ -1,0 +1,142 @@
+/**
+ * Slack request signature verification.
+ *
+ * The signing secret is resolved from SLACK_SIGNING_SECRET first, then from the
+ * encrypted `signingSecret` stored on the Slack integration record. The database
+ * fallback matters: OAuth-installed workspaces persist the secret there, so an
+ * env-only lookup silently found nothing and every request went unverified.
+ *
+ * Verification fails closed. When no secret can be resolved, requests are
+ * rejected rather than trusted — an unverified `/api/slack/*` endpoint lets
+ * anyone who can reach the URL acknowledge, resolve and reassign incidents.
+ */
+
+import crypto from 'crypto';
+import prisma from './prisma';
+import { logger } from './logger';
+import { decrypt } from './encryption';
+
+/** Slack rejects its own replays past 5 minutes; mirror that here. */
+const MAX_TIMESTAMP_SKEW_SECONDS = 300;
+
+/** Short TTL so a re-install is picked up quickly without a DB read per event. */
+const SECRET_CACHE_TTL_MS = 60_000;
+
+let cachedSecret: { value: string; expiresAt: number } | null = null;
+
+/** Test seam — clears the memoised secret. */
+export function resetSigningSecretCache(): void {
+  cachedSecret = null;
+}
+
+/**
+ * Resolve the Slack signing secret, preferring the environment variable and
+ * falling back to the encrypted secret on the enabled Slack integration.
+ * Returns null when neither source yields a usable secret.
+ */
+export async function getSlackSigningSecret(): Promise<string | null> {
+  const fromEnv = process.env.SLACK_SIGNING_SECRET?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  if (cachedSecret && cachedSecret.expiresAt > Date.now()) {
+    return cachedSecret.value;
+  }
+
+  try {
+    const integration = await prisma.slackIntegration.findFirst({
+      where: { enabled: true, NOT: { signingSecret: null } },
+      orderBy: { updatedAt: 'desc' },
+      select: { signingSecret: true },
+    });
+
+    if (!integration?.signingSecret) {
+      return null;
+    }
+
+    const decrypted = (await decrypt(integration.signingSecret)).trim();
+    if (!decrypted) {
+      return null;
+    }
+
+    cachedSecret = { value: decrypted, expiresAt: Date.now() + SECRET_CACHE_TTL_MS };
+    return decrypted;
+  } catch (error) {
+    logger.error('[Slack] Failed to load signing secret from integration', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Slack delivers interactive payloads with a `response_url` the app may POST
+ * back to. It arrives in the request body, so it is attacker-controlled input:
+ * fetching it unchecked is a server-side request forgery primitive that can be
+ * aimed at internal services or the cloud metadata endpoint.
+ *
+ * Slack only ever issues these on hooks.slack.com over HTTPS.
+ */
+const TRUSTED_RESPONSE_HOSTS = new Set(['hooks.slack.com']);
+
+export function isTrustedSlackResponseUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || !value) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && TRUSTED_RESPONSE_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export type SignatureFailure = 'no_secret' | 'missing_headers' | 'stale_timestamp' | 'mismatch';
+
+export type SignatureResult = { valid: true } | { valid: false; reason: SignatureFailure };
+
+/**
+ * Verify an inbound Slack request signature against the raw request body.
+ */
+export async function verifySlackSignature(
+  body: string,
+  signature: string,
+  timestamp: string
+): Promise<SignatureResult> {
+  const secret = await getSlackSigningSecret();
+
+  if (!secret) {
+    logger.error(
+      '[Slack] Rejecting request: no signing secret configured. Set SLACK_SIGNING_SECRET, ' +
+        'or store it on the Slack integration by reconnecting Slack in Settings > Slack.'
+    );
+    return { valid: false, reason: 'no_secret' };
+  }
+
+  if (!signature || !timestamp) {
+    return { valid: false, reason: 'missing_headers' };
+  }
+
+  const requestTime = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(requestTime)) {
+    return { valid: false, reason: 'missing_headers' };
+  }
+
+  const skew = Math.abs(Math.floor(Date.now() / 1000) - requestTime);
+  if (skew > MAX_TIMESTAMP_SKEW_SECONDS) {
+    return { valid: false, reason: 'stale_timestamp' };
+  }
+
+  const computed =
+    'v0=' + crypto.createHmac('sha256', secret).update(`v0:${timestamp}:${body}`).digest('hex');
+
+  try {
+    // timingSafeEqual throws on length mismatch — a malformed signature is invalid, not an error
+    const matches = crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(signature));
+    return matches ? { valid: true } : { valid: false, reason: 'mismatch' };
+  } catch {
+    return { valid: false, reason: 'mismatch' };
+  }
+}

--- a/src/lib/slack-signature.ts
+++ b/src/lib/slack-signature.ts
@@ -78,19 +78,42 @@ export async function getSlackSigningSecret(): Promise<string | null> {
  *
  * Slack only ever issues these on hooks.slack.com over HTTPS.
  */
-const TRUSTED_RESPONSE_HOSTS = new Set(['hooks.slack.com']);
+const SLACK_RESPONSE_ORIGIN = 'https://hooks.slack.com';
 
 export function isTrustedSlackResponseUrl(value: unknown): value is string {
+  return toSlackResponseUrl(value) !== null;
+}
+
+/**
+ * Validate a `response_url` and rebuild it against a literal origin.
+ *
+ * Returning a reconstructed URL rather than the caller's string is deliberate:
+ * the host is a compile-time constant, so no attacker-controlled value can
+ * influence which server is contacted, only the path beneath Slack's own host.
+ * A boolean-only guard leaves the tainted string flowing into fetch(), which is
+ * both weaker and unprovable to static analysis.
+ *
+ * Returns null when the value is not an HTTPS Slack hooks URL.
+ */
+export function toSlackResponseUrl(value: unknown): string | null {
   if (typeof value !== 'string' || !value) {
-    return false;
+    return null;
   }
 
+  let parsed: URL;
   try {
-    const url = new URL(value);
-    return url.protocol === 'https:' && TRUSTED_RESPONSE_HOSTS.has(url.hostname);
+    parsed = new URL(value);
   } catch {
-    return false;
+    return null;
   }
+
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'hooks.slack.com') {
+    return null;
+  }
+
+  // URL.pathname is always normalised and leading-slashed, so concatenating it
+  // onto the literal origin cannot escape the host.
+  return `${SLACK_RESPONSE_ORIGIN}${parsed.pathname}${parsed.search}`;
 }
 
 export type SignatureFailure = 'no_secret' | 'missing_headers' | 'stale_timestamp' | 'mismatch';

--- a/tests/lib/slack-signature.test.ts
+++ b/tests/lib/slack-signature.test.ts
@@ -173,12 +173,17 @@ describe('Slack signature verification', () => {
 
     it('rebuilds the URL against a literal Slack origin', () => {
       // The returned host is a constant, so no input can redirect the request.
+      expect(toSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc')).toBe(
+        'https://hooks.slack.com/actions/T1/2/abc'
+      );
+      // Query strings are dropped — Slack never sets one
       expect(toSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc?x=1')).toBe(
-        'https://hooks.slack.com/actions/T1/2/abc?x=1'
+        'https://hooks.slack.com/actions/T1/2/abc'
       );
-      expect(toSlackResponseUrl('https://hooks.slack.com/a/../../b')).toBe(
-        'https://hooks.slack.com/b'
-      );
+      // Path must match the expected shape
+      expect(toSlackResponseUrl('https://hooks.slack.com/a/../../b')).toBeNull();
+      expect(toSlackResponseUrl('https://hooks.slack.com/actions/T1/2/a%2Fb')).toBeNull();
+      expect(toSlackResponseUrl('https://hooks.slack.com/')).toBeNull();
       expect(toSlackResponseUrl('https://attacker.example.com/x')).toBeNull();
     });
 

--- a/tests/lib/slack-signature.test.ts
+++ b/tests/lib/slack-signature.test.ts
@@ -7,6 +7,7 @@ import {
   getSlackSigningSecret,
   resetSigningSecretCache,
   isTrustedSlackResponseUrl,
+  toSlackResponseUrl,
 } from '@/lib/slack-signature';
 
 vi.mock('@/lib/prisma', () => ({
@@ -168,6 +169,17 @@ describe('Slack signature verification', () => {
     // server-side request forgery primitive (CodeQL js/request-forgery).
     it('accepts Slack response URLs', () => {
       expect(isTrustedSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc')).toBe(true);
+    });
+
+    it('rebuilds the URL against a literal Slack origin', () => {
+      // The returned host is a constant, so no input can redirect the request.
+      expect(toSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc?x=1')).toBe(
+        'https://hooks.slack.com/actions/T1/2/abc?x=1'
+      );
+      expect(toSlackResponseUrl('https://hooks.slack.com/a/../../b')).toBe(
+        'https://hooks.slack.com/b'
+      );
+      expect(toSlackResponseUrl('https://attacker.example.com/x')).toBeNull();
     });
 
     it('rejects internal and metadata targets', () => {

--- a/tests/lib/slack-signature.test.ts
+++ b/tests/lib/slack-signature.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import crypto from 'crypto';
+import prisma from '@/lib/prisma';
+import { decrypt } from '@/lib/encryption';
+import {
+  verifySlackSignature,
+  getSlackSigningSecret,
+  resetSigningSecretCache,
+  isTrustedSlackResponseUrl,
+} from '@/lib/slack-signature';
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    slackIntegration: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/encryption', () => ({
+  decrypt: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const SECRET = 'test-signing-secret';
+const BODY = 'payload=%7B%22type%22%3A%22block_actions%22%7D';
+
+function sign(body: string, timestamp: string, secret: string): string {
+  return (
+    'v0=' + crypto.createHmac('sha256', secret).update(`v0:${timestamp}:${body}`).digest('hex')
+  );
+}
+
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+describe('Slack signature verification', () => {
+  const originalSecret = process.env.SLACK_SIGNING_SECRET;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSigningSecretCache();
+    delete process.env.SLACK_SIGNING_SECRET;
+    vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue(null as any);
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.SLACK_SIGNING_SECRET;
+    } else {
+      process.env.SLACK_SIGNING_SECRET = originalSecret;
+    }
+  });
+
+  describe('secret resolution', () => {
+    it('prefers the environment variable', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+
+      await expect(getSlackSigningSecret()).resolves.toBe(SECRET);
+      expect(prisma.slackIntegration.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the encrypted secret on the Slack integration', async () => {
+      // OAuth-installed workspaces persist the secret here, so an env-only
+      // lookup found nothing and every request went unverified.
+      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+        signingSecret: 'encrypted_blob',
+      } as any);
+      vi.mocked(decrypt).mockResolvedValue(SECRET);
+
+      await expect(getSlackSigningSecret()).resolves.toBe(SECRET);
+      expect(decrypt).toHaveBeenCalledWith('encrypted_blob');
+    });
+
+    it('returns null when decryption fails rather than throwing', async () => {
+      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+        signingSecret: 'corrupt',
+      } as any);
+      vi.mocked(decrypt).mockRejectedValue(new Error('bad key'));
+
+      await expect(getSlackSigningSecret()).resolves.toBeNull();
+    });
+
+    it('returns null when no source has a secret', async () => {
+      await expect(getSlackSigningSecret()).resolves.toBeNull();
+    });
+  });
+
+  describe('verification', () => {
+    it('fails closed when no secret is configured', async () => {
+      const ts = String(nowSeconds());
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+
+      expect(result).toEqual({ valid: false, reason: 'no_secret' });
+    });
+
+    it('accepts a correctly signed request', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('accepts a request signed with the secret from the database', async () => {
+      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+        signingSecret: 'encrypted_blob',
+      } as any);
+      vi.mocked(decrypt).mockResolvedValue(SECRET);
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('rejects a signature made with a different secret', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, 'attacker-secret'), ts);
+      expect(result).toEqual({ valid: false, reason: 'mismatch' });
+    });
+
+    it('rejects a tampered body', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+      const signature = sign(BODY, ts, SECRET);
+
+      const result = await verifySlackSignature(BODY + '&extra=1', signature, ts);
+      expect(result).toEqual({ valid: false, reason: 'mismatch' });
+    });
+
+    it('rejects a replayed request older than five minutes', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds() - 601);
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET), ts);
+      expect(result).toEqual({ valid: false, reason: 'stale_timestamp' });
+    });
+
+    it('rejects a request whose signature was made for a different body length', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+      const ts = String(nowSeconds());
+
+      const result = await verifySlackSignature(BODY, sign(BODY, ts, SECRET).slice(0, 20), ts);
+      expect(result).toEqual({ valid: false, reason: 'mismatch' });
+    });
+
+    it('rejects missing headers without throwing on length mismatch', async () => {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+
+      await expect(verifySlackSignature(BODY, '', '')).resolves.toEqual({
+        valid: false,
+        reason: 'missing_headers',
+      });
+
+      const ts = String(nowSeconds());
+      await expect(verifySlackSignature(BODY, 'v0=short', ts)).resolves.toEqual({
+        valid: false,
+        reason: 'mismatch',
+      });
+    });
+  });
+
+  describe('response_url trust check', () => {
+    // response_url arrives in the request body, so fetching it unchecked is a
+    // server-side request forgery primitive (CodeQL js/request-forgery).
+    it('accepts Slack response URLs', () => {
+      expect(isTrustedSlackResponseUrl('https://hooks.slack.com/actions/T1/2/abc')).toBe(true);
+    });
+
+    it('rejects internal and metadata targets', () => {
+      const hostile = [
+        'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+        'http://localhost:3000/api/admin',
+        'http://127.0.0.1/',
+        'https://attacker.example.com/collect',
+        // Lookalike hosts that a naive substring check would accept
+        'https://hooks.slack.com.attacker.example.com/x',
+        'https://attacker.example.com/?q=hooks.slack.com',
+        // Right host, wrong scheme
+        'http://hooks.slack.com/actions/T1/2/abc',
+      ];
+
+      for (const url of hostile) {
+        expect(isTrustedSlackResponseUrl(url), url).toBe(false);
+      }
+    });
+
+    it('rejects absent or malformed values', () => {
+      for (const value of [undefined, null, '', 'not-a-url', 42, {}]) {
+        expect(isTrustedSlackResponseUrl(value)).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
**Supersedes #280 and #281** — one PR so everything lands together and CodeQL evaluates the final state in a single pass.

Five fixes, all confirmed against the running test server.

## 1. Signature verification was effectively off 🔴

All three `/api/slack/*` routes read only `process.env.SLACK_SIGNING_SECRET` and returned `true` when unset — trusting every unsigned request.

```
$ docker exec opsknight sh -c '[ -n "$SLACK_SIGNING_SECRET" ] && echo SET || echo UNSET'
UNSET
$ curl -o /dev/null -w "%{http_code}" -X POST -d '{}' localhost:3000/api/slack/events
200
```

**OAuth was never the problem.** OAuth returns a *bot token* (outbound: create channels, post cards) — it does not return a signing secret, which is an app-level credential for verifying *inbound* requests. Your DB had it all along on `SlackIntegration.signingSecret`; nothing read it.

- New `src/lib/slack-signature.ts`: env var → encrypted integration record, memoised 60s
- **Fails closed** — no secret means 401
- One shared implementation replaces three near-identical copies

## 2. Critical SSRF via `response_url` 🔴

CodeQL `js/request-forgery`. `payload.response_url` arrives in the request body and was fetched unvalidated — combined with #1, an unsigned request could make the server POST anywhere, including `169.254.169.254` for EC2 credentials.

`toSlackResponseUrl` validates the host **and rebuilds the URL on a literal origin**, so the destination host is a compile-time constant and only the path beneath `hooks.slack.com` can vary. A boolean-only allowlist left the tainted string flowing into `fetch()` — weaker, and CodeQL correctly kept flagging it.

## 3. Slack buttons never sent notifications

*"assign to me got assigned but didn't trigger notification."*

`ack` / `resolve` / `assign_me` write to Prisma directly, so unlike the web console they never called `sendIncidentNotifications`. Same class as the escalation bug in #278. Each now dispatches the event the web path does, fire-and-forget to stay inside Slack's 3s timeout.

## 4. Timeline showed raw Slack IDs

> `👀 Incident acknowledged by <@U0673U4TWAJ> (1-Click Slack Button)`

One string served both the Slack reply and the DB event; Slack renders mentions, the timeline stores them literally. Ack and resolve never resolved the clicker at all. `resolveSlackActor` now resolves once (email → real name → username); Slack keeps the mention, the timeline gets `Acknowledged via Slack button by <name>`.

## 5. Pins wrote twice

A 📌 reaction created a note *and* a timeline event. Now the note only, with a guard so it can't report success in Slack after writing nothing.

## Deploy safety

Failing closed only works if the stored secret decrypts. Verified on the test server that `signingSecret` is a `v2` envelope encrypted with the same key by the same function as `botToken` — which demonstrably decrypts today, since the buttons work. **This will not lock the existing integration out.** Also documents `SLACK_SIGNING_SECRET` in `.env.example`.

## Verification

`tsc --noEmit` clean. Full suite with CI flags: **128 files, 1027 passed**, on Node 20 and Node 22. 16 new tests: secret resolution, fail-closed, replay/tamper rejection, and the SSRF allowlist including lookalike hosts like `hooks.slack.com.attacker.example.com`.

## Still requires Slack-side config

Pins remain blocked until the app is reinstalled — the installed grant is from Aug 10 and lacks `reactions:read`, `channels:history`, `groups:history` — and Event Subscriptions is enabled with `reaction_added` subscribed. No code change can grant those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)