### PR TITLE
fix: harden incident notification and escalation reliability

### DIFF
--- a/src/app/(app)/incidents/bulk-actions.ts
+++ b/src/app/(app)/incidents/bulk-actions.ts
@@ -18,33 +18,40 @@ export async function bulkAcknowledge(incidentIds: string[]) {
   }
 
   try {
-    // Update all selected incidents to ACKNOWLEDGED
-    await prisma.incident.updateMany({
-      where: {
-        id: { in: incidentIds },
-        status: { in: ['OPEN', 'ACKNOWLEDGED', 'SNOOZED', 'SUPPRESSED'] }, // Only update non-resolved incidents
-      },
-      data: {
-        status: 'ACKNOWLEDGED',
-        acknowledgedAt: new Date(),
-        escalationStatus: 'COMPLETED',
-        nextEscalationAt: null,
-      },
-    });
-
-    // Log events for each incident (batch create)
     const user = await getCurrentUser();
-    await prisma.incidentEvent.createMany({
-      data: incidentIds.map(incidentId => ({
-        incidentId,
-        type: 'ACKNOWLEDGED',
-        message: `Bulk acknowledged${user ? ` by ${user.name}` : ''}`,
-      })),
+    const changedIncidentIds = await prisma.$transaction(async tx => {
+      const eligible = await tx.incident.findMany({
+        where: {
+          id: { in: incidentIds },
+          status: { in: ['OPEN', 'ACKNOWLEDGED', 'SNOOZED', 'SUPPRESSED'] },
+        },
+        select: { id: true },
+      });
+      const eligibleIds = eligible.map(incident => incident.id);
+      if (eligibleIds.length === 0) return [];
+
+      await tx.incident.updateMany({
+        where: { id: { in: eligibleIds } },
+        data: {
+          status: 'ACKNOWLEDGED',
+          acknowledgedAt: new Date(),
+          escalationStatus: 'COMPLETED',
+          nextEscalationAt: null,
+        },
+      });
+      await tx.incidentEvent.createMany({
+        data: eligibleIds.map(incidentId => ({
+          incidentId,
+          type: 'ACKNOWLEDGED',
+          message: `Bulk acknowledged${user ? ` by ${user.name}` : ''}`,
+        })),
+      });
+      return eligibleIds;
     });
 
-    // Fetch all incidents in a single query for notifications and webhooks
+    // Notify only incidents that were actually eligible and changed.
     const incidents = await prisma.incident.findMany({
-      where: { id: { in: incidentIds } },
+      where: { id: { in: changedIncidentIds } },
       include: {
         service: { select: { id: true, name: true } },
         assignee: {
@@ -90,7 +97,7 @@ export async function bulkAcknowledge(incidentIds: string[]) {
 
     revalidatePath('/incidents');
     revalidatePath('/');
-    return { success: true, count: incidentIds.length };
+    return { success: true, count: changedIncidentIds.length };
   } catch (error) {
     logger.error('Bulk acknowledge failed', { component: 'bulk-actions', error, incidentIds });
     return { success: false, error: 'Failed to acknowledge incidents' };

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -223,22 +223,10 @@ export async function POST(req: NextRequest) {
   try {
     if (hasEscalationPolicy) {
       const { sendServiceNotifications } = await import('@/lib/service-notifications');
-      // Run in background, don't await to keep API fast
-      sendServiceNotifications(incident.id, 'triggered').catch(err => {
-        logger.error('api.incident.service_notification_failed', {
-          error: err.message,
-          incidentId: incident.id,
-        });
-      });
+      await sendServiceNotifications(incident.id, 'triggered');
     } else {
       const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-      // Run in background, don't await to keep API fast
-      sendIncidentNotifications(incident.id, 'triggered').catch(err => {
-        logger.error('api.incident.user_notification_failed', {
-          error: err.message,
-          incidentId: incident.id,
-        });
-      });
+      await sendIncidentNotifications(incident.id, 'triggered');
     }
   } catch (e) {
     logger.error('api.incident.service_notification_import_failed', {
@@ -246,16 +234,10 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  // Notify status page subscribers (Email) - run in background to avoid blocking API response
+  // Await delivery so serverless runtimes cannot terminate it with the request.
   try {
     const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
-    // Don't await - run in background for faster API response on resource-constrained systems
-    notifyStatusPageSubscribers(incident.id, 'triggered').catch(err => {
-      logger.error('api.incident.status_page_notification_failed', {
-        error: err instanceof Error ? err.message : String(err),
-        incidentId: incident.id,
-      });
-    });
+    await notifyStatusPageSubscribers(incident.id, 'triggered');
   } catch (e) {
     logger.error('api.incident.status_page_notification_import_failed', {
       error: e instanceof Error ? e.message : String(e),
@@ -263,16 +245,10 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  // ChatOps: Auto-create war-room for qualifying incidents (fire-and-forget)
+  // ChatOps: Auto-create war-room for qualifying incidents.
   try {
     const { createIncidentWarRoom } = await import('@/lib/chatops/war-room');
-    createIncidentWarRoom(incident.id).catch(err => {
-      logger.error('ChatOps war-room creation failed', {
-        component: 'incidents-api',
-        error: err instanceof Error ? err.message : String(err),
-        incidentId: incident.id,
-      });
-    });
+    await createIncidentWarRoom(incident.id);
   } catch (e) {
     logger.error('Failed to load chatops/war-room', { error: e });
   }

--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -257,7 +257,11 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
     },
   });
 
-  if (!incident || !incident.service.policy?.steps?.length) {
+  if (!incident) {
+    return { escalated: false, reason: 'Incident not found' };
+  }
+
+  if (!incident.service.policy?.steps?.length) {
     // Clear escalation status if no policy
     await prisma.incident.update({
       where: { id: incidentId },

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -55,6 +55,30 @@ const channelStates = new Map<NotificationChannel, ChannelState>();
 const processedDedupeKeys = new Map<string, number>();
 let flushTimer: NodeJS.Timeout | null = null;
 let isProcessing = false;
+const pendingRetries = new Map<NodeJS.Timeout, QueuedNotification>();
+
+function ensureFlushTimer(): void {
+  if (!flushTimer && queue.length > 0) {
+    flushTimer = setInterval(flushQueue, FLUSH_INTERVAL_MS);
+  }
+}
+
+function scheduleRetry(notification: QueuedNotification, delayMs: number): void {
+  const timer = setTimeout(() => {
+    pendingRetries.delete(timer);
+    if (queue.length >= MAX_QUEUE_SIZE) {
+      logger.warn('[NotificationQueue] Queue full, dropping retry', {
+        incidentId: notification.incidentId,
+        userId: notification.userId,
+        channel: notification.channel,
+      });
+      return;
+    }
+    queue.push(notification);
+    ensureFlushTimer();
+  }, delayMs);
+  pendingRetries.set(timer, notification);
+}
 
 /**
  * Initialize channel states
@@ -159,9 +183,7 @@ export function queueNotification(
   });
 
   // Start flush timer if not running
-  if (!flushTimer) {
-    flushTimer = setInterval(flushQueue, FLUSH_INTERVAL_MS);
-  }
+  ensureFlushTimer();
 
   return true;
 }
@@ -209,9 +231,7 @@ export function queueBulkNotifications(
   }
 
   // Start flush timer if not running
-  if (!flushTimer && queued > 0) {
-    flushTimer = setInterval(flushQueue, FLUSH_INTERVAL_MS);
-  }
+  if (queued > 0) ensureFlushTimer();
 
   return { queued, dropped, duplicates };
 }
@@ -293,9 +313,10 @@ async function processChannelNotifications(
         const retryCount = (n.retryCount || 0) + 1;
         if (retryCount <= 5) {
           const delayMs = Math.pow(2, retryCount) * 1000;
-          setTimeout(() => {
-            queue.push({ ...n, priority: Math.min(n.priority + 1, 3), retryCount });
-          }, delayMs);
+          scheduleRetry(
+            { ...n, priority: Math.min(n.priority + 1, 3), retryCount },
+            delayMs
+          );
         } else {
           logger.error('[NotificationQueue] Notification permanently dropped due to rate limits', {
             incidentId: n.incidentId,
@@ -410,6 +431,12 @@ export async function forceFlush(): Promise<void> {
     flushTimer = null;
   }
 
+  for (const [timer, notification] of pendingRetries) {
+    clearTimeout(timer);
+    if (queue.length < MAX_QUEUE_SIZE) queue.push(notification);
+  }
+  pendingRetries.clear();
+
   // Process remaining items
   while (queue.length > 0) {
     await flushQueue();
@@ -421,6 +448,8 @@ export async function forceFlush(): Promise<void> {
  */
 export function clearQueue(): void {
   queue.length = 0;
+  for (const timer of pendingRetries.keys()) clearTimeout(timer);
+  pendingRetries.clear();
   processedDedupeKeys.clear();
   channelStates.clear();
 

--- a/tests/lib/bulk-actions.test.ts
+++ b/tests/lib/bulk-actions.test.ts
@@ -64,7 +64,11 @@ describe('Bulk Actions', () => {
       vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 2 });
       vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 2 });
       vi.mocked(prisma.incident.findMany)
-        .mockResolvedValueOnce(incidentIds.map(id => ({ id })) as any)
+        .mockResolvedValueOnce(
+          incidentIds.map(id => ({ id })) as unknown as Awaited<
+            ReturnType<typeof prisma.incident.findMany>
+          >
+        )
         .mockResolvedValueOnce([]);
 
       const result = await bulkAcknowledge(incidentIds);

--- a/tests/lib/bulk-actions.test.ts
+++ b/tests/lib/bulk-actions.test.ts
@@ -9,18 +9,23 @@ import prisma from '@/lib/prisma';
 import { getCurrentUser, assertResponderOrAbove } from '@/lib/rbac';
 
 // Mock dependencies
-vi.mock('@/lib/prisma', () => ({
-  __esModule: true,
-  default: {
-    incident: {
-      updateMany: vi.fn(),
-      findUnique: vi.fn(),
-      findMany: vi.fn(),
-    },
-    incidentEvent: {
-      create: vi.fn(),
-      createMany: vi.fn(),
-    },
+vi.mock('@/lib/prisma', () => {
+  const incident = {
+    updateMany: vi.fn(),
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+  };
+  const incidentEvent = {
+    create: vi.fn(),
+    createMany: vi.fn(),
+  };
+  const client = {
+    incident,
+    incidentEvent,
+    $transaction: vi.fn(
+      async (callback: (tx: { incident: typeof incident; incidentEvent: typeof incidentEvent }) => unknown) =>
+        callback({ incident, incidentEvent })
+    ),
     auditLog: {
       create: vi.fn(),
     },
@@ -28,8 +33,9 @@ vi.mock('@/lib/prisma', () => ({
       findUnique: vi.fn(),
       upsert: vi.fn(),
     },
-  },
-}));
+  };
+  return { __esModule: true, default: client };
+});
 
 vi.mock('@/lib/rbac', () => ({
   getCurrentUser: vi.fn(),
@@ -57,17 +63,16 @@ describe('Bulk Actions', () => {
       const incidentIds = ['incident-1', 'incident-2'];
       vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 2 });
       vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 2 });
-      vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.incident.findMany)
+        .mockResolvedValueOnce(incidentIds.map(id => ({ id })) as any)
+        .mockResolvedValueOnce([]);
 
       const result = await bulkAcknowledge(incidentIds);
 
       expect(result.success).toBe(true);
       expect(result.count).toBe(2);
       expect(prisma.incident.updateMany).toHaveBeenCalledWith({
-        where: {
-          id: { in: incidentIds },
-          status: { in: ['OPEN', 'ACKNOWLEDGED', 'SNOOZED', 'SUPPRESSED'] },
-        },
+        where: { id: { in: incidentIds } },
         data: {
           status: 'ACKNOWLEDGED',
           acknowledgedAt: expect.any(Date),

--- a/tests/lib/escalation.test.ts
+++ b/tests/lib/escalation.test.ts
@@ -216,8 +216,9 @@ describe('executeEscalation', () => {
 
     expect(result).toEqual({
       escalated: false,
-      reason: 'No escalation policy configured',
+      reason: 'Incident not found',
     });
+    expect(prisma.incident.update).not.toHaveBeenCalled();
   });
 
   it('returns early when no escalation policy configured', async () => {

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -40,6 +40,9 @@ describe('incident flow safeguards', () => {
 
   it('bulk acknowledge stops escalation', async () => {
     prismaMock.incident.updateMany.mockResolvedValue({ count: 2 });
+    prismaMock.incident.findMany
+      .mockResolvedValueOnce([{ id: 'inc-1' }, { id: 'inc-2' }])
+      .mockResolvedValueOnce([]);
 
     await bulkAcknowledge(['inc-1', 'inc-2']);
 

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -37,7 +37,7 @@ describe('incident flow safeguards', () => {
     vi.clearAllMocks();
     prismaMock.$transaction.mockImplementation(async (cb: any) => cb(prismaMock));
     prismaMock.incident.findMany.mockReset().mockResolvedValue([]);
-    prismaMock.incidentEvent.createMany.mockReset().mockResolvedValue({ count: 0 });
+    prismaMock.incidentEvent.createMany = vi.fn().mockResolvedValue({ count: 0 });
   });
 
   it('bulk acknowledge stops escalation', async () => {

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -36,6 +36,8 @@ describe('incident flow safeguards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.$transaction.mockImplementation(async (cb: any) => cb(prismaMock));
+    prismaMock.incident.findMany.mockReset().mockResolvedValue([]);
+    prismaMock.incidentEvent.createMany.mockReset().mockResolvedValue({ count: 0 });
   });
 
   it('bulk acknowledge stops escalation', async () => {


### PR DESCRIPTION
## Why

Several core incident paths could silently lose work or record incorrect state:

- rate-limited notification retries could be requeued after the worker timer stopped
- API-triggered notifications could be terminated with the serverless request
- bulk acknowledgement could create events for missing or ineligible incidents
- escalation processing attempted to update incidents that had already been deleted

## What changed

- Added tracked notification retry timers and restart queue processing when a delayed retry is reinserted.
- Drain pending retry timers during graceful shutdown and clear them during queue reset.
- Await service, user, status-page, and ChatOps work before returning from incident creation.
- Made bulk acknowledgement and event creation atomic inside a transaction.
- Scope bulk events, notifications, and returned counts to incidents that were actually eligible for mutation.
- Return cleanly when escalation processing cannot find the incident.
- Added regression coverage for missing incidents and updated bulk-action test infrastructure for transactions.

## Operational impact

Incident creation may remain open slightly longer while notification work completes. This deliberately trades a small amount of API latency for delivery reliability until these operations are moved to a durable outbox/job pipeline.

No schema changes or migrations are included.

## Verification

- `git diff --check` passed.
- GitHub Actions is the runtime verification gate because Node.js tooling is unavailable in the current workspace.
- Typecheck and initial security checks are passing; remaining checks are running.

## Review focus

- notification retry lifecycle in `src/lib/notification-queue.ts`
- transaction boundaries and eligible-ID filtering in `bulkAcknowledge`
- request-lifetime behavior in the incident creation API

## Origin

Addresses four concrete findings from the focused Bugbot core-component audit.