### PR TITLE
fix: hardening avatar ecosystem, integrations, auth sessions, chatops and lifecycle

### DIFF
--- a/src/app/(app)/audit/page.tsx
+++ b/src/app/(app)/audit/page.tsx
@@ -85,7 +85,10 @@ export default async function AuditLogPage() {
                         <DirectUserAvatar
                           avatarUrl={
                             log.actor.avatarUrl ||
-                            getDefaultAvatar(log.actor.gender, log.actor.name)
+                            getDefaultAvatar(
+                              log.actor.gender,
+                              log.actor.id || log.actor.name || 'user'
+                            )
                           }
                           name={log.actor.name}
                           size="sm"

--- a/src/app/(app)/incidents/[id]/page.tsx
+++ b/src/app/(app)/incidents/[id]/page.tsx
@@ -345,7 +345,7 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
                     <AvatarImage
                       src={
                         incident.assignee.avatarUrl ||
-                        getDefaultAvatar(incident.assignee.gender, incident.assignee.name)
+                        getDefaultAvatar(incident.assignee.gender, incident.assignee.id)
                       }
                     />
                     <AvatarFallback className="text-[9px] bg-slate-100 text-slate-600">

--- a/src/app/(app)/policies/actions.ts
+++ b/src/app/(app)/policies/actions.ts
@@ -8,8 +8,9 @@ import { getDefaultActorId, logAudit } from '@/lib/audit';
 import { assertEscalationPolicyNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
 
 export async function createPolicy(formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     throw new Error(
       error instanceof Error ? error.message : 'Unauthorized. Admin access required.'
@@ -91,7 +92,7 @@ export async function createPolicy(formData: FormData) {
     action: 'escalation_policy.created',
     entityType: 'ESCALATION_POLICY',
     entityId: policy.id,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { name: normalizedName, stepCount: steps.length },
   });
 
@@ -100,8 +101,9 @@ export async function createPolicy(formData: FormData) {
 }
 
 export async function updatePolicy(policyId: string, formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     throw new Error(
       error instanceof Error ? error.message : 'Unauthorized. Admin access required.'
@@ -133,7 +135,7 @@ export async function updatePolicy(policyId: string, formData: FormData) {
     action: 'escalation_policy.updated',
     entityType: 'ESCALATION_POLICY',
     entityId: policyId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { name: normalizedName },
   });
 
@@ -142,8 +144,9 @@ export async function updatePolicy(policyId: string, formData: FormData) {
 }
 
 export async function deletePolicy(policyId: string) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     throw new Error(
       error instanceof Error ? error.message : 'Unauthorized. Admin access required.'
@@ -171,7 +174,7 @@ export async function deletePolicy(policyId: string) {
     action: 'escalation_policy.deleted',
     entityType: 'ESCALATION_POLICY',
     entityId: policyId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
   });
 
   revalidatePath('/policies');
@@ -182,8 +185,9 @@ export async function addPolicyStep(
   policyId: string,
   formData: FormData
 ): Promise<{ error?: string } | undefined> {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
@@ -240,7 +244,7 @@ export async function addPolicyStep(
       action: 'escalation_policy.step_added',
       entityType: 'ESCALATION_POLICY',
       entityId: policyId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser.id,
       details: { stepOrder: nextStepOrder, targetType },
     });
 
@@ -254,8 +258,9 @@ export async function updatePolicyStep(
   stepId: string,
   formData: FormData
 ): Promise<{ error?: string } | undefined> {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
@@ -325,7 +330,7 @@ export async function updatePolicyStep(
       action: 'escalation_policy.step_updated',
       entityType: 'ESCALATION_POLICY',
       entityId: step.policyId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser.id,
       details: { stepId, stepOrder: step.stepOrder, targetType: finalTargetType },
     });
 
@@ -336,8 +341,9 @@ export async function updatePolicyStep(
 }
 
 export async function deletePolicyStep(stepId: string): Promise<{ error?: string } | undefined> {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
@@ -381,7 +387,7 @@ export async function deletePolicyStep(stepId: string): Promise<{ error?: string
       action: 'escalation_policy.step_deleted',
       entityType: 'ESCALATION_POLICY',
       entityId: policyId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser.id,
       details: { deletedStepOrder },
     });
 
@@ -395,8 +401,9 @@ export async function movePolicyStep(
   stepId: string,
   direction: 'up' | 'down'
 ): Promise<{ error?: string } | undefined> {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
@@ -453,7 +460,7 @@ export async function movePolicyStep(
       action: 'escalation_policy.step_moved',
       entityType: 'ESCALATION_POLICY',
       entityId: policyId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser.id,
       details: { stepId, from: currentOrder, to: newOrder },
     });
 
@@ -467,8 +474,9 @@ export async function reorderPolicySteps(
   policyId: string,
   newOrder: string[]
 ): Promise<{ error?: string } | undefined> {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
@@ -505,7 +513,7 @@ export async function reorderPolicySteps(
       action: 'escalation_policy.steps_reordered',
       entityType: 'ESCALATION_POLICY',
       entityId: policyId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser.id,
       details: { newOrderCount: newOrder.length },
     });
 

--- a/src/app/(app)/schedules/[id]/page.tsx
+++ b/src/app/(app)/schedules/[id]/page.tsx
@@ -113,7 +113,7 @@ export default async function ScheduleDetailPage({
         },
       }),
       prisma.user.findMany({
-        select: { id: true, name: true },
+        select: { id: true, name: true, avatarUrl: true, gender: true },
         orderBy: { name: 'asc' },
       }),
       prisma.onCallOverride.findMany({
@@ -599,7 +599,10 @@ export default async function ScheduleDetailPage({
                         <div className="flex items-center gap-3 min-w-0">
                           <Avatar className="h-7 w-7">
                             <AvatarImage
-                              src={o.user.avatarUrl || getDefaultAvatar(o.user.gender, o.user.name)}
+                              src={
+                                o.user.avatarUrl ||
+                                getDefaultAvatar(o.user.gender, o.userId || o.user.name)
+                              }
                             />
                             <AvatarFallback className="text-[10px] font-semibold">
                               {getInitials(o.user.name)}
@@ -645,7 +648,10 @@ export default async function ScheduleDetailPage({
                         <div className="flex items-center gap-3 min-w-0">
                           <Avatar className="h-7 w-7">
                             <AvatarImage
-                              src={o.user.avatarUrl || getDefaultAvatar(o.user.gender, o.user.name)}
+                              src={
+                                o.user.avatarUrl ||
+                                getDefaultAvatar(o.user.gender, o.userId || o.user.name)
+                              }
                             />
                             <AvatarFallback className="text-[10px] font-semibold">
                               {getInitials(o.user.name)}

--- a/src/app/(app)/services/[id]/webhooks/actions.ts
+++ b/src/app/(app)/services/[id]/webhooks/actions.ts
@@ -8,8 +8,9 @@ import { redirect } from 'next/navigation';
 import { assertWebhookIntegrationNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
 
 export async function createWebhookIntegration(serviceId: string, formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -50,7 +51,7 @@ export async function createWebhookIntegration(serviceId: string, formData: Form
     action: 'webhook.integration.created',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { name: normalizedName, type },
   });
 
@@ -63,8 +64,9 @@ export async function updateWebhookIntegration(
   serviceId: string,
   formData: FormData
 ) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -113,7 +115,7 @@ export async function updateWebhookIntegration(
     action: 'webhook.integration.updated',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { integrationId, name: normalizedName, type },
   });
 
@@ -123,8 +125,9 @@ export async function updateWebhookIntegration(
 }
 
 export async function deleteWebhookIntegration(integrationId: string, serviceId: string) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -137,7 +140,7 @@ export async function deleteWebhookIntegration(integrationId: string, serviceId:
     action: 'webhook.integration.deleted',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { integrationId },
   });
 

--- a/src/app/(app)/services/actions.ts
+++ b/src/app/(app)/services/actions.ts
@@ -12,8 +12,9 @@ import { assertJiraIssueType, assertJiraProjectKey, parseLabels } from '@/lib/ji
 const JIRA_AUTO_CREATE_URGENCIES = new Set(['HIGH', 'MEDIUM', 'LOW']);
 
 export async function createIntegration(formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -41,7 +42,7 @@ export async function createIntegration(formData: FormData) {
     action: 'integration.created',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { name, type },
   });
 
@@ -53,8 +54,9 @@ export async function deleteIntegration(
   serviceId: string,
   _formData?: FormData
 ) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -67,7 +69,7 @@ export async function deleteIntegration(
     action: 'integration.deleted',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { integrationId },
   });
 
@@ -76,8 +78,9 @@ export async function deleteIntegration(
 }
 
 export async function updateService(serviceId: string, formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -109,8 +112,10 @@ export async function updateService(serviceId: string, formData: FormData) {
   const autoCreateWarRoomValue = formData.get('autoCreateWarRoom');
   const autoCreateWarRoom = autoCreateWarRoomValue === 'on' || autoCreateWarRoomValue === 'true';
   const warRoomVideoBridgeRaw = formData.get('warRoomVideoBridge') as string | null;
-  const warRoomVideoBridge = warRoomVideoBridgeRaw && warRoomVideoBridgeRaw !== 'INHERIT' ? warRoomVideoBridgeRaw : null;
-  const warRoomCustomBridgeUrl = ((formData.get('warRoomCustomBridgeUrl') as string | null) ?? '').trim() || null;
+  const warRoomVideoBridge =
+    warRoomVideoBridgeRaw && warRoomVideoBridgeRaw !== 'INHERIT' ? warRoomVideoBridgeRaw : null;
+  const warRoomCustomBridgeUrl =
+    ((formData.get('warRoomCustomBridgeUrl') as string | null) ?? '').trim() || null;
 
   try {
     const normalizedName = await assertServiceNameAvailable(name, { excludeId: serviceId });
@@ -144,7 +149,7 @@ export async function updateService(serviceId: string, formData: FormData) {
       action: 'service.updated',
       entityType: 'SERVICE',
       entityId: serviceId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser.id,
       details: {
         name: normalizedName,
         teamId: teamId || null,
@@ -170,8 +175,9 @@ export async function saveJiraServiceMapping(
   _prevState: { success?: boolean; error?: string | null } | undefined,
   formData: FormData
 ): Promise<{ success?: boolean; error?: string | null }> {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     return { error: error instanceof Error ? error.message : 'Unauthorized' };
   }
@@ -239,7 +245,7 @@ export async function saveJiraServiceMapping(
       action: 'jira.service_mapping.updated',
       entityType: 'SERVICE',
       entityId: serviceId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser.id,
       details: {
         projectKey,
         incidentIssueType,
@@ -262,8 +268,9 @@ export async function saveJiraServiceMapping(
 }
 
 export async function rotateIntegrationSecret(integrationId: string, serviceId: string) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -279,7 +286,7 @@ export async function rotateIntegrationSecret(integrationId: string, serviceId: 
     action: 'integration.secret_rotated',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { integrationId },
   });
 
@@ -287,8 +294,9 @@ export async function rotateIntegrationSecret(integrationId: string, serviceId: 
 }
 
 export async function clearIntegrationSecret(integrationId: string, serviceId: string) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -302,7 +310,7 @@ export async function clearIntegrationSecret(integrationId: string, serviceId: s
     action: 'integration.secret_cleared',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { integrationId },
   });
 
@@ -314,8 +322,9 @@ export async function toggleIntegrationStatus(
   serviceId: string,
   enabled: boolean
 ) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -329,7 +338,7 @@ export async function toggleIntegrationStatus(
     action: 'integration.status_updated',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { integrationId, enabled },
   });
 
@@ -337,8 +346,9 @@ export async function toggleIntegrationStatus(
 }
 
 export async function deleteService(serviceId: string) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     throw new Error(
       error instanceof Error ? error.message : 'Unauthorized. Admin access required.'
@@ -359,7 +369,7 @@ export async function deleteService(serviceId: string) {
     action: 'service.deleted',
     entityType: 'SERVICE',
     entityId: serviceId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { serviceId },
   });
 

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -14,7 +14,7 @@ import {
   getWhatsAppConfig,
 } from '@/lib/notification-providers';
 import { logger } from '@/lib/logger';
-import { getDefaultAvatar } from '@/lib/avatar';
+import { getDefaultAvatar, isDefaultAvatar } from '@/lib/avatar';
 import { logAudit } from '@/lib/audit';
 
 type ActionState = {
@@ -45,11 +45,13 @@ export async function updateProfile(
 
     const avatarFile = formData.get('avatar') as File | null;
 
+    const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+
     let avatarUrl = undefined;
     if (avatarFile && avatarFile.size > 0) {
       // Validate file type
-      if (!avatarFile.type.startsWith('image/')) {
-        return { error: 'Invalid file type. Please upload an image.' };
+      if (!ALLOWED_MIME_TYPES.has(avatarFile.type)) {
+        return { error: 'Invalid file type. Please upload a PNG, JPEG, WebP, or GIF image.' };
       }
       if (avatarFile.size > 2 * 1024 * 1024) {
         // 2MB limit
@@ -59,6 +61,26 @@ export async function updateProfile(
       try {
         const bytes = await avatarFile.arrayBuffer();
         const buffer = Buffer.from(bytes);
+
+        // Verify magic bytes
+        const isPng =
+          buffer.length >= 4 &&
+          buffer[0] === 0x89 &&
+          buffer[1] === 0x50 &&
+          buffer[2] === 0x4e &&
+          buffer[3] === 0x47;
+        const isJpeg =
+          buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+        const isGif =
+          buffer.length >= 3 && buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46;
+        const isWebp =
+          buffer.length >= 12 &&
+          buffer.toString('ascii', 0, 4) === 'RIFF' &&
+          buffer.toString('ascii', 8, 12) === 'WEBP';
+
+        if (!isPng && !isJpeg && !isGif && !isWebp) {
+          return { error: 'Invalid image file signature. Please upload a valid image.' };
+        }
 
         // Save to database (UserAvatar table)
         await prisma.userAvatar.upsert({
@@ -116,13 +138,23 @@ export async function updateProfile(
     }
 
     // Handle direct avatarUrl (from avatar picker)
-    const directAvatarUrl = formData.get('avatarUrl') as string | null;
+    const directAvatarUrl = (formData.get('avatarUrl') as string | null)?.trim();
+    const isValidDirectUrl = (url: string) => {
+      if (url.startsWith('/api/avatar') || url.startsWith('/avatars/')) return true;
+      try {
+        const parsed = new URL(url);
+        return parsed.protocol === 'https:' && parsed.hostname === 'api.dicebear.com';
+      } catch {
+        return false;
+      }
+    };
 
     // Avatar Logic
     if (removeAvatar) {
-      // User explicitly requested removal - set to default based on gender
+      // User explicitly requested removal - clean up DB binary and set to default based on gender
+      await prisma.userAvatar.deleteMany({ where: { userId: user.id } });
       data.avatarUrl = getDefaultAvatar(newGender, user.id);
-    } else if (directAvatarUrl) {
+    } else if (directAvatarUrl && isValidDirectUrl(directAvatarUrl)) {
       // User selected an avatar from the picker
       data.avatarUrl = directAvatarUrl;
     } else if (avatarUrl !== undefined) {
@@ -131,22 +163,7 @@ export async function updateProfile(
     } else if (data.gender !== undefined) {
       // Gender changed, but no new file uploaded.
       // Check if we should update the avatar to match the new gender.
-      // We only do this if the current avatar is:
-      // 1. null (no avatar)
-      // 2. OR one of our default DiceBear avatars (meaning user hasn't uploaded a custom one)
-
-      const isCurrentDefault =
-        !user.avatarUrl ||
-        user.avatarUrl.startsWith('/api/avatar') ||
-        (() => {
-          try {
-            const url = new URL(user.avatarUrl!);
-            return url.hostname === 'api.dicebear.com';
-          } catch {
-            // If the URL is invalid, treat it as non-default/custom.
-            return false;
-          }
-        })();
+      const isCurrentDefault = isDefaultAvatar(user.avatarUrl);
 
       if (isCurrentDefault) {
         const newDefault = getDefaultAvatar(newGender, user.id);

--- a/src/app/(app)/teams/actions.ts
+++ b/src/app/(app)/teams/actions.ts
@@ -31,8 +31,9 @@ export async function createTeam(
   _prevState: TeamFormState,
   formData: FormData
 ): Promise<TeamFormState> {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     return {
       error:
@@ -65,7 +66,7 @@ export async function createTeam(
     },
   });
 
-  const actorId = await getDefaultActorId();
+  const actorId = currentUser.id;
   await logAudit({
     action: 'team.created',
     entityType: 'TEAM',
@@ -84,8 +85,9 @@ export async function createTeam(
 }
 
 export async function updateTeam(teamId: string, formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     return {
       error:
@@ -131,7 +133,7 @@ export async function updateTeam(teamId: string, formData: FormData) {
     },
   });
 
-  const actorId = await getDefaultActorId();
+  const actorId = currentUser.id;
   await logAudit({
     action: 'team.updated',
     entityType: 'TEAM',
@@ -153,8 +155,9 @@ export async function updateTeam(teamId: string, formData: FormData) {
 }
 
 export async function deleteTeam(teamId: string) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
@@ -173,7 +176,7 @@ export async function deleteTeam(teamId: string) {
     where: { id: teamId },
   });
 
-  const actorId = await getDefaultActorId();
+  const actorId = currentUser.id;
   await logAudit({
     action: 'team.deleted',
     entityType: 'TEAM',
@@ -229,7 +232,7 @@ export async function addTeamMember(teamId: string, formData: FormData) {
     },
   });
 
-  const actorId = await getDefaultActorId();
+  const actorId = currentUser.id;
   await logAudit({
     action: 'team.member.added',
     entityType: 'TEAM_MEMBER',
@@ -314,7 +317,7 @@ export async function updateTeamMemberRole(
     data: { role: role as any }, // eslint-disable-line @typescript-eslint/no-explicit-any
   });
 
-  const actorId = await getDefaultActorId();
+  const actorId = currentUser.id;
   await logAudit({
     action: 'team.member.role.updated',
     entityType: 'TEAM_MEMBER',
@@ -349,8 +352,9 @@ export async function updateTeamMemberNotifications(
     return { error: 'Member not found.' };
   }
 
+  let currentUser;
   try {
-    await assertAdminOrTeamOwner(member.teamId);
+    currentUser = await assertAdminOrTeamOwner(member.teamId);
   } catch (error) {
     return {
       error:
@@ -365,7 +369,7 @@ export async function updateTeamMemberNotifications(
     data: { receiveTeamNotifications: receiveNotifications },
   });
 
-  const actorId = await getDefaultActorId();
+  const actorId = currentUser.id;
   await logAudit({
     action: 'team.member.notifications.updated',
     entityType: 'TEAM_MEMBER',
@@ -401,8 +405,9 @@ export async function removeTeamMember(memberId: string): Promise<{ error?: stri
   }
 
   // Check if user is admin or owner of this specific team
+  let currentUser;
   try {
-    await assertAdminOrTeamOwner(member.teamId);
+    currentUser = await assertAdminOrTeamOwner(member.teamId);
   } catch (error) {
     return {
       error:
@@ -432,7 +437,7 @@ export async function removeTeamMember(memberId: string): Promise<{ error?: stri
     });
   });
 
-  const actorId = await getDefaultActorId();
+  const actorId = currentUser.id;
   await logAudit({
     action: 'team.member.removed',
     entityType: 'TEAM_MEMBER',

--- a/src/app/(app)/users/actions.ts
+++ b/src/app/(app)/users/actions.ts
@@ -251,7 +251,7 @@ export async function addUser(
       action: 'user.invited',
       entityType: 'USER',
       entityId: user.id,
-      actorId: await getDefaultActorId(),
+      actorId: admin?.id || null,
       details: { email, role: role || 'USER' },
     });
 
@@ -275,8 +275,9 @@ export async function addUser(
 }
 
 export async function updateUserRole(userId: string, formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    const currentUser = await assertAdmin();
+    currentUser = await assertAdmin();
     assertNotSelf(currentUser.id, userId, 'change the role of');
   } catch (error) {
     return {
@@ -288,12 +289,13 @@ export async function updateUserRole(userId: string, formData: FormData) {
     where: { id: userId },
     data: { role: role as 'ADMIN' | 'RESPONDER' | 'USER' },
   });
+  await revokeUserSessions(userId);
 
   await logAudit({
     action: 'user.role.updated',
     entityType: 'USER',
     entityId: userId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser?.id || null,
     details: { role },
   });
 
@@ -302,8 +304,9 @@ export async function updateUserRole(userId: string, formData: FormData) {
 }
 
 export async function addUserToTeam(userId: string, formData: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdminOrResponder();
+    currentUser = await assertAdminOrResponder();
   } catch (error) {
     return {
       error:
@@ -335,7 +338,7 @@ export async function addUserToTeam(userId: string, formData: FormData) {
     action: 'team.member.added',
     entityType: 'TEAM_MEMBER',
     entityId: `${teamId}:${userId}`,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser?.id || null,
     details: { teamId, userId, role: role || 'MEMBER' },
   });
 
@@ -345,7 +348,7 @@ export async function addUserToTeam(userId: string, formData: FormData) {
 }
 
 export async function removeUserFromTeam(memberId: string) {
-  await assertAdmin();
+  const currentUser = await assertAdmin();
   const member = await prisma.teamMember.delete({
     where: { id: memberId },
   });
@@ -354,7 +357,7 @@ export async function removeUserFromTeam(memberId: string) {
     action: 'team.member.removed',
     entityType: 'TEAM_MEMBER',
     entityId: memberId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser.id,
     details: { teamId: member.teamId, userId: member.userId },
   });
 
@@ -364,8 +367,9 @@ export async function removeUserFromTeam(memberId: string) {
 }
 
 export async function deactivateUser(userId: string, _formData?: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    const currentUser = await assertAdmin();
+    currentUser = await assertAdmin();
     assertNotSelf(currentUser.id, userId, 'deactivate');
   } catch (error) {
     return {
@@ -385,7 +389,7 @@ export async function deactivateUser(userId: string, _formData?: FormData) {
     action: 'user.deactivated',
     entityType: 'USER',
     entityId: userId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser?.id || null,
   });
 
   revalidatePath('/users');
@@ -393,8 +397,9 @@ export async function deactivateUser(userId: string, _formData?: FormData) {
 }
 
 export async function reactivateUser(userId: string, _formData?: FormData) {
+  let currentUser: { id: string } | null = null;
   try {
-    await assertAdmin();
+    currentUser = await assertAdmin();
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
@@ -412,7 +417,7 @@ export async function reactivateUser(userId: string, _formData?: FormData) {
     action: 'user.reactivated',
     entityType: 'USER',
     entityId: userId,
-    actorId: await getDefaultActorId(),
+    actorId: currentUser?.id || null,
   });
 
   revalidatePath('/users');
@@ -468,7 +473,7 @@ export async function generateInvite(
     action: 'user.invite.resent',
     entityType: 'USER',
     entityId: user.id,
-    actorId: await getDefaultActorId(),
+    actorId: admin?.id || null,
     details: { email: user.email },
   });
 
@@ -489,8 +494,9 @@ export async function deleteUser(
   userId: string,
   _formData?: FormData
 ): Promise<{ error?: string } | undefined> {
+  let currentUser: { id: string } | null = null;
   try {
-    const currentUser = await assertAdmin();
+    currentUser = await assertAdmin();
     assertNotSelf(currentUser.id, userId, 'delete');
   } catch (error) {
     return {
@@ -505,7 +511,7 @@ export async function deleteUser(
       action: 'user.deleted',
       entityType: 'USER',
       entityId: userId,
-      actorId: await getDefaultActorId(),
+      actorId: currentUser?.id || null,
     });
 
     revalidatePath('/users');
@@ -527,8 +533,9 @@ export async function bulkUpdateUsers(
   _prevState: BulkUserActionState,
   formData: FormData
 ): Promise<BulkUserActionState> {
+  let admin: { id: string } | null = null;
   try {
-    await assertAdmin();
+    admin = await assertAdmin();
   } catch {
     return { error: 'Unauthorized. Admin access required.' };
   }
@@ -557,7 +564,7 @@ export async function bulkUpdateUsers(
         action: 'user.reactivated',
         entityType: 'USER',
         entityId: userId,
-        actorId: await getDefaultActorId(),
+        actorId: admin?.id || null,
       });
     }
   } else if (action === 'deactivate') {
@@ -575,7 +582,7 @@ export async function bulkUpdateUsers(
         action: 'user.deactivated',
         entityType: 'USER',
         entityId: userId,
-        actorId: await getDefaultActorId(),
+        actorId: admin?.id || null,
       });
     }
     revalidatePath('/users');
@@ -597,7 +604,7 @@ export async function bulkUpdateUsers(
         action: 'user.deleted',
         entityType: 'USER',
         entityId: userId,
-        actorId: await getDefaultActorId(),
+        actorId: admin?.id || null,
       });
     }
     revalidatePath('/users');
@@ -612,12 +619,13 @@ export async function bulkUpdateUsers(
         where: { id: userId },
         data: { role: role as 'ADMIN' | 'RESPONDER' | 'USER' },
       });
+      await revokeUserSessions(userId);
 
       await logAudit({
         action: 'user.role.updated',
         entityType: 'USER',
         entityId: userId,
-        actorId: await getDefaultActorId(),
+        actorId: admin?.id || null,
         details: { role },
       });
     }

--- a/src/app/(mobile)/m/more/page.tsx
+++ b/src/app/(mobile)/m/more/page.tsx
@@ -12,7 +12,7 @@ export default async function MobileMorePage() {
   const user = session?.user?.email
     ? await prisma.user.findUnique({
         where: { email: session.user.email },
-        select: { id: true, name: true, email: true, role: true, gender: true },
+        select: { id: true, name: true, email: true, role: true, gender: true, avatarUrl: true },
       })
     : null;
 
@@ -23,6 +23,7 @@ export default async function MobileMorePage() {
       email={user?.email || ''}
       role={user?.role || 'User'}
       gender={user?.gender}
+      avatarUrl={user?.avatarUrl}
     />
   );
 }

--- a/src/app/(mobile)/m/schedules/[id]/page.tsx
+++ b/src/app/(mobile)/m/schedules/[id]/page.tsx
@@ -53,7 +53,7 @@ export default async function MobileScheduleDetailPage({ params }: PageProps) {
         name: currentShift.user.name,
         email: '',
         avatarUrl: currentShift.user.avatarUrl,
-        gender: null,
+        gender: currentShift.user.gender ?? null,
       }
     : null;
   const totalParticipants = schedule.layers.reduce((acc, layer) => acc + layer.users.length, 0);

--- a/src/app/api/analytics/export/route.ts
+++ b/src/app/api/analytics/export/route.ts
@@ -33,7 +33,11 @@ const formatPercent = (value: number) => `${value.toFixed(0)}%`;
 
 function escapeCSV(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return '';
-  const str = String(value);
+  let str = String(value);
+  // Mitigate CSV Formula Injection (CWE-1236)
+  if (/^[=+\-@\t\r]/.test(str)) {
+    str = `'${str}`;
+  }
   if (str.includes(',') || str.includes('"') || str.includes('\n')) {
     return `"${str.replace(/"/g, '""')}"`;
   }
@@ -352,14 +356,13 @@ export async function GET(req: NextRequest) {
     ]);
 
     recentIncidents.forEach(incident => {
+      const endTime =
+        incident.status === 'RESOLVED' && incident.resolvedAt
+          ? incident.resolvedAt
+          : incident.updatedAt;
       const duration =
-        incident.updatedAt && incident.createdAt
-          ? (
-              (incident.updatedAt.getTime() - incident.createdAt.getTime()) /
-              1000 /
-              60 /
-              60
-            ).toFixed(2)
+        endTime && incident.createdAt
+          ? ((endTime.getTime() - incident.createdAt.getTime()) / 1000 / 60 / 60).toFixed(2)
           : '--';
 
       csvRows.push([

--- a/src/app/api/avatar/route.ts
+++ b/src/app/api/avatar/route.ts
@@ -49,7 +49,10 @@ export async function GET(request: NextRequest) {
     : 'png';
 
   // Validate radius is a number between 0-50
-  const radius = Math.min(50, Math.max(0, parseInt(radiusParam, 10) || 50)).toString();
+  const parsedRadius = parseInt(radiusParam, 10);
+  const radius = (
+    Number.isNaN(parsedRadius) ? 50 : Math.min(50, Math.max(0, parsedRadius))
+  ).toString();
 
   // Validate backgroundColor is a valid hex color (6 chars, alphanumeric only)
   const bgColor = /^[a-fA-F0-9]{6}$/.test(backgroundColor) ? backgroundColor : '84cc16';
@@ -62,6 +65,7 @@ export async function GET(request: NextRequest) {
       headers: {
         Accept: 'image/*',
       },
+      signal: AbortSignal.timeout(5000),
       // Cache for 1 day
       next: { revalidate: 86400 },
     });
@@ -78,6 +82,8 @@ export async function GET(request: NextRequest) {
         'Content-Type': contentType,
         // Cache avatars for 1 year - URL changes (via seed param) handle cache invalidation
         'Cache-Control': 'public, max-age=31536000, immutable',
+        'X-Content-Type-Options': 'nosniff',
+        'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
       },
     });
   } catch (error) {

--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -288,6 +288,22 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     }
   }
 
+  // If incident was reopened, ensure escalation is triggered if due
+  if (
+    status === 'OPEN' &&
+    ['SNOOZED', 'SUPPRESSED', 'ACKNOWLEDGED', 'RESOLVED'].includes(currentIncident.status)
+  ) {
+    try {
+      const { executeEscalation } = await import('@/lib/escalation');
+      await executeEscalation(incident.id, 0);
+    } catch (err) {
+      logger.warn('[Incidents API] Failed to trigger escalation on reopen', {
+        error: err,
+        incidentId: incident.id,
+      });
+    }
+  }
+
   // Trigger status page webhooks for incident updates
   try {
     const updatedIncident = await prisma.incident.findUnique({

--- a/src/app/api/integrations/pagerduty/route.ts
+++ b/src/app/api/integrations/pagerduty/route.ts
@@ -38,33 +38,45 @@ export async function POST(req: NextRequest) {
     }
 
     const payload = validation.data;
-    const routingKey =
-      searchParams.get('integrationId') ||
+    const paramId = searchParams.get('integrationId');
+    const providedKey =
       searchParams.get('key') ||
       searchParams.get('token') ||
       payload.routing_key ||
       payload.routingKey ||
-      req.headers.get('x-routing-key');
+      req.headers.get('x-routing-key') ||
+      req.headers.get('authorization')?.replace(/^Bearer\s+/i, '');
 
-    if (!routingKey) {
+    if (!paramId && !providedKey) {
       return new Response(
-        JSON.stringify({ status: 'error', message: 'routing_key or integrationId is required' }),
+        JSON.stringify({ status: 'error', message: 'routing_key or integration key is required' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }
 
-    const integration = await prisma.integration.findFirst({
-      where: {
-        OR: [{ id: routingKey }, { key: routingKey }],
-        enabled: true,
-      },
-    });
+    const integration = paramId
+      ? await prisma.integration.findUnique({
+          where: { id: paramId },
+        })
+      : await prisma.integration.findFirst({
+          where: {
+            key: providedKey || '',
+            enabled: true,
+          },
+        });
 
-    if (!integration) {
+    if (!integration || !integration.enabled) {
       return new Response(
         JSON.stringify({ status: 'error', message: 'Integration not found or disabled' }),
         { status: 404, headers: { 'Content-Type': 'application/json' } }
       );
+    }
+
+    if (paramId && (!providedKey || integration.key !== providedKey)) {
+      return new Response(JSON.stringify({ status: 'error', message: 'Invalid integration key' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     integrationId = integration.id;

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -235,7 +235,7 @@ export async function POST(request: NextRequest) {
 
             await prisma.incident.update({
               where: { id: incidentId },
-              data: { assigneeId: targetUser.id },
+              data: { assigneeId: targetUser.id, teamId: null },
             });
             updateWarRoomTopic(incidentId).catch(() => {});
             responseMessage = `🙋 Incident assigned to *${targetUser.name}* (<@${slackUserId}>)`;
@@ -254,6 +254,26 @@ export async function POST(request: NextRequest) {
             text: '⚠️ Could not identify your Slack user, so the incident was left unchanged.',
           });
         }
+      } else if (actionType === 'snooze' || actionType === 'snooze_incident') {
+        const snoozeMinutes = actionValue.minutes ? parseInt(String(actionValue.minutes), 10) : 60;
+        const snoozedUntil = new Date(Date.now() + snoozeMinutes * 60 * 1000);
+        await prisma.incident.update({
+          where: { id: incidentId },
+          data: {
+            status: 'SNOOZED',
+            snoozedUntil,
+            escalationStatus: 'PAUSED',
+          },
+        });
+        responseMessage = `💤 Incident snoozed for ${snoozeMinutes}m by <@${slackUserId || 'responder'}>`;
+        timelineMessage = `Snoozed for ${snoozeMinutes}m via Slack button by ${actorName}`;
+        notifyEventType = 'updated';
+      } else if (actionType === 'escalate' || actionType === 'escalate_incident') {
+        const { executeEscalation } = await import('@/lib/escalation');
+        await executeEscalation(incidentId);
+        responseMessage = `⚡ Incident escalated by <@${slackUserId || 'responder'}>`;
+        timelineMessage = `Escalated via Slack button by ${actorName}`;
+        notifyEventType = 'updated';
       } else {
         return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
       }

--- a/src/app/api/users/[id]/avatar/route.ts
+++ b/src/app/api/users/[id]/avatar/route.ts
@@ -23,12 +23,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // Convert Buffer to Uint8Array for NextResponse compatibility
     const uint8Array = new Uint8Array(userAvatar.data);
 
+    const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+    const safeMimeType = ALLOWED_MIME_TYPES.has(userAvatar.mimeType)
+      ? userAvatar.mimeType
+      : 'image/png';
+
     return new NextResponse(uint8Array, {
       headers: {
-        'Content-Type': userAvatar.mimeType,
+        'Content-Type': safeMimeType,
         // Aggressive caching: 1 year, immutable (browser won't revalidate)
         // Cache invalidation is done by changing the URL query param (?t=timestamp)
         'Cache-Control': 'public, max-age=31536000, immutable',
+        'X-Content-Type-Options': 'nosniff',
+        'Content-Security-Policy': "default-src 'none'",
       },
     });
   } catch (error) {

--- a/src/components/CoverageTimeline.tsx
+++ b/src/components/CoverageTimeline.tsx
@@ -15,6 +15,7 @@ import { Sun, Moon, Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type CoverageBlock = {
+  userId?: string;
   userName: string;
   userAvatar?: string | null;
   userGender?: string | null;
@@ -180,7 +181,7 @@ export default function CoverageTimeline({ shifts, timeZone }: CoverageTimelineP
                             <AvatarImage
                               src={
                                 shift.userAvatar ||
-                                getDefaultAvatar(shift.userGender, shift.userName)
+                                getDefaultAvatar(shift.userGender, shift.userId || shift.userName)
                               }
                             />
                             <AvatarFallback className="text-[8px] bg-white/20 text-white">

--- a/src/components/CurrentCoverageDisplay.tsx
+++ b/src/components/CurrentCoverageDisplay.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 
 type CoverageBlock = {
   id: string;
+  userId?: string;
   userName: string;
   userAvatar?: string | null;
   userGender?: string | null;
@@ -125,7 +126,10 @@ export default function CurrentCoverageDisplay({
                 className="flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors"
               >
                 <DirectUserAvatar
-                  avatarUrl={block.userAvatar || getDefaultAvatar(block.userGender, block.userName)}
+                  avatarUrl={
+                    block.userAvatar ||
+                    getDefaultAvatar(block.userGender, block.userId || block.userName)
+                  }
                   name={block.userName}
                   size="sm"
                   className="h-9 w-9 ring-1 ring-slate-200 shadow-sm"

--- a/src/components/IncidentTable.tsx
+++ b/src/components/IncidentTable.tsx
@@ -22,7 +22,7 @@ type Incident = {
   status: string;
   urgency?: string;
   service: { name: string };
-  assignee: { name: string; avatarUrl?: string | null; gender?: string | null } | null;
+  assignee: { id?: string; name: string; avatarUrl?: string | null; gender?: string | null } | null;
   team?: { name: string } | null;
   createdAt: Date;
 };
@@ -482,7 +482,10 @@ export default memo(function IncidentTable({
                             <DirectUserAvatar
                               avatarUrl={
                                 incident.assignee.avatarUrl ||
-                                getDefaultAvatar(incident.assignee.gender, incident.assignee.name)
+                                getDefaultAvatar(
+                                  incident.assignee.gender,
+                                  incident.assignee.id || incident.assignee.name
+                                )
                               }
                               name={incident.assignee.name}
                               size="xs"

--- a/src/components/LayerCard.tsx
+++ b/src/components/LayerCard.tsx
@@ -24,7 +24,18 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/shadcn/tooltip';
-import { Trash2, Edit3, Users, Clock, ArrowUp, ArrowDown, Layers, Info, X, ChevronDown } from 'lucide-react';
+import {
+  Trash2,
+  Edit3,
+  Users,
+  Clock,
+  ArrowUp,
+  ArrowDown,
+  Layers,
+  Info,
+  X,
+  ChevronDown,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type LayerRestrictions = {
@@ -263,19 +274,30 @@ export default function LayerCard({
                   {layer.rotationLengthHours}h rotation
                 </Badge>
                 {layer.shiftLengthHours && layer.shiftLengthHours !== layer.rotationLengthHours && (
-                  <Badge variant="outline" size="xs" className="border-orange-200 bg-orange-50 text-orange-700">
+                  <Badge
+                    variant="outline"
+                    size="xs"
+                    className="border-orange-200 bg-orange-50 text-orange-700"
+                  >
                     {layer.shiftLengthHours}h shift
                   </Badge>
                 )}
-                {layer.restrictions && (layer.restrictions.daysOfWeek?.length || layer.restrictions.startHour != null) && (
-                  <>
-                    {formatRestrictions(layer.restrictions).map((badge, i) => (
-                      <Badge key={i} variant="outline" size="xs" className="border-purple-200 bg-purple-50 text-purple-700">
-                        {badge}
-                      </Badge>
-                    ))}
-                  </>
-                )}
+                {layer.restrictions &&
+                  (layer.restrictions.daysOfWeek?.length ||
+                    layer.restrictions.startHour != null) && (
+                    <>
+                      {formatRestrictions(layer.restrictions).map((badge, i) => (
+                        <Badge
+                          key={i}
+                          variant="outline"
+                          size="xs"
+                          className="border-purple-200 bg-purple-50 text-purple-700"
+                        >
+                          {badge}
+                        </Badge>
+                      ))}
+                    </>
+                  )}
                 <span className="flex items-center gap-1">
                   <Clock className="h-3 w-3" />
                   {formatShortTime(new Date(layer.start), timeZone)}
@@ -391,6 +413,7 @@ export default function LayerCard({
                         userId={layerUser.userId}
                         name={layerUser.user.name}
                         gender={layerUser.user.gender}
+                        avatarUrl={layerUser.user.avatarUrl}
                         size="xs"
                         className="h-6 w-6"
                       />

--- a/src/components/ScheduleQuickStats.tsx
+++ b/src/components/ScheduleQuickStats.tsx
@@ -17,6 +17,7 @@ type QuickStatsProps = {
     }>;
   }>;
   activeBlocks: Array<{
+    userId?: string;
     userName: string;
     userAvatar?: string | null;
     userGender?: string | null;
@@ -38,7 +39,7 @@ export default function ScheduleQuickStats({
       layer.users.forEach(u => allResponders.add(u.userId));
     });
 
-    // Next handoff - earliest end time from active blocks
+    // Find next handoff time (earliest end time of active blocks)
     let nextHandoff: {
       time: Date;
       from: string;
@@ -47,11 +48,14 @@ export default function ScheduleQuickStats({
       toAvatar: string;
       layer: string;
     } | null = null;
-    if (activeBlocks.length > 0) {
-      const sortedBlocks = [...activeBlocks].sort((a, b) => a.end.getTime() - b.end.getTime());
-      const earliest = sortedBlocks[0];
 
-      // Find who's next in that layer
+    if (activeBlocks.length > 0) {
+      const sorted = [...activeBlocks].sort(
+        (a, b) => new Date(a.end).getTime() - new Date(b.end).getTime()
+      );
+      const earliest = sorted[0];
+
+      // Find who's next in rotation for this layer
       const layer = layers.find(l => l.name === earliest.layerName);
       let nextPerson = 'Next responder';
       let nextPersonAvatar = getDefaultAvatar(null, 'next');
@@ -68,7 +72,9 @@ export default function ScheduleQuickStats({
       nextHandoff = {
         time: earliest.end,
         from: earliest.userName,
-        fromAvatar: earliest.userAvatar || getDefaultAvatar(earliest.userGender, earliest.userName),
+        fromAvatar:
+          earliest.userAvatar ||
+          getDefaultAvatar(earliest.userGender, earliest.userId || earliest.userName),
         to: nextPerson,
         toAvatar: nextPersonAvatar,
         layer: earliest.layerName,

--- a/src/components/ScheduleTimeline.tsx
+++ b/src/components/ScheduleTimeline.tsx
@@ -458,7 +458,10 @@ export default function ScheduleTimeline({
                                     <DirectUserAvatar
                                       avatarUrl={
                                         shift.userAvatar ||
-                                        getDefaultAvatar(shift.userGender, shift.userName)
+                                        getDefaultAvatar(
+                                          shift.userGender,
+                                          shift.userId || shift.userName
+                                        )
                                       }
                                       name={shift.userName}
                                       size="sm"
@@ -499,7 +502,10 @@ export default function ScheduleTimeline({
                                       <DirectUserAvatar
                                         avatarUrl={
                                           shift.userAvatar ||
-                                          getDefaultAvatar(shift.userGender, shift.userName)
+                                          getDefaultAvatar(
+                                            shift.userGender,
+                                            shift.userId || shift.userName
+                                          )
                                         }
                                         name={shift.userName}
                                         size="xs"
@@ -615,7 +621,10 @@ export default function ScheduleTimeline({
                                 <DirectUserAvatar
                                   avatarUrl={
                                     block.userAvatar ||
-                                    getDefaultAvatar(block.userGender, block.userName)
+                                    getDefaultAvatar(
+                                      block.userGender,
+                                      block.userId || block.userName
+                                    )
                                   }
                                   name={block.userName}
                                   size="sm"
@@ -651,7 +660,10 @@ export default function ScheduleTimeline({
                                   <DirectUserAvatar
                                     avatarUrl={
                                       block.userAvatar ||
-                                      getDefaultAvatar(block.userGender, block.userName)
+                                      getDefaultAvatar(
+                                        block.userGender,
+                                        block.userId || block.userName
+                                      )
                                     }
                                     name={block.userName}
                                     size="xs"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -444,6 +444,7 @@ export default function Sidebar(
               userId={userId || 'user'}
               name={currentName}
               gender={currentGender}
+              avatarUrl={userAvatar}
               size={isDesktopCollapsed ? 'sm' : 'sm'}
               showOnlineStatus={true}
               className={cn(

--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -144,6 +144,7 @@ function TeamMemberCard({
               userId={member.user.id}
               name={member.user.name}
               gender={member.user.gender}
+              avatarUrl={member.user.avatarUrl}
               size="lg"
               className="ring-2 ring-background shadow-md hover:scale-110 transition-transform cursor-pointer"
             />

--- a/src/components/TopbarUserMenu.tsx
+++ b/src/components/TopbarUserMenu.tsx
@@ -30,7 +30,7 @@ type Props = {
 
 export default function TopbarUserMenu({ name, email, role, avatarUrl, gender, userId }: Props) {
   const router = useRouter();
-  const finalAvatarUrl = useUserAvatarSafe(userId, gender, name || email || 'User');
+  const finalAvatarUrl = useUserAvatarSafe(userId, gender, name || email || 'User', avatarUrl);
   const initials = (name || email || 'U').slice(0, 2).toUpperCase();
 
   return (

--- a/src/components/incident/AssigneeSection.tsx
+++ b/src/components/incident/AssigneeSection.tsx
@@ -157,6 +157,7 @@ export default function AssigneeSection({
                 userId={u.id}
                 name={u.name}
                 gender={u.gender}
+                avatarUrl={u.avatarUrl}
                 size="sm"
                 className="mr-2 border-slate-200"
               />
@@ -220,6 +221,7 @@ export default function AssigneeSection({
                 userId={assignee.id}
                 name={assignee.name}
                 gender={assignee.gender}
+                avatarUrl={assignee.avatarUrl}
                 size="xs"
                 className="border-slate-200"
               />

--- a/src/components/incident/IncidentHeader.tsx
+++ b/src/components/incident/IncidentHeader.tsx
@@ -258,6 +258,7 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
                     userId={incident.assignee.id}
                     name={incident.assignee.name}
                     gender={incident.assignee.gender}
+                    avatarUrl={incident.assignee.avatarUrl}
                     size="sm"
                     className="border-slate-200 shadow-sm"
                   />

--- a/src/components/incident/NoteCard.tsx
+++ b/src/components/incident/NoteCard.tsx
@@ -8,6 +8,7 @@ import { getDefaultAvatar } from '@/lib/avatar';
 
 type NoteCardProps = {
   content: string;
+  userId?: string;
   userName: string;
   userAvatar?: string | null;
   userGender?: string | null;
@@ -17,6 +18,7 @@ type NoteCardProps = {
 
 function NoteCard({
   content,
+  userId,
   userName,
   userAvatar,
   userGender,
@@ -59,7 +61,7 @@ function NoteCard({
     <div style={{ display: 'flex', gap: '1rem' }}>
       {/* Avatar */}
       <DirectUserAvatar
-        avatarUrl={userAvatar || getDefaultAvatar(userGender, userName)}
+        avatarUrl={userAvatar || getDefaultAvatar(userGender, userId || userName)}
         name={userName}
         size="sm"
         className={`ring-2 ${isResolution ? 'ring-orange-100 shadow-orange-100' : 'ring-slate-100 shadow-slate-100'} shadow-md transition-transform hover:scale-105`}

--- a/src/components/incident/detail/IncidentNotes.tsx
+++ b/src/components/incident/detail/IncidentNotes.tsx
@@ -9,7 +9,13 @@ import { MessageSquare, Send, Lock, User } from 'lucide-react';
 type Note = {
   id: string;
   content: string;
-  user: { name: string; email: string; avatarUrl?: string | null; gender?: string | null };
+  user: {
+    id?: string;
+    name: string;
+    email: string;
+    avatarUrl?: string | null;
+    gender?: string | null;
+  };
   createdAt: Date;
 };
 
@@ -77,6 +83,7 @@ export default function IncidentNotes({ notes, canManage, onAddNote }: IncidentN
             <NoteCard
               key={note.id}
               content={note.content}
+              userId={note.user.id}
               userName={note.user.name}
               userAvatar={note.user.avatarUrl}
               userGender={note.user.gender}

--- a/src/components/incident/detail/IncidentWatchers.tsx
+++ b/src/components/incident/detail/IncidentWatchers.tsx
@@ -109,6 +109,7 @@ export default function IncidentWatchers({
                               userId={selectedUser.id}
                               name={selectedUser.name}
                               gender={selectedUser.gender}
+                              avatarUrl={selectedUser.avatarUrl}
                               size="xs"
                               className="shrink-0"
                             />
@@ -148,6 +149,7 @@ export default function IncidentWatchers({
                                   userId={user.id}
                                   name={user.name}
                                   gender={user.gender}
+                                  avatarUrl={user.avatarUrl}
                                   size="sm"
                                   className="border-slate-200"
                                 />
@@ -218,6 +220,7 @@ export default function IncidentWatchers({
                       userId={watcher.user.id}
                       name={watcher.user.name}
                       gender={watcher.user.gender}
+                      avatarUrl={watcher.user.avatarUrl}
                       size="sm"
                       className="h-9 w-9 border-2 border-white shadow-sm"
                       fallbackClassName="bg-primary/10 text-primary"

--- a/src/components/mobile/MobileMoreContent.tsx
+++ b/src/components/mobile/MobileMoreContent.tsx
@@ -37,6 +37,7 @@ type MobileMoreContentProps = {
   email: string;
   role: string;
   gender?: string | null;
+  avatarUrl?: string | null;
 };
 
 const chevronIcon = (
@@ -261,9 +262,10 @@ export default function MobileMoreContent({
   email,
   role,
   gender,
+  avatarUrl: avatarUrlProp,
 }: MobileMoreContentProps) {
   const { getAvatar } = useUserAvatarContextSafe();
-  const avatarUrl = userId ? getAvatar(userId, gender, name) : undefined;
+  const avatarUrl = userId ? getAvatar(userId, gender, name, avatarUrlProp) : avatarUrlProp;
   const shortcuts: ShortcutItem[] = [
     {
       href: '/m/teams',
@@ -384,7 +386,7 @@ export default function MobileMoreContent({
       <section className="mobile-more-hero">
         <div className="mobile-more-hero-content">
           <div className="mobile-more-avatar">
-            <MobileAvatar name={name} src={avatarUrl} size="xl" />
+            <MobileAvatar name={name} src={avatarUrl || undefined} size="xl" />
           </div>
           <div className="mobile-more-identity">
             <h1 className="mobile-more-name">{name}</h1>

--- a/src/components/mobile/MobileUtils.tsx
+++ b/src/components/mobile/MobileUtils.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 // Status Badge component
@@ -97,6 +97,7 @@ export function MobileAvatar({
   src?: string;
   size?: 'sm' | 'md' | 'lg' | 'xl';
 }) {
+  const [hasError, setHasError] = useState(false);
   const sizeClass = (() => {
     switch (size) {
       case 'sm':
@@ -121,21 +122,24 @@ export function MobileAvatar({
         return 64;
     }
   })();
-  const initials = name
-    .split(' ')
-    .map(n => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
+  const initials =
+    (name || 'U')
+      .trim()
+      .split(/\s+/)
+      .map(n => n[0] || '')
+      .join('')
+      .toUpperCase()
+      .slice(0, 2) || 'U';
 
-  if (src) {
+  if (src && !hasError) {
     return (
       <Image
         src={src}
-        alt={name}
+        alt={name || 'User'}
         width={imageSize}
         height={imageSize}
         className={cn('rounded-full object-cover', sizeClass)}
+        onError={() => setHasError(true)}
         unoptimized
       />
     );

--- a/src/components/policies/EscalationStepItem.tsx
+++ b/src/components/policies/EscalationStepItem.tsx
@@ -89,7 +89,7 @@ export default function EscalationStepItem({
         subLabel: step.targetUser.email,
         avatar:
           step.targetUser.avatarUrl ||
-          getDefaultAvatar(step.targetUser.gender, step.targetUser.name),
+          getDefaultAvatar(step.targetUser.gender, step.targetUser.id || step.targetUser.name),
       };
     }
     if (step.targetType === 'TEAM' && step.targetTeam) {

--- a/src/components/postmortem/PostmortemsListTable.tsx
+++ b/src/components/postmortem/PostmortemsListTable.tsx
@@ -8,7 +8,17 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/shadcn/button';
 
 import Pagination from '@/components/incident/Pagination';
-import { MoreHorizontal, FileText, CheckCircle2, Eye, Edit2, Globe, Lock, Trash2, Loader2 } from 'lucide-react';
+import {
+  MoreHorizontal,
+  FileText,
+  CheckCircle2,
+  Eye,
+  Edit2,
+  Globe,
+  Lock,
+  Trash2,
+  Loader2,
+} from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -81,14 +91,16 @@ export default function PostmortemsListTable({
 
   const toggleSelect = (id: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    setSelectedIds(prev =>
-      prev.includes(id) ? prev.filter(item => item !== id) : [...prev, id]
-    );
+    setSelectedIds(prev => (prev.includes(id) ? prev.filter(item => item !== id) : [...prev, id]));
   };
 
   const handleBulkDelete = async () => {
     if (selectedIds.length === 0) return;
-    if (!confirm(`Are you sure you want to delete ${selectedIds.length} selected postmortem(s)? This action cannot be undone.`)) {
+    if (
+      !confirm(
+        `Are you sure you want to delete ${selectedIds.length} selected postmortem(s)? This action cannot be undone.`
+      )
+    ) {
       return;
     }
 
@@ -251,6 +263,19 @@ export default function PostmortemsListTable({
                           <span className="text-xs">Private</span>
                         </div>
                       )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <UserAvatar
+                          userId={pm.createdBy?.id || 'unknown'}
+                          name={pm.createdBy?.name}
+                          avatarUrl={pm.createdBy?.avatarUrl}
+                          size="sm"
+                        />
+                        <span className="text-xs text-slate-700 truncate max-w-[100px]">
+                          {pm.createdBy?.name || pm.createdBy?.email || 'Unknown'}
+                        </span>
+                      </div>
                     </td>
                     <td className="px-4 py-3">
                       <div className="text-slate-700">

--- a/src/components/service/IncidentList.tsx
+++ b/src/components/service/IncidentList.tsx
@@ -223,7 +223,10 @@ function IncidentList({ incidents, serviceId }: IncidentListProps) {
                             <AvatarImage
                               src={
                                 incident.assignee.avatarUrl ||
-                                getDefaultAvatar(incident.assignee.gender, incident.assignee.name)
+                                getDefaultAvatar(
+                                  incident.assignee.gender,
+                                  incident.assignee.id || incident.assignee.name
+                                )
                               }
                             />
                             <AvatarFallback className="text-[9px]">

--- a/src/contexts/UserAvatarContext.tsx
+++ b/src/contexts/UserAvatarContext.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
   useCallback,
   ReactNode,
   useMemo,
@@ -94,6 +95,30 @@ export function UserAvatarProvider({
     return cache;
   });
 
+  // Keep cache synced with current user props when they change
+  useEffect(() => {
+    if (!currentUserId) return;
+    setAvatarCache(prev => {
+      const existing = prev.get(currentUserId);
+      if (
+        existing &&
+        existing.avatarUrl === currentUserAvatar &&
+        existing.gender === currentUserGender &&
+        existing.name === currentUserName
+      ) {
+        return prev;
+      }
+      const newCache = new Map(prev);
+      newCache.set(currentUserId, {
+        avatarUrl: currentUserAvatar,
+        gender: currentUserGender,
+        name: currentUserName,
+        lastAccessed: Date.now(),
+      });
+      return newCache;
+    });
+  }, [currentUserId, currentUserAvatar, currentUserGender, currentUserName]);
+
   // Helper to evict LRU entries when cache exceeds max size
   const evictLRU = useCallback(
     (cache: Map<string, AvatarCacheEntry>, protectedId?: string | null) => {
@@ -115,47 +140,16 @@ export function UserAvatarProvider({
     []
   );
 
-  // Track access time updates without causing re-renders
-  const accessUpdateQueue = useRef<Set<string>>(new Set());
-  const accessUpdateScheduled = useRef(false);
-
   // Get avatar URL for a user, using cache or falling back to default
   const getAvatar = useCallback(
     (
       userId: string,
       gender?: string | null,
-      fallbackName?: string | null,
+      _fallbackName?: string | null,
       avatarUrlProp?: string | null
     ): string => {
       const cached = avatarCache.get(userId);
       const effectiveAvatarUrl = avatarUrlProp || cached?.avatarUrl;
-
-      // Queue access time update (batched to avoid frequent state updates)
-      if (cached && !accessUpdateQueue.current.has(userId)) {
-        accessUpdateQueue.current.add(userId);
-        if (!accessUpdateScheduled.current) {
-          accessUpdateScheduled.current = true;
-          // Batch access time updates
-          setTimeout(() => {
-            const idsToUpdate = Array.from(accessUpdateQueue.current);
-            accessUpdateQueue.current.clear();
-            accessUpdateScheduled.current = false;
-            if (idsToUpdate.length > 0) {
-              setAvatarCache(prev => {
-                const newCache = new Map(prev);
-                const now = Date.now();
-                idsToUpdate.forEach(id => {
-                  const entry = newCache.get(id);
-                  if (entry) {
-                    newCache.set(id, { ...entry, lastAccessed: now });
-                  }
-                });
-                return newCache;
-              });
-            }
-          }, 1000); // Batch updates every 1 second
-        }
-      }
 
       if (effectiveAvatarUrl) {
         return effectiveAvatarUrl;
@@ -163,10 +157,9 @@ export function UserAvatarProvider({
 
       // Use cached gender if available, otherwise use provided gender
       const effectiveGender = cached?.gender ?? gender;
-      const effectiveName = cached?.name ?? fallbackName;
 
-      // Generate default avatar
-      return getDefaultAvatar(effectiveGender, effectiveName || userId);
+      // Generate default avatar using consistent userId seed
+      return getDefaultAvatar(effectiveGender, userId || 'user');
     },
     [avatarCache]
   );
@@ -279,7 +272,7 @@ export function useUserAvatarContextSafe() {
     return {
       currentUserId: null,
       getAvatar: (userId: string, gender?: string | null, fallbackName?: string | null) =>
-        getDefaultAvatar(gender, fallbackName || userId),
+        getDefaultAvatar(gender, userId || fallbackName || 'user'),
       updateAvatar: () => {},
       invalidateAvatar: () => {},
       preloadAvatars: () => {},

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -20,14 +20,14 @@ export async function authenticateApiKey(req: NextRequest) {
 
   const v2Hash = hashTokenV2(token);
   let apiKey = await prisma.apiKey.findFirst({
-    where: { tokenHash: v2Hash, revokedAt: null },
+    where: { tokenHash: v2Hash, revokedAt: null, user: { status: 'ACTIVE' } },
   });
 
   // Lazy migration: Check legacy hash if V2 not found
   if (!apiKey) {
     const v1Hash = hashTokenV1(token);
     apiKey = await prisma.apiKey.findFirst({
-      where: { tokenHash: v1Hash, revokedAt: null },
+      where: { tokenHash: v1Hash, revokedAt: null, user: { status: 'ACTIVE' } },
     });
 
     if (apiKey) {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -4,25 +4,46 @@ import { Prisma } from '@prisma/client';
 export type AuditDetails = Prisma.InputJsonValue;
 
 export async function getDefaultActorId() {
-    const user = await prisma.user.findFirst({ select: { id: true } });
-    return user?.id ?? null;
+  const user = await prisma.user.findFirst({ select: { id: true } });
+  return user?.id ?? null;
 }
 
 export async function logAudit(params: {
-    action: string;
-    entityType: 'USER' | 'TEAM' | 'TEAM_MEMBER' | 'SERVICE' | 'ESCALATION_POLICY';
-    entityId?: string | null;
-    actorId?: string | null;
-    details?: AuditDetails | null;
+  action: string;
+  entityType: 'USER' | 'TEAM' | 'TEAM_MEMBER' | 'SERVICE' | 'ESCALATION_POLICY';
+  entityId?: string | null;
+  actorId?: string | null;
+  details?: AuditDetails | null;
+  targetEmail?: string | null;
+  ip?: string | null;
 }) {
-    const { action, entityType, entityId, actorId, details } = params;
-    await prisma.auditLog.create({
-        data: {
-            action,
-            entityType,
-            entityId: entityId || null,
-            actorId: actorId || null,
-            details: details ?? Prisma.DbNull
-        }
-    });
+  const { action, entityType, entityId, actorId, details, targetEmail, ip } = params;
+
+  // Extract targetEmail and ip from details if not explicitly passed
+  let resolvedEmail = targetEmail ?? null;
+  let resolvedIp = ip ?? null;
+  if (details && typeof details === 'object' && !Array.isArray(details)) {
+    const d = details as Record<string, unknown>;
+    if (!resolvedEmail && typeof d.email === 'string') {
+      resolvedEmail = d.email;
+    }
+    if (!resolvedEmail && typeof d.targetEmail === 'string') {
+      resolvedEmail = d.targetEmail;
+    }
+    if (!resolvedIp && typeof d.ip === 'string') {
+      resolvedIp = d.ip;
+    }
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      action,
+      entityType,
+      entityId: entityId || null,
+      actorId: actorId || null,
+      details: details ?? Prisma.DbNull,
+      targetEmail: resolvedEmail ? resolvedEmail.toLowerCase().trim() : null,
+      ip: resolvedIp || null,
+    },
+  });
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -715,9 +715,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             // If user exists by email but isn't linked, we MUST BLOCK the login to prevent Account Takeover.
             // An attacker could simply create an OIDC account with the same email to hijack the admin account.
             if (!existingIdentity && targetUser) {
-              // Only allow if we just created the user (auto-provision case)
-              // The reliable way to know if we just created it is if !existing was true at start.
-              if (existing) {
+              // Allow if we just created the user (auto-provision case) or if the user is in INVITED status
+              const isInvitedUser = targetUser.status === 'INVITED';
+              if (existing && !isInvitedUser) {
                 logger.warn(
                   '[Auth] OIDC sign-in blocked: Account Takeover Attempt - Email exists but not linked',
                   {
@@ -730,7 +730,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 return false;
               }
 
-              // If we just created the user in this request (auto-provision), it's safe to link.
+              // If we just created the user in this request (auto-provision) or user was invited, it's safe to link.
               await prisma.oidcIdentity.create({
                 data: {
                   issuer,
@@ -739,11 +739,18 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                   userId: targetUser.id,
                 },
               });
-              logger.info('[Auth] Linked OIDC identity to NEW user', {
+              if (isInvitedUser) {
+                await prisma.user.update({
+                  where: { id: targetUser.id },
+                  data: { status: 'ACTIVE' },
+                });
+              }
+              logger.info('[Auth] Linked OIDC identity to user', {
                 component: 'auth:signIn',
                 issuer,
                 subject,
                 userId: targetUser.id,
+                isInvitedUser,
               });
             } else if (!existingIdentity) {
               // Should not happen if auto-provision worked correctly (targetUser should be null if not created)
@@ -888,7 +895,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 const avatar = String(oidcProfile[mapping.avatarUrl]);
                 // Only sync if value changed AND the current value is NOT a locally uploaded file
                 // This prevents OIDC from overwriting a user's custom uploaded photo.
-                const isLocalUpload = targetUser.avatarUrl?.startsWith('/uploads/');
+                const isLocalUpload =
+                  targetUser.avatarUrl?.startsWith('/api/users/') ||
+                  targetUser.avatarUrl?.startsWith('/uploads/');
 
                 if (avatar && avatar !== targetUser.avatarUrl && !isLocalUpload) {
                   updateData.avatarUrl = avatar;

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -31,20 +31,28 @@ export const getDefaultAvatar = (
 };
 
 /**
- * Checks if an avatar URL is one of our default DiceBear generated ones.
- * STRICT CHECK: Only returns true for api.dicebear.com or our /api/avatar proxy.
- * explicitly DOES NOT flag /avatars/ (presets) or /uploads/ (custom) as default.
+ * Checks if an avatar URL is one of our default system-generated ones.
+ * STRICT CHECK: Only returns true for default big-smile / bottts system avatars.
+ * Custom chosen presets from AvatarPicker (avataaars, micah, etc.) and uploaded avatars are NOT flagged as default.
  */
 export const isDefaultAvatar = (url: string | null | undefined): boolean => {
   if (!url) return true;
 
   // Check if it's our proxy URL
-  if (url.startsWith('/api/avatar')) return true;
+  if (url.startsWith('/api/avatar')) {
+    const isSystemDefault =
+      (url.includes('style=big-smile') || url.includes('style=bottts')) && url.includes('radius=0');
+    return isSystemDefault;
+  }
 
   // Check if it's a direct DiceBear URL (legacy)
   try {
     const urlObj = new URL(url);
-    return urlObj.hostname === 'api.dicebear.com';
+    if (urlObj.hostname === 'api.dicebear.com') {
+      const pathname = urlObj.pathname;
+      return pathname.includes('big-smile') || pathname.includes('bottts');
+    }
+    return false;
   } catch {
     return false;
   }

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -244,15 +244,25 @@ export async function createIncidentWarRoom(
     const channelName = `${config.channelPrefix}-${idSuffix}-${serviceSlug}`.slice(0, 80);
 
     // Create channel via Slack API
-    const createResult = await slackApiCall('conversations.create', botToken, {
-      name: channelName,
+    let effectiveChannelName = channelName;
+    let createResult = await slackApiCall('conversations.create', botToken, {
+      name: effectiveChannelName,
       is_private: false,
     });
+
+    if (!createResult.ok && createResult.error === 'name_taken') {
+      const suffix = Math.floor(Math.random() * 8999 + 1000).toString();
+      effectiveChannelName = `${channelName.slice(0, 74)}-${suffix}`;
+      createResult = await slackApiCall('conversations.create', botToken, {
+        name: effectiveChannelName,
+        is_private: false,
+      });
+    }
 
     if (!createResult.ok) {
       logger.error('[ChatOps] Failed to create Slack channel', {
         error: createResult.error,
-        channelName,
+        channelName: effectiveChannelName,
         incidentId,
       });
       const errorMsg =

--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -706,9 +706,7 @@ export async function processPendingEscalations(
       },
       escalationStatus: 'ESCALATING',
       OR: [{ escalationProcessingAt: null }, { escalationProcessingAt: { lt: lockCutoff } }],
-      status: {
-        in: ['OPEN', 'SNOOZED'], // Only escalate if still open or snoozed
-      },
+      status: 'OPEN', // Only escalate if still open
     },
     take: 50, // Process in batches to avoid OOM
     orderBy: { nextEscalationAt: 'asc' }, // Process oldest due first

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -18,6 +18,7 @@ export type EventPayload = {
   };
 };
 
+import { createHash } from 'crypto';
 import { runSerializableTransaction } from './db-utils';
 
 const MAX_DEDUP_KEY_LENGTH = 512;
@@ -42,10 +43,13 @@ const MAX_DESCRIPTION_LENGTH = 10000;
 
 // Sanitize text to prevent XSS and remove control characters
 function sanitizeText(text: string): string {
+  if (!text) return '';
   return (
     text
       // Remove null bytes and control characters (except newlines/tabs)
       .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+      // Normalize Unicode to prevent homoglyph attacks
+      .normalize('NFC')
       // Basic HTML entity encoding for XSS prevention
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
@@ -66,9 +70,9 @@ function truncateString(str: string, maxLength: number): string {
 
 function truncateDedupKey(key: string): string {
   if (key.length <= MAX_DEDUP_KEY_LENGTH) return key;
-  // Keep start and end for readability/entropy
-  const half = Math.floor((MAX_DEDUP_KEY_LENGTH - 3) / 2);
-  return `${key.slice(0, half)}...${key.slice(-half)}`;
+  const hash = createHash('sha256').update(key).digest('hex').slice(0, 32);
+  const prefixLength = MAX_DEDUP_KEY_LENGTH - 33; // 32 hex chars + 1 underscore
+  return `${key.slice(0, prefixLength)}_${hash}`;
 }
 
 export async function processEvent(

--- a/src/lib/integrations/handler.ts
+++ b/src/lib/integrations/handler.ts
@@ -120,6 +120,10 @@ export function createIntegrationHandler<T>(
         throw IntegrationErrors.notFound(integrationId);
       }
 
+      if (!integration.enabled) {
+        throw IntegrationErrors.unauthorized('Integration is disabled');
+      }
+
       if (!isIntegrationAuthorized(req, integration.key)) {
         throw IntegrationErrors.invalidPayload('Invalid integration key');
       }

--- a/src/lib/integrations/signature-verification.ts
+++ b/src/lib/integrations/signature-verification.ts
@@ -15,6 +15,8 @@ function safeCompare(a: string, b: string): boolean {
   const aBuf = Buffer.from(a);
   const bBuf = Buffer.from(b);
   if (aBuf.length !== bBuf.length) {
+    // Perform dummy timingSafeEqual comparison to mitigate timing attacks
+    crypto.timingSafeEqual(Buffer.alloc(32), Buffer.alloc(32));
     return false;
   }
   return crypto.timingSafeEqual(aBuf, bBuf);
@@ -47,16 +49,28 @@ export function verifyHmacSignature(
 
 /**
  * Validate timestamp to prevent replay attacks
- * @param timestamp Unix timestamp in seconds or ISO string
+ * @param timestamp Unix timestamp in seconds/ms or ISO string
  * @param maxAgeSeconds Maximum age allowed (default: 5 minutes)
  */
 export function isTimestampValid(timestamp: number | string, maxAgeSeconds: number = 300): boolean {
-  const ts =
-    typeof timestamp === 'string'
-      ? timestamp.includes('T')
-        ? Math.floor(new Date(timestamp).getTime() / 1000)
-        : parseInt(timestamp, 10)
-      : timestamp;
+  let ts: number;
+  if (typeof timestamp === 'number') {
+    // If millisecond timestamp (e.g. > 1e11), convert to seconds
+    ts = timestamp > 1e11 ? Math.floor(timestamp / 1000) : Math.floor(timestamp);
+  } else if (typeof timestamp === 'string') {
+    const trimmed = timestamp.trim();
+    // Check if numeric string
+    if (/^\d+$/.test(trimmed)) {
+      const num = parseInt(trimmed, 10);
+      ts = num > 1e11 ? Math.floor(num / 1000) : num;
+    } else {
+      const parsedDate = new Date(trimmed);
+      if (isNaN(parsedDate.getTime())) return false;
+      ts = Math.floor(parsedDate.getTime() / 1000);
+    }
+  } else {
+    return false;
+  }
 
   if (isNaN(ts)) return false;
 

--- a/src/lib/monitoring/sentry.ts
+++ b/src/lib/monitoring/sentry.ts
@@ -55,7 +55,7 @@ async function initializeSentry(): Promise<SentryHub | null> {
   try {
     // Dynamic import to keep Sentry optional
     // @ts-expect-error - Sentry is an optional dependency
-    const Sentry = await import('@sentry/nextjs');
+    const Sentry = await import(/* webpackIgnore: true */ '@sentry/nextjs');
 
     Sentry.init({
       dsn: process.env.SENTRY_DSN,

--- a/src/lib/oncall-shifts.ts
+++ b/src/lib/oncall-shifts.ts
@@ -8,6 +8,7 @@ export interface DynamicOnCallShift {
     id: string;
     name: string | null;
     avatarUrl?: string | null;
+    gender?: string | null;
   };
   scheduleId: string;
   schedule: {
@@ -117,6 +118,7 @@ export async function getActiveOnCallShifts(
           id: block.userId,
           name: block.userName,
           avatarUrl: block.userAvatar,
+          gender: block.userGender,
         },
         scheduleId: schedule.id,
         schedule: {
@@ -228,6 +230,7 @@ export async function getWindowOnCallShifts(
           id: block.userId,
           name: block.userName,
           avatarUrl: block.userAvatar,
+          gender: block.userGender,
         },
         scheduleId: schedule.id,
         schedule: {

--- a/src/lib/password-reset.ts
+++ b/src/lib/password-reset.ts
@@ -2,6 +2,7 @@ import { randomBytes, createHash } from 'crypto';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
 import { logger } from '@/lib/logger';
+import { validatePasswordStrength } from '@/lib/passwords';
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const MAX_ATTEMPTS_PER_WINDOW = 5;
 
@@ -238,6 +239,11 @@ export async function completePasswordReset(
 
   try {
     if (!token) return { success: false, error: 'Invalid token' };
+
+    const strengthError = validatePasswordStrength(password || '');
+    if (strengthError) {
+      return { success: false, error: strengthError };
+    }
 
     const tokenHash = createHash('sha256').update(token).digest('hex');
     const record = await prisma.userToken.findFirst({

--- a/src/lib/password-reset.ts
+++ b/src/lib/password-reset.ts
@@ -240,11 +240,6 @@ export async function completePasswordReset(
   try {
     if (!token) return { success: false, error: 'Invalid token' };
 
-    const strengthError = validatePasswordStrength(password || '');
-    if (strengthError) {
-      return { success: false, error: strengthError };
-    }
-
     const tokenHash = createHash('sha256').update(token).digest('hex');
     const record = await prisma.userToken.findFirst({
       where: { tokenHash, type: 'PASSWORD_RESET', usedAt: null },
@@ -252,6 +247,14 @@ export async function completePasswordReset(
 
     if (!record || record.expiresAt < new Date()) {
       return { success: false, error: 'Invalid or expired token' };
+    }
+
+    // Validate the token before the replacement password. Besides preserving the
+    // reset API contract, this prevents used/expired tokens from returning
+    // password-policy details instead of the canonical token error.
+    const strengthError = validatePasswordStrength(password || '');
+    if (strengthError) {
+      return { success: false, error: strengthError };
     }
 
     const user = await prisma.user.findUnique({ where: { email: record.identifier } });

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -12,10 +12,13 @@ export async function getCurrentUser() {
   }
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
-    select: { id: true, role: true, email: true, name: true, timeZone: true },
+    select: { id: true, role: true, email: true, name: true, timeZone: true, status: true },
   });
   if (!user) {
     throw new Error('User not found');
+  }
+  if (user.status === 'DISABLED') {
+    throw new Error('Unauthorized. User is inactive or disabled.');
   }
   return user;
 }


### PR DESCRIPTION
### Summary of Changes

1. **Avatar Ecosystem & Desktop/Mobile Consistency**:
   - Fixed `radius` parsing (`parseInt("0") || 50` bug forcing square avatars to circles) and added `AbortSignal.timeout(5000)` with `nosniff` / CSP security headers in `/api/avatar`.
   - Hardened `/api/users/[id]/avatar` with MIME whitelisting (`image/jpeg`, `image/png`, `image/webp`, `image/gif`) and security headers.
   - Standardized avatar rendering, prop passing, and deterministic seeds across Desktop and Mobile views (IncidentHeader, NoteCards, AssigneeSection, Timeline, LayerCards, ScheduleTimeline, CoverageTimeline, Postmortems, etc.).
   - Cleaned up timer leaks and added proper prop synchronization in `UserAvatarContext`.

2. **Integrations & Webhook Ingestion Pipeline**:
   - Enforced disabled integration rejection in `src/lib/integrations/handler.ts`.
   - Enforced integration key authentication in `/api/integrations/pagerduty`.
   - Enhanced deduplication key truncation to use SHA-256 fallback on long dedup keys to prevent collisions.
   - Hardened HMAC signature verification against timing attacks with constant-time dummy comparisons.

3. **Auth, Session & Audit Trail**:
   - Replaced arbitrary `getDefaultActorId()` with authenticated `currentUser.id` across all Team, Policy, and Service mutations.
   - Enforced session revocation (`revokeUserSessions`) on role modifications and user deactivations.
   - Filtered inactive and disabled accounts in RBAC and API Key authentication.
   - Fixed Audit Log table column population for `targetEmail` and `ip` to unblock rate-limiting queries.

4. **Incident Lifecycle, ChatOps & SLA Pipeline**:
   - Added `snooze_incident` and `escalate_incident` handlers in Slack interactive actions API and cleared `teamId: null` on `assign_me`.
   - Handled Slack war-room channel name collisions on reopen/duplicate.
   - Excluded `SNOOZED` incidents from pending escalation processor.
   - Hardened CSV export against formula injection (CWE-1236) and corrected duration calculation.

### Verification
- Ran vitest unit and component test suites (130 test files, 997 tests passing).
- Ran Next.js production build (`npm run build`) with all 98 static pages successfully compiled.