### PR TITLE
fix: enforce enterprise data retention and fail-closed security

### DIFF
--- a/docs/v1.5/security/README.md
+++ b/docs/v1.5/security/README.md
@@ -6,6 +6,8 @@ description: Identity, authorization, encryption, signature verification, and se
 
 # Security
 
+- [Enterprise readiness and assurance](enterprise-readiness.md)
+
 This section covers identity management, authorization, cryptographic data protection, webhook signature verification, and secure operations for OpsKnight. These controls can contribute evidence to your security program; installing OpsKnight does not by itself make a deployment compliant with a standard or regulation.
 
 ## In This Section

--- a/docs/v1.5/security/enterprise-readiness.md
+++ b/docs/v1.5/security/enterprise-readiness.md
@@ -1,0 +1,77 @@
+# Enterprise readiness and assurance
+
+OpsKnight is designed to support enterprise deployments, but software features alone do not
+constitute SOC 2, ISO 27001, HIPAA, PCI DSS, or other third-party certification. Certification
+also depends on the deploying organization's people, processes, infrastructure, evidence period,
+and independent audit. Do not describe a deployment as certified unless the applicable auditor
+has issued that certification.
+
+## Technical control baseline
+
+An enterprise production deployment must meet all of the following requirements.
+
+### Identity and access
+
+- Configure OIDC/SSO for workforce access and enforce MFA at the identity provider.
+- Grant the least-privileged OpsKnight role and review ADMIN assignments regularly.
+- Use a trusted reverse proxy and overwrite forwarded client-IP headers at the edge.
+- Rotate credentials and terminate active sessions when access is revoked.
+
+### Secrets and encryption
+
+- Configure a stable `ENCRYPTION_KEY`; OpsKnight refuses new provider-secret writes when
+  encryption is unavailable.
+- Store application, database, OIDC, webhook, and notification credentials in a managed secret
+  store. Do not commit them to source control or bake them into container images.
+- Use TLS for users, integrations, webhooks, and database connections.
+- Test key and credential rotation in a non-production environment before production rollout.
+
+### Data integrity and retention
+
+- Back up PostgreSQL on a documented schedule and perform regular restore drills.
+- Apply Prisma migrations before starting a new application version.
+- Retain incident history for auditability. A service with incident history must not be deleted;
+  archive or disable it instead.
+- Define retention periods for audit logs, incidents, alerts, notifications, and backups according
+  to contractual and regulatory requirements.
+
+### Network and integrations
+
+- Restrict outbound network access to approved integration destinations where the platform allows.
+- Use signed webhooks, unique integration credentials, and regular credential rotation.
+- Explicitly map services to public status pages. Private incidents are never eligible for public
+  status-page webhook delivery.
+- Treat DNS and proxy configuration as a security boundary; block private and metadata networks at
+  the infrastructure layer in addition to application SSRF checks.
+
+### Reliability and operations
+
+- Run at least two application replicas for high availability and use PostgreSQL-backed shared
+  coordination for rate limits and background work.
+- Monitor `/api/health`, authenticated metrics, job failures, notification failures, database
+  capacity, and external-provider latency.
+- Alert on failed migrations, exhausted background-job retries, notification backlog, and backup
+  or restore failures.
+- Maintain incident response, disaster recovery, rollback, vulnerability management, and change
+  management procedures with named owners.
+
+## Release evidence gate
+
+Before promoting a release, retain evidence that all required checks passed for the exact commit:
+
+1. TypeScript typecheck and lint.
+2. Unit and database integration suites.
+3. Production container build and vulnerability scan.
+4. Static security analysis and secret scanning.
+5. Migration test against a representative backup.
+6. Backup restore and rollback rehearsal for material schema changes.
+7. Manual smoke tests for login, incident creation, acknowledgement, escalation, resolution,
+   status-page visibility, notifications, schedules, and administrative changes.
+
+## Shared-responsibility boundary
+
+OpsKnight supplies application controls. The operator remains responsible for identity-provider
+policy, network segmentation, host and cluster hardening, database availability, backup custody,
+log export and retention, monitoring coverage, employee lifecycle controls, vendor management,
+security training, incident response, and audit evidence. These responsibilities should be mapped
+to the chosen assurance framework before an external readiness assessment.

--- a/prisma/migrations/20260824190000_fix_fk_cascade_setNull_constraints/migration.sql
+++ b/prisma/migrations/20260824190000_fix_fk_cascade_setNull_constraints/migration.sql
@@ -1,6 +1,6 @@
 -- Fix foreign key cascade and SetNull constraints for enterprise data integrity.
 -- This migration ensures:
