### PR TITLE
ci: keep main Docker builds amd64-only

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up QEMU
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -103,14 +104,14 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta_test_main.outputs.tags }}
           labels: ${{ steps.meta_test_main.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
-          provenance: mode=max
-          sbom: true
+          provenance: false
+          sbom: false
 
       - name: Build + push (release channel - version tag)
         if: startsWith(github.ref, 'refs/tags/v')

--- a/docs/v1.3/deployment/README.md
+++ b/docs/v1.3/deployment/README.md
@@ -67,7 +67,7 @@ See the [Configuration reference](../getting-started/configuration) for advanced
 
 Stable images are published only at `ghcr.io/opsknight-labs/opsknight`; main-branch validation images use `ghcr.io/opsknight-labs/opsknight-test`. Do not substitute the test channel in production.
 
-Source changes do not modify an image that was already published. In particular, the immutable `1.3.1` release predates the fail-closed migration entrypoint and multi-architecture publishing changes in this repository revision and is an amd64 image. Those runtime changes take effect in the next stable release built after this work. Inspect the selected image manifest and release notes rather than inferring capabilities from the checked-in deployment YAML.
+Source changes do not modify an image that was already published. In particular, the immutable `1.3.1` release predates the fail-closed migration entrypoint and multi-architecture publishing changes in this repository revision and is an amd64 image. Tagged stable releases are built for amd64 and arm64, while the continuously updated test image from `main` is amd64-only to keep feedback fast. Those runtime changes take effect in the next stable release built after this work. Inspect the selected image manifest and release notes rather than inferring capabilities from the checked-in deployment YAML.
 
 ## Release workflow
 

--- a/docs/v1.3/deployment/docker.md
+++ b/docs/v1.3/deployment/docker.md
@@ -39,7 +39,7 @@ APP_PORT=3000
 OPSKNIGHT_IMAGE=ghcr.io/opsknight-labs/opsknight:1.3.1
 ```
 
-Pin `OPSKNIGHT_IMAGE` to the immutable version or digest you tested. The default remains `latest` for convenience and should not be the production release policy. The published `1.3.1` image is amd64-only and predates the fail-closed migration change; select a newer stable release once one containing this revision is published.
+Pin `OPSKNIGHT_IMAGE` to the immutable version or digest you tested. The default remains `latest` for convenience and should not be the production release policy. The published `1.3.1` image is amd64-only and predates the fail-closed migration change; select a newer stable release once one containing this revision is published. Tagged stable images are published for amd64 and arm64; the test image built from `main` is amd64-only.
 
 The checked-in fallbacks are development values, not production secrets. Keep `ENCRYPTION_KEY` stable and backed up with the database; losing it means re-entering encrypted provider/integration credentials.
 

--- a/docs/v1.3/deployment/helm.md
+++ b/docs/v1.3/deployment/helm.md
@@ -8,7 +8,7 @@ description: Deploy the OpsKnight Helm chart with safe database, networking, sec
 
 The chart is shipped at `helm/opsknight`. The chart version and default application image version track the OpsKnight application release; production deployments should still pin a tested immutable image tag or digest explicitly.
 
-The published `1.3.1` image is amd64-only and predates the fail-closed migration entrypoint in this source revision. Chart and manifest hardening applies immediately, but the new container runtime behavior and multi-architecture output require the next stable image release.
+The published `1.3.1` image is amd64-only and predates the fail-closed migration entrypoint in this source revision. Chart and manifest hardening applies immediately, but the new container runtime behavior and multi-architecture output require the next tagged stable image release. The continuously updated test image from `main` remains amd64-only.
 
 The chart creates the application Deployment, Service, ConfigMap, Secret, optional Ingress, optional HPA, PodDisruptionBudget, optional NetworkPolicy, and optionally a single PostgreSQL StatefulSet.
 

--- a/docs/v1.3/deployment/kubernetes.md
+++ b/docs/v1.3/deployment/kubernetes.md
@@ -49,7 +49,7 @@ The checked-in base is an example, not a production release:
 
 Never apply the base unchanged to production and never commit real Secret values. Build an overlay or use the Helm production-values process.
 
-The published `1.3.1` image is amd64-only and predates the fail-closed migration entrypoint in this source revision. The raw manifests gain their configuration hardening immediately, but the new runtime behavior and multi-architecture output require the next stable image release.
+The published `1.3.1` image is amd64-only and predates the fail-closed migration entrypoint in this source revision. The raw manifests gain their configuration hardening immediately, but the new runtime behavior and multi-architecture output require the next tagged stable image release. The continuously updated test image from `main` remains amd64-only.
 
 The application ServiceAccount token is not mounted by default because OpsKnight does not require Kubernetes API access. Keep it disabled unless a deliberate extension needs that credential.
 

--- a/tests/lib/deployment-config-unit.test.ts
+++ b/tests/lib/deployment-config-unit.test.ts
@@ -105,12 +105,24 @@ describe('deployment configuration invariants', () => {
     expect(compose).not.toContain('com.docker.network.bridge.name');
   });
 
-  it('publishes future images for amd64 and arm64 with supply-chain attestations', () => {
+  it('keeps main builds fast and publishes multi-arch tagged releases with attestations', () => {
     const workflow = read('.github/workflows/docker-image.yml');
-    expect(workflow).toContain('docker/setup-qemu-action@v3');
-    expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
-    expect(workflow).toContain('provenance: mode=max');
-    expect(workflow).toContain('sbom: true');
+    const mainBuild = workflow.slice(
+      workflow.indexOf('- name: Build + push (test channel - main)'),
+      workflow.indexOf('- name: Build + push (release channel - version tag)')
+    );
+    const releaseBuild = workflow.slice(
+      workflow.indexOf('- name: Build + push (release channel - version tag)')
+    );
+    expect(workflow).toContain(
+      "if: startsWith(github.ref, 'refs/tags/v')\n        uses: docker/setup-qemu-action@v3"
+    );
+    expect(mainBuild).toContain('platforms: linux/amd64');
+    expect(mainBuild).toContain('provenance: false');
+    expect(mainBuild).toContain('sbom: false');
+    expect(releaseBuild).toContain('platforms: linux/amd64,linux/arm64');
+    expect(releaseBuild).toContain('provenance: mode=max');
+    expect(releaseBuild).toContain('sbom: true');
     expect(workflow).toContain('scripts/validate-release-tag.cjs');
   });
 


### PR DESCRIPTION
## Summary

- build and push the continuously updated `main` test image for `linux/amd64` only
- disable provenance and SBOM generation for the fast test-channel build
- run QEMU only for version-tag release builds
- preserve `linux/amd64,linux/arm64`, full provenance, and SBOM generation for tagged stable releases
- clarify the test-versus-release architecture policy in v1.3 deployment docs
- strengthen deployment invariants so the channel-specific behavior cannot regress

## Context

PR #347 enabled multi-architecture builds for both `main` and release tags. The ARM64 QEMU leg caused normal `main` builds to run far beyond their previous ~5-minute feedback time. Multi-architecture publishing remains enabled for official tagged releases.

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- targeted Vitest suite could not be executed locally because Node/npm is unavailable in this environment