### PR TITLE
feat: add enterprise assurance and resilience toolkit

### DIFF
--- a/.github/workflows/deployment-validation.yml
+++ b/.github/workflows/deployment-validation.yml
@@ -7,6 +7,8 @@ on:
       - 'Dockerfile'
       - 'docker-entrypoint.sh'
       - 'scripts/auto-recover-migrations.ts'
+      - 'scripts/verify-backup-restore.sh'
+      - 'scripts/verify-k8s-failover.sh'
       - 'scripts/validate-release-tag.cjs'
       - 'docker-compose.yml'
       - 'docker-compose.external-db.yml'
@@ -23,6 +25,8 @@ on:
       - 'Dockerfile'
       - 'docker-entrypoint.sh'
       - 'scripts/auto-recover-migrations.ts'
+      - 'scripts/verify-backup-restore.sh'
+      - 'scripts/verify-k8s-failover.sh'
       - 'scripts/validate-release-tag.cjs'
       - 'docker-compose.yml'
       - 'docker-compose.external-db.yml'
@@ -43,7 +47,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Validate entrypoint shell syntax
-        run: sh -n docker-entrypoint.sh
+        run: |
+          sh -n docker-entrypoint.sh
+          bash -n scripts/verify-backup-restore.sh
+          bash -n scripts/verify-k8s-failover.sh
 
       - name: Validate Docker Compose configuration
         run: |
@@ -93,6 +100,8 @@ jobs:
           set -euo pipefail
           grep -q 'ghcr.io/opsknight-labs/opsknight:' /tmp/opsknight-helm.yaml
           grep -q 'startupProbe:' /tmp/opsknight-helm.yaml
+          grep -q 'maxUnavailable: 0' /tmp/opsknight-helm.yaml
+          grep -q 'topologySpreadConstraints:' /tmp/opsknight-helm.yaml
           grep -q 'checksum/config:' /tmp/opsknight-helm.yaml
           grep -q 'checksum/secret:' /tmp/opsknight-helm.yaml
           grep -q 'NEXT_PUBLIC_APP_URL' /tmp/opsknight-helm.yaml
@@ -103,6 +112,12 @@ jobs:
           grep -q 'port: 6432' /tmp/opsknight-helm-external-db.yaml
           grep -q 'ghcr.io/opsknight-labs/opsknight@sha256:0000000000000000000000000000000000000000000000000000000000000000' /tmp/opsknight-helm-external-secret.yaml
           grep -q 'name: opsknight-runtime' /tmp/opsknight-helm-external-secret.yaml
+          helm template opsknight helm/opsknight \
+            --namespace opsknight \
+            -f helm/opsknight/examples/values-enterprise-ha.yaml \
+            > /tmp/opsknight-helm-enterprise.yaml
+          grep -q 'minReplicas: 3' /tmp/opsknight-helm-enterprise.yaml
+          grep -q 'minAvailable: 2' /tmp/opsknight-helm-enterprise.yaml
           if grep -q '^kind: Secret$' /tmp/opsknight-helm-external-secret.yaml; then
             echo 'chart rendered a Secret even though secrets.existingSecret is configured'
             exit 1

