### PR TITLE
feat(slack): generate a copyable app manifest from one shared scope source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ ci_*.txt
 # Playwright
 playwright-report/
 test-results/
+
+# TypeScript incremental build cache
+tsconfig.tsbuildinfo

--- a/src/app/api/slack/oauth/route.ts
+++ b/src/app/api/slack/oauth/route.ts
@@ -10,6 +10,7 @@ import prisma from '@/lib/prisma';
 import { decrypt } from '@/lib/encryption';
 import { getAppUrl } from '@/lib/app-url';
 import crypto from 'crypto';
+import { SLACK_BOT_SCOPES } from '@/lib/slack/app-manifest';
 
 const isLocalhostUrl = (value: string) =>
   value.includes('localhost') || value.includes('127.0.0.1');
@@ -95,22 +96,9 @@ export async function GET(request: NextRequest) {
     // For now, we'll pass it in the callback URL
     const _callbackUrl = `${SLACK_REDIRECT_URI}?state=${state}${serviceId ? `&serviceId=${serviceId}` : ''}`;
 
-    // Slack OAuth scopes needed for alerts and ChatOps war-rooms
-    const scopes = [
-      'chat:write',
-      'channels:read',
-      'channels:join',
-      'channels:manage',
-      'channels:history', // Read pinned message text for emoji reaction timeline sync
-      'groups:read',
-      'groups:write',
-      'groups:history', // Same, for private war-room channels
-      'im:read',
-      'mpim:read',
-      'reactions:read', // Receive reaction_added events (:pushpin: -> incident timeline)
-      'users:read',
-      'users:read.email',
-    ].join(',');
+    // Single source of truth, shared with the app manifest and the
+    // Settings scope checklist so the three cannot drift apart.
+    const scopes = SLACK_BOT_SCOPES.join(',');
 
     const authUrl =
       `https://slack.com/oauth/v2/authorize?` +

--- a/src/components/settings/GuidedSlackSetup.tsx
+++ b/src/components/settings/GuidedSlackSetup.tsx
@@ -16,6 +16,7 @@ import { Badge } from '@/components/ui/shadcn/badge';
 import { Alert, AlertDescription } from '@/components/ui/shadcn/alert';
 import { Slack, ExternalLink, Copy, CheckCircle2, ArrowRight, ArrowLeft, Info } from 'lucide-react';
 import { toast } from 'sonner';
+import SlackManifestCard from '@/components/settings/SlackManifestCard';
 
 type SetupStep = 1 | 2 | 3;
 
@@ -133,6 +134,10 @@ export default function GuidedSlackSetup() {
         {/* Step 1: Create Slack App */}
         {step === 1 && (
           <div className="space-y-6">
+            <div className="mb-6 rounded-lg border bg-background p-4">
+              <SlackManifestCard baseUrl={getBaseUrl()} />
+            </div>
+
             <div className="space-y-4">
               <div className="flex items-center gap-2">
                 <div className="flex items-center justify-center h-6 w-6 rounded-full bg-primary text-primary-foreground text-xs font-medium">

--- a/src/components/settings/SlackIntegrationPage.tsx
+++ b/src/components/settings/SlackIntegrationPage.tsx
@@ -41,6 +41,9 @@ import {
 } from '@/components/settings/slack';
 import GuidedSlackSetup from '@/components/settings/GuidedSlackSetup';
 import SlackSigningSecretCard from '@/components/settings/SlackSigningSecretCard';
+import SlackManifestCard from '@/components/settings/SlackManifestCard';
+import { getBaseUrl } from '@/lib/env-validation';
+import { SLACK_REQUIRED_BOT_SCOPES, SLACK_OPTIONAL_BOT_SCOPES } from '@/lib/slack/app-manifest';
 import { Badge } from '@/components/ui/shadcn/badge';
 import {
   AlertDialog,
@@ -113,19 +116,10 @@ export default function SlackIntegrationPage({
     variant: 'default',
   });
 
-  // Mirrors the scopes requested in /api/slack/oauth. Required = the war-room
-  // flow breaks without them; optional = private-channel support only.
-  const requiredScopes = [
-    'chat:write',
-    'channels:read',
-    'channels:join',
-    'channels:manage',
-    'channels:history',
-    'reactions:read',
-    'users:read',
-    'users:read.email',
-  ];
-  const optionalScopes = ['groups:read', 'groups:write', 'groups:history', 'im:read', 'mpim:read'];
+  // Shared with the OAuth request and the generated app manifest, so the
+  // checklist cannot claim a healthy install while the code asks for more.
+  const requiredScopes = [...SLACK_REQUIRED_BOT_SCOPES];
+  const optionalScopes = [...SLACK_OPTIONAL_BOT_SCOPES];
   const scopeSet = useMemo(() => new Set(integration?.scopes ?? []), [integration]);
   const missingRequiredScopes = requiredScopes.filter(scope => !scopeSet.has(scope));
 
@@ -529,6 +523,14 @@ export default function SlackIntegrationPage({
           <SlackSigningSecretCard isConfigured={isSigningSecretConfigured} />
         )}
 
+        {/* Manifest stays available after setup: scopes and event subscriptions
+            change as features land, and this is how an existing app catches up */}
+        {isOAuthConfigured && isAdmin && (
+          <div className="mb-4 rounded-lg border bg-background p-4">
+            <SlackManifestCard baseUrl={getBaseUrl()} />
+          </div>
+        )}
+
         {/* Configuration Actions */}
         {isOAuthConfigured && isAdmin && (
           <div className="flex justify-end mb-4">
@@ -626,8 +628,12 @@ export default function SlackIntegrationPage({
                   <AlertTitle>Missing Slack scopes</AlertTitle>
                   <AlertDescription className="space-y-2">
                     <p>
-                      Add these scopes in Slack and reconnect the app:{' '}
+                      Not granted to this workspace:{' '}
                       <strong>{missingRequiredScopes.join(', ')}</strong>
+                    </p>
+                    <p className="text-xs">
+                      Reconnecting alone will not add them — Slack only grants scopes the app itself
+                      declares. Apply the App Manifest below first, then reinstall.
                     </p>
                     {isAdmin && (
                       <Button size="sm" asChild>

--- a/src/components/settings/SlackManifestCard.tsx
+++ b/src/components/settings/SlackManifestCard.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Alert, AlertDescription } from '@/components/ui/shadcn/alert';
+import { Button } from '@/components/ui/shadcn/button';
+import { Badge } from '@/components/ui/shadcn/badge';
+import { Check, Copy, ExternalLink, FileJson, Info } from 'lucide-react';
+import { buildSlackAppManifestJson } from '@/lib/slack/app-manifest';
+
+/**
+ * Renders the complete Slack app manifest for this deployment.
+ *
+ * Slack can create an app directly from a manifest, which configures scopes,
+ * Event Subscriptions, interactivity and the slash command in one step. Setting
+ * those by hand is what produced every Slack misconfiguration we have hit:
+ * missing reaction scopes, an events subscription that was never enabled, and a
+ * slash-command hint advertising subcommands that do not exist.
+ */
+export default function SlackManifestCard({ baseUrl }: { baseUrl: string }) {
+  const [copied, setCopied] = useState(false);
+  const manifest = useMemo(() => buildSlackAppManifestJson({ baseUrl }), [baseUrl]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(manifest);
+      setCopied(true);
+      toast.success('Manifest copied', {
+        description: 'Paste it into Slack under "Create an app > From a manifest".',
+      });
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      toast.error('Could not copy', {
+        description: 'Select the manifest text and copy it manually.',
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h4 className="text-sm font-semibold flex items-center gap-2">
+            <FileJson className="h-4 w-4 text-blue-600" />
+            App Manifest
+            <Badge variant="secondary" size="xs">
+              Recommended
+            </Badge>
+          </h4>
+          <p className="text-sm text-muted-foreground">
+            Configures every scope, the events subscription, interactivity and the{' '}
+            <code className="font-mono text-xs">/incident</code> command in one step — no manual
+            toggles to miss.
+          </p>
+        </div>
+        <Button onClick={handleCopy} size="sm" variant={copied ? 'secondary' : 'default'}>
+          {copied ? <Check className="h-4 w-4 mr-2" /> : <Copy className="h-4 w-4 mr-2" />}
+          {copied ? 'Copied' : 'Copy Manifest'}
+        </Button>
+      </div>
+
+      <pre className="max-h-72 overflow-auto rounded-md border bg-muted/40 p-3 text-xs font-mono leading-relaxed">
+        {manifest}
+      </pre>
+
+      <Alert>
+        <Info className="h-4 w-4" />
+        <AlertDescription className="space-y-2">
+          <p>
+            <strong>New app:</strong> Slack API → Create New App → <em>From a manifest</em> → pick
+            your workspace → paste.
+          </p>
+          <p>
+            <strong>Existing app:</strong> your app → <em>App Manifest</em> → replace and save, then
+            reinstall so newly added scopes are granted. Slack does not grant new scopes to an
+            existing installation until it is reinstalled.
+          </p>
+        </AlertDescription>
+      </Alert>
+
+      <Button asChild variant="ghost" size="sm">
+        <a href="https://api.slack.com/apps" target="_blank" rel="noreferrer">
+          <ExternalLink className="h-4 w-4 mr-2" />
+          Open Slack API Console
+        </a>
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/slack/app-manifest.ts
+++ b/src/lib/slack/app-manifest.ts
@@ -1,0 +1,118 @@
+/**
+ * Single source of truth for what the OpsKnight Slack app needs.
+ *
+ * The OAuth request, the scope checklist in Settings and the generated app
+ * manifest all read from here. Keeping three hand-maintained copies is what let
+ * them drift: the checklist reported "all required scopes present" for an
+ * install that could not create a war-room channel, and the manifest omitted
+ * scopes the OAuth flow asked for, so a reinstall would have failed.
+ */
+
+/** Scopes without which core incident features break. */
+export const SLACK_REQUIRED_BOT_SCOPES = [
+  'chat:write', // Post incident cards and war-room updates
+  'channels:read', // List channels for service configuration
+  'channels:join', // Join channels the bot was not invited to
+  'channels:manage', // Create the war-room channel, set topic, archive
+  'channels:history', // Read a pinned message so it can be saved as a note
+  'reactions:read', // Receive reaction_added for 📌 pin sync
+  'users:read', // Resolve Slack users for attribution
+  'users:read.email', // Match Slack users to OpsKnight accounts (auto-invite)
+] as const;
+
+/** Scopes that extend coverage; absence degrades rather than breaks. */
+export const SLACK_OPTIONAL_BOT_SCOPES = [
+  'groups:read', // Private channel support
+  'groups:write', // Private war-room channels
+  'groups:history', // Pin sync inside private channels
+  'im:read',
+  'mpim:read',
+] as const;
+
+export const SLACK_BOT_SCOPES: string[] = [
+  ...SLACK_REQUIRED_BOT_SCOPES,
+  ...SLACK_OPTIONAL_BOT_SCOPES,
+];
+
+/** Bot events OpsKnight subscribes to. */
+export const SLACK_BOT_EVENTS = ['reaction_added'] as const;
+
+/** Subcommands the dispatcher actually implements — keeps the hint honest. */
+export const SLACK_COMMAND_USAGE_HINT =
+  'ack | resolve [summary] | note <message> | who | postmortem | help';
+
+export interface SlackManifestOptions {
+  /** Public base URL, e.g. https://opsknight.example.com */
+  baseUrl: string;
+  appName?: string;
+  botDisplayName?: string;
+}
+
+/**
+ * Build a Slack app manifest describing every permission and endpoint OpsKnight
+ * needs. Slack can create an app directly from this, which configures scopes,
+ * Event Subscriptions, interactivity and the slash command in one step instead
+ * of a dozen manual toggles.
+ */
+export function buildSlackAppManifest({
+  baseUrl,
+  appName = 'OpsKnight',
+  botDisplayName = 'OpsKnight',
+}: SlackManifestOptions) {
+  const origin = baseUrl.replace(/\/+$/, '');
+
+  return {
+    display_information: {
+      name: appName,
+      description: 'OpsKnight Incident Management',
+      background_color: '#202d3b',
+    },
+    features: {
+      bot_user: {
+        display_name: botDisplayName,
+        always_online: false,
+      },
+      slash_commands: [
+        {
+          command: '/incident',
+          url: `${origin}/api/slack/commands`,
+          description: 'Manage OpsKnight incidents from Slack',
+          usage_hint: SLACK_COMMAND_USAGE_HINT,
+          should_escape: false,
+        },
+      ],
+    },
+    oauth_config: {
+      redirect_urls: [`${origin}/api/slack/oauth/callback`],
+      scopes: {
+        bot: SLACK_BOT_SCOPES,
+      },
+    },
+    settings: {
+      // Emoji pin sync. Separate from interactivity below — buttons can work
+      // while events silently do not, which is easy to miss.
+      event_subscriptions: {
+        request_url: `${origin}/api/slack/events`,
+        bot_events: [...SLACK_BOT_EVENTS],
+      },
+      interactivity: {
+        is_enabled: true,
+        request_url: `${origin}/api/slack/actions`,
+      },
+      org_deploy_enabled: false,
+      socket_mode_enabled: false,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+/** Pretty-printed manifest, ready to paste into Slack. */
+export function buildSlackAppManifestJson(options: SlackManifestOptions): string {
+  return JSON.stringify(buildSlackAppManifest(options), null, 2);
+}
+
+/** Required scopes the workspace has not granted. */
+export function findMissingRequiredScopes(grantedScopes: string[] | undefined | null): string[] {
+  const granted = new Set(grantedScopes ?? []);
+  return SLACK_REQUIRED_BOT_SCOPES.filter(scope => !granted.has(scope));
+}

--- a/tests/lib/slack-app-manifest.test.ts
+++ b/tests/lib/slack-app-manifest.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSlackAppManifest,
+  buildSlackAppManifestJson,
+  findMissingRequiredScopes,
+  SLACK_BOT_SCOPES,
+  SLACK_REQUIRED_BOT_SCOPES,
+} from '@/lib/slack/app-manifest';
+
+const BASE = 'https://opsknight.example.com';
+
+describe('Slack app manifest', () => {
+  it('points every endpoint at the deployment base URL', () => {
+    const m = buildSlackAppManifest({ baseUrl: BASE });
+
+    expect(m.oauth_config.redirect_urls).toEqual([`${BASE}/api/slack/oauth/callback`]);
+    expect(m.settings.interactivity.request_url).toBe(`${BASE}/api/slack/actions`);
+    expect(m.settings.event_subscriptions.request_url).toBe(`${BASE}/api/slack/events`);
+    expect(m.features.slash_commands[0].url).toBe(`${BASE}/api/slack/commands`);
+  });
+
+  it('tolerates a base URL with a trailing slash', () => {
+    const m = buildSlackAppManifest({ baseUrl: `${BASE}/` });
+    expect(m.settings.event_subscriptions.request_url).toBe(`${BASE}/api/slack/events`);
+  });
+
+  it('subscribes to reaction_added so pin sync can work', () => {
+    // Event Subscriptions is separate from interactivity — buttons work while
+    // events silently do not, which is exactly how pin sync failed in prod.
+    const m = buildSlackAppManifest({ baseUrl: BASE });
+    expect(m.settings.event_subscriptions.bot_events).toContain('reaction_added');
+    expect(m.settings.interactivity.is_enabled).toBe(true);
+  });
+
+  it('declares every scope the OAuth flow requests', () => {
+    // The manifest previously omitted scopes the OAuth URL asked for, so a
+    // reinstall would drop users:read.email and break responder auto-invite.
+    const m = buildSlackAppManifest({ baseUrl: BASE });
+    for (const scope of SLACK_BOT_SCOPES) {
+      expect(m.oauth_config.scopes.bot, scope).toContain(scope);
+    }
+  });
+
+  it('includes the scopes the war-room flow depends on', () => {
+    const required = [...SLACK_REQUIRED_BOT_SCOPES];
+    expect(required).toContain('channels:manage'); // create the war-room
+    expect(required).toContain('users:read.email'); // auto-invite responders
+    expect(required).toContain('reactions:read'); // receive pin events
+    expect(required).toContain('channels:history'); // read the pinned message
+  });
+
+  it('advertises only slash subcommands that exist', () => {
+    const hint = buildSlackAppManifest({ baseUrl: BASE }).features.slash_commands[0].usage_hint;
+    for (const real of ['ack', 'resolve', 'note', 'who', 'postmortem', 'help']) {
+      expect(hint).toContain(real);
+    }
+    for (const fake of ['reassign', 'create', 'list']) {
+      expect(hint).not.toContain(fake);
+    }
+  });
+
+  it('serialises to valid, pasteable JSON', () => {
+    const json = buildSlackAppManifestJson({ baseUrl: BASE });
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(json).toContain('\n  '); // pretty-printed for a human to read
+  });
+
+  describe('findMissingRequiredScopes', () => {
+    it('reports nothing when every required scope is granted', () => {
+      expect(findMissingRequiredScopes([...SLACK_REQUIRED_BOT_SCOPES])).toEqual([]);
+    });
+
+    it('reports the gap for the real pre-fix production grant', () => {
+      // Exactly what the Aug 10 install had — the checklist called this healthy.
+      const granted = [
+        'chat:write',
+        'channels:read',
+        'groups:read',
+        'im:read',
+        'mpim:read',
+        'users:read',
+        'channels:join',
+        'channels:manage',
+        'groups:write',
+        'users:read.email',
+      ];
+      expect(findMissingRequiredScopes(granted)).toEqual(['channels:history', 'reactions:read']);
+    });
+
+    it('treats a missing scope list as everything missing', () => {
+      expect(findMissingRequiredScopes(undefined)).toEqual([...SLACK_REQUIRED_BOT_SCOPES]);
+    });
+  });
+});


### PR DESCRIPTION
Every Slack misconfiguration this week traces to the same root cause: the same facts were hand-maintained in **three** places — the OAuth request, the Settings scope checklist, and the Slack app itself — and they drifted.

| Symptom | Cause |
|---|---|
| Checklist said *"All required scopes present"* on an install that couldn't create a war-room | Checklist listed 4 scopes predating war-rooms |
| A reinstall would have dropped `users:read.email` and broken responder auto-invite | Manifest omitted 4 scopes the OAuth flow requests |
| 📌 pins silently did nothing while buttons worked | Event Subscriptions never configured — nothing in the product mentions it |
| Slash hint advertised `reassign \| create \| list` | None of those subcommands exist |

## Single source of truth

`src/lib/slack/app-manifest.ts` now owns this. The OAuth route, the scope checklist and the generated manifest all read from it, so they can't disagree again.

## The manifest feature

`buildSlackAppManifest()` produces a complete, deployment-specific manifest — scopes, `event_subscriptions` with `reaction_added`, interactivity, and `/incident` with a usage hint listing only subcommands that actually exist.

`SlackManifestCard` renders it with a copy button in two places:

- **Guided setup, step 1** — Slack supports *Create an app → From a manifest*, so setup collapses from a dozen manual toggles to one paste
- **Settings page, for existing installs** — scopes and events change as features land; this is how an already-created app catches up

## Corrected guidance

The missing-scope alert used to say *"Add these scopes in Slack and reconnect"*. Reconnecting cannot help — Slack only grants scopes the app itself declares — so it now says to apply the manifest first, then reinstall. That wrong advice is exactly what we followed for hours.

## Also

Gitignores `tsconfig.tsbuildinfo`. A stale cache is why my local typecheck passed while CI failed on the same commit.

## Verification

`tsc --noEmit` clean from a cleared cache. Full suite: **129 files, 1037 passed**.

New tests cover endpoint URLs, trailing-slash handling, `reaction_added` presence, manifest-vs-OAuth scope parity, and the usage hint. `findMissingRequiredScopes` is tested against the **real pre-fix production grant**, asserting it reports `channels:history` and `reactions:read` — the two the old checklist called healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)