### PR TITLE
fix(sla): add explicit PostgreSQL enum casts for urgency and status filters in queryRaw

### DIFF
--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -292,11 +292,13 @@ async function calculateDbAggregateMetrics(
 
   const urgencyFilter = (whereClause as { urgency?: string }).urgency;
   const urgencyFilterSql = urgencyFilter
-    ? Prisma.sql`AND "urgency" = ${urgencyFilter}`
+    ? Prisma.sql`AND "urgency" = ${urgencyFilter}::"IncidentUrgency"`
     : Prisma.empty;
 
   const statusFilter = (whereClause as { status?: string }).status;
-  const statusFilterSql = statusFilter ? Prisma.sql`AND "status" = ${statusFilter}` : Prisma.empty;
+  const statusFilterSql = statusFilter
+    ? Prisma.sql`AND "status" = ${statusFilter}::"IncidentStatus"`
+    : Prisma.empty;
 
   const assigneeIdFilter = (whereClause as { assigneeId?: string | null }).assigneeId;
   const assigneeFilterSql =


### PR DESCRIPTION
### Summary of Changes

Fixes PostgreSQL `42883` / `42601` query failure in `src/lib/sla-server.ts` when calculating database aggregate metrics with active status or urgency filters.

#### Root Cause
In `calculateDbAggregateMetrics()`, `urgencyFilterSql` and `statusFilterSql` passed raw string parameters against enum columns (`"urgency"` and `"status"`) without explicit `::"IncidentUrgency"` and `::"IncidentStatus"` casts. In PostgreSQL, comparing an enum column against an untyped text parameter generates an operator mismatch error (`operator does not exist: "IncidentStatus" = text`).

#### Fix
- Added `::"IncidentUrgency"` to `urgencyFilterSql`.
- Added `::"IncidentStatus"` to `statusFilterSql`.

#### Verification
- Vitest SLA test suite: 73/73 passed.
- TypeScript compiler (`tsc --noEmit`): 0 errors.