--- a/.github/workflows/enterprise-readiness.yml
+++ b/.github/workflows/enterprise-readiness.yml
@@ -1,0 +1,106 @@
+name: Enterprise readiness drills
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Staging URL to load test (include https://)
+        required: true
+        type: string
+      virtual_users:
+        description: Concurrent virtual users
+        required: true
+        default: '20'
+        type: string
+      duration:
+        description: k6 duration (for example 2m)
+        required: true
+        default: '2m'
+        type: string
+      run_backup_restore:
+        description: Run an isolated database backup/restore drill
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  load-test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate target
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+        run: |
+          case "$BASE_URL" in
+            https://*) ;;
+            *) echo 'Only HTTPS staging targets are allowed'; exit 2 ;;
+          esac
+      - name: Run k6 readiness load test
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          VUS: ${{ inputs.virtual_users }}
+          DURATION: ${{ inputs.duration }}
+        run: |
+          mkdir -p reports
+          docker run --rm \
+            -e BASE_URL -e VUS -e DURATION \
+            -v "$PWD:/workspace" \
+            grafana/k6:0.54.0 run --summary-export=/workspace/reports/k6-summary.json \
+            /workspace/scripts/load/opsknight-smoke.js
+      - name: Upload load-test evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enterprise-load-test-${{ github.sha }}
+          path: reports/k6-summary.json
+          if-no-files-found: warn
+          retention-days: 90
+
+  backup-restore-drill:
+    if: ${{ inputs.run_backup_restore }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: opsknight
+          POSTGRES_PASSWORD: opsknight
+          POSTGRES_DB: opsknight
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U opsknight -d opsknight"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://opsknight:opsknight@127.0.0.1:5432/opsknight
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - name: Build representative database
+        run: npx prisma migrate deploy
+      - name: Create backup
+        run: |
+          mkdir -p reports
+          docker run --rm --network host -v "$PWD/reports:/reports" postgres:15-alpine \
+            pg_dump --format=custom --file=/reports/opsknight-drill.dump "$DATABASE_URL"
+      - name: Restore and verify backup
+        run: scripts/verify-backup-restore.sh "$PWD/reports/opsknight-drill.dump" | tee reports/restore-drill.txt
+      - name: Upload restore evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enterprise-restore-drill-${{ github.sha }}
+          path: reports/
+          retention-days: 90

--- a/docs/v1.5/deployment/README.md
+++ b/docs/v1.5/deployment/README.md
@@ -116,6 +116,7 @@ Restore into an isolated environment with the original encryption key, then veri
 - [Kustomize](./kustomize)
 - [Helm](./helm)
 - [Monitoring](./monitoring)
+- [Enterprise validation drills](./enterprise-validation)
 - [Maintenance](./maintenance)
 - [Database migrations](./database-migrations)
 - [Backup and restore](./backup-restore)

--- a/docs/v1.5/deployment/enterprise-validation.md
+++ b/docs/v1.5/deployment/enterprise-validation.md
@@ -1,0 +1,79 @@
+---
+order: 12
+title: Enterprise validation drills
+description: Produce repeatable load, recovery, and availability evidence for an OpsKnight deployment.
+---
+
+# Enterprise validation drills
+
+Run these drills against staging before production promotion and after material infrastructure,
+database, or incident-processing changes. Store the output with the exact Git commit, image digest,
+environment name, execution time, and approver.
+
+## Load and latency
+
+Use the manually triggered **Enterprise readiness drills** GitHub workflow. Supply an HTTPS staging
+URL, virtual-user count, and duration. The k6 profile fails unless readiness availability remains
+above 99%, request failures remain below 1%, p95 latency remains below 750 ms, and p99 remains below
+1.5 seconds.
+
+For a local k6 installation, run:
+
+```bash
+BASE_URL=https://staging.example.com VUS=20 DURATION=2m \
+  k6 run scripts/load/opsknight-smoke.js
+```
+
+Increase load gradually. Define deployment-specific service-level objectives before treating the
+default thresholds as contractual targets.
+
+## Backup and restore
+
+Create a PostgreSQL custom-format or SQL backup, then restore it into an isolated disposable
+database:
+
+```bash
+scripts/verify-backup-restore.sh /absolute/path/to/opsknight.dump
+```
+
+The script never connects to the source database. It creates a temporary PostgreSQL container,
+restores the supplied file, verifies the migration table and core incident/user tables, reports the
+elapsed restore time, and removes the container. Run an additional application-level smoke test
+with the backed-up `ENCRYPTION_KEY` before recording the recovery point objective as achieved.
+
+## Application-pod failover
+
+The failover script deliberately deletes one running application pod and probes the external
+readiness endpoint for one minute. Run it only on an approved staging cluster:
+
+```bash
+CONFIRM_OPSKNIGHT_CHAOS=delete-one-app-pod \
+OPSKNIGHT_NAMESPACE=opsknight \
+OPSKNIGHT_HEALTH_URL=https://staging.example.com/api/health?mode=readiness \
+  scripts/verify-k8s-failover.sh
+```
+
+The drill refuses to start unless at least two application pods are running. It fails if more than
+one readiness request fails or replacement pods do not become ready within five minutes.
+
+## Highly available Helm baseline
+
+Start with `helm/opsknight/examples/values-enterprise-ha.yaml`. It configures three application
+replicas, a two-pod disruption budget, autoscaling, rolling updates with zero unavailable replicas,
+node spreading, network policy, and an external PostgreSQL boundary.
+
+The bundled PostgreSQL StatefulSet is intentionally a single-instance starting topology. An
+enterprise HA deployment must use managed or operator-controlled PostgreSQL with multi-zone
+failover, point-in-time recovery, encrypted transport, monitoring, and separately tested backups.
+
+## Evidence record
+
+For each drill, retain:
+
+- commit SHA and immutable image digest;
+- staging environment and sanitized configuration revision;
+- start/end timestamps and operator;
+- raw workflow logs and uploaded JSON/text artifacts;
+- measured latency, error rate, outage duration, restore duration, and recovery observations;
+- linked incident or corrective action for every failed threshold;
+- approval confirming that unresolved failures block production promotion.

--- a/docs/v1.5/security/README.md
+++ b/docs/v1.5/security/README.md
@@ -7,6 +7,7 @@ description: Identity, authorization, encryption, signature verification, and se
 # Security
 
 - [Enterprise readiness and assurance](enterprise-readiness.md)
+- [Audit evidence checklist](audit-evidence-checklist.md)
 
 This section covers identity management, authorization, cryptographic data protection, webhook signature verification, and secure operations for OpsKnight. These controls can contribute evidence to your security program; installing OpsKnight does not by itself make a deployment compliant with a standard or regulation.
 

--- a/docs/v1.5/security/audit-evidence-checklist.md
+++ b/docs/v1.5/security/audit-evidence-checklist.md
@@ -1,0 +1,44 @@
+# Audit evidence checklist
+
+This checklist prepares evidence for a readiness assessment. It is not a certification or a
+substitute for advice from the chosen auditor, customer, regulator, or legal counsel.
+
+## Product and change assurance
+
+- Preserve protected-branch configuration, required reviews, signed release metadata, CI results,
+  security scan reports, dependency inventory/SBOM, migration review, and production approval.
+- Link every deployed image digest to its source commit and retain rollback instructions.
+- Record exceptions with owner, business justification, compensating control, and expiration date.
+
+## Access control
+
+- Export current administrators, responders, OIDC configuration, identity-provider MFA policy,
+  joiner/mover/leaver samples, quarterly access reviews, and terminated-session evidence.
+- Preserve evidence that production database, cluster, secret store, and CI access use separate
+  least-privileged roles.
+
+## Security operations
+
+- Retain vulnerability scan results, remediation SLAs, penetration-test report, security incidents,
+  tabletop exercises, dependency updates, and secret/key rotation records.
+- Document inbound and outbound network boundaries, webhook signing, TLS, firewall policy, and
+  alert ownership.
+
+## Availability and recovery
+
+- Retain monitoring availability reports, capacity alerts, load-test results, pod/node/database
+  failover exercises, backup reports, restore-drill evidence, and achieved RPO/RTO measurements.
+- Record the on-call owner and corrective actions for missed objectives.
+
+## Data governance
+
+- Document data classification, retention/deletion policy, customer export/deletion handling,
+  backup retention, encryption-key custody, subprocessors, and data residency.
+- Sample audit logs and incident history to prove actor attribution and retention behavior.
+
+## Organizational controls still required
+
+The repository cannot provide employee screening, security training, vendor review, risk committee
+minutes, legal agreements, insurance, physical security, customer commitments, or an independent
+auditor's opinion. Assign these controls to named organizational owners before claiming readiness
+for SOC 2, ISO 27001, or another framework.

--- a/docs/v1.5/security/enterprise-readiness.md
+++ b/docs/v1.5/security/enterprise-readiness.md
@@ -68,6 +68,11 @@ Before promoting a release, retain evidence that all required checks passed for 
 7. Manual smoke tests for login, incident creation, acknowledgement, escalation, resolution,
    status-page visibility, notifications, schedules, and administrative changes.
 
+Use the [enterprise validation drills](../deployment/enterprise-validation.md) to produce repeatable
+load, restore, and application-pod failover evidence. Use the
+[audit evidence checklist](./audit-evidence-checklist.md) to assign and retain the remaining
+technical and organizational evidence.
+
 ## Shared-responsibility boundary
 
 OpsKnight supplies application controls. The operator remains responsible for identity-provider

--- a/helm/opsknight/examples/values-enterprise-ha.yaml
+++ b/helm/opsknight/examples/values-enterprise-ha.yaml
@@ -1,0 +1,35 @@
+replicaCount: 3
+
+postgresql:
+  enabled: false
+
+database:
+  # Use a managed multi-AZ PostgreSQL service. The real TLS URL should be
+  # supplied by the existing Secret referenced below.
+  url: postgresql://replace-me@postgres.example.com:5432/opsknight?sslmode=require
+  port: 5432
+
+secrets:
+  existingSecret: opsknight-runtime
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 65
+  targetMemoryUtilizationPercentage: 75
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi

--- a/helm/opsknight/templates/deployment.yaml
+++ b/helm/opsknight/templates/deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   labels:
     {{- include "opsknight.labels" . | nindent 4 }}
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -24,6 +29,7 @@ spec:
       labels:
         {{- include "opsknight.selectorLabels" . | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -76,6 +82,17 @@ spec:
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "opsknight.selectorLabels" $ | nindent 14 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/helm/opsknight/values.yaml
+++ b/helm/opsknight/values.yaml
@@ -76,6 +76,15 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Spread replicas across nodes by default. Enterprise deployments should use
+# three or more nodes and may change ScheduleAnyway to DoNotSchedule.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+
+terminationGracePeriodSeconds: 30
+
 startupProbe:
   httpGet:
     path: /api/health?mode=readiness

--- a/scripts/load/opsknight-smoke.js
+++ b/scripts/load/opsknight-smoke.js
@@ -1,0 +1,31 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const baseUrl = (__ENV.BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+
+export const options = {
+  scenarios: {
+    readiness: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.VUS || 20),
+      duration: __ENV.DURATION || '2m',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<750', 'p(99)<1500'],
+    checks: ['rate>0.99'],
+  },
+};
+
+export default function () {
+  const response = http.get(`${baseUrl}/api/health?mode=readiness`, {
+    headers: { 'x-load-test': 'enterprise-readiness' },
+    tags: { endpoint: 'readiness' },
+  });
+  check(response, {
+    'readiness returns 200': result => result.status === 200,
+    'request id is present': result => Boolean(result.headers['X-Request-Id']),
+  });
+  sleep(0.2);
+}

--- a/scripts/verify-backup-restore.sh
+++ b/scripts/verify-backup-restore.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+backup_file="${1:-}"
+if [[ -z "$backup_file" || ! -f "$backup_file" ]]; then
+  echo "Usage: scripts/verify-backup-restore.sh /absolute/path/to/backup.sql[.gz]|backup.dump"
+  exit 2
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required for an isolated restore drill."
+  exit 2
+fi
+
+container_name="opsknight-restore-drill-$RANDOM-$RANDOM"
+database_name="opsknight_restore_drill"
+database_user="opsknight_restore"
+database_password="restore-drill-only"
+started_at="$(date +%s)"
+
+cleanup() {
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run -d --name "$container_name" \
+  -e POSTGRES_DB="$database_name" \
+  -e POSTGRES_USER="$database_user" \
+  -e POSTGRES_PASSWORD="$database_password" \
+  postgres:15-alpine >/dev/null
+
+for _ in $(seq 1 60); do
+  if docker exec "$container_name" pg_isready -U "$database_user" -d "$database_name" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+docker exec "$container_name" pg_isready -U "$database_user" -d "$database_name" >/dev/null
+
+docker cp "$backup_file" "$container_name:/tmp/opsknight-backup"
+case "$backup_file" in
+  *.sql.gz)
+    docker exec "$container_name" sh -c \
+      "gunzip -c /tmp/opsknight-backup | psql -v ON_ERROR_STOP=1 -U '$database_user' -d '$database_name'" >/dev/null
+    ;;
+  *.sql)
+    docker exec "$container_name" psql -v ON_ERROR_STOP=1 -U "$database_user" \
+      -d "$database_name" -f /tmp/opsknight-backup >/dev/null
+    ;;
+  *)
+    docker exec "$container_name" pg_restore --exit-on-error --no-owner --no-privileges \
+      -U "$database_user" -d "$database_name" /tmp/opsknight-backup >/dev/null
+    ;;
+esac
+
+docker exec "$container_name" psql -v ON_ERROR_STOP=1 -U "$database_user" -d "$database_name" \
+  -c 'SELECT COUNT(*) AS migration_count FROM "_prisma_migrations";' \
+  -c 'SELECT COUNT(*) AS incident_count FROM "Incident";' \
+  -c 'SELECT COUNT(*) AS user_count FROM "User";'
+
+finished_at="$(date +%s)"
+echo "Restore drill passed in $((finished_at - started_at)) seconds using an isolated PostgreSQL container."

--- a/scripts/verify-k8s-failover.sh
+++ b/scripts/verify-k8s-failover.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CONFIRM_OPSKNIGHT_CHAOS:-}" != "delete-one-app-pod" ]]; then
+  echo "Refusing to disrupt a cluster. Set CONFIRM_OPSKNIGHT_CHAOS=delete-one-app-pod explicitly."
+  exit 2
+fi
+
+namespace="${OPSKNIGHT_NAMESPACE:-opsknight}"
+selector="${OPSKNIGHT_POD_SELECTOR:-app.kubernetes.io/name=opsknight}"
+health_url="${OPSKNIGHT_HEALTH_URL:-}"
+if [[ -z "$health_url" ]]; then
+  echo "OPSKNIGHT_HEALTH_URL must point to the externally reachable readiness endpoint."
+  exit 2
+fi
+
+ready_before="$(kubectl -n "$namespace" get pods -l "$selector" --field-selector=status.phase=Running -o name | wc -l | tr -d ' ')"
+if (( ready_before < 2 )); then
+  echo "At least two running OpsKnight pods are required; found $ready_before."
+  exit 1
+fi
+
+target="$(kubectl -n "$namespace" get pods -l "$selector" -o jsonpath='{.items[0].metadata.name}')"
+echo "Deleting pod $namespace/$target and probing $health_url"
+kubectl -n "$namespace" delete pod "$target" --wait=false
+
+failures=0
+for _ in $(seq 1 60); do
+  if ! curl --fail --silent --show-error --max-time 3 "$health_url" >/dev/null; then
+    failures=$((failures + 1))
+  fi
+  sleep 1
+done
+
+kubectl -n "$namespace" wait --for=condition=Ready pod -l "$selector" --timeout=5m
+if (( failures > 1 )); then
+  echo "Failover drill failed: $failures readiness requests failed."
+  exit 1
+fi
+echo "Failover drill passed with $failures failed readiness request(s)."

