### PR TITLE
ci: reduce workflow feedback time

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   release-quality:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -48,25 +49,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Non-release image validation path
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        run: echo 'Stable release-quality contract is enforced for version tags.'
-
       - name: Set up Node
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm
 
       - name: Install candidate dependencies
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           HUSKY: '0'
         run: npm ci --legacy-peer-deps
 
       - name: Clean-install and migration contract
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           mkdir -p reports
           npx prisma migrate deploy
@@ -81,7 +75,6 @@ jobs:
             tests/lib/deployment-config-unit.test.ts
 
       - name: Event, escalation, and notification contract
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           VITEST_USE_REAL_DB: '1'
         run: |
@@ -91,7 +84,6 @@ jobs:
             tests/integration/job-queue.test.ts
 
       - name: Upgrade from previous stable release
-        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
           set -euo pipefail
@@ -113,7 +105,6 @@ jobs:
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_upgrade?schema=public' npm run prisma:health
 
       - name: Backup and restore contract
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           POSTGRES_CONTAINER="${{ job.services.postgres.id }}"
           test -n "$POSTGRES_CONTAINER"
@@ -128,15 +119,12 @@ jobs:
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_restore?schema=public' node scripts/ci-db-smoke.cjs
 
       - name: Set up Helm
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: azure/setup-helm@v5
 
       - name: Set up kubectl
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: azure/setup-kubectl@v5
 
       - name: Render release deployment contract
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           cp env.example .env
           docker compose config > /tmp/opsknight-compose.yaml
@@ -148,6 +136,9 @@ jobs:
 
   build:
     needs: release-quality
