### PR TITLE
feat(auth): add explicit OIDC linking approval for existing users

### DIFF
--- a/docs/v1.3/administration/authentication.md
+++ b/docs/v1.3/administration/authentication.md
@@ -63,9 +63,35 @@ Default scopes are `openid email profile`; custom scopes are appended. The provi
 
 ### Email and identity safety
 
-OpsKnight requires an email. An explicit `email_verified: false` is rejected. Set `OIDC_REQUIRE_EMAIL_VERIFIED_STRICT=true` to also reject a missing claim.
+OpsKnight requires an email. An explicit `email_verified: false` is rejected. Set `OIDC_REQUIRE_EMAIL_VERIFIED_STRICT=true` to also reject a missing claim for all OIDC sign-ins.
 
-An OIDC identity is bound to normalized issuer plus subject. If an existing local user's email has no such identity link, v1.3 blocks automatic email-only linking to prevent account takeover. Plan account migration and test it before enforcing SSO.
+An OIDC identity is bound to the normalized issuer plus the provider subject (`sub`). OpsKnight does not treat an email address by itself as a stable external identity. This prevents an unrelated OIDC identity that happens to present the same email from silently taking over an existing OpsKnight account.
+
+For an existing account that does not yet have an OIDC identity, first-time linking requires all of the following:
+
+- the configured OIDC provider returns a stable subject;
+- the provider explicitly returns `email_verified: true`;
+- the OpsKnight account has administrator-provisioning evidence, either from the normal invite flow or from an Admin explicitly allowing OIDC linking for that user;
+- the issuer-plus-subject identity is not already linked to another OpsKnight user.
+
+After the first successful link, later sign-ins use the stored issuer-plus-subject identity rather than email-only matching.
+
+### Allow OIDC linking for an existing user
+
+Use this when an existing **Active** user must start using OIDC but does not already have an OIDC identity link.
+
+1. Sign in as an Admin.
+2. Open **Users**.
+3. Find the existing Active user.
+4. Select **Allow OIDC linking** for that user.
+5. Ask the user to sign in through the configured OIDC provider.
+6. Confirm the identity provider returns the same account email and `email_verified: true`.
+
+The action does not change the user's application role or account status and does not create a usable invitation link. It records administrator-provisioning evidence that the authentication flow can use for the next safe first-time link. If the user already has an OIDC identity, OpsKnight reports that no additional linking approval is required.
+
+Do not use this control to work around an email mismatch, an unverified email claim, a missing subject, or an identity already linked to another user. Correct the identity-provider configuration instead.
+
+Users still in **Invited** status already have administrator-provisioning evidence from the supported invite workflow and do not need this additional action.
 
 ### Auto-provisioning and domains
 
@@ -104,19 +130,20 @@ Cookies are HTTP-only where appropriate and use `SameSite=Lax`. `NEXTAUTH_URL` b
 - Restrict auto-provision domains before enabling it.
 - Test normal, denied-domain, missing-claim, disabled-user, and Admin-group cases.
 - Confirm role mapping cannot grant Admin through a user-controlled claim.
+- Verify first-time linking for an explicitly approved existing test user before migrating production accounts.
 - Verify revoke-all and IdP disable behavior.
 - Record the rollback: disable OIDC using the retained local Admin session.
 
 ## Troubleshooting
 
-| Symptom                       | Check                                                                                   |
-| ----------------------------- | --------------------------------------------------------------------------------------- |
-| Redirect/cookie loop          | Exact HTTPS `NEXTAUTH_URL`, forwarded host/scheme, and browser cookie policy.           |
-| Discovery test fails          | Issuer is HTTPS and exposes valid OIDC discovery metadata from the app network.         |
-| Existing local user is denied | Identity is not safely linked; do not bypass by weakening email/subject checks.         |
-| New user is denied            | Auto-provision setting, exact allowed domain, email and verification claims.            |
-| Role does not update          | Requested custom scope, actual ID-token/profile claim, JSON rule order and exact value. |
-| Secret cannot decrypt         | Restore the matching `ENCRYPTION_KEY` or enter a new client secret.                     |
+| Symptom                       | Check                                                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Redirect/cookie loop          | Exact HTTPS `NEXTAUTH_URL`, forwarded host/scheme, and browser cookie policy.                                   |
+| Discovery test fails          | Issuer is HTTPS and exposes valid OIDC discovery metadata from the app network.                                 |
+| Existing local user is denied | User is invited or explicitly approved for OIDC linking, email is verified, subject exists, and identity is free. |
+| New user is denied            | Auto-provision setting, exact allowed domain, email and verification claims.                                    |
+| Role does not update          | Requested custom scope, actual ID-token/profile claim, JSON rule order and exact value.                         |
+| Secret cannot decrypt         | Restore the matching `ENCRYPTION_KEY` or enter a new client secret.                                             |
 
 ## Related topics
 

