### PR TITLE
fix(oncall): harden DST-safe schedule resolution

### DIFF
--- a/docs/v1.5/core-concepts/schedules.md
+++ b/docs/v1.5/core-concepts/schedules.md
@@ -54,11 +54,16 @@ The end time must be after the start. Hours use `0` through `23`; week-day value
 
 ### Daylight Saving Time (DST) Transitions
 
-Rotations in OpsKnight are anchored to wall-clock hours in the schedule's configured IANA timezone:
+OpsKnight resolves schedule boundaries against the configured IANA timezone rather than a fixed UTC offset:
 
-- **Daily and Multi-Day Rotations**: Evaluated with calendar-day arithmetic so shifts always start at the intended local hour (e.g. 09:00 AM) across 23-hour spring-forward and 25-hour fall-back transitions.
-- **Sub-Daily Rotations (1h, 2h, 4h, 6h, 8h, 12h)**: Derived from local day boundaries rather than continuous millisecond addition, preventing rotation drift and eliminating 1-hour overlap or gap defects.
+- **Daily and Multi-Day Rotations**: Evaluated with calendar-day arithmetic so shifts stay anchored to the intended local wall-clock hour across 23-hour, 24-hour, and 25-hour days.
+- **Sub-Daily Wall-Clock Rotations (1h, 2h, 3h, 4h, 6h, 8h, 12h)**: Intervals that divide a local day are anchored to local wall-clock boundaries. A skipped spring-forward boundary can collapse a nominal slot to zero duration; a repeated fall-back hour can lengthen a slot. Coverage remains contiguous because a full-duty slot always ends at the next resolved rotation boundary.
+- **Arbitrary Sub-Daily Rotations**: Durations such as `5h` or `7h` use elapsed-time semantics. They remain exact-duration and contiguous across DST, so their displayed local handoff hour may move when the UTC offset changes.
+- **Non-1-Hour Transitions**: Resolution uses the timezone database and does not assume DST always changes by exactly one hour; half-hour transitions such as `Australia/Lord_Howe` are handled by the same logic.
+- **User-Entered Transition Times**: A local timestamp that does not exist during spring-forward, or occurs twice during fall-back, is rejected instead of being silently shifted to a different instant. Choose an unambiguous local time and save again.
 - **Overrides**: Strictly filter for active users (`status === 'ACTIVE'`) to prevent deactivated users from holding scheduled coverage.
+
+Generated recurrence boundaries use deterministic Temporal-compatible disambiguation: the earlier occurrence during a fall-back overlap and the later representable wall-clock time during a spring-forward gap. This rule applies only to generated recurrence boundaries; ambiguous user input is not silently accepted.
 
 ## Manage participants
 
@@ -113,7 +118,11 @@ Verify participant order, rotation start, rotation length, schedule timezone, la
 
 ### Handoff is an hour early or late
 
-Confirm the IANA timezone and inspect the date for a daylight-saving transition. Avoid treating a fixed UTC offset as a timezone.
+Confirm the IANA timezone and inspect the date for a daylight-saving transition. Avoid treating a fixed UTC offset as a timezone. Also note that not every DST change is one hour.
+
+### A transition-time form value is rejected
+
+The selected local time is either nonexistent (spring-forward) or ambiguous (fall-back) in the schedule timezone. Choose an unambiguous wall-clock time; OpsKnight intentionally refuses to guess which instant you meant.
 
 ### An override has no effect
 

--- a/src/lib/__tests__/oncall.timezone.test.ts
+++ b/src/lib/__tests__/oncall.timezone.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { buildScheduleBlocks } from '../oncall';
 