+    if: >-
+      always() &&
+      (needs.release-quality.result == 'success' || needs.release-quality.result == 'skipped')
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -218,8 +209,8 @@ jobs:
           push: false
           tags: ${{ steps.meta_test_pr.outputs.tags }}
           labels: ${{ steps.meta_test_pr.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=opsknight-main-amd64
+          cache-to: type=gha,scope=opsknight-pr-${{ github.event.pull_request.number }},mode=max
           provenance: false
           sbom: false
 
@@ -233,8 +224,8 @@ jobs:
           push: true
           tags: ${{ steps.meta_test_main.outputs.tags }}
           labels: ${{ steps.meta_test_main.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=opsknight-main-amd64
+          cache-to: type=gha,scope=opsknight-main-amd64,mode=max
           provenance: false
           sbom: false
 
@@ -248,7 +239,9 @@ jobs:
           push: true
           tags: ${{ steps.meta_release_tag.outputs.tags }}
           labels: ${{ steps.meta_release_tag.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: |
+            type=gha,scope=opsknight-release
+            type=gha,scope=opsknight-main-amd64
+          cache-to: type=gha,scope=opsknight-release,mode=max
           provenance: mode=max
           sbom: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -210,7 +210,6 @@ jobs:
           tags: ${{ steps.meta_test_pr.outputs.tags }}
           labels: ${{ steps.meta_test_pr.outputs.labels }}
           cache-from: type=gha,scope=opsknight-main-amd64
-          cache-to: type=gha,scope=opsknight-pr-${{ github.event.pull_request.number }},mode=max
           provenance: false
           sbom: false
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,25 @@ permissions:
   pull-requests: write # Required for results summary comment
 
 jobs:
-  sast:
-    name: SAST (CodeQL & ESLint)
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.37.3
+        with:
+          languages: javascript-typescript
+        continue-on-error: true
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4.37.3
+        continue-on-error: true
+
+  eslint:
+    name: ESLint Security
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,19 +49,8 @@ jobs:
 
       - name: Install dependencies
         env:
-          # CI doesn't need git hooks; this also avoids husky-related setup issues.
           HUSKY: '0'
         run: npm ci --legacy-peer-deps
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.3
-        with:
-          languages: javascript-typescript
-        continue-on-error: true
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.3
-        continue-on-error: true
 
       - name: ESLint Security Scan (SARIF)
         run: |
@@ -52,9 +58,26 @@ jobs:
           npx eslint . --format @microsoft/eslint-formatter-sarif --output-file reports/eslint-security.sarif || true
         continue-on-error: true
 
-      - name: ESLint Security Scan (JUnit)
+      - name: Convert ESLint SARIF to JUnit
         run: |
-          npx eslint . --format junit --output-file reports/eslint-security.xml || true
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const escapeXml = (value) => String(value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&apos;');
+          const sarif = JSON.parse(fs.readFileSync('reports/eslint-security.sarif', 'utf8'));
+          const results = sarif.runs?.flatMap((run) => run.results || []) || [];
+          const cases = results.map((result) => {
+            const rule = escapeXml(result.ruleId || 'eslint');
+            const message = escapeXml(result.message?.text || 'ESLint finding');
+            return `    <testcase name="${rule}" classname="eslint"><failure message="${message}"/></testcase>`;
+          }).join('\n');
+          const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites tests="${results.length}" failures="${results.length}"><testsuite name="ESLint Security" tests="${results.length}" failures="${results.length}">\n${cases}\n</testsuite></testsuites>\n`;
+          fs.writeFileSync('reports/eslint-security.xml', xml);
+          NODE
         continue-on-error: true
 
       - name: Upload ESLint SARIF
@@ -71,6 +94,20 @@ jobs:
           name: sast-reports
           path: reports/eslint-security.xml
         continue-on-error: true
+
+  sast:
+    name: SAST (CodeQL & ESLint)
+    needs: [codeql, eslint]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify SAST jobs
+        env:
+          CODEQL_RESULT: ${{ needs.codeql.result }}
+          ESLINT_RESULT: ${{ needs.eslint.result }}
+        run: |
+          test "$CODEQL_RESULT" = success
+          test "$ESLINT_RESULT" = success
 
   sca:
     name: SCA (Dependencies & Containers)
@@ -279,17 +316,30 @@ jobs:
 
   dast:
     name: DAST (OWASP ZAP)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Resolve DAST target
+        id: dast_target
+        env:
+          DAST_TARGET_URL: ${{ secrets.DAST_TARGET_URL }}
+        run: |
+          if [ -n "$DAST_TARGET_URL" ]; then
+            echo "url=$DAST_TARGET_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo 'No DAST_TARGET_URL configured; skipping ZAP scan.'
+          fi
+
       - name: ZAP Scan
+        if: steps.dast_target.outputs.url != ''
         uses: zaproxy/action-baseline@v0.15.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
-          target: ${{ secrets.DAST_TARGET_URL || 'https://example.com' }} # Set DAST_TARGET_URL secret for real scans
+          target: ${{ steps.dast_target.outputs.url }}
           rules_file_name: '.zap/rules.tsv'
           fail_action: false
         continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,9 +87,6 @@ jobs:
           VITEST_USE_REAL_DB: '1'
         run: npm run test:ci:db
 
-      - name: TypeScript typecheck
-        run: npx tsc --noEmit
-
       - name: Upload test report artifact (JUnit)
         if: always()
         uses: actions/upload-artifact@v4
@@ -205,3 +202,24 @@ jobs:
         with:
           header: vitest
           message: ${{ steps.junit_summary.outputs.markdown }}
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        env:
+          HUSKY: '0'
+        run: npm ci --legacy-peer-deps
+
+      - name: TypeScript typecheck
+        run: npx tsc --noEmit

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ COPY prisma ./prisma/
 # Install production dependencies including optional dependencies
 # Optional dependencies (twilio, @sendgrid/mail, resend, nodemailer, @aws-sdk/client-sns)
 # are needed for notification features. npm ci --omit=dev installs optionalDependencies by default.
-RUN npm ci --omit=dev --legacy-peer-deps --ignore-scripts --no-audit --no-fund && \
-    npm cache clean --force && \
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci --omit=dev --legacy-peer-deps --ignore-scripts --no-audit --no-fund && \
     rm -rf /tmp/*
 
 # Stage 2: Builder
@@ -62,8 +62,8 @@ RUN echo "Build date: $BUILD_DATE"
 COPY prisma ./prisma/
 
 # Install all dependencies (including dev) - essential for build steps
-RUN npm ci --legacy-peer-deps --ignore-scripts --no-audit --no-fund && \
-    npm cache clean --force
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci --legacy-peer-deps --ignore-scripts --no-audit --no-fund
 
 # Copy application source
 COPY . .

--- a/docs/RELEASE_QUALITY_CONTRACT.md
+++ b/docs/RELEASE_QUALITY_CONTRACT.md
@@ -17,7 +17,7 @@ Every stable `vMAJOR.MINOR.PATCH` release must pass:
 9. **Documentation coverage** — resolve v1.4 relative links and verify the capability inventory has destinations for the required product workflows.
 10. **Security and general regression** — the normal test and security workflows must also pass for the release commit.
 
-The `release-quality` job in `.github/workflows/docker-image.yml` runs before stable image publication. If any gate fails, the release image job does not start. Main and pull-request image validation still use a lightweight no-release path.
+The `release-quality` job in `.github/workflows/docker-image.yml` runs only for stable version tags and must pass before stable image publication. If any gate fails, the release image job does not start. Main and pull-request image builds skip this job entirely so they do not start an unused PostgreSQL service.
 
 ## Evidence and exceptions
 


### PR DESCRIPTION
## Summary

- skip the PostgreSQL-backed `release-quality` job entirely for ordinary main and PR image builds while preserving it as a hard gate for version tags
- export complete, scoped BuildKit caches and let releases reuse the amd64 main cache
- share npm downloads between Docker dependency stages with BuildKit cache mounts
- run CodeQL and ESLint concurrently while preserving the existing `SAST (CodeQL & ESLint)` aggregate check
- execute ESLint once and derive the JUnit report from its SARIF output
- run DAST only for scheduled/manual executions and skip it when no real `DAST_TARGET_URL` is configured
- run TypeScript typechecking in parallel with the database-backed test job
- update the release-quality contract documentation

## Measured baseline

From the latest successful main run before this change:

- Docker workflow: 350s; 31s was an otherwise empty release-quality/PostgreSQL job and 288s was BuildKit
- Tests: 237s; typecheck occupied the final 22s sequentially
- Security: 240s; combined SAST took 225s, including two 37s ESLint executions and 97s of CodeQL work
- DAST used 59s scanning the placeholder `example.com`

## Expected effect

- ordinary Docker runs start immediately and gain stronger reusable layer caching after the first cache population
- tests save approximately the sequential 22s typecheck tail
- CodeQL and ESLint move off the same critical path, and the duplicate 37s ESLint pass is removed
- placeholder DAST runner usage is eliminated

## Validation

- all workflow YAML files parse successfully
- focused assertions confirm the tag-only release gate and max-mode main cache
- `git diff --check` passes
- Node/npm and Docker are unavailable in the local execution environment, so application tests and a local image build could not be run