### PR TITLE
fix(release): use matching PostgreSQL backup client

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -115,9 +115,15 @@ jobs:
       - name: Backup and restore contract
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          pg_dump -h localhost -U postgres -Fc opsknight_release > /tmp/opsknight-release.dump
-          createdb -h localhost -U postgres opsknight_restore
-          pg_restore -h localhost -U postgres --no-owner -d opsknight_restore /tmp/opsknight-release.dump
+          POSTGRES_CONTAINER="$(docker ps --filter ancestor=postgres:16-alpine --format '{{.ID}}' | head -n 1)"
+          test -n "$POSTGRES_CONTAINER"
+          # Use the service image's matching PostgreSQL client. The Ubuntu
+          # runner's older pg_dump refuses to dump a PostgreSQL 16 server.
+          docker exec "$POSTGRES_CONTAINER" pg_dump -U postgres -Fc \
+            -f /tmp/opsknight-release.dump opsknight_release
+          docker exec "$POSTGRES_CONTAINER" createdb -U postgres opsknight_restore
+          docker exec "$POSTGRES_CONTAINER" pg_restore -U postgres --no-owner \
+            -d opsknight_restore /tmp/opsknight-release.dump
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_restore?schema=public' npm run prisma:health
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_restore?schema=public' node scripts/ci-db-smoke.cjs
 

--- a/tests/lib/deployment-config-unit.test.ts
+++ b/tests/lib/deployment-config-unit.test.ts
@@ -128,6 +128,8 @@ describe('deployment configuration invariants', () => {
     expect(workflow).toContain('needs: release-quality');
     expect(workflow).toContain('Upgrade from previous stable release');
     expect(workflow).toContain('Backup and restore contract');
+    expect(workflow).toContain('docker exec "$POSTGRES_CONTAINER" pg_dump');
+    expect(workflow).toContain('ancestor=postgres:16-alpine');
     expect(workflow).toContain('Event, escalation, and notification contract');
   });
 


### PR DESCRIPTION
## Summary

- run the release backup/restore contract with the PostgreSQL 16 service container's own client tools
- avoid the Ubuntu runner's PostgreSQL 14 `pg_dump` refusing the PostgreSQL 16 server
- assert the version-matched backup path in deployment configuration tests

## Failure addressed

The first `v1.4.0` tag run stopped before image publication because `pg_dump` 14.24 rejected server 16.15. Clean install, incident delivery, and v1.3.1 upgrade had already passed.

## Validation

- deployment configuration tests: 15 passed
- workflow YAML parses successfully
- tag will be recreated only after this PR merges and main is green
