### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-08-17
+## [1.3.1] - 2026-08-18
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Your entire incident lifecycle, on-call schedules, and status pages in one powe
 [![Docs](https://img.shields.io/badge/Docs-Read-2563eb?style=flat&logo=book&logoColor=white)](https://opsknight.com/docs)
 [![License](https://img.shields.io/badge/License-Apache_2.0-111827?style=flat)](LICENSE)
 [![Docker Package](https://img.shields.io/badge/Docker-ghcr.io-2496ED?style=flat&logo=docker&logoColor=white)](https://github.com/opsknight-labs/OpsKnight/pkgs/container/opsknight)
-[![Status](https://img.shields.io/badge/Status-v1.3.0-success?style=flat)](ROADMAP.md)
+[![Status](https://img.shields.io/badge/Status-v1.3.1-success?style=flat)](ROADMAP.md)
 [![Sponsor](https://img.shields.io/badge/Sponsor-GitHub-ea4aaa?style=flat&logo=github&logoColor=white)](https://github.com/sponsors/dushyant-rahangdale)
 [![Tests](https://github.com/opsknight-labs/OpsKnight/actions/workflows/tests.yml/badge.svg)](https://github.com/opsknight-labs/OpsKnight/actions/workflows/tests.yml)
 [![Security](https://github.com/opsknight-labs/OpsKnight/actions/workflows/security.yml/badge.svg)](https://github.com/opsknight-labs/OpsKnight/actions/workflows/security.yml)
@@ -34,7 +34,7 @@ _Your entire incident lifecycle, on-call schedules, and status pages in one powe
 > timing-safe HMAC checks across all 24 webhook routes, so unverified alerts are
 > rejected rather than trusted.
 >
-> [Release notes](https://github.com/opsknight-labs/OpsKnight/releases/tag/v1.3.0) ·
+> [Release notes](https://github.com/opsknight-labs/OpsKnight/releases/tag/v1.3.1) ·
 > [Integrations](https://opsknight.com/docs/v1.3/integrations) ·
 > [Changelog](CHANGELOG.md)
 >
@@ -246,12 +246,12 @@ authentication needed to pull**.
 
 | Image                                   | Channel                        | Tags                          |
 | :-------------------------------------- | :----------------------------- | :---------------------------- |
-| `ghcr.io/opsknight-labs/opsknight`      | Stable releases                | `1.3.0`, `1.3`, `1`, `latest` |
+| `ghcr.io/opsknight-labs/opsknight`      | Stable releases                | `1.3.1`, `1.3`, `1`, `latest` |
 | `ghcr.io/opsknight-labs/opsknight-test` | Pre-release, built from `main` | `latest`, `sha-<commit>`      |
 
 ```bash
 # Pin a release — recommended for production
-docker pull ghcr.io/opsknight-labs/opsknight:1.3.0
+docker pull ghcr.io/opsknight-labs/opsknight:1.3.1
 
 # Or track the latest stable release
 docker pull ghcr.io/opsknight-labs/opsknight:latest
@@ -325,7 +325,7 @@ Hardening guidance: [Security documentation](docs/v1.3/security/README.md)
 
 ## 🗺️ Roadmap
 
-We are proud to announce **Version 1.3.0 (August 2026)**! 🚀
+We are proud to announce **Version 1.3.1 (August 2026)**! 🚀
 
 - [x] Core Incident Management & On-Call Schedules
 - [x] **Slack ChatOps Incident War Rooms & Interactive Cards**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap outlines our path to building the ultimate open-source incident management platform.
 
-> **Current Status:** Version 1.3.0 is **RELEASED**! We are now focused on community contributions and advanced automation.
+> **Current Status:** Version 1.3.1 is **RELEASED**! We are now focused on community contributions and advanced automation.
 
 ## 🏗 Phase 1: Foundation & Stability (Completed)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opsknight",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Professional Open-Source Incident Management Platform for SREs and DevOps teams.",
   "keywords": [
     "incident-management",


### PR DESCRIPTION
Ships the v1.3 work under **1.3.1**, because the `v1.3.0` tag name cannot be created.

## Why not v1.3.0

**Immutable releases** is enabled on this repo. A `v1.3.0` release existed and was deleted, and GitHub permanently reserves the tag name of a deleted immutable release — so a published tag can never be re-pointed at different code. That is the feature working as intended.

Verified it is the *name*, not a rule:

| Tag pushed | Result |
| --- | --- |
| `zz-probe-delete-me` | ✅ created |
| `v9.9.9-probe` | ✅ created |
| `v1.9.9-probe` | ✅ created |
| **`v1.3.0`** | ❌ `GH013 — creations restricted` |

If a tag ruleset existed, `v1.9.9-probe` would have failed too. The repo has **one** ruleset, targeting branches; no tag protection rules; `rules/branches/refs/tags/v1.3.0` returns `[]`. GitHub's wording ("creations being restricted") is misleading — it is name reservation. All probe tags were cleaned up.

## Changes

- `package.json` → `1.3.1`
- CHANGELOG heading → `[1.3.1] - 2026-08-18`, **renamed rather than split**: 1.3.0 was never published, so there is no released version for a patch entry to describe
- README status badge, release link, container image table and pull example
- ROADMAP current status

## Impact

None for consumers. Images republish as `1.3.1`, `1.3`, `1`, `latest` — anyone tracking `1.3` or `latest` sees the same code either way.

## Verification

Node 20 (the production runtime): **139 files, 1128 tests passing**, `tsc --noEmit` clean. Pre-push hook (tsc + full suite + production build) passed.

## Note for future releases

With immutable releases enabled, **a published tag name is permanently spent** — deleting a release does not free it. Worth treating release tags as one-way.

Separately: the v1.1.0 and v1.2.0 release notes document `docker pull …:v1.2.0`, but published tags carry no `v` prefix, so those commands fail. Immutable releases makes those notes read-only; this release uses the correct `:1.3.1` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)