### PR TITLE
docs: update remaining GHCR URLs for organization move

### DIFF
--- a/docs/v1.1/deployment/kubernetes.md
+++ b/docs/v1.1/deployment/kubernetes.md
@@ -151,7 +151,7 @@ Use AWS RDS, GCP Cloud SQL, or Azure Database:
 ```bash
 # Update image
 kubectl set image deployment/opsknight \
-  opsknight=ghcr.io/your-org/opsknight:latest
+  opsknight=ghcr.io/opsknight-labs/opsknight:latest
 
 # Or apply updated manifests
 kubectl apply -f deployment.yaml

--- a/docs/v1.2/deployment/kubernetes.md
+++ b/docs/v1.2/deployment/kubernetes.md
@@ -151,7 +151,7 @@ Use AWS RDS, GCP Cloud SQL, or Azure Database:
 ```bash
 # Update image
 kubectl set image deployment/opsknight \
-  opsknight=ghcr.io/your-org/opsknight:latest
+  opsknight=ghcr.io/opsknight-labs/opsknight:latest
 
 # Or apply updated manifests
 kubectl apply -f deployment.yaml

--- a/docs/v1.3/deployment/kubernetes.md
+++ b/docs/v1.3/deployment/kubernetes.md
@@ -151,7 +151,7 @@ Use AWS RDS, GCP Cloud SQL, or Azure Database:
 ```bash
 # Update image
 kubectl set image deployment/opsknight \
-  opsknight=ghcr.io/your-org/opsknight:latest
+  opsknight=ghcr.io/opsknight-labs/opsknight:latest
 
 # Or apply updated manifests
 kubectl apply -f deployment.yaml

--- a/docs/v1/deployment/kubernetes.md
+++ b/docs/v1/deployment/kubernetes.md
@@ -151,7 +151,7 @@ Use AWS RDS, GCP Cloud SQL, or Azure Database:
 ```bash
 # Update image
 kubectl set image deployment/opsknight \
-  opsknight=ghcr.io/your-org/opsknight:latest
+  opsknight=ghcr.io/opsknight-labs/opsknight:latest
 
 # Or apply updated manifests
 kubectl apply -f deployment.yaml


### PR DESCRIPTION
## Summary

Updates the remaining OpsKnight-owned GHCR references that were still using the placeholder namespace after the repository moved to the `opsknight-labs` organization.

## Changes

Replaces:

`ghcr.io/your-org/opsknight:latest`

with:

`ghcr.io/opsknight-labs/opsknight:latest`

in the Kubernetes deployment guides for:

- v1
- v1.1
- v1.2
- v1.3

## Verification

I scanned the repository for `ghcr.io` references. Runtime/deployment defaults such as `docker-compose.yml`, `k8s/deployment.yaml`, Helm values, README examples, and the container publishing workflow already point to the organization namespace (or use `${{ github.repository_owner }}` dynamically). External GHCR images such as Dev Container features and ZAP are intentionally unchanged.