### PR TITLE
fix(resilience): add error fallback for Services page SLA query and expand GitHub webhook conclusions

### DIFF
--- a/src/app/(app)/services/page.tsx
+++ b/src/app/(app)/services/page.tsx
@@ -169,8 +169,11 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
     windowDays: slaWindowDays,
     includeActiveIncidents: true,
     serviceId: services.map(s => s.id),
+  }).catch(err => {
+    console.error('Failed to load SLA metrics for services:', err);
+    return { serviceMetrics: [] };
   });
-  const slaServiceMap = new Map(slaMetrics.serviceMetrics.map(s => [s.id, s]));
+  const slaServiceMap = new Map((slaMetrics?.serviceMetrics || []).map(s => [s.id, s]));
 
   const paginatedServices = services.map(service => {
     const slaData = slaServiceMap.get(service.id);

--- a/src/lib/integrations/github.ts
+++ b/src/lib/integrations/github.ts
@@ -15,14 +15,32 @@ export type GitHubEvent = {
     name: string;
     head_branch?: string;
     status: 'queued' | 'in_progress' | 'completed' | 'requested';
-    conclusion?: 'success' | 'failure' | 'cancelled' | 'timed_out';
+    conclusion?:
+      | 'success'
+      | 'failure'
+      | 'neutral'
+      | 'cancelled'
+      | 'timed_out'
+      | 'action_required'
+      | 'stale'
+      | 'skipped'
+      | null;
     html_url: string;
   };
   check_run?: {
     id: number;
     name: string;
     status: 'queued' | 'in_progress' | 'completed';
-    conclusion?: 'success' | 'failure' | 'cancelled' | 'timed_out';
+    conclusion?:
+      | 'success'
+      | 'failure'
+      | 'neutral'
+      | 'cancelled'
+      | 'timed_out'
+      | 'action_required'
+      | 'stale'
+      | 'skipped'
+      | null;
     html_url: string;
   };
   deployment?: {

--- a/src/lib/integrations/schemas/index.ts
+++ b/src/lib/integrations/schemas/index.ts
@@ -171,7 +171,19 @@ export const GitHubEventSchema = z.object({
       name: z.string(),
       head_branch: z.string().optional(),
       status: z.enum(['queued', 'in_progress', 'completed', 'requested']),
-      conclusion: z.enum(['success', 'failure', 'cancelled', 'timed_out']).nullable().optional(),
+      conclusion: z
+        .enum([
+          'success',
+          'failure',
+          'neutral',
+          'cancelled',
+          'timed_out',
+          'action_required',
+          'stale',
+          'skipped',
+        ])
+        .nullable()
+        .optional(),
       html_url: z.string(),
     })
     .optional(),
@@ -180,7 +192,19 @@ export const GitHubEventSchema = z.object({
       id: z.number(),
       name: z.string(),
       status: z.enum(['queued', 'in_progress', 'completed']),
-      conclusion: z.enum(['success', 'failure', 'cancelled', 'timed_out']).nullable().optional(),
+      conclusion: z
+        .enum([
+          'success',
+          'failure',
+          'neutral',
+          'cancelled',
+          'timed_out',
+          'action_required',
+          'stale',
+          'skipped',
+        ])
+        .nullable()
+        .optional(),
       html_url: z.string(),
     })
     .optional(),


### PR DESCRIPTION
### Summary of Changes

1. **Services Page SSR Resilience**:
   - Added a `.catch()` fallback handler around `calculateSLAMetrics()` in `src/app/(app)/services/page.tsx`.
   - Prevents React Server Component rendering failures and Next.js Suspense boundary errors (React Error #441) by gracefully falling back to database service status if an SLA analytics aggregate query experiences transient issues.

2. **GitHub Webhook Validation Schema**:
   - Expanded `check_run.conclusion` and `workflow_run.conclusion` schemas in `src/lib/integrations/schemas/index.ts` and `src/lib/integrations/github.ts` to include `'neutral'`, `'skipped'`, `'stale'`, and `'action_required'`.
   - Eliminates `api.integration.github_validation_failed` warnings for standard GitHub check conclusions.

#### Verification
- Vitest suite: 167/167 test files passed (1,266 tests).
- TypeScript compiler (`tsc --noEmit`): 0 errors.