### PR TITLE
fix(core): SLA SQL percentiles, retry error classification, and subscriber batching (v6)

### DIFF
--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -36,8 +36,12 @@ const DEFAULT_RETRYABLE_ERRORS = (error: unknown): boolean => {
     if (error.message.includes('timeout') || error.message.includes('ETIMEDOUT')) {
       return true;
     }
-    // HTTP 5xx errors (should be checked from response, but catch here for safety)
-    if (error.message.includes('5')) {
+    // HTTP 5xx or 429 status codes
+    if (
+      /\b5\d{2}\b/.test(error.message) ||
+      error.message.includes('HTTP 5') ||
+      error.message.includes('429')
+    ) {
       return true;
     }
   }

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -325,12 +325,11 @@ async function calculateDbAggregateMetrics(
           FILTER (WHERE "status" = 'RESOLVED' AND COALESCE("resolvedAt", "updatedAt") IS NOT NULL AND COALESCE("resolvedAt", "updatedAt") >= "createdAt") as avg_mttr_ms,
         COUNT(*) FILTER (
           WHERE "acknowledgedAt" IS NOT NULL
-          AND "acknowledgedAt" >= "createdAt"
-          AND EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000 <= ${defaultAckMs}
+          AND GREATEST(0, EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000) <= ${defaultAckMs}
         ) as ack_sla_met,
         COUNT(*) FILTER (
           WHERE ("acknowledgedAt" IS NOT NULL
-            AND EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000 > ${defaultAckMs})
+            AND GREATEST(0, EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000) > ${defaultAckMs})
           OR ("acknowledgedAt" IS NULL
             AND "status" != 'RESOLVED'
             AND EXTRACT(EPOCH FROM (NOW() - "createdAt")) * 1000 > ${defaultAckMs})
@@ -338,13 +337,12 @@ async function calculateDbAggregateMetrics(
         COUNT(*) FILTER (
           WHERE "status" = 'RESOLVED'
           AND COALESCE("resolvedAt", "updatedAt") IS NOT NULL
-          AND COALESCE("resolvedAt", "updatedAt") >= "createdAt"
-          AND EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000 <= ${defaultResolveMs}
+          AND GREATEST(0, EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000) <= ${defaultResolveMs}
         ) as resolve_sla_met,
         COUNT(*) FILTER (
           WHERE ("status" = 'RESOLVED'
             AND COALESCE("resolvedAt", "updatedAt") IS NOT NULL
-            AND EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000 > ${defaultResolveMs})
+            AND GREATEST(0, EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000) > ${defaultResolveMs})
           OR ("status" != 'RESOLVED'
             AND EXTRACT(EPOCH FROM (NOW() - "createdAt")) * 1000 > ${defaultResolveMs})
         ) as resolve_sla_breached,
@@ -383,16 +381,16 @@ async function calculateDbAggregateMetrics(
     >`
       SELECT
         PERCENTILE_CONT(0.5) WITHIN GROUP (
-          ORDER BY EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000
+          ORDER BY GREATEST(0, EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000)
         ) FILTER (WHERE "acknowledgedAt" IS NOT NULL) as mtta_p50_ms,
         PERCENTILE_CONT(0.95) WITHIN GROUP (
-          ORDER BY EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000
+          ORDER BY GREATEST(0, EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000)
         ) FILTER (WHERE "acknowledgedAt" IS NOT NULL) as mtta_p95_ms,
         PERCENTILE_CONT(0.5) WITHIN GROUP (
-          ORDER BY EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000
+          ORDER BY GREATEST(0, EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000)
         ) FILTER (WHERE "status" = 'RESOLVED' AND COALESCE("resolvedAt", "updatedAt") IS NOT NULL) as mttr_p50_ms,
         PERCENTILE_CONT(0.95) WITHIN GROUP (
-          ORDER BY EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000
+          ORDER BY GREATEST(0, EXTRACT(EPOCH FROM (COALESCE("resolvedAt", "updatedAt") - "createdAt")) * 1000)
         ) FILTER (WHERE "status" = 'RESOLVED' AND COALESCE("resolvedAt", "updatedAt") IS NOT NULL) as mttr_p95_ms
       FROM "Incident"
       WHERE "createdAt" >= ${start}

--- a/src/lib/status-page-notifications.ts
+++ b/src/lib/status-page-notifications.ts
@@ -121,29 +121,36 @@ export async function notifyStatusPageSubscribers(
         `Sending notifications to ${page.subscriptions.length} subscribers for page ${page.name}`
       );
 
-      const results = await Promise.allSettled(
-        page.subscriptions.map(sub =>
-          sendEmail(
-            {
-              to: sub.email,
-              subject,
-              html: html.replace(
-                '{{unsubscribe_url}}',
-                `${appBaseUrl}/status/unsubscribe/${sub.token}`
-              ),
-            },
-            {
-              source: `status-page-${page.id}`,
-              ...emailConfig,
-            }
-          )
-        )
-      );
+      const BATCH_SIZE = 25;
+      let sent = 0;
+      let failed = 0;
 
-      const sent = results.filter(r => r.status === 'fulfilled' && r.value.success).length;
-      const failed = results.filter(
-        r => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.success)
-      ).length;
+      for (let i = 0; i < page.subscriptions.length; i += BATCH_SIZE) {
+        const batch = page.subscriptions.slice(i, i + BATCH_SIZE);
+        const results = await Promise.allSettled(
+          batch.map(sub =>
+            sendEmail(
+              {
+                to: sub.email,
+                subject,
+                html: html.replaceAll(
+                  '{{unsubscribe_url}}',
+                  `${appBaseUrl}/status/unsubscribe/${sub.token}`
+                ),
+              },
+              {
+                source: `status-page-${page.id}`,
+                ...emailConfig,
+              }
+            )
+          )
+        );
+
+        sent += results.filter(r => r.status === 'fulfilled' && r.value.success).length;
+        failed += results.filter(
+          r => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.success)
+        ).length;
+      }
 
       logger.info(`Status page notifications sent: ${sent} success, ${failed} failed`);
     }

--- a/src/lib/status-page-webhooks.ts
+++ b/src/lib/status-page-webhooks.ts
@@ -130,19 +130,22 @@ export async function triggerStatusPageWebhooks(
       data,
     };
 
-    // Deliver to all webhooks in parallel (don't await - fire and forget)
-    const deliveries = webhooks.map(webhook =>
-      deliverWebhook(webhook.url, webhook.secret, payload).catch(err => {
-        logger.error('api.status_page.webhook.delivery_exception', {
-          webhookId: webhook.id,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        return false;
-      })
-    );
-
-    // Wait for all deliveries (but don't block on failures)
-    await Promise.allSettled(deliveries);
+    // Deliver to webhooks in concurrency-controlled batches
+    const BATCH_SIZE = 25;
+    for (let i = 0; i < webhooks.length; i += BATCH_SIZE) {
+      const batch = webhooks.slice(i, i + BATCH_SIZE);
+      await Promise.allSettled(
+        batch.map(webhook =>
+          deliverWebhook(webhook.url, webhook.secret, payload).catch(err => {
+            logger.error('api.status_page.webhook.delivery_exception', {
+              webhookId: webhook.id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return false;
+          })
+        )
+      );
+    }
 
     logger.info('api.status_page.webhooks.triggered', {
       statusPageId,


### PR DESCRIPTION
## Summary of Changes (v6)

This PR implements the sixth suite of mathematical precision, network retry, and notification pipeline fixes:

### 1. SLA SQL Aggregations & Percentile Clock Skew Protection
- **Percentile Query Clock Skew Guard (`src/lib/sla-server.ts`)**: Wrapped `ORDER BY` clauses in `PERCENTILE_CONT(0.5)` and `PERCENTILE_CONT(0.95)` with `GREATEST(0, EXTRACT(EPOCH FROM ...) * 1000)` to eliminate negative duration skew from corrupting median and P95 MTTA/MTTR metrics.
- **Compliance Counter Durations (`src/lib/sla-server.ts`)**: Guarded `ack_sla_met` and `resolve_sla_met` SQL filters with `GREATEST(0, ...)` so incidents with minor clock skew are counted as met SLA rather than vanishing from compliance totals.

### 2. Network Retry & Error Classification
- **Refined Retryable Error Matching (`src/lib/retry.ts`)**: Replaced loose `error.message.includes('5')` with regex `/\b5\d{2}\b/` and explicit `HTTP 5xx` / `429` status code checks to prevent accidental retries on unrelated error strings containing the digit `5`.

### 3. Status Page Notifications & Subscriber Pipeline
- **Batched Subscriber Email Sending (`src/lib/status-page-notifications.ts`)**: Replaced unbounded parallel `Promise.allSettled` over all subscribers with concurrency-controlled chunks of `25` to protect SMTP connection pools and prevent external rate limit rejections.
- **Template Unsubscribe Replacement (`src/lib/status-page-notifications.ts`)**: Changed `replace` to `replaceAll` for `{{unsubscribe_url}}` so all instances of the unsubscribe link in custom templates are populated.
- **Batched Status Page Webhook Dispatching (`src/lib/status-page-webhooks.ts`)**: Chunked webhook dispatches into batches of `25` for connection pool safety.

### 4. Verification
- `npx tsc --noEmit`: 0 errors
- `npm run test:unit`: All 129 test files and 1,044 unit tests passed
- Production build (`next build`): Succeeded