### PR TITLE
fix(security): validate integration key in webhook handler

### DIFF
--- a/src/lib/integrations/handler.ts
+++ b/src/lib/integrations/handler.ts
@@ -112,11 +112,16 @@ export function createIntegrationHandler<T>(
           serviceId: true,
           enabled: true,
           signatureSecret: true,
+          key: true,
         },
       });
 
       if (!integration) {
         throw IntegrationErrors.notFound(integrationId);
+      }
+
+      if (!isIntegrationAuthorized(req, integration.key)) {
+        throw IntegrationErrors.invalidPayload('Invalid integration key');
       }
 
       integrationType = integration.type;


### PR DESCRIPTION
Fixes a critical security vulnerability where the webhook middleware failed to validate the integration key query parameter, allowing unauthenticated requests if the integration ID was known.