### PR TITLE
fix(release): address PostgreSQL service by job ID

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Backup and restore contract
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          POSTGRES_CONTAINER="$(docker ps --filter ancestor=postgres:16-alpine --format '{{.ID}}' | head -n 1)"
+          POSTGRES_CONTAINER="${{ job.services.postgres.id }}"
           test -n "$POSTGRES_CONTAINER"
           # Use the service image's matching PostgreSQL client. The Ubuntu
           # runner's older pg_dump refuses to dump a PostgreSQL 16 server.

--- a/tests/lib/deployment-config-unit.test.ts
+++ b/tests/lib/deployment-config-unit.test.ts
@@ -129,7 +129,7 @@ describe('deployment configuration invariants', () => {
     expect(workflow).toContain('Upgrade from previous stable release');
     expect(workflow).toContain('Backup and restore contract');
     expect(workflow).toContain('docker exec "$POSTGRES_CONTAINER" pg_dump');
-    expect(workflow).toContain('ancestor=postgres:16-alpine');
+    expect(workflow).toContain('POSTGRES_CONTAINER="${{ job.services.postgres.id }}"');
     expect(workflow).toContain('Event, escalation, and notification contract');
   });
 


### PR DESCRIPTION
Use the authoritative GitHub Actions service-container ID instead of filtering by an image-name variant. The failed v1.4.0 rerun stopped before stable image publication. Deployment configuration tests pass (15/15).