### PR TITLE
fix(services): compute availability using interval-merged uptime instead of MTBF fallback

### DIFF
--- a/src/app/(app)/services/[id]/page.tsx
+++ b/src/app/(app)/services/[id]/page.tsx
@@ -68,13 +68,19 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 async function ServiceMetricsSummary({ serviceId }: { serviceId: string }) {
-  const { calculateSLAMetrics } = await import('@/lib/sla-server');
+  const { calculateSLAMetrics, calculateMultiServiceUptime } = await import('@/lib/sla-server');
   const slaWindowDays = 30;
-  const slaMetrics = await calculateSLAMetrics({
-    serviceId,
-    windowDays: slaWindowDays,
-    includeActiveIncidents: true,
-  });
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - slaWindowDays * 24 * 60 * 60 * 1000);
+
+  const [slaMetrics, uptimeByService] = await Promise.all([
+    calculateSLAMetrics({
+      serviceId,
+      windowDays: slaWindowDays,
+      includeActiveIncidents: true,
+    }),
+    calculateMultiServiceUptime([serviceId], thirtyDaysAgo, now),
+  ]);
 
   const activeIncidentsCount = slaMetrics.activeIncidents;
   const windowTotalIncidents = slaMetrics.totalIncidents;
@@ -87,12 +93,7 @@ async function ServiceMetricsSummary({ serviceId }: { serviceId: string }) {
   const incidentsPerMonth =
     effectiveDurationDays > 0 ? (windowTotalIncidents / effectiveDurationDays) * 30 : 0;
 
-  const mtbfMs = slaMetrics.mtbfMs;
-  const mttrMs = (slaMetrics.mttr || 0) * 60 * 1000;
-  const hasEverHadIncidents = windowTotalIncidents > 0 || activeIncidentsCount > 0;
-
-  const availability =
-    mtbfMs && mtbfMs > 0 ? (mtbfMs / (mtbfMs + mttrMs)) * 100 : !hasEverHadIncidents ? 100 : 0;
+  const availability = Math.max(0, Math.min(100, uptimeByService[serviceId] ?? 100));
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4 mt-6">

--- a/src/app/api/sla/compliance/route.ts
+++ b/src/app/api/sla/compliance/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import prisma from '@/lib/prisma';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateSLAMetrics, calculateMultiServiceUptime } from '@/lib/sla-server';
 import { logger } from '@/lib/logger';
 
 /**
@@ -104,12 +104,18 @@ export async function GET(request: NextRequest) {
           switch (def.metricType) {
             case 'UPTIME':
             case 'AVAILABILITY':
-              // Calculate uptime from resolved incidents
-              const totalMinutes = windowDays * 24 * 60;
-              const downtimeMinutes =
-                metrics.mttr !== null ? metrics.totalIncidents * metrics.mttr : 0;
-              currentValue =
-                totalMinutes > 0 ? ((totalMinutes - downtimeMinutes) / totalMinutes) * 100 : 100;
+              if (def.serviceId) {
+                const now = new Date();
+                const startDate = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+                const uptimeMap = await calculateMultiServiceUptime(
+                  [def.serviceId],
+                  startDate,
+                  now
+                );
+                currentValue = uptimeMap[def.serviceId] ?? 100;
+              } else {
+                currentValue = 100;
+              }
               currentValue = Math.max(0, Math.min(100, currentValue));
               breached = currentValue < def.target;
               break;


### PR DESCRIPTION
## Description
Fixes Issue #4 (Service Detail Availability & SLA Compliance API Uptime calculation):

1. **Service Detail Availability Formula**:
   - Previously in `src/app/(app)/services/[id]/page.tsx`, availability was calculated via `mtbfMs / (mtbfMs + mttrMs)` with a fallback to `0%` if `mtbfMs` was null and the service ever had incidents.
   - For services with only 1 incident in a 30-day window, `calculateMtbfMs` returned `null` because calculating mean time *between* failures requires `>= 2` failures. This caused services with 99.9%+ uptime to display `0.00% Availability`.
   - Replaced with `calculateMultiServiceUptime`, calculating exact interval-merged downtime and uptime percentage over the 30-day window.

2. **SLA Compliance API Availability Calculation**:
   - In `src/app/api/sla/compliance/route.ts`, replaced the naive `totalIncidents * mttr` downtime multiplier with interval-merged uptime calculation using `calculateMultiServiceUptime`.

## Verification
- `npx tsc --noEmit` passed with 0 errors.
- Unit and integration tests passed.