--- a/src/app/(app)/teams/page.tsx
+++ b/src/app/(app)/teams/page.tsx
@@ -175,7 +175,9 @@ export default async function TeamsPage({ searchParams }: TeamsPageProps) {
         avatarUrl: true,
         gender: true,
       },
-      take: 500, // Limit users for the team member add dropdown to avoid unbounded memory
+      // Initial choices for bulk add. The single-member form uses a bounded,
+      // server-backed directory search and can reach users beyond this set.
+      take: 50,
     }),
     prisma.teamMember.groupBy({
       by: ['teamId'],

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -5,7 +5,7 @@ import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { EventSchema } from '@/lib/validation';
-import { logger } from '@/lib/logger';
+import { logger, withRequestContext } from '@/lib/logger';
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 120;
 
@@ -28,7 +28,7 @@ async function getApiUserContext(apiKeyUserId: string) {
   };
 }
 
-export async function POST(req: NextRequest) {
+async function postEvent(req: NextRequest) {
   try {
     // 1. Validate Integration Key or API Key
     const authHeader = req.headers.get('Authorization');
@@ -132,3 +132,5 @@ export async function POST(req: NextRequest) {
     return jsonError('Internal Server Error', 500);
   }
 }
+
+export const POST = withRequestContext(postEvent, 'api.events');

--- a/src/app/api/jira/webhook/route.ts
+++ b/src/app/api/jira/webhook/route.ts
@@ -4,7 +4,7 @@ import prisma from '@/lib/prisma';
 import { decrypt } from '@/lib/encryption';
 import { processJiraWebhookEvent, type JiraWebhookPayload } from '@/lib/jira-sync';
 import { checkRateLimit } from '@/lib/rate-limit';
-import { logger } from '@/lib/logger';
+import { logger, withRequestContext } from '@/lib/logger';
 
 const JiraWebhookSchema = z
   .object({
@@ -68,7 +68,7 @@ async function verifyWebhookSecret(request: NextRequest): Promise<boolean> {
 
 const HANDLED_EVENTS = new Set(['jira:issue_updated', 'jira:issue_deleted']);
 
-export async function POST(request: NextRequest) {
+async function postJiraWebhook(request: NextRequest) {
   try {
     const forwardedFor = request.headers.get('x-forwarded-for');
     const clientIp =
@@ -126,3 +126,5 @@ export async function POST(request: NextRequest) {
     );
   }
 }
+
+export const POST = withRequestContext(postJiraWebhook, 'api.jira.webhook');

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,8 +1,9 @@
 import prisma from '@/lib/prisma';
 import { getAuthOptions } from '@/lib/auth';
 import { getServerSession } from 'next-auth';
+import { withRequestContext } from '@/lib/logger';
 
-export async function GET(req: Request) {
+async function getMetrics(req: Request) {
   // Allow Prometheus scraping via Bearer token OR admin session
   const authHeader = req.headers.get('authorization');
   const prometheusToken = process.env.PROMETHEUS_SCRAPE_TOKEN;
@@ -57,3 +58,5 @@ export async function GET(req: Request) {
     headers: { 'Content-Type': 'text/plain; version=0.0.4; charset=utf-8' },
   });
 }
+
+export const GET = withRequestContext(getMetrics, 'api.metrics');

--- a/src/app/api/teams/[id]/available-users/route.ts
+++ b/src/app/api/teams/[id]/available-users/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest } from 'next/server';
+import prisma from '@/lib/prisma';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { assertResponderOrAbove } from '@/lib/rbac';
+import { logger, withRequestContext } from '@/lib/logger';
+
+const MAX_RESULTS = 50;
+
+async function getAvailableUsers(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await assertResponderOrAbove();
+    const { id: teamId } = await params;
+    const query = (req.nextUrl.searchParams.get('q') || '').trim().slice(0, 100);
+    const requestedLimit = Number(req.nextUrl.searchParams.get('limit')) || 20;
+    const limit = Math.max(1, Math.min(requestedLimit, MAX_RESULTS));
+
+    const team = await prisma.team.findUnique({ where: { id: teamId }, select: { id: true } });
+    if (!team) return jsonError('Team not found', 404);
+
+    const users = await prisma.user.findMany({
+      where: {
+        status: { not: 'DISABLED' },
+        teamMemberships: { none: { teamId } },
+        ...(query.length > 0
+          ? {
+              OR: [
+                { name: { contains: query, mode: 'insensitive' as const } },
+                { email: { contains: query, mode: 'insensitive' as const } },
+              ],
+            }
+          : {}),
+      },
+      orderBy: [{ name: 'asc' }, { email: 'asc' }],
+      take: limit + 1,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        status: true,
+        avatarUrl: true,
+        gender: true,
+      },
+    });
+
+    return jsonOk({ users: users.slice(0, limit), hasMore: users.length > limit });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to search users';
+    logger.error('team.available_users.search_failed', { error: message });
+    if (message.startsWith('Unauthorized')) return jsonError(message, 403);
+    return jsonError('Unable to search the user directory', 500);
+  }
+}
+
+export const GET = withRequestContext(getAvailableUsers, 'api.teams.available-users');

--- a/src/components/TeamMemberForm.tsx
+++ b/src/components/TeamMemberForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTransition, useState } from 'react';
+import { useEffect, useMemo, useState, useTransition } from 'react';
 import { useToast } from '@/hooks/use-product-notification';
 import { Button } from '@/components/ui/shadcn/button';
 import { Label } from '@/components/ui/shadcn/label';
@@ -15,6 +15,7 @@ import {
 import { AlertTriangle, Loader2, UserPlus } from 'lucide-react';
 import UserAvatar from '@/components/UserAvatar';
 import { Badge } from '@/components/ui/shadcn/badge';
+import { Input } from '@/components/ui/shadcn/input';
 
 type User = {
   id: string;
@@ -38,12 +39,51 @@ export default function TeamMemberForm({
   canManageMembers,
   canAssignOwnerAdmin,
   addMember,
-  teamId: _teamId,
+  teamId,
 }: TeamMemberFormProps) {
   const [isPending, startTransition] = useTransition();
   const { showToast } = useToast();
   const [selectedUserId, setSelectedUserId] = useState<string>('');
   const [selectedRole, setSelectedRole] = useState<string>('MEMBER');
+  const [search, setSearch] = useState('');
+  const [searchResults, setSearchResults] = useState<User[]>(availableUsers.slice(0, 20));
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasMore, setHasMore] = useState(availableUsers.length > 20);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const response = await fetch(
+          `/api/teams/${encodeURIComponent(teamId)}/available-users?q=${encodeURIComponent(search)}&limit=30`,
+          { signal: controller.signal, cache: 'no-store' }
+        );
+        if (!response.ok) throw new Error('Search failed');
+        const data = (await response.json()) as { users?: User[]; hasMore?: boolean };
+        setSearchResults(data.users || []);
+        setHasMore(Boolean(data.hasMore));
+      } catch (error) {
+        if (error instanceof Error && error.name !== 'AbortError') {
+          showToast('Unable to search the user directory', 'error');
+        }
+      } finally {
+        if (!controller.signal.aborted) setIsSearching(false);
+      }
+    }, 250);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [search, showToast, teamId]);
+
+  const selectableUsers = useMemo(() => {
+    const selected = availableUsers.find(user => user.id === selectedUserId);
+    return selected && !searchResults.some(user => user.id === selected.id)
+      ? [selected, ...searchResults]
+      : searchResults;
+  }, [availableUsers, searchResults, selectedUserId]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -52,7 +92,7 @@ export default function TeamMemberForm({
     const formData = new FormData();
     formData.set('userId', selectedUserId);
     formData.set('role', selectedRole);
-    const userName = availableUsers.find(u => u.id === selectedUserId)?.name || 'User';
+    const userName = selectableUsers.find(u => u.id === selectedUserId)?.name || 'User';
 
     startTransition(async () => {
       const result = await addMember(formData);
@@ -60,6 +100,7 @@ export default function TeamMemberForm({
         showToast(result.error, 'error');
       } else {
         showToast(`${userName} added as ${selectedRole}`, 'success');
+        setSearchResults(current => current.filter(user => user.id !== selectedUserId));
         setSelectedUserId('');
         setSelectedRole('MEMBER');
       }
@@ -86,20 +127,31 @@ export default function TeamMemberForm({
         <Label htmlFor="userId" className="text-xs">
           Select User
         </Label>
+        <div className="relative">
+          <Input
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            placeholder="Search by name or email…"
+            aria-label="Search available users"
+          />
+          {isSearching && (
+            <Loader2 className="absolute right-3 top-2.5 h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+        </div>
         <Select
           value={selectedUserId}
           onValueChange={setSelectedUserId}
-          disabled={isPending || availableUsers.length === 0}
+          disabled={isPending || isSearching || selectableUsers.length === 0}
         >
           <SelectTrigger>
             <SelectValue
               placeholder={
-                availableUsers.length === 0 ? 'All users are members' : 'Choose a user...'
+                selectableUsers.length === 0 ? 'No matching users' : 'Choose a user...'
               }
             />
           </SelectTrigger>
           <SelectContent className="max-h-[200px]">
-            {availableUsers.map(user => (
+            {selectableUsers.map(user => (
               <SelectItem key={user.id} value={user.id}>
                 <div className="flex items-center gap-2">
                   <UserAvatar userId={user.id} name={user.name} gender={user.gender} size="xs" />
@@ -114,6 +166,11 @@ export default function TeamMemberForm({
             ))}
           </SelectContent>
         </Select>
+        {hasMore && (
+          <p className="text-xs text-muted-foreground">
+            More matches are available. Refine the search to find a specific user.
+          </p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -151,7 +208,7 @@ export default function TeamMemberForm({
       <Button
         type="submit"
         className="w-full gap-2"
-        disabled={availableUsers.length === 0 || !selectedUserId || isPending}
+        disabled={selectableUsers.length === 0 || !selectedUserId || isPending}
       >
         {isPending ? (
           <>

--- a/src/lib/integrations/handler.ts
+++ b/src/lib/integrations/handler.ts
@@ -12,7 +12,7 @@
 import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
-import { logger } from '@/lib/logger';
+import { logger, withRequestContext } from '@/lib/logger';
 import { checkRateLimit, createRateLimitHeaders } from './rate-limiter';
 import { verifyWebhookSignature, isTimestampValid } from './signature-verification';
 import { recordWebhookReceived } from './metrics';
@@ -65,7 +65,7 @@ export function createIntegrationHandler<T>(
   options: HandlerOptions<T>,
   processor: (ctx: IntegrationContext<T>) => Promise<{ action: string; incident?: unknown }>
 ) {
-  return async function handler(req: NextRequest) {
+  const handler = async (req: NextRequest) => {
     const startTime = performance.now();
     let integrationId: string | null = null;
     let integrationType: string = options.integrationType;
@@ -252,6 +252,8 @@ export function createIntegrationHandler<T>(
       return jsonError('Internal Server Error', 500);
     }
   };
+
+  return withRequestContext(handler, `api.integration.${options.integrationType}`);
 }
 
 /**

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -27,11 +27,18 @@ class FallbackAsyncLocalStorage<T> implements AsyncLocalStorageLike<T> {
 
 function createAsyncLocalStorage<T>(): AsyncLocalStorageLike<T> {
   try {
-    const GlobalALS = (
-      globalThis as unknown as { AsyncLocalStorage?: new <V>() => AsyncLocalStorageLike<V> }
-    ).AsyncLocalStorage;
-    if (typeof GlobalALS === 'function') {
-      return new GlobalALS<T>();
+    // Avoid a static node:async_hooks import because this logger is also used
+    // by browser and Edge bundles. Node 20 exposes built-ins synchronously.
+    const runtimeProcess = (
+      globalThis as unknown as {
+        process?: { getBuiltinModule?: (id: string) => unknown };
+      }
+    ).process;
+    const asyncHooks = runtimeProcess?.getBuiltinModule?.('node:async_hooks') as
+      | { AsyncLocalStorage?: new <V>() => AsyncLocalStorageLike<V> }
+      | undefined;
+    if (typeof asyncHooks?.AsyncLocalStorage === 'function') {
+      return new asyncHooks.AsyncLocalStorage<T>();
     }
   } catch {
     // Fallback if not available
@@ -47,6 +54,35 @@ export function runWithContext<T>(context: RequestContext, fn: () => T): T {
 
 export function getRequestContext(): RequestContext {
   return requestContextStorage.getStore() ?? {};
+}
+
+function trustedRequestId(request: Request): string {
+  const supplied = request.headers.get('x-request-id')?.trim();
+  if (supplied && /^[A-Za-z0-9._:-]{1,128}$/.test(supplied)) return supplied;
+  return crypto.randomUUID();
+}
+
+/** Wrap a Node route handler with per-request structured-log correlation. */
+export function withRequestContext<
+  R extends Request,
+  A extends unknown[],
+  T,
+>(handler: (request: R, ...args: A) => Promise<T>, component: string) {
+  return async (request: R, ...args: A): Promise<T> => {
+    const requestId = trustedRequestId(request);
+    return runWithContext({ requestId, component }, async () => {
+      const result = await handler(request, ...args);
+      if (result instanceof Response) {
+        try {
+          if (!result.headers.has('x-request-id')) result.headers.set('x-request-id', requestId);
+        } catch {
+          // Some runtime-generated responses expose immutable headers. Logs
+          // still retain the correlation id in that case.
+        }
+      }
+      return result;
+    });
+  };
 }
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -209,9 +209,17 @@ function getSecurityHeaders(): Record<string, string> {
 export default async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const origin = req.headers.get('origin');
+  const suppliedRequestId = req.headers.get('x-request-id')?.trim();
+  const requestId =
+    suppliedRequestId && /^[A-Za-z0-9._:-]{1,128}$/.test(suppliedRequestId)
+      ? suppliedRequestId
+      : crypto.randomUUID();
+  const forwardedHeaders = new Headers(req.headers);
+  forwardedHeaders.set('x-request-id', requestId);
 
   // Create response with security headers
-  const response = NextResponse.next();
+  const response = NextResponse.next({ request: { headers: forwardedHeaders } });
+  response.headers.set('x-request-id', requestId);
   const securityHeaders = getSecurityHeaders();
   Object.entries(securityHeaders).forEach(([key, value]) => {
     response.headers.set(key, value);
@@ -353,7 +361,8 @@ export default async function middleware(req: NextRequest) {
       // NOTE: Rate limiting is now handled in the individual API routes (Node.js runtime)
       // to support Distributed Rate Limiting via PostgreSQL, which cannot run in Edge Middleware.
 
-      const apiResponse = NextResponse.next();
+      const apiResponse = NextResponse.next({ request: { headers: forwardedHeaders } });
+      apiResponse.headers.set('x-request-id', requestId);
       // Apply CORS headers
       Object.entries(corsHeaders).forEach(([key, value]) => {
         apiResponse.headers.set(key, value);

--- a/tests/api/team-available-users.test.ts
+++ b/tests/api/team-available-users.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import prisma from '@/lib/prisma';
+import { assertResponderOrAbove } from '@/lib/rbac';
+import { GET } from '@/app/api/teams/[id]/available-users/route';
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    team: { findUnique: vi.fn() },
+    user: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  assertResponderOrAbove: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/logger')>();
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+});
+
+describe('team available-user directory search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(assertResponderOrAbove).mockResolvedValue({ id: 'admin-1' } as never);
+    vi.mocked(prisma.team.findUnique).mockResolvedValue({ id: 'team-1' } as never);
+  });
+
+  it('searches active non-members in the database with a bounded result set', async () => {
+    vi.mocked(prisma.user.findMany).mockResolvedValue([
+      { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+      { id: 'user-2', name: 'Alicia', email: 'alicia@example.com' },
+      { id: 'user-3', name: 'Alina', email: 'alina@example.com' },
+    ] as never);
+    const request = new NextRequest(
+      'http://localhost/api/teams/team-1/available-users?q=ali&limit=2'
+    );
+
+    const response = await GET(request, { params: Promise.resolve({ id: 'team-1' }) });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.users).toHaveLength(2);
+    expect(body.hasMore).toBe(true);
+    expect(prisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { not: 'DISABLED' },
+          teamMemberships: { none: { teamId: 'team-1' } },
+        }),
+        take: 3,
+      })
+    );
+  });
+
+  it('does not expose the directory to unauthorized users', async () => {
+    vi.mocked(assertResponderOrAbove).mockRejectedValue(
+      new Error('Unauthorized. Responder access or above required.')
+    );
+    const request = new NextRequest('http://localhost/api/teams/team-1/available-users');
+
+    const response = await GET(request, { params: Promise.resolve({ id: 'team-1' }) });
+
+    expect(response.status).toBe(403);
+    expect(prisma.user.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/deployment-config-unit.test.ts
+++ b/tests/lib/deployment-config-unit.test.ts
@@ -93,6 +93,25 @@ describe('deployment configuration invariants', () => {
     expect(deployment).toContain('include "opsknight.secretName"');
   });
 
+  it('ships an enterprise high-availability baseline and guarded recovery drills', () => {
+    const values = read('helm/opsknight/values.yaml');
+    const deployment = read('helm/opsknight/templates/deployment.yaml');
+    const enterprise = read('helm/opsknight/examples/values-enterprise-ha.yaml');
+    const failover = read('scripts/verify-k8s-failover.sh');
+    const restore = read('scripts/verify-backup-restore.sh');
+
+    expect(values).toContain('topologySpreadConstraints:');
+    expect(deployment).toContain('maxUnavailable: 0');
+    expect(deployment).toContain('terminationGracePeriodSeconds:');
+    expect(enterprise).toContain('replicaCount: 3');
+    expect(enterprise).toContain('minAvailable: 2');
+    expect(enterprise).toContain('enabled: false');
+    expect(failover).toContain('CONFIRM_OPSKNIGHT_CHAOS');
+    expect(failover).toContain('ready_before < 2');
+    expect(restore).toContain('opsknight-restore-drill-');
+    expect(restore).toContain('trap cleanup EXIT');
+  });
+
   it('preserves the existing postgres Service cluster-IP mode for upgrade safety', () => {
     expect(read('k8s/postgres-service.yaml')).not.toContain('clusterIP: None');
     expect(read('helm/opsknight/templates/postgres-service.yaml')).not.toContain('clusterIP: None');

--- a/tests/lib/logger-buffer.test.ts
+++ b/tests/lib/logger-buffer.test.ts
@@ -5,6 +5,7 @@ import {
   sanitizeString,
   runWithContext,
   getRequestContext,
+  withRequestContext,
 } from '@/lib/logger';
 import * as publicLogsRoute from '@/app/api/public-logs/route';
 import { createMockRequest, parseResponse } from '../helpers/api-test';
@@ -128,5 +129,32 @@ describe('AsyncLocalStorage Request Context', () => {
     expect(match?.requestId).toBe('req-custom');
     expect(match?.userId).toBe('user-original');
     expect(match?.component).toBe('worker');
+  });
+
+  it('keeps concurrent asynchronous request contexts isolated', async () => {
+    const observed = await Promise.all([
+      runWithContext({ requestId: 'request-a' }, async () => {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        return getRequestContext().requestId;
+      }),
+      runWithContext({ requestId: 'request-b' }, async () => {
+        await Promise.resolve();
+        return getRequestContext().requestId;
+      }),
+    ]);
+
+    expect(observed).toEqual(['request-a', 'request-b']);
+  });
+
+  it('wraps route handlers and returns a correlation header', async () => {
+    const handler = withRequestContext(async () => {
+      return Response.json({ requestId: getRequestContext().requestId });
+    }, 'api.test');
+    const response = await handler(
+      new Request('http://localhost/api/test', { headers: { 'x-request-id': 'external-123' } })
+    );
+
+    expect(response.headers.get('x-request-id')).toBe('external-123');
+    await expect(response.json()).resolves.toEqual({ requestId: 'external-123' });
   });
 });


### PR DESCRIPTION
## Why this is worth keeping

This closes the remaining repository-controlled enterprise-readiness gaps after #369 and #370. It adds scalable directory behavior, real request correlation, repeatable resilience evidence, and a production-oriented HA baseline without slowing normal PR CI.

## Product scalability and observability

- Replace the 500-user reachability limit with bounded PostgreSQL-backed team-member search.
- Use Node 20 AsyncLocalStorage for concurrent-safe structured-log request context.
- Validate/propagate `x-request-id` through middleware and return it to callers.
- Mount correlation on event ingestion, Jira, metrics, user directory, and standardized integration handlers.
- Add concurrency and route-correlation regression tests.

## Availability and recovery evidence

- Add an opt-in k6 readiness profile with availability and p95/p99 thresholds.
- Add an isolated PostgreSQL backup/restore drill that never connects to the source database.
- Add a guarded Kubernetes pod-failover drill requiring explicit destructive confirmation.
- Add a manual GitHub workflow that stores load and restore evidence artifacts for 90 days.
- Keep these drills manual so routine PR checks remain fast.

## Enterprise Kubernetes baseline

- Three-replica example with HPA minimum 3 and PDB minimum 2.
- Managed/multi-AZ PostgreSQL boundary.
- Zero-unavailable rolling updates.
- Node topology spreading and termination grace period.
- Network policy and increased resource baseline.
- Deployment validation now renders and asserts these invariants.

## Assurance documentation

- Enterprise validation runbook.
- Audit evidence checklist.
- Explicit shared-responsibility and external-certification boundary.

## Safety

- Directory search requires Responder/Admin authorization, excludes disabled users and existing members, caps every query, and hides internal errors.
- Failover tooling refuses to run without an explicit confirmation token and at least two running pods.
- Backup validation restores only into a disposable PostgreSQL container.
- No external certification claim is made.