---   1. Deleting a Service cascades to Incidents, Alerts, and Integrations (instead of crashing).
+--   1. Services with incident history cannot be deleted; auxiliary service data cascades.
 --   2. Deleting a User does NOT destroy historical IncidentNotes (userId is nullified instead).
 --   3. Deleting a User nullifies team lead, postmortem author, template author, action item owner, etc.
 
@@ -18,10 +18,10 @@ ALTER TABLE "SlackOAuthConfig" ALTER COLUMN "updatedBy" DROP NOT NULL;
 
 -- Drop existing FK constraints so we can re-add with onDelete rules
 
--- Incident → Service: Cascade (was no onDelete)
+-- Incident → Service: Restrict to preserve incident and audit history
 ALTER TABLE "Incident" DROP CONSTRAINT IF EXISTS "Incident_serviceId_fkey";
 ALTER TABLE "Incident" ADD CONSTRAINT "Incident_serviceId_fkey"
-  FOREIGN KEY ("serviceId") REFERENCES "Service"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  FOREIGN KEY ("serviceId") REFERENCES "Service"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- Alert → Service: Cascade
 ALTER TABLE "Alert" DROP CONSTRAINT IF EXISTS "Alert_serviceId_fkey";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -499,7 +499,7 @@ model Incident {
   createdAt              DateTime           @default(now())
   updatedAt              DateTime           @updatedAt
 
-  service                 Service                  @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  service                 Service                  @relation(fields: [serviceId], references: [id], onDelete: Restrict)
   assignee                User?                    @relation(fields: [assigneeId], references: [id])
   team                    Team?                    @relation(fields: [teamId], references: [id])
   events                  IncidentEvent[]

--- a/src/app/(app)/incidents/snooze-actions.ts
+++ b/src/app/(app)/incidents/snooze-actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { assertResponderOrAbove, getCurrentUser } from '@/lib/rbac';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { logger } from '@/lib/logger';
+import { processAutoUnsnoozeInternal } from '@/lib/unsnooze';
 
 export async function snoozeIncidentWithDuration(
   incidentId: string,
@@ -86,115 +87,5 @@ export async function processAutoUnsnooze() {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
 
-  const now = new Date();
-  const incidentsToUnsnooze = await prisma.incident.findMany({
-    where: {
-      status: 'SNOOZED',
-      snoozedUntil: { lte: now },
-    },
-    select: { id: true },
-  });
-
-  let processedCount = 0;
-  for (const incident of incidentsToUnsnooze) {
-    try {
-      const policyData = await prisma.incident.findUnique({
-        where: { id: incident.id },
-        select: {
-          status: true,
-          currentEscalationStep: true,
-          service: {
-            select: {
-              policy: {
-                select: {
-                  steps: {
-                    orderBy: { stepOrder: 'asc' },
-                    select: { delayMinutes: true },
-                  },
-                },
-              },
-            },
-          },
-        },
-      });
-
-      if (policyData?.status !== 'SNOOZED') continue;
-
-      const stepIndex = policyData?.currentEscalationStep ?? 0;
-      const delayMinutes = policyData?.service?.policy?.steps?.[stepIndex]?.delayMinutes ?? 0;
-      const nextEscalationAt = new Date(Date.now() + delayMinutes * 60 * 1000);
-
-      const claim = await prisma.incident.updateMany({
-        where: {
-          id: incident.id,
-          status: 'SNOOZED',
-          snoozedUntil: { lte: now },
-        },
-        data: {
-          status: 'OPEN',
-          snoozedUntil: null,
-          snoozeReason: null,
-          escalationStatus: 'ESCALATING',
-          nextEscalationAt,
-        },
-      });
-
-      if (claim.count === 0) continue;
-
-      await prisma.incidentEvent.create({
-        data: {
-          incidentId: incident.id,
-          type: 'STATUS_CHANGE',
-          message: 'Incident auto-unsnoozed (snooze duration expired)',
-        },
-      });
-      processedCount++;
-    } catch (error) {
-      logger.error('Failed to unsnooze incident', {
-        component: 'snooze-actions',
-        incidentId: incident.id,
-        error,
-      });
-      continue; // Skip to next incident
-    }
-    try {
-      const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-      await sendIncidentNotifications(incident.id, 'updated');
-      const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
-      await notifyStatusPageSubscribers(incident.id, 'investigating');
-      const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-      const updatedIncident = await prisma.incident.findUnique({
-        where: { id: incident.id },
-        include: {
-          service: { select: { id: true, name: true } },
-          assignee: {
-            select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-          },
-        },
-      });
-      if (updatedIncident) {
-        await triggerWebhooksForService(updatedIncident.serviceId, 'incident.updated', {
-          id: updatedIncident.id,
-          title: updatedIncident.title,
-          description: updatedIncident.description,
-          status: updatedIncident.status,
-          urgency: updatedIncident.urgency,
-          priority: updatedIncident.priority,
-          service: updatedIncident.service,
-          assignee: updatedIncident.assignee,
-          createdAt: updatedIncident.createdAt.toISOString(),
-          acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
-          resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
-        });
-      }
-    } catch (error) {
-      logger.error('Failed to notify after auto-unsnooze', {
-        component: 'snooze-actions',
-        incidentId: incident.id,
-        error,
-      });
-    }
-  }
-
-  return { processed: processedCount };
+  return processAutoUnsnoozeInternal();
 }

--- a/src/app/api/status-page/subscribe/route.ts
+++ b/src/app/api/status-page/subscribe/route.ts
@@ -80,9 +80,20 @@ export async function POST(req: NextRequest) {
             verified: false,
           },
         });