--- a/docs/v1.3/core-concepts/users.md
+++ b/docs/v1.3/core-concepts/users.md
@@ -45,6 +45,19 @@ The invite link is a credential. Do not place it in tickets, public chat, screen
 
 If email delivery fails, the account and copyable link can still be created. Configure a provider and resend, or share the link securely.
 
+## Allow an existing user to link OIDC
+
+Use this for an existing **Active** account that needs to start using the configured OIDC provider and does not already have a linked OIDC identity.
+
+1. Open **Users** as an Admin.
+2. Find the Active user.
+3. Select **Allow OIDC linking**.
+4. Ask the user to sign in through OIDC.
+
+The control does not change the user's role or account status and does not issue a usable invitation link. It records administrator approval for first-time identity linking. The next OIDC sign-in is still accepted only when the configured provider supplies a stable subject and explicitly reports `email_verified: true`, and when that issuer-plus-subject identity is not linked to another OpsKnight account.
+
+Users still in **Invited** status already carry administrator-provisioning evidence from the invite workflow and do not need this extra step. If an existing user is denied after approval, do not repeatedly approve the account; check the provider subject, verified-email claim, email value, allowed-domain policy, and existing OIDC identity links. See [Authentication](../administration/authentication.md#allow-oidc-linking-for-an-existing-user).
+
 ## Find and manage accounts
 
 The Users page shows 20 users per page and supports search by name/email, filters for status, application role, and team, plus sorting by creation date, name, email, or status. It also shows user/team audit activity.
@@ -54,6 +67,7 @@ An Admin can:
 - change another user's application role;
 - activate or deactivate accounts individually or in bulk;
 - generate a new invite;
+- explicitly allow first-time OIDC linking for an existing Active user;
 - add users to teams;
 - delete accounts after safety checks.
 
@@ -136,6 +150,10 @@ Deletion of a sole Team Owner or the last Admin is blocked. Prefer deactivation 
 
 Use the copyable invite link, inspect the email provider and logs, verify sender/domain configuration, and generate a new invite if the earlier token should be invalidated.
 
+### An existing user still cannot sign in with OIDC
+
+Confirm the user is Invited or an Admin selected **Allow OIDC linking**, then verify the configured provider returns a stable subject, the same account email, and `email_verified: true`. Also check allowed-domain policy and whether the external identity is already linked to another user.
+
 ### A user is targeted but receives no page
 
 Confirm account status, channel preference, contact/device data, team notification participation, workspace provider, and notification history.
@@ -150,4 +168,5 @@ Check whether it is the current Admin, last Admin, a sole Team Owner, or still r
 - [On-call schedules](schedules.md)
 - [Escalation policies](escalation-policies.md)
 - [Authentication and security](authentication-security.md)
+- [Authentication](../administration/authentication.md)
 - [Published API and CLI guides](../api/README.md)

--- a/src/app/(app)/users/oidc-actions.ts
+++ b/src/app/(app)/users/oidc-actions.ts
@@ -1,0 +1,91 @@
+'use server';
+
+import { createHash, randomBytes } from 'crypto';
+import { revalidatePath } from 'next/cache';
+import prisma from '@/lib/prisma';
+import { assertAdmin } from '@/lib/rbac';
+import { logAudit } from '@/lib/audit';
+import { logger } from '@/lib/logger';
+
+export type OidcLinkingApprovalResult = {
+  success?: boolean;
+  alreadyLinked?: boolean;
+  error?: string;
+};
+
+/**
+ * Explicitly authorizes first-time OIDC linking for an existing user without
+ * changing the account status or issuing a usable invitation credential.
+ *
+ * The auth flow introduced in #336 treats an INVITE record as durable
+ * administrator-provisioning evidence. For existing ACTIVE users that predate
+ * that flow, this action records equivalent evidence as an already-used,
+ * immediately-expired marker. It cannot be redeemed as an invite link.
+ */
+export async function allowOidcLinking(userId: string): Promise<OidcLinkingApprovalResult> {
+  let admin: { id: string; email: string };
+  try {
+    admin = await assertAdmin();
+  } catch {
+    return { error: 'Unauthorized. Admin access required.' };
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, status: true },
+  });
+
+  if (!user) return { error: 'User not found.' };
+  if (user.status === 'DISABLED') {
+    return { error: 'Reactivate the user before allowing OIDC linking.' };
+  }
+
+  const existingIdentity = await prisma.oidcIdentity.findFirst({
+    where: { userId },
+    select: { id: true },
+  });
+  if (existingIdentity) {
+    return { success: true, alreadyLinked: true };
+  }
+
+  const identifier = user.email.toLowerCase();
+  const existingProvisioningEvidence = await prisma.userToken.findFirst({
+    where: { identifier, type: 'INVITE' },
+    select: { id: true },
+  });
+
+  if (!existingProvisioningEvidence) {
+    const now = new Date();
+    const marker = randomBytes(32).toString('base64url');
+    const tokenHash = createHash('sha256').update(marker).digest('hex');
+
+    await prisma.userToken.create({
+      data: {
+        identifier,
+        type: 'INVITE',
+        tokenHash,
+        expiresAt: now,
+        usedAt: now,
+      },
+    });
+  }
+
+  await logAudit({
+    action: 'user.oidc_linking.approved',
+    entityType: 'USER',
+    entityId: user.id,
+    actorId: admin.id,
+    details: { email: identifier },
+  });
+
+  logger.info('[Auth] Admin approved first-time OIDC linking', {
+    component: 'users-actions',
+    userId: user.id,
+    email: identifier,
+    adminId: admin.id,
+  });
+
+  revalidatePath('/users');
+  revalidatePath('/audit');
+  return { success: true };
+}

