### PR TITLE
feat(slack): make signing-secret entry reachable, fix scope checklist, add events setup

### DIFF
--- a/src/app/(app)/settings/integrations/slack/page.tsx
+++ b/src/app/(app)/settings/integrations/slack/page.tsx
@@ -1,14 +1,14 @@
-import { getUserPermissions } from '@/lib/rbac'
-import { redirect } from 'next/navigation'
-import prisma from '@/lib/prisma'
-import SlackIntegrationPage from '@/components/settings/SlackIntegrationPage'
-import { SettingsPageHeader } from '@/components/settings/layout/SettingsPageHeader'
+import { getUserPermissions } from '@/lib/rbac';
+import { redirect } from 'next/navigation';
+import prisma from '@/lib/prisma';
+import SlackIntegrationPage from '@/components/settings/SlackIntegrationPage';
+import { SettingsPageHeader } from '@/components/settings/layout/SettingsPageHeader';
 
 export default async function GlobalSlackIntegrationPage() {
-  const permissions = await getUserPermissions()
+  const permissions = await getUserPermissions();
 
   if (!permissions) {
-    redirect('/login')
+    redirect('/login');
   }
 
   // Get global Slack integration (not tied to any service)
@@ -33,15 +33,17 @@ export default async function GlobalSlackIntegrationPage() {
       },
     },
     orderBy: { updatedAt: 'desc' },
-  })
+  });
 
   // Check if OAuth is configured (database only - no env vars for UI-driven setup)
   const oauthConfig = await prisma.slackOAuthConfig.findFirst({
     where: { enabled: true },
     orderBy: { updatedAt: 'desc' },
-  })
+  });
 
-  const isOAuthConfigured = !!(oauthConfig?.clientId && oauthConfig?.clientSecret)
+  const isOAuthConfigured = !!(oauthConfig?.clientId && oauthConfig?.clientSecret);
+  const isSigningSecretConfigured =
+    !!oauthConfig?.signingSecret || !!process.env.SLACK_SIGNING_SECRET;
 
   return (
     <div className="space-y-6">
@@ -60,8 +62,9 @@ export default async function GlobalSlackIntegrationPage() {
       <SlackIntegrationPage
         integration={globalIntegration}
         isOAuthConfigured={isOAuthConfigured}
+        isSigningSecretConfigured={isSigningSecretConfigured}
         isAdmin={permissions.isAdmin}
       />
     </div>
-  )
+  );
 }

