### PR TITLE
fix(ui): move OIDC linking approval into user actions

### DIFF
--- a/docs/v1.3/administration/authentication.md
+++ b/docs/v1.3/administration/authentication.md
@@ -71,27 +71,30 @@ For an existing account that does not yet have an OIDC identity, first-time link
 
 - the configured OIDC provider returns a stable subject;
 - the provider explicitly returns `email_verified: true`;
-- the OpsKnight account has administrator-provisioning evidence, either from the normal invite flow or from an Admin explicitly allowing OIDC linking for that user;
+- the OpsKnight account has administrator-provisioning evidence from the invite flow or from an Admin allowing OIDC linking;
 - the issuer-plus-subject identity is not already linked to another OpsKnight user.
 
 After the first successful link, later sign-ins use the stored issuer-plus-subject identity rather than email-only matching.
 
-### Allow OIDC linking for an existing user
+### Manage OIDC linking for an existing user
 
-Use this when an existing **Active** user must start using OIDC but does not already have an OIDC identity link.
+Use this workflow for an existing **Active** account that needs to establish its first OIDC identity link.
 
-1. Sign in as an Admin.
-2. Open **Users**.
-3. Find the existing Active user.
-4. Select **Allow OIDC linking** for that user.
+1. Sign in as an Admin and open **Users**.
+2. Open the user's **⋯** actions menu.
+3. Select **Allow OIDC linking**.
+4. Review the confirmation and select **Allow linking**.
 5. Ask the user to sign in through the configured OIDC provider.
-6. Confirm the identity provider returns the same account email and `email_verified: true`.
 
-The action does not change the user's application role or account status and does not create a usable invitation link. It records administrator-provisioning evidence that the authentication flow can use for the next safe first-time link. If the user already has an OIDC identity, OpsKnight reports that no additional linking approval is required.
+The approval does not change the user's role, status, password, or existing sessions. The next first-time OIDC link is still accepted only when the provider returns the same account email, a stable subject, and `email_verified: true`, and the external identity is not linked elsewhere.
 
-Do not use this control to work around an email mismatch, an unverified email claim, a missing subject, or an identity already linked to another user. Correct the identity-provider configuration instead.
+Until an OIDC identity is established, the same **⋯** menu shows **Revoke OIDC linking approval**. Revoking removes the stored first-link provisioning evidence for that Active user. It does not disable the account or affect password authentication.
 
-Users still in **Invited** status already have administrator-provisioning evidence from the supported invite workflow and do not need this additional action.
+Once an OIDC identity has been established, the menu shows **OIDC linked**. Approval revocation is intentionally not used as an unlink operation; removing an established external identity is a separate security-sensitive lifecycle operation.
+
+Users still in **Invited** status already have administrator-provisioning evidence from the supported invite workflow. The explicit allow/revoke control is therefore limited to Active accounts.
+
+Do not use approval to work around an email mismatch, an unverified email claim, a missing subject, or an identity already linked to another user. Correct the identity-provider configuration instead.
 
 ### Auto-provisioning and domains
 
@@ -130,20 +133,21 @@ Cookies are HTTP-only where appropriate and use `SameSite=Lax`. `NEXTAUTH_URL` b
 - Restrict auto-provision domains before enabling it.
 - Test normal, denied-domain, missing-claim, disabled-user, and Admin-group cases.
 - Confirm role mapping cannot grant Admin through a user-controlled claim.
-- Verify first-time linking for an explicitly approved existing test user before migrating production accounts.
+- Verify allow, revoke, and first-link behavior with a non-Admin test account before migrating production accounts.
 - Verify revoke-all and IdP disable behavior.
 - Record the rollback: disable OIDC using the retained local Admin session.
 
 ## Troubleshooting
 
