### PR TITLE
ci: clone the public website without a PAT in docs-sync

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -7,50 +7,46 @@ on:
       - 'docs/**'
       - 'scripts/sync-docs-to-website.sh'
       - '.github/workflows/docs-sync.yml'
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
-    if: ${{ !contains(github.event.head_commit.message, '[skip docs-sync]') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip docs-sync]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout app repo
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Checkout website repo
         uses: actions/checkout@v7
         with:
           repository: opsknight-labs/OpsKnight-website
-          token: ${{ secrets.OPSKNIGHT_WEBSITE_PAT }}
           path: opsknight-website
-
-      - name: Configure git author
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Configure git author (website repo)
-        working-directory: opsknight-website
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Public clone. Passing an empty or invalid PAT here fails the job
+          # even when the website repo is public.
+          persist-credentials: false
 
       - name: Sync app docs to website
         run: ./scripts/sync-docs-to-website.sh ./opsknight-website
 
-      - name: Commit website changes
+      - name: Commit and push website docs
         working-directory: opsknight-website
+        env:
+          OPSKNIGHT_WEBSITE_PAT: ${{ secrets.OPSKNIGHT_WEBSITE_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if [ -n "$(git status --porcelain)" ]; then
-            git add -A
-            git commit -m "sync docs from app repo"
-            git push origin HEAD:main
-          else
+          if [ -z "$(git status --porcelain)" ]; then
             echo "No website changes to commit."
+            exit 0
           fi
+          if [ -z "$OPSKNIGHT_WEBSITE_PAT" ]; then
+            echo "::error::Docs differ from the website, but secret OPSKNIGHT_WEBSITE_PAT is missing. Add a fine-grained PAT with Contents: Read and write on opsknight-labs/OpsKnight-website as an Actions secret on OpsKnight or the opsknight-labs org."
+            exit 1
+          fi
+          git add -A
+          git commit -m "sync docs from app repo"
+          git push "https://x-access-token:${OPSKNIGHT_WEBSITE_PAT}@github.com/opsknight-labs/OpsKnight-website.git" HEAD:main


### PR DESCRIPTION
An empty or invalid OPSKNIGHT_WEBSITE_PAT made checkout fail. Clone anonymously; only require the secret when there are docs to push.

## 📝 Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## 🧪 Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## 🛡️ How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Check (please describe)

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
