### PR TITLE
fix: close Bugbot access and integrity gaps

### DIFF
--- a/src/app/(app)/postmortems/actions.ts
+++ b/src/app/(app)/postmortems/actions.ts
@@ -182,8 +182,13 @@ export async function upsertPostmortem(incidentId: string, data: PostmortemData)
  * Get postmortem for an incident
  */
 export async function getPostmortem(incidentId: string) {
+  const user = await getCurrentUser();
+  const canViewDrafts = user.role === 'ADMIN' || user.role === 'RESPONDER';
   const postmortem = await prisma.postmortem.findUnique({
-    where: { incidentId },
+    where: {
+      incidentId,
+      ...(canViewDrafts ? {} : { status: 'PUBLISHED' }),
+    },
     include: {
       createdBy: {
         select: { id: true, name: true, email: true },
@@ -227,7 +232,7 @@ export async function getPostmortem(incidentId: string) {
   // Rolling migration aid: old postmortems may still only have JSON action
   // items. Hydrate normalized rows on first read so Jira linking works without
   // requiring a maintenance window.
-  if (actionItemRecords.length === 0) {
+  if (canViewDrafts && actionItemRecords.length === 0) {
     const legacyItems = normalizeLegacyActionItems(actionItems, {
       legacyIdPrefix: `postmortem-${postmortem.id}`,
     });
@@ -521,8 +526,9 @@ export async function generatePostmortemDraft(incidentId: string, userTimeZone?:
  * Bulk delete postmortems by IDs
  */
 export async function bulkDeletePostmortems(ids: string[]) {
+  let user: Awaited<ReturnType<typeof assertResponderOrAbove>>;
   try {
-    await assertResponderOrAbove();
+    user = await assertResponderOrAbove();
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -531,12 +537,28 @@ export async function bulkDeletePostmortems(ids: string[]) {
     return { success: false, error: 'No postmortems selected' };
   }
 
-  await prisma.postmortem.deleteMany({
+  const selected = await prisma.postmortem.findMany({
     where: {
       OR: [{ id: { in: ids } }, { incidentId: { in: ids } }],
     },
+    select: { id: true, createdById: true },
+  });
+
+  if (selected.length === 0) {
+    return { success: false, error: 'No matching postmortems found' };
+  }
+
+  if (user.role !== 'ADMIN' && selected.some(postmortem => postmortem.createdById !== user.id)) {
+    return {
+      success: false,
+      error: 'Only administrators or the postmortem author can delete the selected records',
+    };
+  }
+
+  const deleted = await prisma.postmortem.deleteMany({
+    where: { id: { in: selected.map(postmortem => postmortem.id) } },
   });
 
   revalidatePath('/postmortems');
-  return { success: true, count: ids.length };
+  return { success: true, count: deleted.count };
 }

--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -152,6 +152,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const status: IncidentStatus | null = parsed.data.status ?? null;
   const urgency: IncidentUrgency | null = parsed.data.urgency ?? null;
   const hasAssigneeUpdate = Object.prototype.hasOwnProperty.call(body, 'assigneeId');
+  const assigneeId = hasAssigneeUpdate ? (parsed.data.assigneeId ?? null) : undefined;
 
   const updates: Record<string, unknown> = {};
   if (status) {
@@ -222,7 +223,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     updates.urgency = urgency;
   }
   if (hasAssigneeUpdate) {
-    updates.assigneeId = parsed.data.assigneeId ?? null;
+    updates.assigneeId = assigneeId;
   }
 
   if (Object.keys(updates).length === 0) {
@@ -266,7 +267,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     });
   }
 
-  if (assigneeId !== null && assigneeId !== currentIncident.assigneeId) {
+  if (hasAssigneeUpdate && assigneeId !== currentIncident.assigneeId) {
     if (!assigneeId) {
       await prisma.incidentEvent.create({
         data: {

--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -120,11 +120,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   } catch (_error) {
     return jsonError('Invalid JSON in request body.', 400);
   }
-  const parsed = IncidentPatchSchema.safeParse({
-    status: body.status,
-    urgency: body.urgency,
-    assigneeId: body.assigneeId ?? null,
-  });
+  const parsed = IncidentPatchSchema.safeParse(body);
   if (!parsed.success) {
     return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
   }
@@ -155,8 +151,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   }
   const status: IncidentStatus | null = parsed.data.status ?? null;
   const urgency: IncidentUrgency | null = parsed.data.urgency ?? null;
-  const assigneeId: string | null =
-    typeof parsed.data.assigneeId === 'string' ? parsed.data.assigneeId : null;
+  const hasAssigneeUpdate = Object.prototype.hasOwnProperty.call(body, 'assigneeId');
 
   const updates: Record<string, unknown> = {};
   if (status) {
@@ -226,8 +221,8 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     }
     updates.urgency = urgency;
   }
-  if (assigneeId !== null) {
-    updates.assigneeId = assigneeId || null;
+  if (hasAssigneeUpdate) {
+    updates.assigneeId = parsed.data.assigneeId ?? null;
   }
 
   if (Object.keys(updates).length === 0) {

--- a/src/app/api/status/history/route.ts
+++ b/src/app/api/status/history/route.ts
@@ -3,6 +3,8 @@ import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { logger } from '@/lib/logger';
 import { authorizeStatusApiRequest } from '@/lib/status-api-auth';
+import { getServerSession } from 'next-auth';
+import { getAuthOptions } from '@/lib/auth';
 
 /**
  * Get Status Page Historical Data
@@ -51,16 +53,20 @@ export async function GET(req: NextRequest) {
       return jsonError(authResult.error || 'Unauthorized', authResult.status || 401);
     }
 
+    if (statusPage.requireAuth) {
+      const session = await getServerSession(await getAuthOptions());
+      if (!session) {
+        return jsonError('Authentication required', 401);
+      }
+    }
+
     const serviceIds = statusPage.services.filter(sp => sp.showOnPage).map(sp => sp.serviceId);
 
-    const effectiveServiceIds =
-      serviceIds.length > 0
-        ? serviceId && serviceIds.includes(serviceId)
-          ? [serviceId]
-          : serviceIds
-        : serviceId
-          ? [serviceId]
-          : [];
+    if (serviceId && !serviceIds.includes(serviceId)) {
+      return jsonError('Service is not available on this status page', 404);
+    }
+
+    const effectiveServiceIds = serviceId ? [serviceId] : serviceIds;
 
     if (effectiveServiceIds.length === 0) {
       return jsonOk({ incidents: [], services: [] }, 200);

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -104,6 +104,7 @@ export async function GET(req: NextRequest) {
             incidents: {
               where: {
                 status: { in: ['OPEN', 'ACKNOWLEDGED'] },
+                visibility: 'PUBLIC',
               },
             },
           },
@@ -119,6 +120,7 @@ export async function GET(req: NextRequest) {
       serviceId: serviceIds,
       includeIncidents: true,
       incidentLimit: 20,
+      visibility: 'PUBLIC',
     });
 
     const recentIncidents = metrics.recentIncidents || [];
@@ -149,7 +151,12 @@ export async function GET(req: NextRequest) {
     }));
 
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    const uptimeMap = await calculateMultiServiceUptime(serviceIds, thirtyDaysAgo);
+    const uptimeMap = await calculateMultiServiceUptime(
+      serviceIds,
+      thirtyDaysAgo,
+      new Date(),
+      'PUBLIC'
+    );
     const uptimeMetrics = services.map(service => ({
       serviceId: service.id,
       uptime: parseFloat((uptimeMap[service.id] || 100).toFixed(3)),

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -2601,7 +2601,8 @@ function calculateMergedDuration(intervals: Array<{ start: Date; end: Date }>): 
 export async function calculateMultiServiceUptime(
   serviceIds: string[],
   startDate: Date,
-  endDate: Date = new Date()
+  endDate: Date = new Date(),
+  visibility?: 'PUBLIC' | 'PRIVATE'
 ): Promise<Record<string, number>> {
   const { default: prisma } = await import('./prisma');
 
@@ -2614,6 +2615,7 @@ export async function calculateMultiServiceUptime(
   const incidents = await prisma.incident.findMany({
     where: {
       serviceId: { in: serviceIds },
+      ...(visibility ? { visibility } : {}),
       AND: [
         { createdAt: { lt: effectiveEnd } },
         {

--- a/tests/lib/sla-server.test.ts
+++ b/tests/lib/sla-server.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import prisma from '@/lib/prisma';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateMultiServiceUptime, calculateSLAMetrics } from '@/lib/sla-server';
 import { clearRetentionPolicyCache } from '@/lib/retention-policy';
 
 // Local mock for this test file to ensure isolation
@@ -87,6 +87,25 @@ const prismaMock = prisma as unknown as PrismaMock & {
   systemSettings?: PrismaMock['systemSettings'];
   sLADefinition?: PrismaMock['sLADefinition'];
 };
+
+describe('calculateMultiServiceUptime visibility', () => {
+  it('applies the requested incident visibility to the uptime query', async () => {
+    prismaMock.incident.findMany.mockResolvedValueOnce([]);
+
+    await calculateMultiServiceUptime(
+      ['service-public'],
+      new Date('2026-01-01T00:00:00.000Z'),
+      new Date('2026-01-02T00:00:00.000Z'),
+      'PUBLIC'
+    );
+
+    expect(prismaMock.incident.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ visibility: 'PUBLIC' }),
+      })
+    );
+  });
+});
 
 // Initialize the new mock functions
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Fixes all five findings from the repository-wide Bugbot investigation.

- restrict public status metrics, incident summaries, active counts, and uptime calculations to `PUBLIC` incidents
- enforce `requireAuth` on status history and reject services not configured for the active status page
- authenticate postmortem reads, expose drafts only to responders/admins, and prevent viewer-triggered legacy migration writes
- enforce the same admin-or-author ownership policy for bulk postmortem deletion as single deletion
- delete only resolved postmortem records and return the database's actual deletion count
- preserve field presence in incident PATCH requests so `assigneeId: null` explicitly unassigns an incident
- add regression coverage verifying public visibility reaches multi-service uptime queries

## Security impact

- prevents private incident titles, IDs, state, and downtime from affecting public status responses
- prevents unauthenticated access to draft/private postmortem content and read-triggered mutations
- prevents responders from bulk-deleting postmortems authored by other users
- prevents status-history scope escape through arbitrary service IDs

## Validation

- `git diff --check` passes
- focused regression test added for visibility-scoped uptime
- GitHub Actions will run typecheck, unit/database tests, security analysis, and the production Docker build