-| Symptom                       | Check                                                                                                           |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Redirect/cookie loop          | Exact HTTPS `NEXTAUTH_URL`, forwarded host/scheme, and browser cookie policy.                                   |
-| Discovery test fails          | Issuer is HTTPS and exposes valid OIDC discovery metadata from the app network.                                 |
-| Existing local user is denied | User is invited or explicitly approved for OIDC linking, email is verified, subject exists, and identity is free. |
-| New user is denied            | Auto-provision setting, exact allowed domain, email and verification claims.                                    |
-| Role does not update          | Requested custom scope, actual ID-token/profile claim, JSON rule order and exact value.                         |
-| Secret cannot decrypt         | Restore the matching `ENCRYPTION_KEY` or enter a new client secret.                                             |
+| Symptom                       | Check                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Redirect/cookie loop          | Exact HTTPS `NEXTAUTH_URL`, forwarded host/scheme, and browser cookie policy.                                      |
+| Discovery test fails          | Issuer is HTTPS and exposes valid OIDC discovery metadata from the app network.                                    |
+| Existing local user is denied | Approval/invite evidence, verified email, stable subject, allowed domain, and whether the identity is already used. |
+| Approval shows OIDC linked    | The user already has a stored issuer-plus-subject identity; approval revoke is not an unlink operation.            |
+| New user is denied            | Auto-provision setting, exact allowed domain, email and verification claims.                                       |
+| Role does not update          | Requested custom scope, actual ID-token/profile claim, JSON rule order and exact value.                            |
+| Secret cannot decrypt         | Restore the matching `ENCRYPTION_KEY` or enter a new client secret.                                                |
 
 ## Related topics
 

--- a/docs/v1.3/core-concepts/users.md
+++ b/docs/v1.3/core-concepts/users.md
@@ -45,18 +45,23 @@ The invite link is a credential. Do not place it in tickets, public chat, screen
 
 If email delivery fails, the account and copyable link can still be created. Configure a provider and resend, or share the link securely.
 
-## Allow an existing user to link OIDC
+## Manage first-time OIDC linking
 
-Use this for an existing **Active** account that needs to start using the configured OIDC provider and does not already have a linked OIDC identity.
+For an existing **Active** account that has not linked OIDC yet:
 
 1. Open **Users** as an Admin.
-2. Find the Active user.
+2. Open the user's **⋯** actions menu.
 3. Select **Allow OIDC linking**.
-4. Ask the user to sign in through OIDC.
+4. Review the confirmation and select **Allow linking**.
+5. Ask the user to sign in through the configured OIDC provider.
 
-The control does not change the user's role or account status and does not issue a usable invitation link. It records administrator approval for first-time identity linking. The next OIDC sign-in is still accepted only when the configured provider supplies a stable subject and explicitly reports `email_verified: true`, and when that issuer-plus-subject identity is not linked to another OpsKnight account.
+The approval does not change role, account status, password, or existing sessions. First-time linking still requires the configured provider to return the same email, a stable subject, and `email_verified: true`, and the external identity must not already belong to another OpsKnight account.
 
