### PR TITLE
feat(runtime): add backward-compatible dedicated job worker role

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,6 +8,44 @@
  */
 
 let shutdownHandlersRegistered = false;
+let stopScheduler: (() => Promise<void>) | null = null;
+let stopJobWorkerService: (() => Promise<void>) | null = null;
+let shutdownPromise: Promise<void> | null = null;
+
+async function stopRuntimeServices(): Promise<void> {
+  const stops: Promise<void>[] = [];
+
+  if (stopScheduler) {
+    stops.push(stopScheduler());
+  }
+
+  if (stopJobWorkerService) {
+    stops.push(stopJobWorkerService());
+  }
+
+  const results = await Promise.allSettled(stops);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('[Runtime] Graceful shutdown failed', result.reason);
+    }
+  }
+
+  stopScheduler = null;
+  stopJobWorkerService = null;
+}
+
+function requestShutdown(): void {
+  if (!shutdownPromise) {
+    shutdownPromise = stopRuntimeServices()
+      .catch(error => {
+        console.error('[Runtime] Graceful shutdown failed', error);
+      })
+      .finally(() => {
+        shutdownPromise = null;
+      });
+  }
+  void shutdownPromise;
+}
 
 export async function register() {
   // Only run validation in Node.js runtime (not Edge)
@@ -21,19 +59,39 @@ export async function register() {
     const { validateProductionEnv } = await import('./lib/env-validation');
     validateProductionEnv();
 
-    // Start the cron scheduler for background jobs
-    const { startCronScheduler, stopCronScheduler } = await import('./lib/cron-scheduler');
-    startCronScheduler();
+    const { getOpsKnightProcessRole, getRuntimeResponsibilities } = await import(
+      './lib/runtime-role'
+    );
+    const role = getOpsKnightProcessRole();
+    const responsibilities = getRuntimeResponsibilities(role);
+
+    // Keep Node-only runtime imports inside the Node runtime guard. Next.js also
+    // analyzes instrumentation for non-Node targets during build, and moving
+    // these imports outside this guard can pull Node-only provider modules into
+    // an incompatible bundle.
+    if (responsibilities.startScheduler) {
+      const { startCronScheduler, stopCronScheduler } = await import('./lib/cron-scheduler');
+      startCronScheduler();
+      stopScheduler = stopCronScheduler;
+    }
+
+    if (responsibilities.startJobWorker) {
+      const { startJobWorker, stopJobWorker } = await import('./lib/job-worker');
+      startJobWorker();
+      stopJobWorkerService = stopJobWorker;
+    }
+
+    const { logger } = await import('./lib/logger');
+    logger.info('[Runtime] Process role initialized', {
+      role,
+      scheduler: responsibilities.startScheduler,
+      jobWorker: responsibilities.startJobWorker,
+    });
 
     if (!shutdownHandlersRegistered) {
       shutdownHandlersRegistered = true;
-      const stopScheduler = () => {
-        void stopCronScheduler().catch(error => {
-          console.error('[Cron] Graceful shutdown failed', error);
-        });
-      };
-      process.once('SIGTERM', stopScheduler);
-      process.once('SIGINT', stopScheduler);
+      process.once('SIGTERM', requestShutdown);
+      process.once('SIGINT', requestShutdown);
     }
   }
 }