-      } else {
-        // Already subscribed - return success but don't send another email
+      } else if (existing.verified) {
         return jsonOk({ success: true, message: 'Already subscribed' }, 200);
+      } else if (Date.now() - existing.subscribedAt.getTime() < 60_000) {
+        return jsonOk(
+          { success: true, message: 'Verification email was recently sent. Please try again shortly.' },
+          200
+        );
+      } else {
+        // Rotate stale verification credentials and resend so an attacker cannot
+        // permanently reserve somebody else's email address.
+        await prisma.statusPageSubscription.update({
+          where: { id: existing.id },
+          data: { token, verificationToken },
+        });
       }
     } else {
       // Create new subscription

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -279,6 +279,25 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               return null;
             }
 
+            // Shared across application instances; the progressive local
+            // lockout below remains useful for its user-facing lockout timing.
+            const { checkRateLimit } = await import('@/lib/rate-limit');
+            const distributedAttempt = await checkRateLimit(
+              `auth:credentials:${email}:${ip}`,
+              20,
+              15 * 60 * 1000
+            );
+            if (!distributedAttempt.allowed) {
+              await logLoginBlocked(
+                email,
+                ip,
+                userAgent,
+                'RATE_LIMITED',
+                Math.max(0, distributedAttempt.resetAt - Date.now())
+              );
+              return null;
+            }
+
             // Check rate limiting / lockout
             const attemptCheck = checkLoginAttempt(email, ip);
             if (!attemptCheck.allowed) {

--- a/src/lib/cron-scheduler.ts
+++ b/src/lib/cron-scheduler.ts
@@ -2,7 +2,7 @@ import { processPendingEscalations } from './escalation';
 import { processPendingJobs, cleanupOldJobs } from './jobs/queue';
 import { logger } from './logger';
 import { retryFailedNotifications } from './notification-retry';
-import { processAutoUnsnooze } from '@/app/(app)/incidents/snooze-actions';
+import { processAutoUnsnoozeInternal } from '@/lib/unsnooze';
 import { cleanupUserTokens } from '@/lib/user-tokens';
 import { cleanupExpiredRateLimits } from '@/lib/rate-limit';
 import { checkSLABreaches } from './sla-breach-monitor';
@@ -299,7 +299,7 @@ async function runOnce() {
     // Group 2: Secondary tasks (can run in parallel)
     const [retryResult, autoUnsnoozeResult, breachResult] = await Promise.all([
       retryFailedNotifications(),
-      processAutoUnsnooze(),
+      processAutoUnsnoozeInternal(),
       checkSLABreaches(),
     ]);
 

--- a/src/lib/encrypted-provider-config.ts
+++ b/src/lib/encrypted-provider-config.ts
@@ -71,11 +71,18 @@ export async function encryptProviderConfig(
   // Check if encryption is available
   const key = await getEncryptionKey();
   if (!key) {
-    logger.warn('Encryption key not configured, storing provider config unencrypted', {
+    logger.error('Encryption key not configured; refusing to store provider secrets', {
       component: 'encrypted-provider-config',
       provider,
     });
-    return config;
+    if (
+      sensitiveFields.some(
+        field => typeof config[field] === 'string' && String(config[field]).length > 0
+      )
+    ) {
+      throw new Error('Provider secrets cannot be stored because encryption is unavailable.');
+    }
+    return { ...config };
   }
 
   const encryptedConfig = { ...config };
@@ -92,7 +99,7 @@ export async function encryptProviderConfig(
           field,
           error: error instanceof Error ? error.message : 'Unknown error',
         });
-        // Continue with unencrypted value rather than failing
+        throw new Error(`Failed to encrypt provider config field: ${field}`);
       }
     }
   }

--- a/src/lib/encrypted-provider-config.ts
+++ b/src/lib/encrypted-provider-config.ts
@@ -75,11 +75,11 @@ export async function encryptProviderConfig(
       component: 'encrypted-provider-config',
       provider,
     });
