### PR TITLE
fix(dashboard): fix Command Center metric scope mismatch and 101% insight calculation

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -214,6 +214,8 @@ export default async function Dashboard({
       // Return safe default object matching return type
       return {
         totalIncidents: 0,
+        activeIncidents: 0,
+        activeCount: 0,
         openCount: 0,
         acknowledgedCount: 0,
         resolvedCount: 0,
@@ -268,14 +270,19 @@ export default async function Dashboard({
   // Map SLA Server metrics to Dashboard variables
   const activeShifts = slaMetrics.currentShifts;
   const metricsTotalCount = slaMetrics.totalIncidents;
-  const metricsOpenCount = slaMetrics.openCount;
+  const metricsOpenCount = slaMetrics.statusMix.find(s => s.status === 'OPEN')?.count ?? 0;
   const metricsResolvedCount = slaMetrics.statusMix.find(s => s.status === 'RESOLVED')?.count ?? 0;
   const unassignedCount = slaMetrics.unassignedActive;
 
-  const allOpenIncidentsCount = slaMetrics.openCount;
+  const allActiveIncidentsCount =
+    slaMetrics.activeIncidents ??
+    slaMetrics.activeCount ??
+    slaMetrics.openCount + slaMetrics.acknowledgedCount;
+  const allOpenIncidentsCount = allActiveIncidentsCount;
   const allAcknowledgedCount = slaMetrics.acknowledgedCount;
   const currentCriticalActive = slaMetrics.criticalCount;
-  const currentPeriodAcknowledged = allAcknowledgedCount;
+  const currentPeriodAcknowledged =
+    slaMetrics.statusMix.find(s => s.status === 'ACKNOWLEDGED')?.count ?? 0;
   const mttaMinutes = slaMetrics.mttd;
 
   // Calculate system status
@@ -357,6 +364,8 @@ export default async function Dashboard({
       criticalCount: serviceMetric.criticalCount ?? 0,
     }));
 
+  const topServiceByVolume = slaMetrics.serviceMetrics?.[0];
+
   const teamLoad = slaMetrics.assigneeLoad
     .slice()
     .sort((a, b) => b.count - a.count)
@@ -423,11 +432,11 @@ export default async function Dashboard({
         {/* Smart Insights Banner - Auto-generated alerts */}
         <SmartInsightsBanner
           totalIncidents={totalInRange}
-          openIncidents={metricsOpenCount}
+          openIncidents={allActiveIncidentsCount}
           criticalIncidents={currentCriticalActive}
           unassignedIncidents={unassignedCount}
-          topServiceName={servicesAtRisk[0]?.name}
-          topServiceCount={servicesAtRisk[0]?.activeCount}
+          topServiceName={topServiceByVolume?.name}
+          topServiceCount={topServiceByVolume?.count}
         />
 
         <div className="grid grid-cols-1 xl:grid-cols-12 gap-6 items-start">

--- a/src/components/dashboard/SmartInsightsBanner.tsx
+++ b/src/components/dashboard/SmartInsightsBanner.tsx
@@ -8,143 +8,151 @@ import { Button } from '@/components/ui/shadcn/button';
 import { useState } from 'react';
 
 type Insight = {
-    id: string;
-    type: 'warning' | 'info' | 'success';
-    icon: React.ReactNode;
-    message: string;
+  id: string;
+  type: 'warning' | 'info' | 'success';
+  icon: React.ReactNode;
+  message: string;
 };
 
 type SmartInsightsBannerProps = {
-    totalIncidents: number;
-    openIncidents: number;
-    criticalIncidents: number;
-    unassignedIncidents: number;
-    avgIncidentsPerDay?: number;
-    topServiceName?: string;
-    topServiceCount?: number;
+  totalIncidents: number;
+  openIncidents: number;
+  criticalIncidents: number;
+  unassignedIncidents: number;
+  avgIncidentsPerDay?: number;
+  topServiceName?: string;
+  topServiceCount?: number;
 };
 
 export default function SmartInsightsBanner({
+  totalIncidents,
+  openIncidents,
+  criticalIncidents,
+  unassignedIncidents,
+  avgIncidentsPerDay = 0,
+  topServiceName,
+  topServiceCount = 0,
+}: SmartInsightsBannerProps) {
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+
+  const insights = useMemo(() => {
+    const results: Insight[] = [];
+
+    // High unassigned ratio
+    if (openIncidents > 0 && unassignedIncidents / openIncidents > 0.3) {
+      const unassignedPct = Math.min(
+        100,
+        Math.max(0, Math.round((unassignedIncidents / openIncidents) * 100))
+      );
+      results.push({
+        id: 'unassigned',
+        type: 'warning',
+        icon: <AlertTriangle className="h-4 w-4" />,
+        message: `${unassignedPct}% of open incidents are unassigned. Consider distributing workload.`,
+      });
+    }
+
+    // Critical incidents spike
+    if (criticalIncidents >= 3) {
+      results.push({
+        id: 'critical-spike',
+        type: 'warning',
+        icon: <Zap className="h-4 w-4" />,
+        message: `${criticalIncidents} critical incidents active. Prioritize immediate response.`,
+      });
+    }
+
+    // Service concentration
+    if (topServiceName && topServiceCount >= 3 && totalIncidents > 0) {
+      const concentration = Math.min(
+        100,
+        Math.max(0, Math.round((topServiceCount / totalIncidents) * 100))
+      );
+      if (concentration >= 40) {
+        results.push({
+          id: 'service-concentration',
+          type: 'info',
+          icon: <Lightbulb className="h-4 w-4" />,
+          message: `${concentration}% of incidents originate from "${topServiceName}". Consider investigating root cause.`,
+        });
+      }
+    }
+
+    // High volume day
+    if (avgIncidentsPerDay > 0 && totalIncidents > avgIncidentsPerDay * 1.5) {
+      const volumePct = Math.max(0, Math.round((totalIncidents / avgIncidentsPerDay - 1) * 100));
+      results.push({
+        id: 'high-volume',
+        type: 'info',
+        icon: <TrendingUp className="h-4 w-4" />,
+        message: `Incident volume is ${volumePct}% higher than average today.`,
+      });
+    }
+
+    // All clear
+    if (results.length === 0 && openIncidents === 0) {
+      results.push({
+        id: 'all-clear',
+        type: 'success',
+        icon: <Lightbulb className="h-4 w-4" />,
+        message: 'All systems operational. No active incidents.',
+      });
+    }
+
+    return results.filter(insight => !dismissedIds.has(insight.id));
+  }, [
     totalIncidents,
     openIncidents,
     criticalIncidents,
     unassignedIncidents,
-    avgIncidentsPerDay = 0,
+    avgIncidentsPerDay,
     topServiceName,
-    topServiceCount = 0,
-}: SmartInsightsBannerProps) {
-    const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+    topServiceCount,
+    dismissedIds,
+  ]);
 
-    const insights = useMemo(() => {
-        const results: Insight[] = [];
+  const dismissInsight = (id: string) => {
+    setDismissedIds(prev => new Set([...prev, id]));
+  };
 
-        // High unassigned ratio
-        if (openIncidents > 0 && unassignedIncidents / openIncidents > 0.3) {
-            results.push({
-                id: 'unassigned',
-                type: 'warning',
-                icon: <AlertTriangle className="h-4 w-4" />,
-                message: `${Math.round((unassignedIncidents / openIncidents) * 100)}% of open incidents are unassigned. Consider distributing workload.`,
-            });
-        }
+  if (insights.length === 0) return null;
 
-        // Critical incidents spike
-        if (criticalIncidents >= 3) {
-            results.push({
-                id: 'critical-spike',
-                type: 'warning',
-                icon: <Zap className="h-4 w-4" />,
-                message: `${criticalIncidents} critical incidents active. Prioritize immediate response.`,
-            });
-        }
+  const typeStyles = {
+    warning: 'bg-amber-50 border-amber-200 text-amber-800',
+    info: 'bg-blue-50 border-blue-200 text-blue-800',
+    success: 'bg-emerald-50 border-emerald-200 text-emerald-800',
+  };
 
-        // Service concentration
-        if (topServiceName && topServiceCount >= 3 && totalIncidents > 0) {
-            const concentration = Math.round((topServiceCount / totalIncidents) * 100);
-            if (concentration >= 40) {
-                results.push({
-                    id: 'service-concentration',
-                    type: 'info',
-                    icon: <Lightbulb className="h-4 w-4" />,
-                    message: `${concentration}% of incidents originate from "${topServiceName}". Consider investigating root cause.`,
-                });
-            }
-        }
+  const iconStyles = {
+    warning: 'text-amber-600',
+    info: 'text-blue-600',
+    success: 'text-emerald-600',
+  };
 
-        // High volume day
-        if (avgIncidentsPerDay > 0 && totalIncidents > avgIncidentsPerDay * 1.5) {
-            results.push({
-                id: 'high-volume',
-                type: 'info',
-                icon: <TrendingUp className="h-4 w-4" />,
-                message: `Incident volume is ${Math.round((totalIncidents / avgIncidentsPerDay - 1) * 100)}% higher than average today.`,
-            });
-        }
-
-        // All clear
-        if (results.length === 0 && openIncidents === 0) {
-            results.push({
-                id: 'all-clear',
-                type: 'success',
-                icon: <Lightbulb className="h-4 w-4" />,
-                message: 'All systems operational. No active incidents.',
-            });
-        }
-
-        return results.filter((insight) => !dismissedIds.has(insight.id));
-    }, [
-        totalIncidents,
-        openIncidents,
-        criticalIncidents,
-        unassignedIncidents,
-        avgIncidentsPerDay,
-        topServiceName,
-        topServiceCount,
-        dismissedIds,
-    ]);
-
-    const dismissInsight = (id: string) => {
-        setDismissedIds((prev) => new Set([...prev, id]));
-    };
-
-    if (insights.length === 0) return null;
-
-    const typeStyles = {
-        warning: 'bg-amber-50 border-amber-200 text-amber-800',
-        info: 'bg-blue-50 border-blue-200 text-blue-800',
-        success: 'bg-emerald-50 border-emerald-200 text-emerald-800',
-    };
-
-    const iconStyles = {
-        warning: 'text-amber-600',
-        info: 'text-blue-600',
-        success: 'text-emerald-600',
-    };
-
-    return (
-        <div className="space-y-2 animate-in fade-in slide-in-from-top-2 duration-300">
-            {insights.map((insight) => (
-                <div
-                    key={insight.id}
-                    className={cn(
-                        'flex items-center justify-between gap-3 px-4 py-2.5 rounded-lg border',
-                        typeStyles[insight.type]
-                    )}
-                >
-                    <div className="flex items-center gap-2.5">
-                        <span className={cn('shrink-0', iconStyles[insight.type])}>{insight.icon}</span>
-                        <span className="text-sm font-medium">{insight.message}</span>
-                    </div>
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 w-6 p-0 hover:bg-black/5"
-                        onClick={() => dismissInsight(insight.id)}
-                    >
-                        <X className="h-3.5 w-3.5" />
-                    </Button>
-                </div>
-            ))}
+  return (
+    <div className="space-y-2 animate-in fade-in slide-in-from-top-2 duration-300">
+      {insights.map(insight => (
+        <div
+          key={insight.id}
+          className={cn(
+            'flex items-center justify-between gap-3 px-4 py-2.5 rounded-lg border',
+            typeStyles[insight.type]
+          )}
+        >
+          <div className="flex items-center gap-2.5">
+            <span className={cn('shrink-0', iconStyles[insight.type])}>{insight.icon}</span>
+            <span className="text-sm font-medium">{insight.message}</span>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 hover:bg-black/5"
+            onClick={() => dismissInsight(insight.id)}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
         </div>
-    );
+      ))}
+    </div>
+  );
 }

--- a/tests/components/SmartInsightsBanner.test.tsx
+++ b/tests/components/SmartInsightsBanner.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import SmartInsightsBanner from '@/components/dashboard/SmartInsightsBanner';
+
+describe('SmartInsightsBanner', () => {
+  it('should clamp service concentration percentage to a maximum of 100%', () => {
+    // If topServiceCount exceeds totalIncidents (e.g. from mismatched data), it should never exceed 100%
+    render(
+      <SmartInsightsBanner
+        totalIncidents={100}
+        openIncidents={50}
+        criticalIncidents={0}
+        unassignedIncidents={0}
+        topServiceName="Github Alert"
+        topServiceCount={150}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        '100% of incidents originate from "Github Alert". Consider investigating root cause.'
+      )
+    ).toBeDefined();
+    expect(screen.queryByText(/150%/)).toBeNull();
+  });
+
+  it('should accurately calculate normal service concentration percentage', () => {
+    render(
+      <SmartInsightsBanner
+        totalIncidents={200}
+        openIncidents={50}
+        criticalIncidents={0}
+        unassignedIncidents={0}
+        topServiceName="Authentication Service"
+        topServiceCount={120}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        '60% of incidents originate from "Authentication Service". Consider investigating root cause.'
+      )
+    ).toBeDefined();
+  });
+
+  it('should clamp unassigned percentage to 100% and render unassigned alert when ratio > 0.3', () => {
+    render(
+      <SmartInsightsBanner
+        totalIncidents={50}
+        openIncidents={20}
+        criticalIncidents={0}
+        unassignedIncidents={10}
+      />
+    );
+
+    expect(
+      screen.getByText('50% of open incidents are unassigned. Consider distributing workload.')
+    ).toBeDefined();
+  });
+
+  it('should show critical spike banner when criticalIncidents >= 3', () => {
+    render(
+      <SmartInsightsBanner
+        totalIncidents={50}
+        openIncidents={10}
+        criticalIncidents={5}
+        unassignedIncidents={0}
+      />
+    );
+
+    expect(
+      screen.getByText('5 critical incidents active. Prioritize immediate response.')
+    ).toBeDefined();
+  });
+
+  it('should show all systems operational when all incidents are clear', () => {
+    render(
+      <SmartInsightsBanner
+        totalIncidents={0}
+        openIncidents={0}
+        criticalIncidents={0}
+        unassignedIncidents={0}
+      />
+    );
+
+    expect(screen.getByText('All systems operational. No active incidents.')).toBeDefined();
+  });
+
+  it('should allow dismissing an insight', () => {
+    render(
+      <SmartInsightsBanner
+        totalIncidents={50}
+        openIncidents={10}
+        criticalIncidents={4}
+        unassignedIncidents={0}
+      />
+    );
+
+    const message = screen.getByText('4 critical incidents active. Prioritize immediate response.');
+    expect(message).toBeDefined();
+
+    // Click close/dismiss button
+    const dismissButton = screen.getByRole('button');
+    fireEvent.click(dismissButton);
+
+    expect(
+      screen.queryByText('4 critical incidents active. Prioritize immediate response.')
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description
Fixes metric discrepancies in the Command Center hero cards and the Smart Insights Banner:

1. **Command Center Metric Scope Mismatch**:
   - `metricsOpenCount` was reading all-time active open incidents (`slaMetrics.openCount`) while the card was labeled `OPEN (30d)` alongside 30-day `TOTAL` and `RESOLVED` metrics, causing `OPEN` to exceed `TOTAL`.
   - Changed `metricsOpenCount` to derive from `slaMetrics.statusMix` (`status === 'OPEN'`) matching the selected time range.
   - Updated `currentPeriodAcknowledged` to also read from `statusMix` (`status === 'ACKNOWLEDGED'`) for consistent range exports.
   - Fixed System Status header active count to reflect all active incidents (`OPEN + ACKNOWLEDGED`).

2. **Smart Insights Banner 101% Calculation**:
   - The service concentration insight was comparing `topService.activeCount` (all-time active) against `totalInRange` (30-day window total), resulting in concentrations > 100% (e.g. 101%).
   - Changed the service volume calculation to pass the top service's total incident count in that range (`slaMetrics.serviceMetrics[0].count`).
   - Clamped all insight percentages with `Math.min(100, Math.max(0, ...))` as a safety guardrail.

3. **Tests**:
   - Added unit test suite in `tests/components/SmartInsightsBanner.test.tsx` covering clamping, accurate percentage calculations, and banner dismissal.

## Verification
- `npx tsc --noEmit` passed with 0 errors.
- `npx vitest run -c vitest.unit.config.ts` passed (140 test files, 1134 tests passed).