### PR TITLE
ci: finish Node 24 action migration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Publish test results to GitHub Checks
         if: always()
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: '✅ Tests: Unit (Vitest)'
           path: reports/*.xml

--- a/tests/lib/deployment-config-unit.test.ts
+++ b/tests/lib/deployment-config-unit.test.ts
@@ -115,7 +115,7 @@ describe('deployment configuration invariants', () => {
       workflow.indexOf('- name: Build + push (release channel - version tag)')
     );
     expect(workflow).toContain(
-      "if: startsWith(github.ref, 'refs/tags/v')\n        uses: docker/setup-qemu-action@v3"
+      "if: startsWith(github.ref, 'refs/tags/v')\n        uses: docker/setup-qemu-action@v4"
     );
     expect(mainBuild).toContain('platforms: linux/amd64');
     expect(mainBuild).toContain('provenance: false');


### PR DESCRIPTION
## Summary

- update the deployment workflow contract test to expect `docker/setup-qemu-action@v4` already merged in #359
- upgrade `dorny/test-reporter` from v2 to its Node 24-compatible v3 major

## Why this follow-up exists

PR #359 was merged before its test run completed. The product tests exposed the stale v3 assertion, and the reporter step exposed one additional Node 20 compatibility warning.

## Verification

- confirmed `dorny/test-reporter@v3` declares `using: node24` upstream
- workflow YAML parses successfully
- `git diff --check` passes
- CI will exercise the updated contract assertion and reporter action

No application code or application Node.js runtime is changed.