--- a/src/lib/job-worker.ts
+++ b/src/lib/job-worker.ts
@@ -1,0 +1,208 @@
+import { processPendingJobs } from './jobs/queue';
+import { logger } from './logger';
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_CONCURRENCY = 15;
+const DEFAULT_IDLE_POLL_MS = 1000;
+const DEFAULT_BUSY_POLL_MS = 100;
+
+const MAX_BATCH_SIZE = 500;
+const MAX_CONCURRENCY = 50;
+const MAX_IDLE_POLL_MS = 60_000;
+const MAX_BUSY_POLL_MS = 5_000;
+
+export interface JobWorkerConfig {
+  batchSize: number;
+  concurrency: number;
+  idlePollMs: number;
+  busyPollMs: number;
+}
+
+let timer: NodeJS.Timeout | null = null;
+let initialized = false;
+let activeRun: Promise<void> | null = null;
+let workerConfig: JobWorkerConfig | null = null;
+let lastRunAt: Date | null = null;
+let lastSuccessAt: Date | null = null;
+let lastError: string | null = null;
+
+function readBoundedInteger(
+  rawValue: string | undefined,
+  name: string,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  const raw = rawValue?.trim();
+  if (!raw) return fallback;
+
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}.`);
+  }
+
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+/**
+ * Read worker tuning from the environment with hard safety bounds. Invalid
+ * values fail startup instead of silently creating an unexpectedly aggressive
+ * worker that could exhaust PostgreSQL or a notification provider.
+ */
+export function getJobWorkerConfig(env: NodeJS.ProcessEnv = process.env): JobWorkerConfig {
+  const batchSize = readBoundedInteger(
+    env.OPSKNIGHT_WORKER_BATCH_SIZE,
+    'OPSKNIGHT_WORKER_BATCH_SIZE',
+    DEFAULT_BATCH_SIZE,
+    1,
+    MAX_BATCH_SIZE
+  );
+  const concurrency = readBoundedInteger(
+    env.OPSKNIGHT_WORKER_CONCURRENCY,
+    'OPSKNIGHT_WORKER_CONCURRENCY',
+    DEFAULT_CONCURRENCY,
+    1,
+    MAX_CONCURRENCY
+  );
+  const idlePollMs = readBoundedInteger(
+    env.OPSKNIGHT_WORKER_IDLE_POLL_MS,
+    'OPSKNIGHT_WORKER_IDLE_POLL_MS',
+    DEFAULT_IDLE_POLL_MS,
+    100,
+    MAX_IDLE_POLL_MS
+  );
+  const busyPollMs = readBoundedInteger(
+    env.OPSKNIGHT_WORKER_BUSY_POLL_MS,
+    'OPSKNIGHT_WORKER_BUSY_POLL_MS',
+    DEFAULT_BUSY_POLL_MS,
+    10,
+    MAX_BUSY_POLL_MS
+  );
+
+  if (concurrency > batchSize) {
+    throw new Error('OPSKNIGHT_WORKER_CONCURRENCY cannot exceed OPSKNIGHT_WORKER_BATCH_SIZE.');
+  }
+
+  return { batchSize, concurrency, idlePollMs, busyPollMs };
+}
+
+function withIdleJitter(delayMs: number): number {
+  // Jitter keeps multiple idle workers from polling PostgreSQL in lock-step.
+  const jitterWindow = Math.max(1, Math.floor(delayMs / 4));
+  return delayMs + Math.floor(Math.random() * jitterWindow);
+}
+
+function scheduleNextRun(delayMs: number): void {
+  if (!initialized) return;
+
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => {
+    timer = null;
+    activeRun = runOnce().finally(() => {
+      activeRun = null;
+    });
+    void activeRun;
+  }, delayMs);
+}
+
+async function runOnce(): Promise<void> {
+  if (!initialized || !workerConfig) return;
+
+  lastRunAt = new Date();
+  const startedAt = Date.now();
+
+  try {
+    const result = await processPendingJobs(workerConfig.batchSize, workerConfig.concurrency);
+    lastSuccessAt = new Date();
+    lastError = null;
+
+    logger.debug('[JobWorker] Batch processed', {
+      processed: result.processed,
+      failed: result.failed,
+      claimed: result.total,
+      durationMs: Date.now() - startedAt,
+    });
+
+    const delay = result.total > 0 ? workerConfig.busyPollMs : withIdleJitter(workerConfig.idlePollMs);
+    scheduleNextRun(delay);
+  } catch (error) {
+    lastError = error instanceof Error ? error.message : String(error);
+    logger.error('[JobWorker] Batch failed', {
+      error: lastError,
+      durationMs: Date.now() - startedAt,
+    });
+
+    // A queue/database failure must not create a hot retry loop.
+    scheduleNextRun(withIdleJitter(workerConfig.idlePollMs));
+  }
+}
+
+/**
+ * Start a dedicated durable-job worker. The queue's PostgreSQL SKIP LOCKED
+ * claim is the concurrency boundary, so multiple worker processes can safely
+ * call this loop against the same database.
+ */
+export function startJobWorker(): void {
+  if (initialized) {
+    logger.debug('[JobWorker] Already initialized, skipping');
+    return;
+  }
+
+  workerConfig = getJobWorkerConfig();
+  initialized = true;
+  lastRunAt = null;
+  lastSuccessAt = null;
+  lastError = null;
+
+  logger.info('[JobWorker] Starting', {
+    batchSize: workerConfig.batchSize,
+    concurrency: workerConfig.concurrency,
+    idlePollMs: workerConfig.idlePollMs,
+    busyPollMs: workerConfig.busyPollMs,
+  });
+
+  // Start immediately. Subsequent iterations are paced based on queue activity.
+  scheduleNextRun(0);
+}
+
+/**
+ * Stop claiming new jobs and allow the current batch to finish. Kubernetes
+ * should keep terminationGracePeriodSeconds long enough for normal in-flight
+ * work; the existing queue lease recovery remains the safety net for a forced
+ * process kill.
+ */
+export async function stopJobWorker(): Promise<void> {
+  const wasRunning = initialized || timer !== null || activeRun !== null;
+  initialized = false;
+
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+
+  const inFlight = activeRun;
+  if (inFlight) {
+    await inFlight;
+  }
+
+  workerConfig = null;
+
+  if (wasRunning) {
+    logger.info('[JobWorker] Stopped');
+  }
+}
+
+export function getJobWorkerStatus() {
+  return {
+    running: initialized,
+    inFlight: activeRun !== null,
+    lastRunAt,
+    lastSuccessAt,
+    lastError,
+    config: workerConfig ? { ...workerConfig } : null,
+  };
+}

--- a/src/lib/runtime-role.ts
+++ b/src/lib/runtime-role.ts
@@ -1,0 +1,49 @@
+export const OPSKNIGHT_PROCESS_ROLES = ['integrated', 'web', 'scheduler', 'worker'] as const;
+
+export type OpsKnightProcessRole = (typeof OPSKNIGHT_PROCESS_ROLES)[number];
+
+export interface RuntimeResponsibilities {
+  startScheduler: boolean;
+  startJobWorker: boolean;
+}
+
+const DEFAULT_PROCESS_ROLE: OpsKnightProcessRole = 'integrated';
+
+/**
+ * Resolve the role for this process.
+ *
+ * The default deliberately preserves the pre-worker-plane runtime: every
+ * application process starts the existing distributed cron scheduler. New
+ * deployments can opt into separated web/scheduler/worker responsibilities
+ * without forcing a flag-day migration on existing installations.
+ */
+export function getOpsKnightProcessRole(
+  value: string | undefined = process.env.OPSKNIGHT_PROCESS_ROLE
+): OpsKnightProcessRole {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return DEFAULT_PROCESS_ROLE;
+
+  if ((OPSKNIGHT_PROCESS_ROLES as readonly string[]).includes(normalized)) {
+    return normalized as OpsKnightProcessRole;
+  }
+
+  throw new Error(
+    `Invalid OPSKNIGHT_PROCESS_ROLE "${normalized}". Expected one of: ${OPSKNIGHT_PROCESS_ROLES.join(', ')}.`
+  );
+}
+
+/**
+ * Keep process-role policy in one place so startup code and tests cannot drift.
+ */
+export function getRuntimeResponsibilities(role: OpsKnightProcessRole): RuntimeResponsibilities {
+  switch (role) {
+    case 'integrated':
+      return { startScheduler: true, startJobWorker: false };
+    case 'web':
+      return { startScheduler: false, startJobWorker: false };
+    case 'scheduler':
+      return { startScheduler: true, startJobWorker: false };
+    case 'worker':
+      return { startScheduler: false, startJobWorker: true };
+  }
+}

--- a/tests/lib/job-worker.test.ts
+++ b/tests/lib/job-worker.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/jobs/queue', () => ({
+  processPendingJobs: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { processPendingJobs } from '@/lib/jobs/queue';
+import {
+  getJobWorkerConfig,
+  getJobWorkerStatus,
+  startJobWorker,
+  stopJobWorker,
+} from '@/lib/job-worker';
+
+type WorkerResult = { processed: number; failed: number; total: number };
+
+function testEnv(values: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return { NODE_ENV: 'test', ...values };
+}
+
+describe('dedicated job worker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.mocked(processPendingJobs).mockResolvedValue({ processed: 0, failed: 0, total: 0 });
+
+    delete process.env.OPSKNIGHT_WORKER_BATCH_SIZE;
+    delete process.env.OPSKNIGHT_WORKER_CONCURRENCY;
+    delete process.env.OPSKNIGHT_WORKER_IDLE_POLL_MS;
+    delete process.env.OPSKNIGHT_WORKER_BUSY_POLL_MS;
+  });
+
+  afterEach(async () => {
+    await stopJobWorker();
+    vi.useRealTimers();
+  });
+
+  it('uses conservative bounded defaults', () => {
+    expect(getJobWorkerConfig(testEnv())).toEqual({
+      batchSize: 100,
+      concurrency: 15,
+      idlePollMs: 1000,
+      busyPollMs: 100,
+    });
+  });
+
+  it('rejects unsafe or inconsistent configuration', () => {
+    expect(() =>
+      getJobWorkerConfig(testEnv({ OPSKNIGHT_WORKER_CONCURRENCY: '51' }))
+    ).toThrow(/OPSKNIGHT_WORKER_CONCURRENCY/);
+
+    expect(() =>
+      getJobWorkerConfig(
+        testEnv({
+          OPSKNIGHT_WORKER_BATCH_SIZE: '10',
+          OPSKNIGHT_WORKER_CONCURRENCY: '11',
+        })
+      )
+    ).toThrow(/cannot exceed/);
+  });
+
+  it('starts immediately and processes the durable queue with existing queue defaults', async () => {
+    startJobWorker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+    expect(processPendingJobs).toHaveBeenCalledWith(100, 15);
+    expect(getJobWorkerStatus().running).toBe(true);
+  });
+
+  it('does not overlap queue batches within a worker process', async () => {
+    let finishFirst!: (value: WorkerResult) => void;
+    vi.mocked(processPendingJobs).mockImplementationOnce(
+      () =>
+        new Promise<WorkerResult>(resolve => {
+          finishFirst = resolve;
+        })
+    );
+
+    startJobWorker();
+
+    // Run the zero-delay timer synchronously so the worker enters its first
+    // unresolved batch without making the test wait for that batch to finish.
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+
+    // A long clock advance must not start another batch while the first promise
+    // is still in flight.
+    vi.advanceTimersByTime(5000);
+    await Promise.resolve();
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+
+    finishFirst({ processed: 0, failed: 0, total: 0 });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('waits for an in-flight batch during graceful shutdown and does not claim again', async () => {
+    let finishFirst!: (value: WorkerResult) => void;
+    vi.mocked(processPendingJobs).mockImplementationOnce(
+      () =>
+        new Promise<WorkerResult>(resolve => {
+          finishFirst = resolve;
+        })
+    );
+
+    startJobWorker();
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+
+    let shutdownCompleted = false;
+    const shutdown = stopJobWorker().then(() => {
+      shutdownCompleted = true;
+    });
+    await Promise.resolve();
+
+    expect(shutdownCompleted).toBe(false);
+    expect(getJobWorkerStatus().running).toBe(false);
+
+    finishFirst({ processed: 1, failed: 0, total: 1 });
+    await shutdown;
+    expect(shutdownCompleted).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('backs off and retries after a queue processor failure', async () => {
+    vi.mocked(processPendingJobs)
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce({ processed: 0, failed: 0, total: 0 });
+
+    startJobWorker();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+
+    // Idle retry jitter is bounded to less than 25%, so 1.25s is enough to
+    // observe exactly one retry without reaching the following idle poll.
+    await vi.advanceTimersByTimeAsync(1250);
+    expect(processPendingJobs).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops claiming new batches after graceful shutdown', async () => {
+    startJobWorker();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+
+    await stopJobWorker();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(processPendingJobs).toHaveBeenCalledTimes(1);
+    expect(getJobWorkerStatus().running).toBe(false);
+  });
+});

--- a/tests/lib/runtime-role.test.ts
+++ b/tests/lib/runtime-role.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getOpsKnightProcessRole,
+  getRuntimeResponsibilities,
+} from '@/lib/runtime-role';
+
+describe('runtime process roles', () => {
+  it('preserves the existing integrated runtime by default', () => {
+    expect(getOpsKnightProcessRole(undefined)).toBe('integrated');
+    expect(getRuntimeResponsibilities('integrated')).toEqual({
+      startScheduler: true,
+      startJobWorker: false,
+    });
+  });
+
+  it('separates web, scheduler, and worker responsibilities', () => {
+    expect(getRuntimeResponsibilities('web')).toEqual({
+      startScheduler: false,
+      startJobWorker: false,
+    });
+    expect(getRuntimeResponsibilities('scheduler')).toEqual({
+      startScheduler: true,
+      startJobWorker: false,
+    });
+    expect(getRuntimeResponsibilities('worker')).toEqual({
+      startScheduler: false,
+      startJobWorker: true,
+    });
+  });
+
+  it('normalizes configured role names', () => {
+    expect(getOpsKnightProcessRole(' Worker ')).toBe('worker');
+  });
+
+  it('fails closed for an unknown role', () => {
+    expect(() => getOpsKnightProcessRole('wrkerr')).toThrow(/Invalid OPSKNIGHT_PROCESS_ROLE/);
+  });
+});


### PR DESCRIPTION
## Component 1 — worker-plane foundation

This is intentionally additive and backward-compatible.

### Invariants preserved
- `OPSKNIGHT_PROCESS_ROLE` is optional; unset defaults to `integrated`, which starts the existing cron scheduler exactly as current deployments do.
- Docker Compose remains a single integrated OpsKnight container unless an operator explicitly opts into another role.
- No incident, notification, API, database schema, queue claim, retry, or UI behavior is changed.
- Dedicated `worker` processes reuse the existing PostgreSQL `FOR UPDATE SKIP LOCKED` durable queue implementation.
- A worker never overlaps batches within the same process.
- The worker stop routine stops new claims and waits for its current batch; existing queue zombie recovery remains the forced-termination safety net.
- Next.js standalone has its own SIGTERM/SIGINT shutdown lifecycle, so full dedicated-pod drain semantics must be finalized with the deployment topology rather than being overstated here.
- Invalid process roles and unsafe worker concurrency settings fail startup instead of silently degrading safety.

### New opt-in roles
- `integrated` (default): existing runtime behavior
- `web`: web/API only
- `scheduler`: existing distributed scheduler
- `worker`: dedicated BackgroundJob consumer

### Safety bounds
Worker batch size, concurrency, and poll timings are configurable but hard-bounded to prevent accidental database/provider exhaustion. Idle polling is jittered to avoid synchronized database polling across worker replicas.

### Validation — final SHA `0451bcd`
All merge gates completed successfully:
- TypeScript typecheck ✅
- Unit tests ✅
- Real-PostgreSQL integration tests ✅
- 1330/1330 Vitest tests passed; 0 failed, 0 skipped ✅
- DB smoke test ✅
- Migration validation and migration health ✅
- Production Docker PR build ✅
- CodeQL, ESLint security, dependency/container scanning, secret scanning, and Checkov ✅

The earlier generic object-injection warning caused by dynamic environment-property access was removed by switching to explicit allow-listed worker environment fields; the old review location is now outdated.

This PR remains draft intentionally. Deployment topology, dedicated-pod lifecycle semantics, and database connection budgeting are separate follow-up components.