### PR TITLE
feat(slack): enter the signing secret in the UI instead of an env var

### DIFF
--- a/prisma/migrations/20260816150000_add_slack_signing_secret_to_oauth_config/migration.sql
+++ b/prisma/migrations/20260816150000_add_slack_signing_secret_to_oauth_config/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: store the Slack app signing secret alongside the other app-level
+-- credentials. Slack never returns it from OAuth, so it is admin-entered and
+-- encrypted exactly like clientSecret.
+ALTER TABLE "SlackOAuthConfig" ADD COLUMN "signingSecret" TEXT;
+
+-- Data fix: SlackIntegration.signingSecret was populated by the OAuth callback
+-- with tokenData.authed_user.id — the Slack user ID of whoever installed the
+-- app, not a signing secret. It can never verify a signature, so clear it
+-- rather than leave a mislabelled value that looks configured.
+UPDATE "SlackIntegration" SET "signingSecret" = NULL WHERE "signingSecret" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -294,8 +294,8 @@ model Service {
   serviceNotifyOnSlaBreach    Boolean               @default(false)
   // ChatOps War-Room overrides
   autoCreateWarRoom           Boolean               @default(true) // Auto-create dedicated Slack channel for critical incidents
-  warRoomVideoBridge           String? // Override video bridge provider: JITSI, ZOOM, GOOGLE_MEET, NONE
-  warRoomCustomBridgeUrl       String? // Override custom bridge URL for this service
+  warRoomVideoBridge          String? // Override video bridge provider: JITSI, ZOOM, GOOGLE_MEET, NONE
+  warRoomCustomBridgeUrl      String? // Override custom bridge URL for this service
   slaDefinitions              SLADefinition[]
   createdAt                   DateTime              @default(now())
   updatedAt                   DateTime              @updatedAt
@@ -394,15 +394,16 @@ model WebhookIntegration {
 
 // Slack OAuth Configuration (Global - stored in database)
 model SlackOAuthConfig {
-  id           String   @id @default(cuid())
-  clientId     String // Slack App Client ID
-  clientSecret String // Encrypted Slack App Client Secret
-  redirectUri  String? // Custom redirect URI (optional)
-  enabled      Boolean  @default(true)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  updatedBy    String // User ID who last updated the config
-  updater      User     @relation("SlackOAuthConfigUpdater", fields: [updatedBy], references: [id])
+  id            String   @id @default(cuid())
+  clientId      String // Slack App Client ID
+  clientSecret  String // Encrypted Slack App Client Secret
+  signingSecret String? // Encrypted Slack App Signing Secret (verifies inbound requests)
+  redirectUri   String? // Custom redirect URI (optional)
+  enabled       Boolean  @default(true)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  updatedBy     String // User ID who last updated the config
+  updater       User     @relation("SlackOAuthConfigUpdater", fields: [updatedBy], references: [id])
 
   @@unique([id]) // Only one config record
 }
@@ -1487,12 +1488,12 @@ model RateLimit {
 model ChatOpsConfig {
   id                      String   @id @default("default")
   enabled                 Boolean  @default(false)
-  autoCreateOnUrgency     String[] @default(["HIGH"])     // Urgency levels that trigger auto-creation
+  autoCreateOnUrgency     String[] @default(["HIGH"]) // Urgency levels that trigger auto-creation
   autoCreateOnPriority    String[] @default(["P1", "P2"]) // Priority levels that trigger auto-creation
-  channelPrefix           String   @default("inc")        // Channel name prefix (e.g. #inc-104-...)
-  archiveOnResolve        Boolean  @default(true)         // Auto-archive war-room channels on resolve
-  defaultVideoBridge      String   @default("JITSI")      // JITSI, ZOOM, GOOGLE_MEET, NONE
-  customBridgeUrlTemplate String?                         // Custom URL pattern with {incidentId} placeholder
+  channelPrefix           String   @default("inc") // Channel name prefix (e.g. #inc-104-...)
+  archiveOnResolve        Boolean  @default(true) // Auto-archive war-room channels on resolve
+  defaultVideoBridge      String   @default("JITSI") // JITSI, ZOOM, GOOGLE_MEET, NONE
+  customBridgeUrlTemplate String? // Custom URL pattern with {incidentId} placeholder
   createdAt               DateTime @default(now())
   updatedAt               DateTime @updatedAt
 

--- a/src/app/(app)/settings/slack-oauth/actions.ts
+++ b/src/app/(app)/settings/slack-oauth/actions.ts
@@ -19,6 +19,7 @@ export async function saveSlackOAuthConfig(
 
   const clientId = formData.get('clientId') as string;
   const clientSecret = formData.get('clientSecret') as string;
+  const signingSecret = formData.get('signingSecret') as string;
   const redirectUri = formData.get('redirectUri') as string;
   const enabledValue = formData.get('enabled');
   const enabled = enabledValue === 'on' || enabledValue === 'true';
@@ -40,6 +41,13 @@ export async function saveSlackOAuthConfig(
     return { error: 'Client Secret is required for new configuration' };
   }
 
+  // Slack never returns the signing secret from OAuth — it is an app-level
+  // credential entered once here, and preserved when the field is left masked.
+  let encryptedSigningSecret = existing?.signingSecret ?? null;
+  if (signingSecret && signingSecret !== '********' && signingSecret.trim() !== '') {
+    encryptedSigningSecret = await encrypt(signingSecret.trim());
+  }
+
   const user = await getCurrentUser();
   const actorId = user.id;
 
@@ -50,6 +58,7 @@ export async function saveSlackOAuthConfig(
       id: 'default',
       clientId,
       clientSecret: encryptedSecret!,
+      signingSecret: encryptedSigningSecret,
       redirectUri: redirectUri || null,
       enabled,
       updatedBy: actorId,
@@ -57,6 +66,7 @@ export async function saveSlackOAuthConfig(
     update: {
       clientId,
       ...(encryptedSecret ? { clientSecret: encryptedSecret } : {}),
+      signingSecret: encryptedSigningSecret,
       redirectUri: redirectUri || null,
       enabled,
       updatedBy: actorId,
@@ -68,7 +78,12 @@ export async function saveSlackOAuthConfig(
     entityType: 'USER',
     entityId: user.id,
     actorId,
-    details: { enabled, clientId: clientId.substring(0, 10) + '...', configType: 'slack-oauth' },
+    details: {
+      enabled,
+      clientId: clientId.substring(0, 10) + '...',
+      configType: 'slack-oauth',
+      signingSecretConfigured: Boolean(encryptedSigningSecret),
+    },
   });
 
   revalidatePath('/settings/integrations/slack');

--- a/src/app/api/slack/oauth/callback/route.ts
+++ b/src/app/api/slack/oauth/callback/route.ts
@@ -142,9 +142,11 @@ export async function GET(request: NextRequest) {
 
     // Encrypt tokens before storing
     const encryptedBotToken = await encrypt(botToken);
-    const encryptedSigningSecret = tokenData.authed_user?.id
-      ? await encrypt(tokenData.authed_user.id)
-      : null;
+    // Slack does not return a signing secret from OAuth. This previously stored
+    // tokenData.authed_user.id — the installing user's Slack ID — under a field
+    // named signingSecret, which could never verify a request signature. The
+    // real secret is admin-entered on SlackOAuthConfig.
+    const encryptedSigningSecret = null;
 
     // Store or update integration
     const integrationData = {

--- a/src/components/settings/GuidedSlackSetup.tsx
+++ b/src/components/settings/GuidedSlackSetup.tsx
@@ -30,15 +30,16 @@ export default function GuidedSlackSetup() {
   const [step, setStep] = useState<SetupStep>(1);
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
+  const [signingSecret, setSigningSecret] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const router = useRouter();
 
   const redirectUri = `${getBaseUrl()}/api/slack/oauth/callback`;
 
   const handleSave = async () => {
-    if (!clientId || !clientSecret) {
+    if (!clientId || !clientSecret || !signingSecret) {
       toast.error('Missing credentials', {
-        description: 'Please enter both Client ID and Client Secret',
+        description: 'Please enter the Client ID, Client Secret and Signing Secret',
       });
       return;
     }
@@ -48,6 +49,7 @@ export default function GuidedSlackSetup() {
       const formData = new FormData();
       formData.append('clientId', clientId);
       formData.append('clientSecret', clientSecret);
+      formData.append('signingSecret', signingSecret);
       formData.append('redirectUri', redirectUri);
       formData.append('enabled', 'true');
 
@@ -290,6 +292,26 @@ export default function GuidedSlackSetup() {
                       Click &quot;Show&quot; next to Client Secret in Slack, then copy it here
                     </p>
                   </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="signingSecret">
+                      Signing Secret <span className="text-destructive">*</span>
+                    </Label>
+                    <Input
+                      id="signingSecret"
+                      type="password"
+                      value={signingSecret}
+                      onChange={e => setSigningSecret(e.target.value)}
+                      placeholder="Paste Signing Secret here"
+                      className="font-mono"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Same page in Slack, just below Client Secret. Required to verify that slash
+                      commands, buttons and events genuinely came from Slack — without it those
+                      requests are rejected. Slack never sends this during OAuth, so reconnecting
+                      will not fill it in.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -299,7 +321,10 @@ export default function GuidedSlackSetup() {
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 Back
               </Button>
-              <Button onClick={handleSave} disabled={!clientId || !clientSecret || isSaving}>
+              <Button
+                onClick={handleSave}
+                disabled={!clientId || !clientSecret || !signingSecret || isSaving}
+              >
                 {isSaving ? 'Saving...' : 'Save & Continue'}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>

--- a/src/lib/slack-signature.ts
+++ b/src/lib/slack-signature.ts
@@ -1,10 +1,14 @@
 /**
  * Slack request signature verification.
  *
- * The signing secret is resolved from SLACK_SIGNING_SECRET first, then from the
- * encrypted `signingSecret` stored on the Slack integration record. The database
- * fallback matters: OAuth-installed workspaces persist the secret there, so an
- * env-only lookup silently found nothing and every request went unverified.
+ * The signing secret is resolved from the encrypted `signingSecret` on
+ * SlackOAuthConfig — entered once in Settings > Slack, alongside the client
+ * secret — with SLACK_SIGNING_SECRET as an optional env override.
+ *
+ * It deliberately does NOT come from SlackIntegration.signingSecret: the OAuth
+ * callback used to populate that column with `authed_user.id`, the Slack user ID
+ * of whoever installed the app. Slack never returns a signing secret from OAuth,
+ * so no install can supply one.
  *
  * Verification fails closed. When no secret can be resolved, requests are
  * rejected rather than trusted — an unverified `/api/slack/*` endpoint lets
@@ -45,17 +49,17 @@ export async function getSlackSigningSecret(): Promise<string | null> {
   }
 
   try {
-    const integration = await prisma.slackIntegration.findFirst({
-      where: { enabled: true, NOT: { signingSecret: null } },
+    const config = await prisma.slackOAuthConfig.findFirst({
+      where: { NOT: { signingSecret: null } },
       orderBy: { updatedAt: 'desc' },
       select: { signingSecret: true },
     });
 
-    if (!integration?.signingSecret) {
+    if (!config?.signingSecret) {
       return null;
     }
 
-    const decrypted = (await decrypt(integration.signingSecret)).trim();
+    const decrypted = (await decrypt(config.signingSecret)).trim();
     if (!decrypted) {
       return null;
     }
@@ -63,7 +67,7 @@ export async function getSlackSigningSecret(): Promise<string | null> {
     cachedSecret = { value: decrypted, expiresAt: Date.now() + SECRET_CACHE_TTL_MS };
     return decrypted;
   } catch (error) {
-    logger.error('[Slack] Failed to load signing secret from integration', {
+    logger.error('[Slack] Failed to load signing secret from Slack OAuth config', {
       error: error instanceof Error ? error.message : String(error),
     });
     return null;
@@ -143,8 +147,9 @@ export async function verifySlackSignature(
 
   if (!secret) {
     logger.error(
-      '[Slack] Rejecting request: no signing secret configured. Set SLACK_SIGNING_SECRET, ' +
-        'or store it on the Slack integration by reconnecting Slack in Settings > Slack.'
+      '[Slack] Rejecting request: no signing secret configured. Add it under ' +
+        'Settings > Integrations > Slack (Slack app > Basic Information > Signing Secret). ' +
+        'Reconnecting Slack does not supply it — OAuth never returns a signing secret.'
     );
     return { valid: false, reason: 'no_secret' };
   }

--- a/tests/integration/slack-oauth.test.ts
+++ b/tests/integration/slack-oauth.test.ts
@@ -60,6 +60,7 @@ describe('Slack OAuth Integration', () => {
       id: 'default',
       clientId: 'test-client-id',
       clientSecret: 'encrypted_secret',
+      signingSecret: null,
       redirectUri: null,
       enabled: true,
       createdAt: new Date(),

--- a/tests/lib/slack-signature.test.ts
+++ b/tests/lib/slack-signature.test.ts
@@ -13,7 +13,7 @@ import {
 vi.mock('@/lib/prisma', () => ({
   __esModule: true,
   default: {
-    slackIntegration: { findFirst: vi.fn() },
+    slackOAuthConfig: { findFirst: vi.fn() },
   },
 }));
 
@@ -43,7 +43,7 @@ describe('Slack signature verification', () => {
     vi.clearAllMocks();
     resetSigningSecretCache();
     delete process.env.SLACK_SIGNING_SECRET;
-    vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue(null as any);
+    vi.mocked(prisma.slackOAuthConfig.findFirst).mockResolvedValue(null as any);
   });
 
   afterEach(() => {
@@ -59,13 +59,13 @@ describe('Slack signature verification', () => {
       process.env.SLACK_SIGNING_SECRET = SECRET;
 
       await expect(getSlackSigningSecret()).resolves.toBe(SECRET);
-      expect(prisma.slackIntegration.findFirst).not.toHaveBeenCalled();
+      expect(prisma.slackOAuthConfig.findFirst).not.toHaveBeenCalled();
     });
 
-    it('falls back to the encrypted secret on the Slack integration', async () => {
-      // OAuth-installed workspaces persist the secret here, so an env-only
-      // lookup found nothing and every request went unverified.
-      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+    it('falls back to the encrypted secret on the Slack OAuth config', async () => {
+      // Admin-entered in Settings > Slack. Slack never returns a signing secret
+      // from OAuth, so this is the only real source besides the env override.
+      vi.mocked(prisma.slackOAuthConfig.findFirst).mockResolvedValue({
         signingSecret: 'encrypted_blob',
       } as any);
       vi.mocked(decrypt).mockResolvedValue(SECRET);
@@ -75,7 +75,7 @@ describe('Slack signature verification', () => {
     });
 
     it('returns null when decryption fails rather than throwing', async () => {
-      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+      vi.mocked(prisma.slackOAuthConfig.findFirst).mockResolvedValue({
         signingSecret: 'corrupt',
       } as any);
       vi.mocked(decrypt).mockRejectedValue(new Error('bad key'));
@@ -105,7 +105,7 @@ describe('Slack signature verification', () => {
     });
 
     it('accepts a request signed with the secret from the database', async () => {
-      vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue({
+      vi.mocked(prisma.slackOAuthConfig.findFirst).mockResolvedValue({
         signingSecret: 'encrypted_blob',
       } as any);
       vi.mocked(decrypt).mockResolvedValue(SECRET);


### PR DESCRIPTION
## The bug

Slack verification currently fails with `reason: "mismatch"` on the test server — not `no_secret`. A secret *was* found and used; it just isn't a signing secret.

[callback/route.ts](src/app/api/slack/oauth/callback/route.ts) stored this:

```ts
const encryptedSigningSecret = tokenData.authed_user?.id
  ? await encrypt(tokenData.authed_user.id)   // ← a Slack user ID, e.g. U0673U4TWAJ
  : null;
```

It encrypts and decrypts cleanly, which is exactly why it looked configured — my pre-deploy check confirmed it *decrypts* and I wrongly concluded it would *work*. HMAC against a user ID can never match.

Before #282 the code failed open, so a wrong secret and no secret behaved identically. Failing closed turned a silent security hole into a visible outage.

## Why it can't be automatic

**Slack never returns a signing secret from OAuth.** It's an app-level credential on Basic Information, identical across every workspace install. There is nothing for the callback to populate it from, and **reconnecting Slack will not fix it** — it just re-runs the same line.

One human copy-paste is unavoidable. The only real choice is *where it lands*.

## The approach

`.env` means a redeploy to rotate and a credential living outside the app. So it goes where the **client secret already lives**: encrypted on `SlackOAuthConfig`, entered in the guided Slack setup.

| | Before | After |
|---|---|---|
| Source | `authed_user.id`, mislabelled | Admin-entered, encrypted |
| To change | Edit `.env`, recreate container | Settings form, takes effect immediately |
| Survives reinstall | n/a | ✅ |
| Env var | required | optional override for local dev |

- `SlackOAuthConfig.signingSecret`, encrypted, masked-preserve on update (same pattern as `clientSecret`)
- Field added to `GuidedSlackSetup`, required alongside client ID/secret, with copy explaining OAuth won't supply it
- Resolver reads `SlackOAuthConfig`; `SLACK_SIGNING_SECRET` still wins if set
- Callback no longer writes `authed_user.id` under a `signingSecret` field
- Migration clears existing mislabelled values, so nothing reports as configured when it isn't

## Deploying

Slack inbound is **down right now** — buttons, `/incident` and events all 401, because #282 correctly rejects the bad secret. Order:

1. Merge and deploy this
2. Settings → Integrations → Slack → paste the Signing Secret (Slack app → Basic Information)
3. Slack works again immediately — no restart, no redeploy
4. Then save the manifest; the Request URL challenge will verify

If you need Slack back before this lands, `SLACK_SIGNING_SECRET` in `~/app/.env` plus a container recreate still works and remains supported.

## Verification

`tsc --noEmit` clean. Full suite: **128 files, 1027 passed**, on Node 20 and Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)