--- a/src/app/(app)/settings/slack-oauth/actions.ts
+++ b/src/app/(app)/settings/slack-oauth/actions.ts
@@ -24,14 +24,16 @@ export async function saveSlackOAuthConfig(
   const enabledValue = formData.get('enabled');
   const enabled = enabledValue === 'on' || enabledValue === 'true';
 
-  if (!clientId) {
-    return { error: 'Client ID is required' };
-  }
-
-  // Get existing config to preserve secret if not provided
+  // Get existing config to preserve values that were not resubmitted
   const existing = await prisma.slackOAuthConfig.findFirst({
     orderBy: { updatedAt: 'desc' },
   });
+
+  // Allows updating just the signing secret without re-entering app credentials
+  const effectiveClientId = clientId || existing?.clientId;
+  if (!effectiveClientId) {
+    return { error: 'Client ID is required' };
+  }
 
   // If updating and secret is not provided (or is placeholder), keep existing
   let encryptedSecret = existing?.clientSecret;
@@ -56,7 +58,7 @@ export async function saveSlackOAuthConfig(
     where: { id: existing?.id || 'default' },
     create: {
       id: 'default',
-      clientId,
+      clientId: effectiveClientId,
       clientSecret: encryptedSecret!,
       signingSecret: encryptedSigningSecret,
       redirectUri: redirectUri || null,
@@ -64,10 +66,10 @@ export async function saveSlackOAuthConfig(
       updatedBy: actorId,
     },
     update: {
-      clientId,
+      clientId: effectiveClientId,
       ...(encryptedSecret ? { clientSecret: encryptedSecret } : {}),
       signingSecret: encryptedSigningSecret,
-      redirectUri: redirectUri || null,
+      redirectUri: redirectUri || existing?.redirectUri || null,
       enabled,
       updatedBy: actorId,
     },
@@ -80,7 +82,7 @@ export async function saveSlackOAuthConfig(
     actorId,
     details: {
       enabled,
-      clientId: clientId.substring(0, 10) + '...',
+      clientId: effectiveClientId.substring(0, 10) + '...',
       configType: 'slack-oauth',
       signingSecretConfigured: Boolean(encryptedSigningSecret),
     },

--- a/src/components/settings/GuidedSlackSetup.tsx
+++ b/src/components/settings/GuidedSlackSetup.tsx
@@ -236,7 +236,21 @@ export default function GuidedSlackSetup() {
                   Scroll to &quot;Scopes&quot; → &quot;Bot Token Scopes&quot; and add these:
                 </p>
                 <div className="flex flex-wrap gap-2">
-                  {['chat:write', 'channels:read', 'channels:join', 'groups:read'].map(scope => (
+                  {[
+                    'chat:write',
+                    'channels:read',
+                    'channels:join',
+                    'channels:manage',
+                    'channels:history',
+                    'reactions:read',
+                    'users:read',
+                    'users:read.email',
+                    'groups:read',
+                    'groups:write',
+                    'groups:history',
+                    'im:read',
+                    'mpim:read',
+                  ].map(scope => (
                     <Badge key={scope} variant="secondary" size="xs" className="font-mono">
                       {scope}
                     </Badge>
@@ -245,8 +259,33 @@ export default function GuidedSlackSetup() {
                 <Alert>
                   <Info className="h-4 w-4" />
                   <AlertDescription>
-                    <strong>groups:read</strong> is optional but required for private channel
-                    support.
+                    <strong>channels:manage</strong> creates incident war-room channels,{' '}
+                    <strong>users:read.email</strong> matches Slack users to OpsKnight accounts so
+                    responders are auto-invited, and <strong>reactions:read</strong> plus{' '}
+                    <strong>channels:history</strong> capture 📌 pinned messages as incident notes.
+                    The <strong>groups:*</strong> scopes add private channel support.
+                  </AlertDescription>
+                </Alert>
+              </div>
+
+              {/* 2b-ii: Event Subscriptions */}
+              <div className="space-y-3 pl-8">
+                <h4 className="text-sm font-semibold">2b-ii. Enable Event Subscriptions</h4>
+                <p className="text-sm text-muted-foreground">
+                  Open &quot;Event Subscriptions&quot;, turn it on, and set the Request URL:
+                </p>
+                <Input value={`${getBaseUrl()}/api/slack/events`} readOnly className="font-mono" />
+                <p className="text-sm text-muted-foreground">
+                  Then under &quot;Subscribe to bot events&quot; add{' '}
+                  <Badge variant="secondary" size="xs" className="font-mono">
+                    reaction_added
+                  </Badge>
+                </p>
+                <Alert>
+                  <Info className="h-4 w-4" />
+                  <AlertDescription>
+                    Without this, reacting 📌 to a message will not save it to the incident. This is
+                    separate from Interactivity — buttons can work while events do not.
                   </AlertDescription>
                 </Alert>
               </div>

--- a/src/components/settings/SlackIntegrationPage.tsx
+++ b/src/components/settings/SlackIntegrationPage.tsx
@@ -40,6 +40,7 @@ import {
   type ChannelFilter,
 } from '@/components/settings/slack';
 import GuidedSlackSetup from '@/components/settings/GuidedSlackSetup';
+import SlackSigningSecretCard from '@/components/settings/SlackSigningSecretCard';
 import { Badge } from '@/components/ui/shadcn/badge';
 import {
   AlertDialog,
@@ -70,12 +71,14 @@ interface SlackIntegration {
 interface SlackIntegrationPageProps {
   integration: SlackIntegration | null;
   isOAuthConfigured: boolean;
+  isSigningSecretConfigured: boolean;
   isAdmin: boolean;
 }
 
 export default function SlackIntegrationPage({
   integration,
   isOAuthConfigured,
+  isSigningSecretConfigured,
   isAdmin,
 }: SlackIntegrationPageProps) {
   const router = useRouter();
@@ -110,8 +113,19 @@ export default function SlackIntegrationPage({
     variant: 'default',
   });
 
-  const requiredScopes = ['chat:write', 'channels:read', 'channels:join'];
-  const optionalScopes = ['groups:read'];
+  // Mirrors the scopes requested in /api/slack/oauth. Required = the war-room
+  // flow breaks without them; optional = private-channel support only.
+  const requiredScopes = [
+    'chat:write',
+    'channels:read',
+    'channels:join',
+    'channels:manage',
+    'channels:history',
+    'reactions:read',
+    'users:read',
+    'users:read.email',
+  ];
+  const optionalScopes = ['groups:read', 'groups:write', 'groups:history', 'im:read', 'mpim:read'];
   const scopeSet = useMemo(() => new Set(integration?.scopes ?? []), [integration]);
   const missingRequiredScopes = requiredScopes.filter(scope => !scopeSet.has(scope));
 
@@ -508,6 +522,12 @@ export default function SlackIntegrationPage({
       >
         {/* Guided Setup Wizard (Admin Only) */}
         {!isOAuthConfigured && isAdmin && <GuidedSlackSetup />}
+
+        {/* Signing secret — the guided setup is hidden once Slack is connected,
+            so an existing install needs somewhere to supply it */}
+        {isOAuthConfigured && isAdmin && (
+          <SlackSigningSecretCard isConfigured={isSigningSecretConfigured} />
+        )}
 
         {/* Configuration Actions */}
         {isOAuthConfigured && isAdmin && (

--- a/src/components/settings/SlackSigningSecretCard.tsx
+++ b/src/components/settings/SlackSigningSecretCard.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/shadcn/alert';
+import { Button } from '@/components/ui/shadcn/button';
+import { Input } from '@/components/ui/shadcn/input';
+import { Label } from '@/components/ui/shadcn/label';
+import { AlertTriangle, ExternalLink, ShieldCheck, Loader2 } from 'lucide-react';
+
+/**
+ * Lets an admin supply the Slack signing secret on an already-configured
+ * workspace.
+ *
+ * The guided setup only renders before Slack is connected, so without this an
+ * existing install has nowhere to enter the secret. Slack never returns it from
+ * OAuth — it is an app-level credential — so reconnecting cannot supply it
+ * either, and inbound requests stay rejected until it is set.
+ */
+export default function SlackSigningSecretCard({ isConfigured }: { isConfigured: boolean }) {
+  const [signingSecret, setSigningSecret] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (!signingSecret.trim()) {
+      toast.error('Signing Secret required', {
+        description: 'Paste the value from Slack > Basic Information > Signing Secret',
+      });
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const formData = new FormData();
+      formData.append('signingSecret', signingSecret.trim());
+
+      const response = await fetch('/api/settings/slack-oauth', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok || data?.error) {
+        toast.error('Failed to save Signing Secret', {
+          description: data?.error || 'Please try again.',
+        });
+        return;
+      }
+
+      toast.success('Signing Secret saved', {
+        description: 'Slack commands, buttons and events are verified from now on.',
+      });
+      setSigningSecret('');
+      window.location.reload();
+    } catch (error) {
+      toast.error('Failed to save Signing Secret', {
+        description: error instanceof Error ? error.message : 'Unexpected error',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isConfigured) {
+    return (
+      <Alert className="mb-4">
+        <ShieldCheck className="h-4 w-4 text-emerald-600" />
+        <AlertTitle>Request verification active</AlertTitle>
+        <AlertDescription>
+          A signing secret is configured, so slash commands, interactive buttons and events are
+          verified as genuinely coming from Slack.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert variant="destructive" className="mb-4">
+      <AlertTriangle className="h-4 w-4" />
+      <AlertTitle>Signing Secret required</AlertTitle>
+      <AlertDescription>
+        <p className="mb-3">
+          Slack requests cannot be verified without it, so slash commands, interactive buttons and
+          emoji events are all rejected. Slack does not provide this during OAuth — reconnecting
+          will not fill it in.
+        </p>
+
+        <div className="space-y-2 max-w-md">
+          <Label htmlFor="slackSigningSecret">Signing Secret</Label>
+          <Input
+            id="slackSigningSecret"
+            type="password"
+            value={signingSecret}
+            onChange={e => setSigningSecret(e.target.value)}
+            placeholder="Paste Signing Secret here"
+            className="font-mono"
+          />
+          <div className="flex items-center gap-2 pt-1">
+            <Button onClick={handleSave} disabled={!signingSecret.trim() || isSaving} size="sm">
+              {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Save Signing Secret
+            </Button>
+            <Button asChild variant="ghost" size="sm">
+              <a href="https://api.slack.com/apps" target="_blank" rel="noreferrer">
+                <ExternalLink className="h-4 w-4 mr-2" />
+                Basic Information
+              </a>
+            </Button>
+          </div>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/tests/components/settings/SlackIntegrationPage.test.tsx
+++ b/tests/components/settings/SlackIntegrationPage.test.tsx
@@ -34,7 +34,14 @@ describe('SlackIntegrationPage', () => {
   });
 
   it('renders setup wizard trigger when OAuth is not configured', () => {
-    render(<SlackIntegrationPage integration={null} isOAuthConfigured={false} isAdmin={true} />);
+    render(
+      <SlackIntegrationPage
+        integration={null}
+        isOAuthConfigured={false}
+        isSigningSecretConfigured={false}
+        isAdmin={true}
+      />
+    );
 
     expect(screen.getByText('Connect Your Slack Workspace')).toBeInTheDocument();
     expect(
@@ -57,6 +64,7 @@ describe('SlackIntegrationPage', () => {
       <SlackIntegrationPage
         integration={integrationFixture}
         isOAuthConfigured={true}
+        isSigningSecretConfigured={true}
         isAdmin={true}
       />
     );


### PR DESCRIPTION
Follow-up to #283, which merged while this was still in progress. #283 added the signing-secret field to the guided setup — but **on an already-connected workspace that field is unreachable**, so the outage it was meant to fix persists.

## 1. The field couldn't be reached 🔴

```tsx
{!isOAuthConfigured && isAdmin && <GuidedSlackSetup />}
```

The guided setup only renders *before* Slack is connected. Your install has `clientId` + `clientSecret`, so it's hidden — leaving nowhere to enter the secret while inbound Slack stays rejected.

- **`SlackSigningSecretCard`** shows to admins once Slack is connected: a destructive alert with an inline input while the secret is missing, and a confirmation once set
- `saveSlackOAuthConfig` accepts a **signing-secret-only** submit, preserving the existing client ID and redirect URI rather than demanding they be re-entered

## 2. The scope checklist was lying

It listed four scopes predating war-rooms entirely:

```ts
const requiredScopes = ['chat:write', 'channels:read', 'channels:join'];
const optionalScopes = ['groups:read'];
```

So it reported **"All required scopes present"** for an install that cannot create a war-room channel, invite a responder, or read a pinned message. That badge is exactly what an admin trusts when something isn't working.

| | Scopes |
|---|---|
| **Required** | `chat:write`, `channels:read`, `channels:join`, `channels:manage`, `channels:history`, `reactions:read`, `users:read`, `users:read.email` |
| **Optional** | `groups:read`, `groups:write`, `groups:history`, `im:read`, `mpim:read` |

Now mirrors what `/api/slack/oauth` actually requests. The guided setup lists the same set with an explanation of what each enables.

## 3. Event Subscriptions was never mentioned anywhere

Nothing in the product has ever told anyone to configure it — not the setup wizard, not the docs. Yet 📌 sync cannot work without it, and it's **separate from Interactivity**, so buttons work while events silently do nothing. That's precisely the failure we hit: zero requests to `/api/slack/events` while buttons worked fine.

The guided setup now has a step for it, with the Request URL prefilled and `reaction_added` called out.

## Verification

`tsc --noEmit` clean from a cleared build cache. Full suite: **128 files, 1027 passed**.

## Deploy

Slack inbound is still down until the secret is entered. After this ships: Settings → Integrations → Slack → the red card is right at the top → paste → save. No restart, no `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)