### PR TITLE
fix(auth): securely link admin-provisioned users on first OIDC login

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -705,32 +705,54 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             const subject =
               account?.providerAccountId ||
               (profile as any)?.sub || // eslint-disable-line @typescript-eslint/no-explicit-any
-              user.id;
+              null;
+
+            if (!subject) {
+              logger.warn('[Auth] OIDC sign-in rejected: stable subject claim missing', {
+                component: 'auth:signIn',
+                issuer,
+                email,
+              });
+              return false;
+            }
 
             const existingIdentity = await prisma.oidcIdentity.findUnique({
               where: { issuer_subject: { issuer, subject } },
             });
 
-            // SECURITY: If no identity link exists, check if user exists by email.
-            // If user exists by email but isn't linked, we MUST BLOCK the login to prevent Account Takeover.
-            // An attacker could simply create an OIDC account with the same email to hijack the admin account.
-            if (!existingIdentity && targetUser) {
-              // Allow if we just created the user (auto-provision case) or if the user is in INVITED status
+            if (!existingIdentity) {
               const isInvitedUser = targetUser.status === 'INVITED';
+              let hasProvisioningEvidence = false;
+
+              // Existing ACTIVE users may have completed the password invite before trying SSO.
+              // The used INVITE token is intentionally retained for audit history, so it is a
+              // durable server-side signal that an administrator provisioned this email address.
               if (existing && !isInvitedUser) {
-                logger.warn(
-                  '[Auth] OIDC sign-in blocked: Account Takeover Attempt - Email exists but not linked',
-                  {
+                const inviteRecord = await prisma.userToken.findFirst({
+                  where: { identifier: email, type: 'INVITE' },
+                  select: { id: true },
+                });
+                hasProvisioningEvidence = !!inviteRecord;
+              }
+
+              // SECURITY: Never link a pre-existing account on email match alone. For an
+              // existing user we require BOTH explicit admin-provisioning evidence and an
+              // explicit email_verified=true claim from the configured OIDC provider.
+              if (existing) {
+                const adminProvisioned = isInvitedUser || hasProvisioningEvidence;
+                if (!adminProvisioned || emailVerifiedClaim !== true) {
+                  logger.warn('[Auth] OIDC sign-in blocked: existing account is not safe to link', {
                     component: 'auth:signIn',
                     email,
                     issuer,
                     subject,
-                  }
-                );
-                return false;
+                    adminProvisioned,
+                    emailVerified: emailVerifiedClaim === true,
+                  });
+                  return false;
+                }
               }
 
-              // If we just created the user in this request (auto-provision) or user was invited, it's safe to link.
               await prisma.oidcIdentity.create({
                 data: {
                   issuer,
@@ -751,12 +773,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 subject,
                 userId: targetUser.id,
                 isInvitedUser,
+                adminProvisioned: !!existing,
               });
-            } else if (!existingIdentity) {
-              // Should not happen if auto-provision worked correctly (targetUser should be null if not created)
-              // But if targetUser exists (which it does via auto-provision), we handle it above.
-              // This block effectively unreachable if targetUser is ensured.
-            } else if (existingIdentity && existingIdentity.userId !== targetUser.id) {
+            } else if (existingIdentity.userId !== targetUser.id) {
               logger.warn('[Auth] OIDC sign-in rejected: identity already linked to another user', {
                 component: 'auth:signIn',
                 issuer,

--- a/tests/lib/auth-oidc-unit.test.ts
+++ b/tests/lib/auth-oidc-unit.test.ts
@@ -24,6 +24,9 @@ vi.mock('@/lib/prisma', () => {
       create: vi.fn(),
       update: vi.fn(),
     },
+    userToken: {
+      findFirst: vi.fn(),
+    },
     oidcIdentity: {
       findUnique: vi.fn(),
       create: vi.fn(),
@@ -51,6 +54,7 @@ describe('Auth JWT + OIDC (unit)', () => {
     (prisma.user.findUnique as any).mockResolvedValue(null);
     (prisma.user.create as any).mockResolvedValue({ id: 'u1' });
     (prisma.user.update as any).mockResolvedValue({});
+    (prisma.userToken.findFirst as any).mockResolvedValue(null);
     (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
     (prisma.oidcIdentity.create as any).mockResolvedValue({ id: 'id1' });
   });
@@ -107,6 +111,67 @@ describe('Auth JWT + OIDC (unit)', () => {
       user: { email: 'user@example.com', name: 'User', id: 'oidc-sub' },
       account: { provider: 'oidc', providerAccountId: 'oidc-sub' },
       profile: { email_verified: true, sub: 'oidc-sub' },
+    });
+
+    expect(result).toBe(false);
+    expect(prisma.userToken.findFirst).toHaveBeenCalledWith({
+      where: { identifier: 'user@example.com', type: 'INVITE' },
+      select: { id: true },
+    });
+    expect(prisma.oidcIdentity.create).not.toHaveBeenCalled();
+  });
+
+  it('links an ACTIVE admin-provisioned user on first OIDC login when email is verified', async () => {
+    const authOptions = await getAuthOptions();
+    const signIn = authOptions.callbacks?.signIn as unknown as (args: any) => Promise<boolean>;
+
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: 'u1',
+      email: 'user@example.com',
+      name: 'User',
+      role: 'USER',
+      status: 'ACTIVE',
+    });
+    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'invite-token-record' });
+    (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
+
+    const user = { email: 'user@example.com', name: 'User', id: 'oidc-sub' };
+    const result = await signIn({
+      user,
+      account: { provider: 'oidc', providerAccountId: 'oidc-sub' },
+      profile: { email_verified: true, sub: 'oidc-sub' },
+    });
+
+    expect(result).toBe(true);
+    expect(prisma.oidcIdentity.create).toHaveBeenCalledWith({
+      data: {
+        issuer: 'https://login.example.com',
+        subject: 'oidc-sub',
+        email: 'user@example.com',
+        userId: 'u1',
+      },
+    });
+    expect(user.id).toBe('u1');
+  });
+
+  it('does not link an existing provisioned user when email_verified is missing', async () => {
+    const authOptions = await getAuthOptions();
+    const signIn = authOptions.callbacks?.signIn as unknown as (args: any) => Promise<boolean>;
+
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: 'u1',
+      email: 'user@example.com',
+      name: 'User',
+      role: 'USER',
+      status: 'ACTIVE',
+    });
+    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'invite-token-record' });
+    (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
+
+    const result = await signIn({
+      user: { email: 'user@example.com', name: 'User', id: 'oidc-sub' },
+      account: { provider: 'oidc', providerAccountId: 'oidc-sub' },
+      profile: { sub: 'oidc-sub' },
     });
 
     expect(result).toBe(false);


### PR DESCRIPTION
## Summary

Fixes the case where a user created by an OpsKnight administrator can authenticate successfully with the configured OIDC provider but receives `Access Denied` because the OIDC identity has not yet been linked.

## Security model

This does **not** restore unsafe email-only auto-linking removed in #70.

For a pre-existing OpsKnight user, first-time OIDC linking now requires:

- a stable OIDC subject (`providerAccountId` / `sub`),
- `email_verified=true` from the configured OIDC provider,
- server-side evidence that the account was administrator-provisioned:
  - the user is still `INVITED`, or
  - OpsKnight retains an `INVITE` token record showing the account was created through the admin invite flow.

Accounts that merely share the same email continue to be rejected. An OIDC identity already linked to another user is also rejected.

New users created through configured OIDC auto-provisioning continue to work as before.

## Why this is needed

Admin-created users may complete the password invite first, which changes their status to `ACTIVE` and clears `invitedAt`. OpsKnight intentionally retains the used invite-token record for audit history, which provides durable provisioning evidence without introducing a new schema field.

## Tests

Adds regression coverage for:

- rejecting an existing account with no provisioning evidence,
- allowing an `ACTIVE` admin-provisioned user with verified OIDC email,
- rejecting a provisioned user when `email_verified` is missing,
- preserving the existing identity-conflict protection.

Related security hardening: #70