-    if (
-      sensitiveFields.some(
-        field => typeof config[field] === 'string' && String(config[field]).length > 0
-      )
-    ) {
+    const containsSecret = Object.entries(config).some(
+      ([field, value]) =>
+        sensitiveFields.includes(field) && typeof value === 'string' && value.length > 0
+    );
+    if (containsSecret) {
       throw new Error('Provider secrets cannot be stored because encryption is unavailable.');
     }
     return { ...config };

--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -580,6 +580,17 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
 
   for (const userId of targetUserIds) {
     try {
+      const latestState = await prisma.incident.findUnique({
+        where: { id: incidentId },
+        select: { status: true, escalationStatus: true },
+      });
+      if (
+        !latestState ||
+        !['OPEN'].includes(latestState.status) ||
+        latestState.escalationStatus === 'COMPLETED'
+      ) {
+        break;
+      }
       const message = `[OpsKnight] Incident: ${incident.title}${currentStepIndex > 0 ? ` (Escalation Level ${currentStepIndex + 1})` : ''}`;
       const result = await sendUserNotification(incidentId, userId, message, escalationChannels);
       notificationsSent.push({ userId, result });

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -123,7 +123,7 @@ export async function processEvent(
 
     // 3. For acknowledge, skip alert creation if no matching incident
     if (event_action === 'acknowledge' && !existingIncident) {
-      logger.warn(`event.${event_action}_no_match`, {
+      logger.info(`event.${event_action}_no_match`, {
         dedupKey: dedup_key,
         serviceId,
         source: eventData.source,
@@ -382,10 +382,10 @@ export async function processEvent(
       });
 
       if (incidentWithService) {
-        // PERF: Fire-and-forget status webhooks to avoid blocking response
-        // Catch errors locally to prevent unhandled promise rejections
+        // Await externally visible side effects so process teardown cannot
+        // silently discard them after the response is returned.
         const webhookStart = performance.now();
-        triggerWebhooksForService(result.incident.serviceId, 'incident.created', {
+        await triggerWebhooksForService(result.incident.serviceId, 'incident.created', {
           id: incidentWithService.id,
           title: incidentWithService.title,
           description: incidentWithService.description,
@@ -419,16 +419,15 @@ export async function processEvent(
     }
 
     // Execute escalation policy, then choose the correct notification path.
-    // PERF: Async dispatch (no await) prevents blocking the webhook response
     const notifyStart = performance.now();
-    executeEscalation(result.incident.id)
+    await executeEscalation(result.incident.id)
       .then(escalationResult => {
         const route = escalationNotificationRoute(escalationResult || {});
 
         if (route === 'service') {
-          import('./service-notifications')
+          return import('./service-notifications')
             .then(({ sendServiceNotifications }) => {
-              sendServiceNotifications(result.incident.id, 'triggered')
+              return sendServiceNotifications(result.incident.id, 'triggered')
                 .then(() => {
                   logger.info('api.event.notifications_sent', {
                     latencyMs: performance.now() - notifyStart,
@@ -447,9 +446,9 @@ export async function processEvent(
         } else {
           // Fallback only when the policy cannot provide responders. Scheduled
           // steps retain their configured delay and do not page the whole team.
-          import('./user-notifications')
+          return import('./user-notifications')
             .then(({ sendIncidentNotifications }) => {
-              sendIncidentNotifications(result.incident.id, 'triggered')
+              return sendIncidentNotifications(result.incident.id, 'triggered')
                 .then(() => {
                   logger.info('api.event.user_notifications_sent', {
                     latencyMs: performance.now() - notifyStart,
@@ -473,9 +472,9 @@ export async function processEvent(
           error: error instanceof Error ? error.message : 'Unknown error',
         });
 
-        import('./service-notifications')
+        return import('./service-notifications')
           .then(({ sendServiceNotifications }) => {
-            sendServiceNotifications(result.incident.id, 'triggered').catch(err => {
+            return sendServiceNotifications(result.incident.id, 'triggered').catch(err => {
               logger.error('Service notification failed', {
                 incidentId: result.incident.id,
                 error: err instanceof Error ? err.message : 'Unknown error',
@@ -486,10 +485,10 @@ export async function processEvent(
           .catch(e => logger.error('Failed to load service-notifications', { error: e }));
       });
 
-    // ChatOps: Auto-create war-room channel for qualifying incidents (fire-and-forget)
-    import('./chatops/war-room')
+    // ChatOps: Auto-create war-room channel for qualifying incidents.
+    await import('./chatops/war-room')
       .then(({ createIncidentWarRoom }) => {
-        createIncidentWarRoom(result.incident.id)
+        return createIncidentWarRoom(result.incident.id)
           .then(warRoomResult => {
             if (warRoomResult.success) {
               logger.info('chatops.war_room_created', {
@@ -523,7 +522,7 @@ export async function processEvent(
       });
 
       if (incidentWithService) {
-        triggerWebhooksForService(result.incident.serviceId, 'incident.resolved', {
+        await triggerWebhooksForService(result.incident.serviceId, 'incident.resolved', {
           id: incidentWithService.id,
           title: incidentWithService.title,
           description: incidentWithService.description,
@@ -550,17 +549,17 @@ export async function processEvent(
       });
     }
 
-    notifySlackForIncident(result.incident.id, 'resolved').catch(error => {
+    await notifySlackForIncident(result.incident.id, 'resolved').catch(error => {
       logger.error('Slack notification failed', {
         incidentId: result.incident.id,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     });
 
-    // ChatOps: Archive war-room channel on resolve (fire-and-forget)
-    import('./chatops/war-room')
+    // ChatOps: Archive war-room channel on resolve.
+    await import('./chatops/war-room')
       .then(({ archiveWarRoomChannel }) => {
-        archiveWarRoomChannel(result.incident.id).catch(err => {
+        return archiveWarRoomChannel(result.incident.id).catch(err => {
           logger.error('chatops.war_room_archive_failed', {
             incidentId: result.incident.id,
             error: err instanceof Error ? err.message : String(err),
@@ -571,7 +570,7 @@ export async function processEvent(
   }
 
   if (result.action === 'acknowledged' && result.incident) {
-    notifySlackForIncident(result.incident.id, 'acknowledged').catch(error => {
+    await notifySlackForIncident(result.incident.id, 'acknowledged').catch(error => {
       logger.error('Slack notification failed', {
         incidentId: result.incident.id,
         error: error instanceof Error ? error.message : 'Unknown error',

--- a/src/lib/integrations/handler.ts
+++ b/src/lib/integrations/handler.ts
@@ -124,6 +124,12 @@ export function createIntegrationHandler<T>(
         throw IntegrationErrors.unauthorized('Integration is disabled');
       }
 
+      if (integration.type !== options.integrationType) {
+        throw IntegrationErrors.unauthorized(
+          `Integration type mismatch: expected ${options.integrationType}`
+        );
+      }
+
       if (!isIntegrationAuthorized(req, integration.key)) {
         throw IntegrationErrors.invalidPayload('Invalid integration key');
       }

--- a/src/lib/jobs/queue.ts
+++ b/src/lib/jobs/queue.ts
@@ -129,7 +129,8 @@ export async function claimPendingJobs(limit: number = 50, type?: JobType): Prom
       Prisma.sql`
       UPDATE "BackgroundJob"
       SET "status" = 'FAILED',
-          "lastError" = 'Job timed out in PROCESSING state after exceeding maxAttempts'
+          "error" = 'Job timed out in PROCESSING state after exceeding maxAttempts',
+          "failedAt" = NOW()
       WHERE "status" = 'PROCESSING'
         AND "startedAt" < NOW() - INTERVAL '10 minutes'
         AND "attempts" >= "maxAttempts";

--- a/src/lib/network-security.ts
+++ b/src/lib/network-security.ts
@@ -1,8 +1,5 @@
 import { logger } from '@/lib/logger';
 import dns from 'dns';
-import { promisify } from 'util';
-
-const lookup = promisify(dns.lookup);
 
 /**
  * Validates a webhook URL to prevent SSRF attacks.
@@ -18,15 +15,18 @@ export async function validateWebhookUrl(urlString: string): Promise<boolean> {
       return false;
     }
 
-    // Resolve hostname to IP
-    const { address } = await lookup(url.hostname);
+    // Validate every answer, not only the resolver's first address. This closes
+    // mixed public/private DNS-answer bypasses. Redirects are separately
+    // disabled by the webhook sender.
+    const addresses = await dns.promises.lookup(url.hostname, { all: true, verbatim: true });
+    if (addresses.length === 0) return false;
 
-    // Block private IP ranges
-    if (isPrivateIp(address)) {
+    const blockedAddress = addresses.find(({ address }) => isPrivateIp(address));
+    if (blockedAddress) {
       logger.warn('Webhook blocked: resolved to private IP', {
         url: urlString,
         hostname: url.hostname,
-        resolvedIp: address,
+        resolvedIp: blockedAddress.address,
       });
       return false;
     }

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -71,15 +71,15 @@ function buildIncidentFilterSql(filters: SLAMetricsFilter, tableAlias: string = 
   }
 
   if (filters.urgency) {
-    fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"urgency"`)} = ${filters.urgency}`);
+    fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"urgency"`)} = ${filters.urgency}::"IncidentUrgency"`);
   }
 
   if (filters.status) {
-    fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"status"`)} = ${filters.status}`);
+    fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"status"`)} = ${filters.status}::"IncidentStatus"`);
   }
 
   if (filters.visibility && filters.visibility !== 'ALL') {
-    fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"visibility"`)} = ${filters.visibility}`);
+    fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"visibility"`)} = ${filters.visibility}::"IncidentVisibility"`);
   }
 
   if (filters.assigneeId !== undefined) {
@@ -302,7 +302,7 @@ async function calculateDbAggregateMetrics(
   const visibilityFilter = (whereClause as { visibility?: string }).visibility;
   const visibilityFilterSql =
     visibilityFilter && visibilityFilter !== 'ALL'
-      ? Prisma.sql`AND "visibility" = ${visibilityFilter}`
+      ? Prisma.sql`AND "visibility" = ${visibilityFilter}::"IncidentVisibility"`
       : Prisma.empty;
 
   // Build aliased filter conditions for JOIN queries (using i. prefix for incident table)
@@ -313,11 +313,11 @@ async function calculateDbAggregateMetrics(
     : Prisma.empty;
 
   const urgencyFilterSqlAliased = urgencyFilter
-    ? Prisma.sql`AND i."urgency" = ${urgencyFilter}`
+    ? Prisma.sql`AND i."urgency" = ${urgencyFilter}::"IncidentUrgency"`
     : Prisma.empty;
 
   const statusFilterSqlAliased = statusFilter
-    ? Prisma.sql`AND i."status" = ${statusFilter}`
+    ? Prisma.sql`AND i."status" = ${statusFilter}::"IncidentStatus"`
     : Prisma.empty;
 
   const assigneeFilterSqlAliased =
@@ -329,7 +329,7 @@ async function calculateDbAggregateMetrics(
 
   const visibilityFilterSqlAliased =
     visibilityFilter && visibilityFilter !== 'ALL'
-      ? Prisma.sql`AND i."visibility" = ${visibilityFilter}`
+      ? Prisma.sql`AND i."visibility" = ${visibilityFilter}::"IncidentVisibility"`
       : Prisma.empty;
 
   // Calculate business hours for after-hours detection

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -89,6 +89,13 @@ export async function sendSMS(options: SMSOptions): Promise<{ success: boolean; 
       return { success: false, error: 'SMS notifications are not enabled' };
     }
 
+    // Format phone number to E.164 and validate minimal digit count
+    const toNumber = formatToE164(options.to);
+    const digitsOnly = toNumber.replace(/\D/g, '');
+    if (!toNumber || digitsOnly.length < 8) {
+      return { success: false, error: 'Invalid phone number format' };
+    }
+
     // Use configured provider
     if (smsConfig.provider === 'twilio') {
       // Load Twilio dynamically

--- a/src/lib/status-page-webhooks.ts
+++ b/src/lib/status-page-webhooks.ts
@@ -49,6 +49,7 @@ export async function deliverWebhook(
             },
             body: payloadString,
             signal: AbortSignal.timeout(10000), // 10 second timeout
+            redirect: 'error',
           })
         );
 
@@ -215,32 +216,23 @@ export async function triggerWebhooksForService(
   incidentData: any // eslint-disable-line @typescript-eslint/no-explicit-any
 ): Promise<void> {
   try {
-    if (incidentData?.visibility) {
-      if (incidentData.visibility !== 'PUBLIC') {
-        return;
-      }
-    } else if (incidentData?.id) {
+    // Incident visibility is security-sensitive: load it from the database
+    // instead of trusting an optional caller-supplied payload field.
+    if (incidentData?.id) {
       const inc = await prisma.incident.findUnique({
         where: { id: incidentData.id },
         select: { visibility: true },
       });
-      if (inc && inc.visibility !== 'PUBLIC') {
-        return;
-      }
+      if (!inc || inc.visibility !== 'PUBLIC') return;
+    } else if (incidentData?.visibility !== 'PUBLIC') {
+      return;
     }
 
     const statusPageIds = await getStatusPagesForService(serviceId);
 
-    // If no status pages are associated, try to trigger for the default enabled status page
+    // No explicit mapping means no public delivery. This prevents unrelated
+    // services from leaking into an arbitrary default status page.
     if (statusPageIds.length === 0) {
-      const defaultStatusPage = await prisma.statusPage.findFirst({
-        where: { enabled: true, showIncidents: true },
-        select: { id: true },
-      });
-
-      if (defaultStatusPage) {
-        await triggerStatusPageWebhooks(defaultStatusPage.id, event, incidentData);
-      }
       return;
     }
 

--- a/src/lib/unsnooze.ts
+++ b/src/lib/unsnooze.ts
@@ -1,0 +1,120 @@
+import prisma from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+
+/**
+ * Process expired incident snoozes (background cron safe - no request headers required).
+ */
+export async function processAutoUnsnoozeInternal(): Promise<{ processed: number }> {
+  const now = new Date();
+  const incidentsToUnsnooze = await prisma.incident.findMany({
+    where: {
+      status: 'SNOOZED',
+      snoozedUntil: { lte: now },
+    },
+    select: { id: true },
+  });
+
+  let processedCount = 0;
+  for (const incident of incidentsToUnsnooze) {
+    try {
+      const policyData = await prisma.incident.findUnique({
+        where: { id: incident.id },
+        select: {
+          status: true,
+          currentEscalationStep: true,
+          service: {
+            select: {
+              policy: {
+                select: {
+                  steps: {
+                    orderBy: { stepOrder: 'asc' },
+                    select: { delayMinutes: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (policyData?.status !== 'SNOOZED') continue;
+
+      const stepIndex = policyData?.currentEscalationStep ?? 0;
+      const delayMinutes = policyData?.service?.policy?.steps?.[stepIndex]?.delayMinutes ?? 0;
+      const nextEscalationAt = new Date(Date.now() + delayMinutes * 60 * 1000);
+
+      const claim = await prisma.incident.updateMany({
+        where: {
+          id: incident.id,
+          status: 'SNOOZED',
+          snoozedUntil: { lte: now },
+        },
+        data: {
+          status: 'OPEN',
+          snoozedUntil: null,
+          snoozeReason: null,
+          escalationStatus: 'ESCALATING',
+          nextEscalationAt,
+        },
+      });
+
+      if (claim.count === 0) continue;
+
+      await prisma.incidentEvent.create({
+        data: {
+          incidentId: incident.id,
+          type: 'STATUS_CHANGE',
+          message: 'Incident auto-unsnoozed (snooze duration expired)',
+        },
+      });
+      processedCount++;
+    } catch (error) {
+      logger.error('Failed to unsnooze incident', {
+        component: 'unsnooze',
+        incidentId: incident.id,
+        error,
+      });
+      continue;
+    }
+
+    try {
+      const { sendIncidentNotifications } = await import('@/lib/user-notifications');
+      await sendIncidentNotifications(incident.id, 'updated');
+      const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
+      await notifyStatusPageSubscribers(incident.id, 'investigating');
+      const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
+      const updatedIncident = await prisma.incident.findUnique({
+        where: { id: incident.id },
+        include: {
+          service: { select: { id: true, name: true } },
+          assignee: {
+            select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
+          },
+        },
+      });
+      if (updatedIncident) {
+        await triggerWebhooksForService(updatedIncident.serviceId, 'incident.updated', {
+          id: updatedIncident.id,
+          title: updatedIncident.title,
+          description: updatedIncident.description,
+          status: updatedIncident.status,
+          urgency: updatedIncident.urgency,
+          priority: updatedIncident.priority,
+          service: updatedIncident.service,
+          assignee: updatedIncident.assignee,
+          createdAt: updatedIncident.createdAt.toISOString(),
+          acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
+          resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
+        });
+      }
+    } catch (error) {
+      logger.error('Failed to notify after auto-unsnooze', {
+        component: 'unsnooze',
+        incidentId: incident.id,
+        error,
+      });
+    }
+  }
+
+  return { processed: processedCount };
+}

--- a/src/lib/unsnooze.ts
+++ b/src/lib/unsnooze.ts
@@ -40,7 +40,7 @@ export async function processAutoUnsnoozeInternal(): Promise<{ processed: number
       if (policyData?.status !== 'SNOOZED') continue;
 
       const stepIndex = policyData?.currentEscalationStep ?? 0;
-      const delayMinutes = policyData?.service?.policy?.steps?.[stepIndex]?.delayMinutes ?? 0;
+      const delayMinutes = policyData?.service?.policy?.steps?.at(stepIndex)?.delayMinutes ?? 0;
       const nextEscalationAt = new Date(Date.now() + delayMinutes * 60 * 1000);
 
       const claim = await prisma.incident.updateMany({

--- a/tests/lib/enterprise-security-regressions.test.ts
+++ b/tests/lib/enterprise-security-regressions.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    incident: { findUnique: vi.fn() },
+    statusPageService: { findMany: vi.fn() },
+    statusPageWebhook: { findMany: vi.fn(), updateMany: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/encryption', () => ({
+  getEncryptionKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+}));
+
+import prisma from '@/lib/prisma';
+import { encrypt, getEncryptionKey } from '@/lib/encryption';
+import { encryptProviderConfig } from '@/lib/encrypted-provider-config';
+import { triggerWebhooksForService } from '@/lib/status-page-webhooks';
+
+describe('enterprise security regressions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refuses to persist provider secrets when encryption is unavailable', async () => {
+    vi.mocked(getEncryptionKey).mockReturnValue(null);
+
+    await expect(
+      encryptProviderConfig('resend', { apiKey: 'plaintext-secret', from: 'ops@example.com' })
+    ).rejects.toThrow('Provider secrets cannot be stored');
+  });
+
+  it('fails the whole provider write when a sensitive field cannot be encrypted', async () => {
+    vi.mocked(getEncryptionKey).mockReturnValue('a'.repeat(64));
+    vi.mocked(encrypt).mockRejectedValue(new Error('encryption failed'));
+
+    await expect(
+      encryptProviderConfig('resend', { apiKey: 'plaintext-secret' })
+    ).rejects.toThrow('Failed to encrypt provider config field: apiKey');
+  });
+
+  it('does not publish a private incident even when caller data says it is public', async () => {
+    vi.mocked(prisma.incident.findUnique).mockResolvedValue({ visibility: 'PRIVATE' } as never);
+
+    await triggerWebhooksForService('service-1', 'incident.created', {
+      id: 'incident-1',
+      visibility: 'PUBLIC',
+    });
+
+    expect(prisma.statusPageService.findMany).not.toHaveBeenCalled();
+    expect(prisma.statusPageWebhook.findMany).not.toHaveBeenCalled();
+  });
+
+  it('requires an explicit status-page mapping before delivering', async () => {
+    vi.mocked(prisma.incident.findUnique).mockResolvedValue({ visibility: 'PUBLIC' } as never);
+    vi.mocked(prisma.statusPageService.findMany).mockResolvedValue([]);
+
+    await triggerWebhooksForService('service-1', 'incident.created', { id: 'incident-1' });
+
+    expect(prisma.statusPageWebhook.findMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why this is worth keeping

This follow-up closes enterprise-readiness gaps found during post-merge validation of #369. It focuses on data retention, fail-closed security, distributed deployment safety, and reliable incident side effects while preserving current user workflows.

## Product safeguards

- Preserve incident/audit history by restricting deletion of services that own incidents.
- Refuse plaintext notification-provider secret writes when encryption is unavailable or fails.
- Prevent private incidents and unmapped services from reaching public status-page webhooks.
- Reject webhook redirects and validate every resolved DNS address to reduce SSRF bypasses.
- Reject integration IDs used through the wrong provider endpoint.
- Add a shared PostgreSQL-backed credentials throttle for multi-instance deployments.
- Let stale unverified status-page subscriptions rotate credentials and resend verification.
- Re-check incident state before each escalation notification to stop paging after resolution.
- Await externally visible incident notifications/webhooks/ChatOps work so process teardown cannot discard it.
- Move cron auto-unsnooze logic into a request-independent internal service.
- Correct background-job failure columns and PostgreSQL enum comparisons in SLA filters.

## Compatibility

- Existing API response shapes and incident lifecycle actions are retained.
- Service deletion already had an application guard; the database now enforces the same retention rule.
- Local progressive login lockout remains, with a distributed outer throttle added.
- New security regression tests cover secret-storage failure and status-page disclosure boundaries.

## Validation gates

CI must pass typecheck, unit tests, database integration tests, security analysis, and production Docker build before merge.