+function expectContinuousCoverage(blocks: Array<{ start: Date; end: Date }>) {
+  let previous: { start: Date; end: Date } | undefined;
+  for (const block of blocks) {
+    if (previous) {
+      expect(previous.end.getTime()).toBe(block.start.getTime());
+    }
+    previous = block;
+  }
+}
+
 // Regression: restrictions should be evaluated in the schedule timezone, not server/local time.
 describe('buildScheduleBlocks timezone-aware restrictions', () => {
   it('skips a block when local day is allowed but schedule timezone day is not', () => {
@@ -29,7 +39,6 @@ describe('buildScheduleBlocks timezone-aware restrictions', () => {
   });
 
   it('preserves wall-clock start time across DST spring-forward boundary', () => {
-    // 2026-03-07 is before DST (EST, UTC-5), 2026-03-08 is transition, 2026-03-09 is after (EDT, UTC-4)
     const layerStart = new Date('2026-03-07T05:00:00Z'); // 2026-03-07 00:00 EST
     const layer = {
       id: 'layer-dst',
@@ -50,11 +59,8 @@ describe('buildScheduleBlocks timezone-aware restrictions', () => {
     const blocks = buildScheduleBlocks([layer], [], windowStart, windowEnd, 'America/New_York');
 
     expect(blocks.length).toBe(3);
-    // Day 0: 2026-03-07 00:00 EST -> 05:00 UTC
     expect(blocks[0].start.toISOString()).toBe('2026-03-07T05:00:00.000Z');
-    // Day 1: 2026-03-08 00:00 EST -> 05:00 UTC
     expect(blocks[1].start.toISOString()).toBe('2026-03-08T05:00:00.000Z');
-    // Day 2: 2026-03-09 00:00 EDT -> 04:00 UTC (not 05:00 UTC!)
     expect(blocks[2].start.toISOString()).toBe('2026-03-09T04:00:00.000Z');
   });
 
@@ -100,8 +106,159 @@ describe('buildScheduleBlocks timezone-aware restrictions', () => {
     expect(blocks[0].end.getTime() - blocks[0].start.getTime()).toBe(13 * 3600_000);
   });
 
+  it('keeps 1-hour wall-clock rotations continuous through spring-forward', () => {
+    const layer = {
+      id: 'hourly-spring',
+      name: 'Hourly',
+      start: new Date('2026-03-08T05:00:00.000Z'), // 00:00 EST
+      end: null,
+      rotationLengthHours: 1,
+      users: [
+        { userId: 'u1', user: { name: 'User One' }, position: 0 },
+        { userId: 'u2', user: { name: 'User Two' }, position: 1 },
+      ],
+    };
+    const blocks = buildScheduleBlocks(
+      [layer],
+      [],
+      layer.start,
+      new Date('2026-03-08T12:00:00.000Z'),
+      'America/New_York'
+    );
+
+    expectContinuousCoverage(blocks);
+    expect(blocks[0].start.toISOString()).toBe('2026-03-08T05:00:00.000Z');
+    expect(blocks[blocks.length - 1].end.toISOString()).toBe('2026-03-08T12:00:00.000Z');
+    expect(blocks.every(block => block.end > block.start)).toBe(true);
+  });
+
+  it('keeps 1-hour wall-clock rotations continuous through fall-back', () => {
+    const layer = {
+      id: 'hourly-fall',
+      name: 'Hourly',
+      start: new Date('2026-11-01T04:00:00.000Z'), // 00:00 EDT
+      end: null,
+      rotationLengthHours: 1,
+      users: [
+        { userId: 'u1', user: { name: 'User One' }, position: 0 },
+        { userId: 'u2', user: { name: 'User Two' }, position: 1 },
+      ],
+    };
+    const blocks = buildScheduleBlocks(
+      [layer],
+      [],
+      layer.start,
+      new Date('2026-11-01T10:00:00.000Z'),
+      'America/New_York'
+    );
+
+    expectContinuousCoverage(blocks);
+    expect(blocks[1].end.getTime() - blocks[1].start.getTime()).toBe(2 * 3600_000);
+  });
+
+  it('never moves a layer that starts in the second fall-back occurrence before its exact start', () => {
+    const layer = {
+      id: 'fall-second-occurrence',
+      name: 'Second Occurrence',
+      start: new Date('2026-11-01T06:30:00.000Z'), // 01:30 EST, the second 01:30
+      end: null,
+      rotationLengthHours: 1,
+      users: [
+        { userId: 'u1', user: { name: 'User One' }, position: 0 },
+        { userId: 'u2', user: { name: 'User Two' }, position: 1 },
+      ],
+    };
+
+    const blocks = buildScheduleBlocks(
+      [layer],
+      [],
+      new Date('2026-11-01T05:00:00.000Z'),
+      new Date('2026-11-01T10:00:00.000Z'),
+      'America/New_York'
+    );
+
+    expect(blocks[0].start.toISOString()).toBe('2026-11-01T06:30:00.000Z');
+    expect(blocks.every(block => block.start >= layer.start)).toBe(true);
+    expectContinuousCoverage(blocks);
+  });
+
+  it('keeps full-day timezone jumps monotonic without duplicate coverage', () => {
+    const layer = {
+      id: 'apia-hourly',
+      name: 'Apia Hourly',
+      start: new Date('2011-12-29T10:00:00.000Z'), // 2011-12-29 00:00 -10
+      end: null,
+      rotationLengthHours: 1,
+      users: [
+        { userId: 'u1', user: { name: 'User One' }, position: 0 },
+        { userId: 'u2', user: { name: 'User Two' }, position: 1 },
+        { userId: 'u3', user: { name: 'User Three' }, position: 2 },
+      ],
+    };
+
+    const windowEnd = new Date('2012-01-02T10:00:00.000Z');
+    const blocks = buildScheduleBlocks([layer], [], layer.start, windowEnd, 'Pacific/Apia');
+    const uniqueIntervals = new Set(
+      blocks.map(block => `${block.start.getTime()}-${block.end.getTime()}`)
+    );
+
+    expect(blocks).toHaveLength(96);
+    expect(uniqueIntervals.size).toBe(blocks.length);
+    expect(blocks[0].start.getTime()).toBe(layer.start.getTime());
+    expect(blocks[blocks.length - 1].end.getTime()).toBe(windowEnd.getTime());
+    expect(blocks.every(block => block.end > block.start)).toBe(true);
+    expectContinuousCoverage(blocks);
+  });
+
+  it('fast-forwards safely past a full-day timezone jump', () => {
+    const layer = {
+      id: 'apia-fast-forward',
+      name: 'Apia Fast Forward',
+      start: new Date('2011-12-29T10:00:00.000Z'),
+      end: null,
+      rotationLengthHours: 1,
+      users: [
+        { userId: 'u1', user: { name: 'User One' }, position: 0 },
+        { userId: 'u2', user: { name: 'User Two' }, position: 1 },
+      ],
+    };
+    const windowStart = new Date('2012-02-01T10:00:00.000Z');
+    const windowEnd = new Date('2012-02-02T10:00:00.000Z');
+
+    const blocks = buildScheduleBlocks([layer], [], windowStart, windowEnd, 'Pacific/Apia');
+    expect(blocks).toHaveLength(24);
+    expect(blocks[0].start.getTime()).toBe(windowStart.getTime());
+    expect(blocks[blocks.length - 1].end.getTime()).toBe(windowEnd.getTime());
+    expectContinuousCoverage(blocks);
+  });
+
+  it('uses fixed elapsed semantics for arbitrary sub-daily rotations without DST gaps', () => {
+    const layer = {
+      id: 'five-hour',
+      name: 'Five Hour',
+      start: new Date('2026-03-08T05:00:00.000Z'), // 00:00 EST
+      end: null,
+      rotationLengthHours: 5,
+      users: [
+        { userId: 'u1', user: { name: 'User One' }, position: 0 },
+        { userId: 'u2', user: { name: 'User Two' }, position: 1 },
+      ],
+    };
+    const blocks = buildScheduleBlocks(
+      [layer],
+      [],
+      layer.start,
+      new Date('2026-03-09T06:00:00.000Z'),
+      'America/New_York'
+    );
+
+    expectContinuousCoverage(blocks);
+    for (const block of blocks) {
+      expect(block.end.getTime() - block.start.getTime()).toBe(5 * 3600_000);
+    }
+  });
+
   it('splits multi-day rotation block into hourly sub-blocks matching restriction window', () => {
-    // 168h (1 week) rotation starting Mon Dec 1 2025 00:00 UTC
     const layerStart = new Date('2025-12-01T00:00:00Z');
     const layer = {
       id: 'layer-restricted',
@@ -117,12 +274,11 @@ describe('buildScheduleBlocks timezone-aware restrictions', () => {
       },
     };
 
-    const windowStart = new Date('2025-12-01T00:00:00Z'); // Monday 00:00 UTC
-    const windowEnd = new Date('2025-12-08T00:00:00Z'); // Next Monday 00:00 UTC
+    const windowStart = new Date('2025-12-01T00:00:00Z');
+    const windowEnd = new Date('2025-12-08T00:00:00Z');
 
     const blocks = buildScheduleBlocks([layer], [], windowStart, windowEnd, 'UTC');
 
-    // 5 business days, 1 block per day from 09:00 to 17:00
     expect(blocks.length).toBe(5);
     expect(blocks[0].start.toISOString()).toBe('2025-12-01T09:00:00.000Z');
     expect(blocks[0].end.toISOString()).toBe('2025-12-01T17:00:00.000Z');

--- a/src/lib/__tests__/timezone.test.ts
+++ b/src/lib/__tests__/timezone.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   addDaysToDateKey,
   formatDateKeyInTimeZone,
+  parseDateTimeInTimeZone,
+  resolveLocalDateTimeInTimeZone,
   startOfDayFromDateKey,
   startOfNextDayFromDateKey,
 } from '../timezone';
@@ -54,5 +56,64 @@ describe('timezone helpers', () => {
         expect(formatDateKeyInTimeZone(nextStart, timeZone)).toBe(addDaysToDateKey(dateKey, 1));
       }
     }
+  });
+
+  it('rejects nonexistent wall-clock input during spring-forward', () => {
+    expect(parseDateTimeInTimeZone('2026-03-08T02:30', 'America/New_York')).toBeNull();
+  });
+
+  it('rejects ambiguous wall-clock input during fall-back', () => {
+    expect(parseDateTimeInTimeZone('2026-11-01T01:30', 'America/New_York')).toBeNull();
+  });
+
+  it('resolves generated recurrence boundaries with Temporal-compatible DST semantics', () => {
+    const spring = resolveLocalDateTimeInTimeZone(
+      { year: 2026, month: 3, day: 8, hour: 2, minute: 30 },
+      'America/New_York',
+      'compatible'
+    );
+    expect(spring?.toISOString()).toBe('2026-03-08T07:30:00.000Z'); // 03:30 EDT
+
+    const fallEarlier = resolveLocalDateTimeInTimeZone(
+      { year: 2026, month: 11, day: 1, hour: 1, minute: 30 },
+      'America/New_York',
+      'compatible'
+    );
+    const fallLater = resolveLocalDateTimeInTimeZone(
+      { year: 2026, month: 11, day: 1, hour: 1, minute: 30 },
+      'America/New_York',
+      'later'
+    );
+    expect(fallEarlier?.toISOString()).toBe('2026-11-01T05:30:00.000Z');
+    expect(fallLater?.toISOString()).toBe('2026-11-01T06:30:00.000Z');
+  });
+
+  it('handles 30-minute DST transitions without assuming a one-hour change', () => {
+    expect(parseDateTimeInTimeZone('2026-10-04T02:15', 'Australia/Lord_Howe')).toBeNull();
+    expect(parseDateTimeInTimeZone('2026-04-05T01:45', 'Australia/Lord_Howe')).toBeNull();
+
+    const compatible = resolveLocalDateTimeInTimeZone(
+      { year: 2026, month: 10, day: 4, hour: 2, minute: 15 },
+      'Australia/Lord_Howe',
+      'compatible'
+    );
+    expect(compatible?.toISOString()).toBe('2026-10-03T15:45:00.000Z'); // 02:45 +11
+  });
+
+  it('handles full-day political timezone jumps', () => {
+    expect(parseDateTimeInTimeZone('2011-12-30T12:00', 'Pacific/Apia')).toBeNull();
+
+    const compatible = resolveLocalDateTimeInTimeZone(
+      { year: 2011, month: 12, day: 30, hour: 12, minute: 0 },
+      'Pacific/Apia',
+      'compatible'
+    );
+    expect(compatible?.toISOString()).toBe('2011-12-30T22:00:00.000Z'); // 2011-12-31 12:00 +14
+  });
+
+  it('rejects invalid calendar values instead of normalizing them', () => {
+    expect(parseDateTimeInTimeZone('2026-02-30T10:00', 'UTC')).toBeNull();
+    expect(parseDateTimeInTimeZone('2026-13-01T10:00', 'UTC')).toBeNull();
+    expect(parseDateTimeInTimeZone('2026-01-01T24:00', 'UTC')).toBeNull();
   });
 });

--- a/src/lib/oncall.ts
+++ b/src/lib/oncall.ts
@@ -1,4 +1,8 @@
-import { getTimeZoneOffsetMs } from './timezone';
+import {
+  getTimeZoneOffsetMs,
+  resolveLocalDateTimeInTimeZone,
+  type LocalDateTimeParts,
+} from './timezone';
 
 type LayerUser = {
   userId: string;
@@ -47,14 +51,44 @@ export type OnCallBlock = {
   isAdditiveOverride?: boolean;
 };
 
+const weekdayHourFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const localDateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getWeekdayHourFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = weekdayHourFormatterCache.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      weekday: 'short',
+      hour: 'numeric',
+      hour12: false,
+      hourCycle: 'h23',
+    });
+    weekdayHourFormatterCache.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+function getLocalDateTimeFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = localDateTimeFormatterCache.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    });
+    localDateTimeFormatterCache.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
 function getDayHourInTimeZone(date: Date, timeZone: string): { day: number; hour: number } {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    weekday: 'short',
-    hour: 'numeric',
-    hour12: false,
-    hourCycle: 'h23',
-  }).formatToParts(date);
+  const parts = getWeekdayHourFormatter(timeZone).formatToParts(date);
 
   const weekday = parts.find(p => p.type === 'weekday')?.value ?? 'Sun';
   const hour = Number(parts.find(p => p.type === 'hour')?.value ?? '0') % 24;
@@ -71,69 +105,115 @@ function getDayHourInTimeZone(date: Date, timeZone: string): { day: number; hour
 
   return { day: dayMap[weekday] ?? 0, hour };
 }
-function addCalendarDaysInTimeZone(base: Date, days: number, timeZone: string): Date {
-  // Get the date parts in the target timezone
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hourCycle: 'h23',
-  });
-  const parts = formatter.formatToParts(base);
-  const get = (type: string) => Number(parts.find(p => p.type === type)?.value ?? '0');
 