-Users still in **Invited** status already carry administrator-provisioning evidence from the invite workflow and do not need this extra step. If an existing user is denied after approval, do not repeatedly approve the account; check the provider subject, verified-email claim, email value, allowed-domain policy, and existing OIDC identity links. See [Authentication](../administration/authentication.md#allow-oidc-linking-for-an-existing-user).
+Before the identity is established, reopen **⋯** and select **Revoke OIDC linking approval** to disallow the first-time link again. Revocation does not deactivate the user or remove password access.
+
+After the identity is established, the menu shows **OIDC linked**. The approval control intentionally does not unlink an established identity.
+
+Users in **Invited** status already carry administrator-provisioning evidence from the invite workflow, so the explicit allow/revoke control is shown only for Active users. See [Authentication](../administration/authentication.md#manage-oidc-linking-for-an-existing-user).
 
 ## Find and manage accounts
 
@@ -67,7 +72,7 @@ An Admin can:
 - change another user's application role;
 - activate or deactivate accounts individually or in bulk;
 - generate a new invite;
-- explicitly allow first-time OIDC linking for an existing Active user;
+- allow or revoke first-time OIDC linking for an existing Active user;
 - add users to teams;
 - delete accounts after safety checks.
 
@@ -152,7 +157,9 @@ Use the copyable invite link, inspect the email provider and logs, verify sender
 
 ### An existing user still cannot sign in with OIDC
 
-Confirm the user is Invited or an Admin selected **Allow OIDC linking**, then verify the configured provider returns a stable subject, the same account email, and `email_verified: true`. Also check allowed-domain policy and whether the external identity is already linked to another user.
+For an Active user, open **⋯** and confirm the menu shows **Revoke OIDC linking approval**, which means first-time linking is currently allowed. Then verify the configured provider returns a stable subject, the same account email, and `email_verified: true`. Also check allowed-domain policy and whether the identity is already linked elsewhere.
+
+If the menu shows **Allow OIDC linking**, approval is not currently present. If it shows **OIDC linked**, the external identity is already established and the problem is not first-link approval.
 
 ### A user is targeted but receives no page
 

--- a/src/app/(app)/users/oidc-actions.ts
+++ b/src/app/(app)/users/oidc-actions.ts
@@ -7,20 +7,58 @@ import { assertAdmin } from '@/lib/rbac';
 import { logAudit } from '@/lib/audit';
 import { logger } from '@/lib/logger';
 
+export type OidcLinkingState = 'not-approved' | 'approved' | 'linked';
+
 export type OidcLinkingApprovalResult = {
   success?: boolean;
   alreadyLinked?: boolean;
+  alreadyApproved?: boolean;
+  state?: OidcLinkingState;
   error?: string;
 };
 
+async function getManagedUser(userId: string) {
+  return prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, status: true },
+  });
+}
+
+async function readOidcLinkingState(userId: string, email: string): Promise<OidcLinkingState> {
+  const existingIdentity = await prisma.oidcIdentity.findFirst({
+    where: { userId },
+    select: { id: true },
+  });
+  if (existingIdentity) return 'linked';
+
+  // #336 treats an INVITE record as administrator-provisioning evidence. This
+  // includes completed historical invites as well as the non-redeemable marker
+  // created by the explicit approval action.
+  const provisioningEvidence = await prisma.userToken.findFirst({
+    where: { identifier: email.toLowerCase(), type: 'INVITE' },
+    select: { id: true },
+  });
+
+  return provisioningEvidence ? 'approved' : 'not-approved';
+}
+
+export async function getOidcLinkingState(userId: string): Promise<OidcLinkingApprovalResult> {
+  try {
+    await assertAdmin();
+  } catch {
+    return { error: 'Unauthorized. Admin access required.' };
+  }
+
+  const user = await getManagedUser(userId);
+  if (!user) return { error: 'User not found.' };
+
+  const state = await readOidcLinkingState(user.id, user.email);
+  return { success: true, state, alreadyLinked: state === 'linked' };
+}
+
 /**
- * Explicitly authorizes first-time OIDC linking for an existing user without
- * changing the account status or issuing a usable invitation credential.
- *
- * The auth flow introduced in #336 treats an INVITE record as durable
- * administrator-provisioning evidence. For existing ACTIVE users that predate
- * that flow, this action records equivalent evidence as an already-used,
- * immediately-expired marker. It cannot be redeemed as an invite link.
+ * Explicitly authorizes first-time OIDC linking for an existing ACTIVE user
+ * without changing the account status or issuing a usable invitation link.
  */
 export async function allowOidcLinking(userId: string): Promise<OidcLinkingApprovalResult> {
   let admin: { id: string; email: string };
@@ -30,45 +68,36 @@ export async function allowOidcLinking(userId: string): Promise<OidcLinkingAppro
     return { error: 'Unauthorized. Admin access required.' };
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { id: true, email: true, status: true },
-  });
-
+  const user = await getManagedUser(userId);
   if (!user) return { error: 'User not found.' };