--- a/src/components/users/OidcLinkingApprovalButton.tsx
+++ b/src/components/users/OidcLinkingApprovalButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { Link2, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/shadcn/button';
+import { allowOidcLinking } from '@/app/(app)/users/oidc-actions';
+
+export default function OidcLinkingApprovalButton({
+  userId,
+  userName,
+}: {
+  userId: string;
+  userName: string;
+}) {
+  const [pending, setPending] = useState(false);
+
+  const approve = async () => {
+    setPending(true);
+    try {
+      const result = await allowOidcLinking(userId);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      if (result.alreadyLinked) {
+        toast.info(`${userName} already has an OIDC identity linked.`);
+        return;
+      }
+      toast.success(`OIDC linking allowed for ${userName}'s next verified sign-in.`);
+    } catch {
+      toast.error('Failed to allow OIDC linking.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      className="h-7 gap-1.5 text-xs"
+      onClick={approve}
+      disabled={pending}
+      title="Allow this existing user to link a verified identity from the configured OIDC provider on their next sign-in"
+    >
+      {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
+      Allow OIDC linking
+    </Button>
+  );
+}

--- a/src/components/users/UserList.tsx
+++ b/src/components/users/UserList.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { UserCard } from './UserCard';
+import OidcLinkingApprovalButton from './OidcLinkingApprovalButton';
 import { Button } from '@/components/ui/shadcn/button';
 import { Checkbox } from '@/components/ui/shadcn/checkbox';
 import type { UserFormState } from '@/app/(app)/users/actions';
@@ -13,7 +14,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSeparator,
 } from '@/components/ui/shadcn/dropdown-menu';
-import { ChevronDown, Trash2, UserX, UserCheck, Shield, MoreHorizontal } from 'lucide-react';
+import { ChevronDown, Trash2, UserX, UserCheck, MoreHorizontal } from 'lucide-react';
 import { toast } from 'sonner';
 
 type User = {
@@ -124,7 +125,6 @@ export default function UserList({
 
   return (
     <div className="space-y-4">
-      {/* Bulk Actions Bar */}
       {selectedIds.size > 0 && (
         <div className="sticky top-0 z-10 flex items-center justify-between p-2 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border rounded-md shadow-sm">
           <div className="flex items-center gap-3 px-2">
@@ -171,12 +171,6 @@ export default function UserList({
         </div>
       )}
 
-      {/* Select All (Only if no active selection bar to avoid duplication, mostly for empty state or consistent header? 
-          Actually, let's keep the standard header if nothing selected, or just merge them. 
-          The user requested "single line". Let's show the standard "Select All" bar when 0 selected, 
-          and swap it for the "Bulk Actions" bar when >0 selected. 
-          Or just keep one bar that transforms.
-      */}
       {users.length > 0 && selectedIds.size === 0 && (
         <div className="flex items-center gap-3 px-4 py-2 bg-muted/30 rounded-md border border-transparent">
           <Checkbox
@@ -188,7 +182,6 @@ export default function UserList({
         </div>
       )}
 
-      {/* User Cards */}
       <div className="space-y-2">
         {users.map(user => {
           const handleUpdateRole = async (role: string) => {
@@ -222,21 +215,27 @@ export default function UserList({
           };
 
           return (
-            <UserCard
-              key={user.id}
-              user={user}
-              selected={selectedIds.has(user.id)}
-              onSelect={() => toggleUser(user.id)}
-              isCurrentUser={user.id === currentUserId}
-              isAdmin={isAdmin}
-              teams={teams}
-              onActivate={user.status === 'DISABLED' ? handleReactivate : undefined}
-              onDeactivate={user.status === 'ACTIVE' ? handleDeactivate : undefined}
-              onDelete={handleDelete}
-              onGenerateInvite={user.status === 'INVITED' ? handleGenerateInvite : undefined}
-              onUpdateRole={handleUpdateRole}
-              onAddToTeam={handleAddToTeam}
-            />
+            <div key={user.id} className="space-y-1.5">
+              <UserCard
+                user={user}
+                selected={selectedIds.has(user.id)}
+                onSelect={() => toggleUser(user.id)}
+                isCurrentUser={user.id === currentUserId}
+                isAdmin={isAdmin}
+                teams={teams}
+                onActivate={user.status === 'DISABLED' ? handleReactivate : undefined}
+                onDeactivate={user.status === 'ACTIVE' ? handleDeactivate : undefined}
+                onDelete={handleDelete}
+                onGenerateInvite={user.status === 'INVITED' ? handleGenerateInvite : undefined}
+                onUpdateRole={handleUpdateRole}
+                onAddToTeam={handleAddToTeam}
+              />
+              {isAdmin && user.status === 'ACTIVE' && user.id !== currentUserId && (
+                <div className="flex justify-end px-1">
+                  <OidcLinkingApprovalButton userId={user.id} userName={user.name} />
+                </div>
+              )}
+            </div>
           );
         })}
       </div>

--- a/tests/lib/oidc-linking-approval.test.ts
+++ b/tests/lib/oidc-linking-approval.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/rbac', () => ({
+  assertAdmin: vi.fn().mockResolvedValue({ id: 'admin-1', email: 'admin@example.com' }),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  logAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    user: { findUnique: vi.fn() },
+    oidcIdentity: { findFirst: vi.fn() },
+    userToken: { findFirst: vi.fn(), create: vi.fn() },
+  },
+}));
+
+import prisma from '@/lib/prisma';
+import { allowOidcLinking } from '@/app/(app)/users/oidc-actions';
+
+describe('allowOidcLinking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: 'user-1',
+      email: 'User@Example.com',
+      status: 'ACTIVE',
+    });
+    (prisma.oidcIdentity.findFirst as any).mockResolvedValue(null);
+    (prisma.userToken.findFirst as any).mockResolvedValue(null);
+    (prisma.userToken.create as any).mockResolvedValue({ id: 'marker-1' });
+  });
+
+  it('records non-redeemable provisioning evidence without changing user status', async () => {
+    const result = await allowOidcLinking('user-1');
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.userToken.create).toHaveBeenCalledTimes(1);
+    expect(prisma.userToken.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        identifier: 'user@example.com',
+        type: 'INVITE',
+        tokenHash: expect.any(String),
+        expiresAt: expect.any(Date),
+        usedAt: expect.any(Date),
+      }),
+    });
+    expect(prisma.user.update).toBeUndefined();
+  });
+
+  it('does not create duplicate evidence when provisioning evidence already exists', async () => {
+    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'existing-invite' });
+
+    const result = await allowOidcLinking('user-1');
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.userToken.create).not.toHaveBeenCalled();
+  });
+
+  it('reports already-linked users without creating provisioning evidence', async () => {
+    (prisma.oidcIdentity.findFirst as any).mockResolvedValue({ id: 'identity-1' });
+
+    const result = await allowOidcLinking('user-1');
+
+    expect(result).toEqual({ success: true, alreadyLinked: true });
+    expect(prisma.userToken.findFirst).not.toHaveBeenCalled();
+    expect(prisma.userToken.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects disabled users', async () => {
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      status: 'DISABLED',
+    });
+
+    const result = await allowOidcLinking('user-1');
+
+    expect(result).toEqual({ error: 'Reactivate the user before allowing OIDC linking.' });
+    expect(prisma.userToken.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an explicit Admin control on **Users** for allowing first-time OIDC linking for an existing Active user without changing that user's account status.

## Behavior

- Admins can select **Allow OIDC linking** for an existing Active user.
- The action records server-side administrator-provisioning evidence without issuing a usable invite link or moving the user back to `INVITED`.
- The existing secure first-linking checks from #336 remain authoritative: the configured IdP must provide a stable subject, `email_verified=true`, and the issuer+subject identity must not already belong to another user.
- If the user already has an OIDC identity, the UI reports that no additional approval is needed.
- Disabled users must be reactivated before approval.
- The action is audited as `user.oidc_linking.approved`.

## UI

Adds an Admin-only **Allow OIDC linking** control for Active users on the Users page.

## Documentation

Updates the v1.3 documentation in both:

- `docs/v1.3/administration/authentication.md`
- `docs/v1.3/core-concepts/users.md`

The docs now describe the security model, exact Admin workflow, requirements for first-time linking, failure cases, and troubleshooting in the same operational style as the existing v1.3 guides.

## Tests

Adds unit coverage for the approval action, including:

- recording non-redeemable provisioning evidence without changing user status;
- avoiding duplicate provisioning evidence;
- already-linked identities;
- disabled-user rejection.

Related: #336, #70