-  // Reconstruct the date with calendar day offset, keeping the same wall-clock time
-  const baseUtc = Date.UTC(
-    get('year'),
-    get('month') - 1,
-    get('day') + days,
-    get('hour') % 24,
-    get('minute'),
-    get('second')
+function getLocalDateTimeParts(date: Date, timeZone: string): Required<LocalDateTimeParts> {
+  const parts = getLocalDateTimeFormatter(timeZone).formatToParts(date);
+  const get = (type: string) => Number(parts.find(part => part.type === type)?.value ?? '0');
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour: get('hour') % 24,
+    minute: get('minute'),
+    second: get('second'),
+    millisecond: date.getUTCMilliseconds(),
+  };
+}
+
+function resolveShiftedWallClock(
+  base: Date,
+  timeZone: string,
+  mutateUtcParts: (date: Date) => void,
+  fallbackMs: number
+): Date {
+  const local = getLocalDateTimeParts(base, timeZone);
+  const pseudoUtc = new Date(
+    Date.UTC(
+      local.year,
+      local.month - 1,
+      local.day,
+      local.hour,
+      local.minute,
+      local.second,
+      local.millisecond
+    )
+  );
+  mutateUtcParts(pseudoUtc);
+
+  const resolved = resolveLocalDateTimeInTimeZone(
+    {
+      year: pseudoUtc.getUTCFullYear(),
+      month: pseudoUtc.getUTCMonth() + 1,
+      day: pseudoUtc.getUTCDate(),
+      hour: pseudoUtc.getUTCHours(),
+      minute: pseudoUtc.getUTCMinutes(),
+      second: pseudoUtc.getUTCSeconds(),
+      millisecond: pseudoUtc.getUTCMilliseconds(),
+    },
+    timeZone,
+    'compatible'
   );
 
-  // Convert back from target timezone to UTC with two-step DST boundary refinement
-  const guessOffsetMs = getTimeZoneOffsetMs(new Date(baseUtc), timeZone);
-  let date = new Date(baseUtc - guessOffsetMs);
-  const actualOffsetMs = getTimeZoneOffsetMs(date, timeZone);
-  if (actualOffsetMs !== guessOffsetMs) {
-    date = new Date(baseUtc - actualOffsetMs);
+  // The timezone was already validated when the schedule was created. Keep a
+  // deterministic elapsed-time fallback for corrupted legacy rows rather than
+  // returning an invalid Date and poisoning the entire escalation path.
+  return resolved ?? new Date(base.getTime() + fallbackMs);
+}
+
+function addCalendarDaysInTimeZone(base: Date, days: number, timeZone: string): Date {
+  if (!Number.isInteger(days)) {
+    return new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
   }
-  return date;
+  return resolveShiftedWallClock(
+    base,
+    timeZone,
+    date => date.setUTCDate(date.getUTCDate() + days),
+    days * 24 * 60 * 60 * 1000
+  );
 }
 
 function addCalendarHoursInTimeZone(base: Date, hours: number, timeZone: string): Date {
-  if (!Number.isInteger(hours)) return new Date(base.getTime() + hours * 60 * 60 * 1000);
-  const formatter = new Intl.DateTimeFormat('en-US', {
+  if (!Number.isInteger(hours)) {
+    return new Date(base.getTime() + hours * 60 * 60 * 1000);
+  }
+  return resolveShiftedWallClock(
+    base,
     timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hourCycle: 'h23',
-  });
-  const parts = formatter.formatToParts(base);
-  const get = (type: string) => Number(parts.find(p => p.type === type)?.value ?? '0');
-  const baseUtc = Date.UTC(
-    get('year'),
-    get('month') - 1,
-    get('day'),
-    (get('hour') % 24) + hours,
-    get('minute'),
-    get('second'),
-    base.getUTCMilliseconds()
+    date => date.setUTCHours(date.getUTCHours() + hours),
+    hours * 60 * 60 * 1000
   );
-  const guessOffsetMs = getTimeZoneOffsetMs(new Date(baseUtc), timeZone);
-  let result = new Date(baseUtc - guessOffsetMs);
-  const actualOffsetMs = getTimeZoneOffsetMs(result, timeZone);
-  if (actualOffsetMs !== guessOffsetMs) result = new Date(baseUtc - actualOffsetMs);
-  return result;
+}
+
+function isCalendarAnchoredRotation(rotationLengthHours: number): boolean {
+  if (!Number.isInteger(rotationLengthHours) || rotationLengthHours <= 0) return false;
+  return (
+    rotationLengthHours % 24 === 0 ||
+    (rotationLengthHours < 24 && 24 % rotationLengthHours === 0)
+  );
+}
+
+function getRotationStartAtIndex(
+  layerStart: Date,
+  index: number,
+  rotationLengthHours: number,
+  timeZone: string
+): Date {
+  // The stored start is already an exact instant. Reinterpreting index 0 as a
+  // wall-clock value can move a start in the second occurrence of a fall-back
+  // overlap to the first occurrence, creating coverage before layer.start.
+  if (index === 0) return new Date(layerStart);
+
+  if (rotationLengthHours % 24 === 0) {
+    return addCalendarDaysInTimeZone(
+      layerStart,
+      index * (rotationLengthHours / 24),
+      timeZone
+    );
+  }
+  if (isCalendarAnchoredRotation(rotationLengthHours)) {
+    return addCalendarHoursInTimeZone(layerStart, index * rotationLengthHours, timeZone);
+  }
+  return new Date(layerStart.getTime() + index * rotationLengthHours * 60 * 60 * 1000);
 }
 
 function splitBlockByRestrictions(
@@ -188,11 +268,9 @@ function splitBlockByRestrictions(
 
     if (allowed) {
       if (!segStart) segStart = new Date(cursor);
-    } else {
-      if (segStart) {
-        result.push({ start: segStart, end: new Date(cursor) });
-        segStart = null;
-      }
+    } else if (segStart) {
+      result.push({ start: segStart, end: new Date(cursor) });
+      segStart = null;
     }
 
     if (nextCursor.getTime() <= cursor.getTime()) {
@@ -217,14 +295,16 @@ function generateLayerBlocks(
 ): OnCallBlock[] {
   const sortedUsers = [...layer.users].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
 
-  if (!sortedUsers || sortedUsers.length === 0) {
+  if (sortedUsers.length === 0) {
     return [];
   }
 
   const rotationMs = layer.rotationLengthHours * 60 * 60 * 1000;
-  const shiftMs = (layer.shiftLengthHours || layer.rotationLengthHours) * 60 * 60 * 1000;
+  const shiftHours = layer.shiftLengthHours || layer.rotationLengthHours;
+  const shiftMs = shiftHours * 60 * 60 * 1000;
+  const calendarAnchoredRotation = isCalendarAnchoredRotation(layer.rotationLengthHours);
 
-  if (rotationMs <= 0 || shiftMs <= 0) {
+  if (rotationMs <= 0 || shiftMs <= 0 || !Number.isFinite(rotationMs) || !Number.isFinite(shiftMs)) {
     return [];
   }
 
@@ -238,91 +318,109 @@ function generateLayerBlocks(
   }
 
   const blocks: OnCallBlock[] = [];
-  let guard = 0;
 
+  // Seek close to the requested range using elapsed time, then intentionally
+  // rewind across the largest civil-time jump supported by the resolver. This
+  // keeps expansion O(window size) rather than O(schedule age), while giving
+  // us enough history to establish a monotonic boundary floor around unusual
+  // transitions such as Pacific/Apia's skipped day.
   let index = 0;
-  // If layerStart is way in the past, skip to near effectiveWindowStart
   if (layerStart < effectiveWindowStart) {
     const elapsed = effectiveWindowStart.getTime() - layerStart.getTime();
-    index = Math.floor(elapsed / rotationMs);
+    index = Math.max(0, Math.floor(elapsed / rotationMs));
+    const transitionLookbackSlots = calendarAnchoredRotation
+      ? Math.ceil((48 * 60 * 60 * 1000) / rotationMs) + 2
+      : 2;
+    index = Math.max(0, index - transitionLookbackSlots);
   }
 
-  // Safety break to prevent infinite loops (max 5 years of shifts or 5000 iterations)
-  const maxIterations = 5000;
-  let iterations = 0;
+  const initialIndex = index;
+  const maxIterations = 1_000_000;
+  let rawRotationStart = getRotationStartAtIndex(
+    layerStart,
+    index,
+    layer.rotationLengthHours,
+    timeZone
+  );
+  let monotonicBoundaryMs = rawRotationStart.getTime();
 
-  while (iterations < maxIterations) {
-    iterations++;
+  while (index - initialIndex < maxIterations) {
+    const rawNextRotationStart = getRotationStartAtIndex(
+      layerStart,
+      index + 1,
+      layer.rotationLengthHours,
+      timeZone
+    );
+    const rawNextMs = rawNextRotationStart.getTime();
 
-    let blockStart: Date;
-    if (layer.rotationLengthHours % 24 === 0) {
-      // Calendar-day math to avoid DST drift for daily/weekly/multi-day rotations
-      blockStart = addCalendarDaysInTimeZone(
-        layerStart,
-        index * (layer.rotationLengthHours / 24),
-        timeZone
-      );
-    } else if (layer.rotationLengthHours < 24 && 24 % layer.rotationLengthHours === 0) {
-      // Calendar-anchored math for sub-daily integer factors of 24 (12h, 8h, 6h, 4h, 2h, 1h)
-      blockStart = addCalendarHoursInTimeZone(
-        layerStart,
-        index * layer.rotationLengthHours,
-        timeZone
-      );
-    } else {
-      const rotationStartTime = layerStart.getTime() + index * rotationMs;
-      blockStart = new Date(rotationStartTime);
-    }
-
-    if (blockStart >= windowEnd) {
-      break;
-    }
-
-    if (layerEnd && blockStart >= layerEnd) {
-      break;
-    }
-
-    let rawEnd: Date;
-    const shiftHours = layer.shiftLengthHours || layer.rotationLengthHours;
-    if (shiftHours % 24 === 0) {
-      rawEnd = addCalendarDaysInTimeZone(blockStart, shiftHours / 24, timeZone);
-    } else {
-      rawEnd = addCalendarHoursInTimeZone(blockStart, shiftHours, timeZone);
-    }
-    const blockEnd = layerEnd && rawEnd > layerEnd ? layerEnd : rawEnd;
-
-    // Check visibility
-    // If the entire duty block is before window start, skip
-    if (blockEnd <= effectiveWindowStart) {
+    // Generated wall-clock boundaries can collapse or even move backward when
+    // a timezone skips a large civil interval (for example Apia skipped an
+    // entire day). Never let a later nominal index rewind the real timeline.
+    // Collapsed/backward positions still consume responder rotation parity but
+    // do not emit duplicate or overlapping coverage.
+    if (rawNextMs <= monotonicBoundaryMs) {
       index++;
-      guard++;
+      rawRotationStart = rawNextRotationStart;
       continue;
     }
 
-    // Determine User
-    const user = sortedUsers[index % sortedUsers.length];
+    const rotationStart = new Date(
+      Math.max(rawRotationStart.getTime(), monotonicBoundaryMs, layerStart.getTime())
+    );
+    const nextRotationStart = rawNextRotationStart;
 
-    // Clamping to visual window
-    const clampedStart = blockStart < windowStart ? windowStart : blockStart;
-    const clampedEnd = blockEnd > windowEnd ? windowEnd : blockEnd;
+    if (rotationStart >= windowEnd) break;
+    if (layerEnd && rotationStart >= layerEnd) break;
 
-    if (clampedStart < clampedEnd) {
-      if (layer.restrictions) {
-        // Split into hourly sub-blocks and filter by restriction
-        const { daysOfWeek, startHour, endHour } = layer.restrictions;
-        const subBlocks = splitBlockByRestrictions(
-          clampedStart,
-          clampedEnd,
-          timeZone,
-          daysOfWeek,
-          startHour,
-          endHour
-        );
-        for (const sub of subBlocks) {
+    let rawEnd: Date;
+    if (shiftHours === layer.rotationLengthHours) {
+      // Full-duty slots meet exactly at the next monotonic rotation boundary.
+      rawEnd = nextRotationStart;
+    } else if (!calendarAnchoredRotation) {
+      rawEnd = new Date(rotationStart.getTime() + shiftMs);
+    } else if (shiftHours % 24 === 0) {
+      rawEnd = addCalendarDaysInTimeZone(rotationStart, shiftHours / 24, timeZone);
+    } else {
+      rawEnd = addCalendarHoursInTimeZone(rotationStart, shiftHours, timeZone);
+    }
+
+    const blockEnd = layerEnd && rawEnd > layerEnd ? layerEnd : rawEnd;
+
+    if (blockEnd > rotationStart && blockEnd > effectiveWindowStart) {
+      const user = sortedUsers[index % sortedUsers.length];
+      const clampedStart = rotationStart < windowStart ? windowStart : rotationStart;
+      const clampedEnd = blockEnd > windowEnd ? windowEnd : blockEnd;
+
+      if (clampedStart < clampedEnd) {
+        if (layer.restrictions) {
+          const { daysOfWeek, startHour, endHour } = layer.restrictions;
+          const subBlocks = splitBlockByRestrictions(
+            clampedStart,
+            clampedEnd,
+            timeZone,
+            daysOfWeek,
+            startHour,
+            endHour
+          );
+          for (const sub of subBlocks) {
+            blocks.push({
+              id: `${layer.id}-${index}-${sub.start.getTime()}`,
+              start: sub.start,
+              end: sub.end,
+              userId: user.userId,
+              userName: user.user.name,
+              userAvatar: user.user.avatarUrl,
+              userGender: user.user.gender,
+              layerId: layer.id,
+              layerName: layer.name,
+              source: 'rotation',
+            });
+          }
+        } else {
           blocks.push({
-            id: `${layer.id}-${index}-${sub.start.getTime()}`,
-            start: sub.start,
-            end: sub.end,
+            id: `${layer.id}-${index}`,
+            start: clampedStart,
+            end: clampedEnd,
             userId: user.userId,
             userName: user.user.name,
             userAvatar: user.user.avatarUrl,
@@ -332,24 +430,16 @@ function generateLayerBlocks(
             source: 'rotation',
           });
         }
-      } else {
-        blocks.push({
-          id: `${layer.id}-${index}`,
-          start: clampedStart,
-          end: clampedEnd,
-          userId: user.userId,
-          userName: user.user.name,
-          userAvatar: user.user.avatarUrl,
-          userGender: user.user.gender,
-          layerId: layer.id,
-          layerName: layer.name,
-          source: 'rotation',
-        });
       }
     }
 
+    monotonicBoundaryMs = rawNextMs;
     index++;
-    guard++;
+    rawRotationStart = rawNextRotationStart;
+  }
+
+  if (index - initialIndex >= maxIterations) {
+    throw new RangeError('Requested on-call schedule window exceeds the safe rotation expansion limit.');
   }
 
   return blocks;

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -16,6 +16,41 @@ type TimeZoneOption = {
   offsetLabel: string;
 };
 
+export type LocalDateTimeParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second?: number;
+  millisecond?: number;
+};
+
+export type TimeZoneDisambiguation = 'reject' | 'earlier' | 'later' | 'compatible';
+
+type NormalizedLocalDateTimeParts = Required<LocalDateTimeParts>;
+
+const validTimeZoneCache = new Set<string>();
+const zonedDateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getZonedDateTimeFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = zonedDateTimeFormatterCache.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    });
+    zonedDateTimeFormatterCache.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
 /**
  * Get user's timezone preference, fallback to UTC
  */
@@ -267,10 +302,15 @@ function formatOffset(minutes: number): string {
  * Validate timezone string
  */
 export function isValidTimeZone(timeZone: string): boolean {
+  if (validTimeZoneCache.has(timeZone)) return true;
+
   try {
     Intl.DateTimeFormat(undefined, { timeZone });
+    validTimeZoneCache.add(timeZone);
     return true;
   } catch {
+    // Do not cache arbitrary invalid strings; callers may pass user input and
+    // an unbounded negative cache would create an avoidable memory sink.
     return false;
   }
 }
@@ -281,22 +321,9 @@ export function isValidTimeZone(timeZone: string): boolean {
  */
 export function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
   try {
-    const formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      // hourCycle h23 keeps midnight as hour 00. `hour12: false` alone is not
-      // enough: on Node 20's ICU, en-US resolves to the h24 cycle and formats
-      // midnight as hour "24", which rolls Date.UTC below into the next day and
-      // yields a 24h offset error. Node 22 defaults to h23, so this diverged by
-      // runtime — see the %24 guard for the same reason.
-      hourCycle: 'h23',
-    });
-    const parts = formatter.formatToParts(date);
+    // Reuse one formatter per timezone. Constructing Intl formatters is far
+    // more expensive than formatToParts and dominated large schedule windows.
+    const parts = getZonedDateTimeFormatter(timeZone).formatToParts(date);
     const partMap: Record<string, string> = {};
     for (const part of parts) {
       if (part.type !== 'literal') {
@@ -319,37 +346,180 @@ export function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
   }
 }
 
+function normalizeLocalDateTimeParts(parts: LocalDateTimeParts): NormalizedLocalDateTimeParts {
+  return {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour: parts.hour,
+    minute: parts.minute,
+    second: parts.second ?? 0,
+    millisecond: parts.millisecond ?? 0,
+  };
+}
+
+function compareLocalDateTimeParts(
+  a: NormalizedLocalDateTimeParts,
+  b: NormalizedLocalDateTimeParts
+): number {
+  if (a.year !== b.year) return a.year - b.year;
+  if (a.month !== b.month) return a.month - b.month;
+  if (a.day !== b.day) return a.day - b.day;
+  if (a.hour !== b.hour) return a.hour - b.hour;
+  if (a.minute !== b.minute) return a.minute - b.minute;
+  if (a.second !== b.second) return a.second - b.second;
+  return a.millisecond - b.millisecond;
+}
+
+function getLocalDateTimePartsForInstant(
+  date: Date,
+  timeZone: string
+): NormalizedLocalDateTimeParts {
+  const parts = getZonedDateTimeFormatter(timeZone).formatToParts(date);
+  const get = (type: string) => Number(parts.find(part => part.type === type)?.value ?? '0');
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour: get('hour') % 24,
+    minute: get('minute'),
+    second: get('second'),
+    millisecond: date.getUTCMilliseconds(),
+  };
+}
+
+function isValidLocalDateTimeParts(parts: NormalizedLocalDateTimeParts): boolean {
+  const candidate = new Date(
+    Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+      parts.millisecond
+    )
+  );
+  return (
+    candidate.getUTCFullYear() === parts.year &&
+    candidate.getUTCMonth() + 1 === parts.month &&
+    candidate.getUTCDate() === parts.day &&
+    candidate.getUTCHours() === parts.hour &&
+    candidate.getUTCMinutes() === parts.minute &&
+    candidate.getUTCSeconds() === parts.second &&
+    candidate.getUTCMilliseconds() === parts.millisecond
+  );
+}
+
+/**
+ * Resolve local wall-clock components into a UTC instant.
+ *
+ * `reject` is the safe choice for user-entered schedule timestamps: it refuses
+ * nonexistent spring-forward times and duplicated fall-back times instead of
+ * silently moving coverage. `compatible` follows Temporal-style behavior for
+ * generated recurrence boundaries (earlier occurrence for overlaps, later
+ * wall-clock time for gaps), which keeps recurring schedules deterministic.
+ */
+export function resolveLocalDateTimeInTimeZone(
+  input: LocalDateTimeParts,
+  timeZone: string,
+  disambiguation: TimeZoneDisambiguation = 'reject'
+): Date | null {
+  if (!isValidTimeZone(timeZone)) return null;
+
+  const target = normalizeLocalDateTimeParts(input);
+  if (!isValidLocalDateTimeParts(target)) return null;
+
+  const nominalUtcMs = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+    target.minute,
+    target.second,
+    target.millisecond
+  );
+
+  // Probe both sides of the requested wall time. ±24h straddles even full-day
+  // political jumps (for example Pacific/Apia), while ±6h catches short DST and
+  // fractional transitions near the target. Five probes discover the relevant
+  // offsets without multiplying formatter work for every schedule boundary.
+  const probeHours = [-24, -6, 0, 6, 24];
+  const offsets = Array.from(
+    new Set(
+      probeHours.map(hours =>
+        getTimeZoneOffsetMs(new Date(nominalUtcMs + hours * 60 * 60 * 1000), timeZone)
+      )
+    )
+  );
+
+  const exactCandidates: Date[] = [];
+  const alternatives: Array<{ date: Date; local: NormalizedLocalDateTimeParts }> = [];
+
+  for (const offsetMs of offsets) {
+    const date = new Date(nominalUtcMs - offsetMs);
+    const local = getLocalDateTimePartsForInstant(date, timeZone);
+    alternatives.push({ date, local });
+    if (compareLocalDateTimeParts(local, target) === 0) {
+      exactCandidates.push(date);
+    }
+  }
+
+  const candidates = Array.from(
+    new Map(exactCandidates.map(candidate => [candidate.getTime(), candidate])).values()
+  ).sort((a, b) => a.getTime() - b.getTime());
+
+  if (candidates.length === 1) return candidates[0];
+
+  if (candidates.length > 1) {
+    if (disambiguation === 'earlier' || disambiguation === 'compatible') {
+      return candidates[0];
+    }
+    if (disambiguation === 'later') {
+      return candidates[candidates.length - 1];
+    }
+    return null;
+  }
+
+  // No exact candidate means the local time lies inside a forward clock jump.
+  // For generated recurrence boundaries, resolve deterministically to the
+  // nearest representable wall time on the requested side of the gap.
+  if (disambiguation === 'reject') return null;
+
+  const before = alternatives
+    .filter(candidate => compareLocalDateTimeParts(candidate.local, target) < 0)
+    .sort((a, b) => compareLocalDateTimeParts(a.local, b.local));
+  const after = alternatives
+    .filter(candidate => compareLocalDateTimeParts(candidate.local, target) > 0)
+    .sort((a, b) => compareLocalDateTimeParts(a.local, b.local));
+
+  if (disambiguation === 'earlier') {
+    return before[before.length - 1]?.date ?? null;
+  }
+  return after[0]?.date ?? null;
+}
+
 /**
  * Parse a datetime-local value as a date in the provided timezone.
+ * Ambiguous and nonexistent wall-clock values are rejected so schedule edits
+ * cannot silently move an on-call handoff across a DST transition.
  */
 export function parseDateTimeInTimeZone(value: string, timeZone: string): Date | null {
-  if (!value) {
-    return null;
-  }
+  if (!value) return null;
 
   const match = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);
-  if (!match) {
-    return null;
-  }
+  if (!match) return null;
 
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const hour = Number(match[4]);
-  const minute = Number(match[5]);
+  const parts: LocalDateTimeParts = {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    hour: Number(match[4]),
+    minute: Number(match[5]),
+  };
 
-  if ([year, month, day, hour, minute].some(Number.isNaN)) {
-    return null;
-  }
-
-  const utcMillis = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
-  const guessOffsetMs = getTimeZoneOffsetMs(new Date(utcMillis), timeZone);
-  let date = new Date(utcMillis - guessOffsetMs);
-  const actualOffsetMs = getTimeZoneOffsetMs(date, timeZone);
-  if (actualOffsetMs !== guessOffsetMs) {
-    date = new Date(utcMillis - actualOffsetMs);
-  }
-  return date;
+  if (Object.values(parts).some(Number.isNaN)) return null;
+  return resolveLocalDateTimeInTimeZone(parts, timeZone, 'reject');
 }
 
 function pad2(value: number): string {
@@ -402,8 +572,16 @@ export function addDaysToDateKey(dateKey: string, days: number): string {
 }
 
 export function startOfDayFromDateKey(dateKey: string, timeZone: string): Date {
-  const value = `${dateKey}T00:00`;
-  return parseDateTimeInTimeZone(value, timeZone) ?? new Date(`${dateKey}T00:00:00Z`);
+  const parts = parseDateKey(dateKey);
+  if (parts) {
+    const resolved = resolveLocalDateTimeInTimeZone(
+      { ...parts, hour: 0, minute: 0 },
+      timeZone,
+      'compatible'
+    );
+    if (resolved) return resolved;
+  }
+  return new Date(`${dateKey}T00:00:00Z`);
 }
 
 export function startOfNextDayFromDateKey(dateKey: string, timeZone: string): Date {


### PR DESCRIPTION
## Summary

Production-hardens OpsKnight on-call scheduling around DST and timezone boundary behavior without a schema migration.

- Rejects nonexistent spring-forward and ambiguous fall-back **user-entered** local timestamps instead of silently moving coverage to a different instant.
- Preserves the exact stored `layer.start` instant, including starts intentionally placed in the second occurrence of a fall-back overlap.
- Adds deterministic Temporal-compatible disambiguation for **generated recurrence boundaries**.
- Enforces monotonic generated boundaries so large political timezone jumps (for example `Pacific/Apia` skipping an entire civil day) cannot rewind the timeline or emit duplicate/overlapping duty blocks.
- Makes full-duty rotation slots end exactly at the next monotonic rotation boundary, preventing accidental DST gaps/overlaps.
- Preserves wall-clock semantics for daily/multi-day rotations and sub-day intervals that divide 24h (`1/2/3/4/6/8/12h`).
- Defines arbitrary intervals such as `5h`/`7h` as exact elapsed-duration rotations so they remain contiguous through DST.
- Handles non-1-hour transitions (for example `Australia/Lord_Howe`) rather than assuming every DST change is 60 minutes.
- Reuses timezone formatters, reduces transition-offset probing, and calculates each next rotation boundary once during expansion to avoid repeated expensive `Intl.DateTimeFormat` construction.
- Keeps near-window expansion bounded and fail-loud rather than silently truncating large schedules.
- Extends regression coverage for spring-forward, fall-back, second-overlap starts, full-day timezone jumps, hourly rotations, arbitrary rotations, invalid calendar input, and 30-minute DST transitions.
- Documents the scheduling semantics and transition-time validation behavior.

## Safety / compatibility

- No database or Prisma migration.
- Existing normal schedule timestamps and common 12h/24h/weekly rotations retain intended wall-clock behavior.
- The stored schedule start is never reinterpreted into a different instant.
- Generated rotation boundaries are monotonic: later nominal positions cannot create coverage before an earlier real boundary.
- Ambiguous/nonexistent form times fail closed rather than guessing.
- Arbitrary non-calendar-aligned rotations keep exact elapsed duration across offset changes.

## Validation

Targeted timezone/on-call TypeScript validation and runtime matrices were exercised for:

- `America/New_York` spring-forward and fall-back
- exact second-occurrence fall-back layer starts
- 1h, 2h, 12h, 24h, weekly, 5h and 7h rotations
- exact coverage-boundary continuity
- fractional offsets
- `Australia/Lord_Howe` 30-minute DST transitions
- `Pacific/Apia` full-day political timezone jump, including far-window fast-forwarding and duplicate-interval detection
- invalid/nonexistent/ambiguous local timestamps
- 90-day hourly schedule expansion, including schedules whose start is years before the requested window

Local benchmark for the reported 90-day hourly case dropped from the reported ~1.68s/layer to roughly **75-100ms/layer** in the validation runtime after formatter caching and resolver/expansion reductions.

The branch is intentionally kept to **one atomic commit** for easy review and rollback.