-  if (user.status === 'DISABLED') {
-    return { error: 'Reactivate the user before allowing OIDC linking.' };
-  }
-
-  const existingIdentity = await prisma.oidcIdentity.findFirst({
-    where: { userId },
-    select: { id: true },
-  });
-  if (existingIdentity) {
-    return { success: true, alreadyLinked: true };
+  if (user.status !== 'ACTIVE') {
+    return { error: 'OIDC linking approval can only be managed for active users.' };
   }
 
   const identifier = user.email.toLowerCase();
-  const existingProvisioningEvidence = await prisma.userToken.findFirst({
-    where: { identifier, type: 'INVITE' },
-    select: { id: true },
-  });
-
-  if (!existingProvisioningEvidence) {
-    const now = new Date();
-    const marker = randomBytes(32).toString('base64url');
-    const tokenHash = createHash('sha256').update(marker).digest('hex');
-
-    await prisma.userToken.create({
-      data: {
-        identifier,
-        type: 'INVITE',
-        tokenHash,
-        expiresAt: now,
-        usedAt: now,
-      },
-    });
+  const state = await readOidcLinkingState(user.id, identifier);
+  if (state === 'linked') {
+    return { success: true, alreadyLinked: true, state };
   }
+  if (state === 'approved') {
+    return { success: true, alreadyApproved: true, state };
+  }
+
+  const now = new Date();
+  const marker = randomBytes(32).toString('base64url');
+  const tokenHash = createHash('sha256').update(marker).digest('hex');
+
+  // This is provisioning evidence only. It is already used and expired, so it
+  // cannot be redeemed as an invitation credential.
+  await prisma.userToken.create({
+    data: {
+      identifier,
+      type: 'INVITE',
+      tokenHash,
+      expiresAt: now,
+      usedAt: now,
+    },
+  });
 
   await logAudit({
     action: 'user.oidc_linking.approved',
@@ -87,5 +116,63 @@ export async function allowOidcLinking(userId: string): Promise<OidcLinkingAppro
 
   revalidatePath('/users');
   revalidatePath('/audit');
-  return { success: true };
+  return { success: true, state: 'approved' };
+}
+
+/**
+ * Revokes first-time OIDC linking eligibility for an ACTIVE user that has not
+ * linked an OIDC identity yet. Existing credentials and account status are not
+ * changed. A linked identity must be managed separately; this action never
+ * silently unlinks an established identity.
+ */
+export async function revokeOidcLinking(userId: string): Promise<OidcLinkingApprovalResult> {
+  let admin: { id: string; email: string };
+  try {
+    admin = await assertAdmin();
+  } catch {
+    return { error: 'Unauthorized. Admin access required.' };
+  }
+
+  const user = await getManagedUser(userId);
+  if (!user) return { error: 'User not found.' };
+  if (user.status !== 'ACTIVE') {
+    return { error: 'OIDC linking approval can only be managed for active users.' };
+  }
+
+  const identifier = user.email.toLowerCase();
+  const state = await readOidcLinkingState(user.id, identifier);
+  if (state === 'linked') {
+    return {
+      error: 'This user already has an OIDC identity linked. Revoking approval does not unlink identities.',
+      alreadyLinked: true,
+      state,
+    };
+  }
+
+  // ACTIVE users no longer need invite credentials. Removing their INVITE
+  // records removes the administrator-provisioning evidence used by #336, so
+  // a future first-time OIDC link is denied again without affecting password
+  // authentication, role, or account status.
+  await prisma.userToken.deleteMany({
+    where: { identifier, type: 'INVITE' },
+  });
+
+  await logAudit({
+    action: 'user.oidc_linking.revoked',
+    entityType: 'USER',
+    entityId: user.id,
+    actorId: admin.id,
+    details: { email: identifier },
+  });
+
+  logger.info('[Auth] Admin revoked first-time OIDC linking approval', {
+    component: 'users-actions',
+    userId: user.id,
+    email: identifier,
+    adminId: admin.id,
+  });
+
+  revalidatePath('/users');
+  revalidatePath('/audit');
+  return { success: true, state: 'not-approved' };
 }

--- a/src/components/users/OidcLinkingApprovalButton.tsx
+++ b/src/components/users/OidcLinkingApprovalButton.tsx
@@ -1,10 +1,25 @@
 'use client';
 
-import { useState } from 'react';
-import { Link2, Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { CheckCircle2, Link2, Loader2, Unlink2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { Button } from '@/components/ui/shadcn/button';
-import { allowOidcLinking } from '@/app/(app)/users/oidc-actions';
+import { DropdownMenuItem } from '@/components/ui/shadcn/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/shadcn/alert-dialog';
+import {
+  allowOidcLinking,
+  getOidcLinkingState,
+  revokeOidcLinking,
+  type OidcLinkingState,
+} from '@/app/(app)/users/oidc-actions';
 
 export default function OidcLinkingApprovalButton({
   userId,
@@ -13,9 +28,30 @@ export default function OidcLinkingApprovalButton({
   userId: string;
   userName: string;
 }) {
+  const [state, setState] = useState<OidcLinkingState | 'loading'>('loading');
   const [pending, setPending] = useState(false);
+  const [dialog, setDialog] = useState<'allow' | 'revoke' | null>(null);
 
-  const approve = async () => {
+  useEffect(() => {
+    let active = true;
+    getOidcLinkingState(userId)
+      .then(result => {
+        if (!active) return;
+        if (result.error || !result.state) {
+          setState('not-approved');
+          return;
+        }
+        setState(result.state);
+      })
+      .catch(() => {
+        if (active) setState('not-approved');
+      });
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  const confirmAllow = async () => {
     setPending(true);
     try {
       const result = await allowOidcLinking(userId);
@@ -24,29 +60,118 @@ export default function OidcLinkingApprovalButton({
         return;
       }
       if (result.alreadyLinked) {
+        setState('linked');
         toast.info(`${userName} already has an OIDC identity linked.`);
         return;
       }
+      setState('approved');
       toast.success(`OIDC linking allowed for ${userName}'s next verified sign-in.`);
     } catch {
       toast.error('Failed to allow OIDC linking.');
     } finally {
       setPending(false);
+      setDialog(null);
+    }
+  };
+
+  const confirmRevoke = async () => {
+    setPending(true);
+    try {
+      const result = await revokeOidcLinking(userId);
+      if (result.error) {
+        if (result.alreadyLinked) setState('linked');
+        toast.error(result.error);
+        return;
+      }
+      setState('not-approved');
+      toast.success(`OIDC linking approval revoked for ${userName}.`);
+    } catch {
+      toast.error('Failed to revoke OIDC linking approval.');
+    } finally {
+      setPending(false);
+      setDialog(null);
     }
   };
 
   return (
-    <Button
-      type="button"
-      size="sm"
-      variant="outline"
-      className="h-7 gap-1.5 text-xs"
-      onClick={approve}
-      disabled={pending}
-      title="Allow this existing user to link a verified identity from the configured OIDC provider on their next sign-in"
-    >
-      {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
-      Allow OIDC linking
-    </Button>
+    <>
+      {state === 'loading' ? (
+        <DropdownMenuItem disabled>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          <span>Checking OIDC linking…</span>
+        </DropdownMenuItem>
+      ) : state === 'linked' ? (
+        <DropdownMenuItem disabled className="text-emerald-700">
+          <CheckCircle2 className="mr-2 h-4 w-4" />
+          <span>OIDC linked</span>
+        </DropdownMenuItem>
+      ) : state === 'approved' ? (
+        <DropdownMenuItem
+          onSelect={event => {
+            event.preventDefault();
+            setDialog('revoke');
+          }}
+          className="text-orange-600 focus:text-orange-700"
+        >
+          <Unlink2 className="mr-2 h-4 w-4" />
+          <span>Revoke OIDC linking approval</span>
+        </DropdownMenuItem>
+      ) : (
+        <DropdownMenuItem
+          onSelect={event => {
+            event.preventDefault();
+            setDialog('allow');
+          }}
+          className="text-blue-600 focus:text-blue-700"
+        >
+          <Link2 className="mr-2 h-4 w-4" />
+          <span>Allow OIDC linking</span>
+        </DropdownMenuItem>
+      )}
+
+      <AlertDialog open={dialog === 'allow'} onOpenChange={open => !open && setDialog(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Allow OIDC linking?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This allows <strong>{userName}</strong> to connect their existing OpsKnight account
+              to a verified identity from the configured OIDC provider on their next sign-in.
+              Their role, account status, and password are not changed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmAllow} disabled={pending}>
+              {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Allow linking
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={dialog === 'revoke'} onOpenChange={open => !open && setDialog(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke OIDC linking approval?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <strong>{userName}</strong> will no longer be allowed to establish a new OIDC
+              identity link. Existing password access, role, and account status are not affected.
+              This does not unlink an identity that has already been established.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmRevoke}
+              disabled={pending}
+              className="bg-orange-600 hover:bg-orange-700"
+            >
+              {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Revoke approval
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Badge } from '@/components/ui/shadcn/badge';
 import UserAvatar from '@/components/UserAvatar';
+import OidcLinkingApprovalButton from './OidcLinkingApprovalButton';
 import { Button } from '@/components/ui/shadcn/button';
 import {
   DropdownMenu,
@@ -30,7 +31,6 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from '@/components/ui/shadcn/select';
 import {
   Dialog,
@@ -38,7 +38,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from '@/components/ui/shadcn/dialog';
 import {
   Mail,
@@ -50,8 +49,6 @@ import {
   UserCheck,
   MoreHorizontal,
   Users,
-  Shield,
-  UserPlus,
   Key,
   Link as LinkIcon,
   Copy,
@@ -112,7 +109,7 @@ export function UserCard({
   onActivate,
   onDeactivate,
   onDelete,
-  onGenerateInvite,
+  onGenerateInvite: _onGenerateInvite,
   onUpdateRole,
   onAddToTeam,
 }: UserCardProps) {
@@ -204,7 +201,6 @@ export function UserCard({
             : 'border-border bg-card hover:border-primary/30'
         )}
       >
-        {/* Selection Checkbox */}
         <input
           type="checkbox"
           name="userIds"
@@ -215,7 +211,6 @@ export function UserCard({
           className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
         />
 
-        {/* Avatar */}
         <UserAvatar
           userId={user.id}
           avatarUrl={user.avatarUrl}
@@ -225,7 +220,6 @@ export function UserCard({
           className="ring-2 ring-background shadow-md transition-transform duration-300 group-hover:scale-105"
         />
 
-        {/* User Info */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
             <h3 className="font-semibold text-sm truncate">{user.name}</h3>
@@ -258,7 +252,6 @@ export function UserCard({
             </div>
           )}
 
-          {/* Team Badges - moved from right side */}
           {user.teamMemberships && user.teamMemberships.length > 0 && (
             <div className="flex flex-wrap items-center gap-1">
               {user.teamMemberships.map(member => (
@@ -276,10 +269,7 @@ export function UserCard({
           )}
         </div>
 
-        {/* Right Side: Badges and Actions */}
         <div className="flex items-center gap-4">
-          {/* Status & Role Badges */}
-
           <div className="flex items-center gap-2">
             {!isCurrentUser && isAdmin && onUpdateRole ? (
               <Select value={user.role} onValueChange={value => onUpdateRole(value)}>
@@ -289,7 +279,6 @@ export function UserCard({
                     roleTriggerColors[user.role as keyof typeof roleTriggerColors]
                   )}
                 >
-                  {/* Manually render value to keep trigger simple while items vary */}
                   <span className="truncate">
                     {user.role === 'ADMIN'
                       ? 'Admin'
@@ -338,7 +327,6 @@ export function UserCard({
             </Badge>
           </div>
 
-          {/* More Actions Dropdown */}
           {!isCurrentUser && isAdmin && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -347,12 +335,11 @@ export function UserCard({
                   <span className="sr-only">Open menu</span>
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuContent align="end" className="w-64">
                 <DropdownMenuLabel>Actions</DropdownMenuLabel>
                 <DropdownMenuSeparator />
 
-                {/* Generate Invite/Reset Link */}
-                {!isCurrentUser && (user.status === 'ACTIVE' || user.status === 'INVITED') && (
+                {(user.status === 'ACTIVE' || user.status === 'INVITED') && (
                   <DropdownMenuItem
                     onClick={handleGenerateLink}
                     className={cn(
@@ -370,7 +357,10 @@ export function UserCard({
                   </DropdownMenuItem>
                 )}
 
-                {/* Add to Team Submenu */}
+                {user.status === 'ACTIVE' && (
+                  <OidcLinkingApprovalButton userId={user.id} userName={user.name} />
+                )}
+
                 {onAddToTeam && availableTeams.length > 0 && (
                   <DropdownMenuSub>
                     <DropdownMenuSubTrigger>
@@ -387,7 +377,6 @@ export function UserCard({
                   </DropdownMenuSub>
                 )}
 
-                {/* Activate Action */}
                 {user.status === 'DISABLED' && onActivate && (
                   <DropdownMenuItem
                     onClick={onActivate}
@@ -398,7 +387,6 @@ export function UserCard({
                   </DropdownMenuItem>
                 )}
 
-                {/* Deactivate Action */}
                 {user.status === 'ACTIVE' && onDeactivate && (
                   <DropdownMenuItem
                     onClick={() => setShowDeactivateDialog(true)}
@@ -411,7 +399,6 @@ export function UserCard({
 
                 <DropdownMenuSeparator />
 
-                {/* Delete Action */}
                 {onDelete && (
                   <DropdownMenuItem
                     onClick={() => setShowDeleteDialog(true)}
@@ -427,7 +414,6 @@ export function UserCard({
         </div>
       </div>
 
-      {/* Deactivate Confirmation Dialog */}
       <AlertDialog open={showDeactivateDialog} onOpenChange={setShowDeactivateDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -452,7 +438,6 @@ export function UserCard({
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* Delete Confirmation Dialog */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -476,7 +461,7 @@ export function UserCard({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      {/* Invite/Reset Link Dialog */}
+
       <Dialog open={showInviteDialog} onOpenChange={setShowInviteDialog}>
         <DialogContent>
           <DialogHeader>

--- a/src/components/users/UserList.tsx
+++ b/src/components/users/UserList.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { UserCard } from './UserCard';
-import OidcLinkingApprovalButton from './OidcLinkingApprovalButton';
 import { Button } from '@/components/ui/shadcn/button';
 import { Checkbox } from '@/components/ui/shadcn/checkbox';
 import type { UserFormState } from '@/app/(app)/users/actions';
@@ -215,27 +214,21 @@ export default function UserList({
           };
 
           return (
-            <div key={user.id} className="space-y-1.5">
-              <UserCard
-                user={user}
-                selected={selectedIds.has(user.id)}
-                onSelect={() => toggleUser(user.id)}
-                isCurrentUser={user.id === currentUserId}
-                isAdmin={isAdmin}
-                teams={teams}
-                onActivate={user.status === 'DISABLED' ? handleReactivate : undefined}
-                onDeactivate={user.status === 'ACTIVE' ? handleDeactivate : undefined}
-                onDelete={handleDelete}
-                onGenerateInvite={user.status === 'INVITED' ? handleGenerateInvite : undefined}
-                onUpdateRole={handleUpdateRole}
-                onAddToTeam={handleAddToTeam}
-              />
-              {isAdmin && user.status === 'ACTIVE' && user.id !== currentUserId && (
-                <div className="flex justify-end px-1">
-                  <OidcLinkingApprovalButton userId={user.id} userName={user.name} />
-                </div>
-              )}
-            </div>
+            <UserCard
+              key={user.id}
+              user={user}
+              selected={selectedIds.has(user.id)}
+              onSelect={() => toggleUser(user.id)}
+              isCurrentUser={user.id === currentUserId}
+              isAdmin={isAdmin}
+              teams={teams}
+              onActivate={user.status === 'DISABLED' ? handleReactivate : undefined}
+              onDeactivate={user.status === 'ACTIVE' ? handleDeactivate : undefined}
+              onDelete={handleDelete}
+              onGenerateInvite={user.status === 'INVITED' ? handleGenerateInvite : undefined}
+              onUpdateRole={handleUpdateRole}
+              onAddToTeam={handleAddToTeam}
+            />
           );
         })}
       </div>

--- a/tests/lib/oidc-linking-approval.test.ts
+++ b/tests/lib/oidc-linking-approval.test.ts
@@ -20,14 +20,18 @@ vi.mock('@/lib/prisma', () => ({
   default: {
     user: { findUnique: vi.fn() },
     oidcIdentity: { findFirst: vi.fn() },
-    userToken: { findFirst: vi.fn(), create: vi.fn() },
+    userToken: { findFirst: vi.fn(), create: vi.fn(), deleteMany: vi.fn() },
   },
 }));
 
 import prisma from '@/lib/prisma';
-import { allowOidcLinking } from '@/app/(app)/users/oidc-actions';
+import {
+  allowOidcLinking,
+  getOidcLinkingState,
+  revokeOidcLinking,
+} from '@/app/(app)/users/oidc-actions';
 
-describe('allowOidcLinking', () => {
+describe('OIDC linking approval management', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (prisma.user.findUnique as any).mockResolvedValue({
@@ -38,12 +42,18 @@ describe('allowOidcLinking', () => {
     (prisma.oidcIdentity.findFirst as any).mockResolvedValue(null);
     (prisma.userToken.findFirst as any).mockResolvedValue(null);
     (prisma.userToken.create as any).mockResolvedValue({ id: 'marker-1' });
+    (prisma.userToken.deleteMany as any).mockResolvedValue({ count: 1 });
+  });
+
+  it('reports not-approved when an active user has no identity or provisioning evidence', async () => {
+    const result = await getOidcLinkingState('user-1');
+    expect(result).toEqual({ success: true, state: 'not-approved', alreadyLinked: false });
   });
 
   it('records non-redeemable provisioning evidence without changing user status', async () => {
     const result = await allowOidcLinking('user-1');
 
-    expect(result).toEqual({ success: true });
+    expect(result).toEqual({ success: true, state: 'approved' });
     expect(prisma.userToken.create).toHaveBeenCalledTimes(1);
     expect(prisma.userToken.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
@@ -57,12 +67,14 @@ describe('allowOidcLinking', () => {
     expect(prisma.user.update).toBeUndefined();
   });
 
-  it('does not create duplicate evidence when provisioning evidence already exists', async () => {
+  it('reports approved when provisioning evidence already exists', async () => {
     (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'existing-invite' });
 
-    const result = await allowOidcLinking('user-1');
+    const state = await getOidcLinkingState('user-1');
+    const allowResult = await allowOidcLinking('user-1');
 
-    expect(result).toEqual({ success: true });
+    expect(state).toEqual({ success: true, state: 'approved', alreadyLinked: false });
+    expect(allowResult).toEqual({ success: true, alreadyApproved: true, state: 'approved' });
     expect(prisma.userToken.create).not.toHaveBeenCalled();
   });
 
@@ -71,21 +83,53 @@ describe('allowOidcLinking', () => {
 
     const result = await allowOidcLinking('user-1');
 
-    expect(result).toEqual({ success: true, alreadyLinked: true });
+    expect(result).toEqual({ success: true, alreadyLinked: true, state: 'linked' });
     expect(prisma.userToken.findFirst).not.toHaveBeenCalled();
     expect(prisma.userToken.create).not.toHaveBeenCalled();
   });
 
-  it('rejects disabled users', async () => {
+  it('revokes pending first-link eligibility without changing credentials or status', async () => {
+    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'existing-invite' });
+
+    const result = await revokeOidcLinking('user-1');
+
+    expect(result).toEqual({ success: true, state: 'not-approved' });
+    expect(prisma.userToken.deleteMany).toHaveBeenCalledWith({
+      where: { identifier: 'user@example.com', type: 'INVITE' },
+    });
+    expect(prisma.user.update).toBeUndefined();
+  });
+
+  it('does not use revoke approval to unlink an established identity', async () => {
+    (prisma.oidcIdentity.findFirst as any).mockResolvedValue({ id: 'identity-1' });
+
+    const result = await revokeOidcLinking('user-1');
+
+    expect(result).toEqual({
+      error: 'This user already has an OIDC identity linked. Revoking approval does not unlink identities.',
+      alreadyLinked: true,
+      state: 'linked',
+    });
+    expect(prisma.userToken.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects approval management for disabled users', async () => {
     (prisma.user.findUnique as any).mockResolvedValue({
       id: 'user-1',
       email: 'user@example.com',
       status: 'DISABLED',
     });
 
-    const result = await allowOidcLinking('user-1');
+    const allowResult = await allowOidcLinking('user-1');
+    const revokeResult = await revokeOidcLinking('user-1');
 
-    expect(result).toEqual({ error: 'Reactivate the user before allowing OIDC linking.' });
+    expect(allowResult).toEqual({
+      error: 'OIDC linking approval can only be managed for active users.',
+    });
+    expect(revokeResult).toEqual({
+      error: 'OIDC linking approval can only be managed for active users.',
+    });
     expect(prisma.userToken.create).not.toHaveBeenCalled();
+    expect(prisma.userToken.deleteMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Refines the OIDC linking workflow introduced in #340 based on the Users UI behavior.

## UI changes

- Removes the standalone **Allow OIDC linking** button rendered below each user card.
- Moves OIDC linking management into the existing per-user **⋯** actions menu.
- Shows the current state in that menu:
  - **Allow OIDC linking** when first-link approval is not present;
  - **Revoke OIDC linking approval** while first-link approval is present;
  - **OIDC linked** once an external identity is already established.
- Adds confirmation dialogs for both allow and revoke operations.

## Security behavior

- Approval/revocation applies only to existing `ACTIVE` users.
- Allowing linking creates non-redeemable administrator-provisioning evidence without changing role, status, password, or sessions.
- Revoking removes first-link provisioning evidence so the user is denied first-time OIDC linking again.
- Revocation never silently unlinks an already-established OIDC identity.
- Existing #336 requirements remain authoritative: stable subject, `email_verified=true`, configured provider, and no identity conflict.

## Audit

- approval: `user.oidc_linking.approved`
- revoke: `user.oidc_linking.revoked`

## Tests

Updates the OIDC linking approval tests to cover:

- not-approved, approved, and linked states;
- allow behavior;
- reversible revoke behavior;
- protection against using revoke as an identity-unlink operation;
- disabled-user rejection.

## Documentation

Updates the v1.3 Authentication and Users documentation to describe the three-dot menu workflow, confirmation behavior, revoke semantics, and linked-identity state.

Related: #340, #336, #70