### PR TITLE
fix(sla): eliminate production raw-query placeholder failures

### DIFF
--- a/src/app/api/sla/compliance/route.ts
+++ b/src/app/api/sla/compliance/route.ts
@@ -151,7 +151,7 @@ export async function GET(request: NextRequest) {
               if (currentValue > previousUptime) trend = 'up';
               else if (currentValue < previousUptime) trend = 'down';
             }
-          } else if (def.metricType === 'MTTA') {
+          } else if (metrics.previousPeriod.available !== false && def.metricType === 'MTTA') {
             // For MTTA, lower is better
             const prev = metrics.previousPeriod.mtta;
             const curr = currentValue;
@@ -159,7 +159,7 @@ export async function GET(request: NextRequest) {
               if (curr < prev) trend = 'up';
               else if (curr > prev) trend = 'down';
             }
-          } else {
+          } else if (metrics.previousPeriod.available !== false) {
             // For time-based metrics (MTTR), lower is better
             if (metrics.previousPeriod.mttr !== null && metrics.mttr !== null) {
               if (metrics.mttr < metrics.previousPeriod.mttr) trend = 'up';

--- a/src/components/analytics/AnalyticsContent.tsx
+++ b/src/components/analytics/AnalyticsContent.tsx
@@ -159,9 +159,16 @@ export default async function AnalyticsContent({
     return 'neutral';
   };
 
-  const incidentDelta = getDelta(metrics.totalIncidents, metrics.previousPeriod.totalIncidents);
-  const mttaDelta = getDelta(metrics.mttd, metrics.previousPeriod.mtta);
-  const mttrDelta = getDelta(metrics.mttr, metrics.previousPeriod.mttr);
+  const previousPeriodAvailable = metrics.previousPeriod.available !== false;
+  const incidentDelta = previousPeriodAvailable
+    ? getDelta(metrics.totalIncidents, metrics.previousPeriod.totalIncidents)
+    : null;
+  const mttaDelta = previousPeriodAvailable
+    ? getDelta(metrics.mttd, metrics.previousPeriod.mtta)
+    : null;
+  const mttrDelta = previousPeriodAvailable
+    ? getDelta(metrics.mttr, metrics.previousPeriod.mttr)
+    : null;
   const smoothingWindow = windowDays <= 3 ? 1 : windowDays <= 14 ? 3 : 7;
   const countSeries = smoothSeries(
     metrics.trendSeries.map(entry => entry.count),

--- a/src/components/reports/widgets/index.ts
+++ b/src/components/reports/widgets/index.ts
@@ -36,20 +36,27 @@ export function getPreviousPeriodValue(
   const previousPeriod = metrics.previousPeriod;
   if (!previousPeriod || previousPeriod.available === false) return null;
 
-  // Map current period keys to previous period keys
-  const keyMap: Record<string, keyof typeof previousPeriod> = {
-    totalIncidents: 'totalIncidents',
-    highUrgencyCount: 'highUrgencyCount',
-    mttd: 'mtta',
-    mttr: 'mttr',
-    ackRate: 'ackRate',
-    resolveRate: 'resolveRate',
-  };
+  // Keep this allowlist explicit so user-controlled report keys never become
+  // dynamic object-property lookups.
+  const value = (() => {
+    switch (metricKey) {
+      case 'totalIncidents':
+        return previousPeriod.totalIncidents;
+      case 'highUrgencyCount':
+        return previousPeriod.highUrgencyCount;
+      case 'mttd':
+        return previousPeriod.mtta;
+      case 'mttr':
+        return previousPeriod.mttr;
+      case 'ackRate':
+        return previousPeriod.ackRate;
+      case 'resolveRate':
+        return previousPeriod.resolveRate;
+      default:
+        return null;
+    }
+  })();
 
-  const prevKey = keyMap[metricKey];
-  if (!prevKey) return null;
-
-  const value = previousPeriod[prevKey];
   return typeof value === 'number' ? value : null;
 }
 

--- a/src/components/reports/widgets/index.ts
+++ b/src/components/reports/widgets/index.ts
@@ -34,7 +34,7 @@ export function getPreviousPeriodValue(
   metricKey: string
 ): number | null {
   const previousPeriod = metrics.previousPeriod;
-  if (!previousPeriod) return null;
+  if (!previousPeriod || previousPeriod.available === false) return null;
 
   // Map current period keys to previous period keys
   const keyMap: Record<string, keyof typeof previousPeriod> = {
@@ -49,7 +49,8 @@ export function getPreviousPeriodValue(
   const prevKey = keyMap[metricKey];
   if (!prevKey) return null;
 
-  return previousPeriod[prevKey] ?? null;
+  const value = previousPeriod[prevKey];
+  return typeof value === 'number' ? value : null;
 }
 
 /**

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -38,69 +38,80 @@ const CUID_REGEX = /^c[a-z0-9]{24,}$/i;
  */
 function buildIncidentFilterSql(filters: SLAMetricsFilter, tableAlias: string = ''): Prisma.Sql {
   const prefix = tableAlias ? `${tableAlias}.` : '';
-  const fragments: Prisma.Sql[] = [];
+  const predicates: Prisma.Sql[] = [];
+  const scopePredicates: Prisma.Sql[] = [];
 
   // serviceId — scalar or array
   if (filters.serviceId) {
     if (Array.isArray(filters.serviceId)) {
       if (filters.serviceId.length > 0) {
-        fragments.push(
-          Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} = ANY(${filters.serviceId}::text[])`
+        scopePredicates.push(
+          Prisma.sql`${Prisma.raw(`${prefix}"serviceId"`)} = ANY(${filters.serviceId}::text[])`
         );
       }
     } else {
-      fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} = ${filters.serviceId}`);
+      scopePredicates.push(
+        Prisma.sql`${Prisma.raw(`${prefix}"serviceId"`)} = ${filters.serviceId}`
+      );
     }
   }
 
   // teamId — uses the Service table via subquery since Incident has no
   // direct teamId column (Incident.teamId may exist but Service.teamId is
-  // the source of truth elsewhere in the code). The `useOrScope` flag is
-  // intentionally NOT honored here — historical aggregates use AND scope
-  // for consistency with the rest of the metrics; OR-scope is a UI
-  // affordance for the recent window only.
+  // the source of truth elsewhere in the code).
   if (filters.teamId) {
     const teamIds = Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId];
     if (teamIds.length > 0) {
-      fragments.push(
-        Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} IN (
+      const serviceTeamPredicate = Prisma.sql`${Prisma.raw(`${prefix}"serviceId"`)} IN (
           SELECT id FROM "Service" WHERE "teamId" = ANY(${teamIds}::text[])
-        )`
+        )`;
+      scopePredicates.push(
+        filters.useOrScope
+          ? Prisma.sql`(${Prisma.raw(`${prefix}"teamId"`)} = ANY(${teamIds}::text[]) OR ${serviceTeamPredicate})`
+          : serviceTeamPredicate
       );
     }
   }
 
   if (filters.urgency) {
-    fragments.push(
-      Prisma.sql`AND ${Prisma.raw(`${prefix}"urgency"`)} = ${filters.urgency}::"IncidentUrgency"`
+    predicates.push(
+      Prisma.sql`${Prisma.raw(`${prefix}"urgency"`)} = ${filters.urgency}::"IncidentUrgency"`
     );
   }
 
   if (filters.status) {
-    fragments.push(
-      Prisma.sql`AND ${Prisma.raw(`${prefix}"status"`)} = ${filters.status}::"IncidentStatus"`
+    predicates.push(
+      Prisma.sql`${Prisma.raw(`${prefix}"status"`)} = ${filters.status}::"IncidentStatus"`
     );
   }
 
   if (filters.visibility && filters.visibility !== 'ALL') {
-    fragments.push(
-      Prisma.sql`AND ${Prisma.raw(`${prefix}"visibility"`)} = ${filters.visibility}::"IncidentVisibility"`
+    predicates.push(
+      Prisma.sql`${Prisma.raw(`${prefix}"visibility"`)} = ${filters.visibility}::"IncidentVisibility"`
     );
   }
 
   if (filters.assigneeId !== undefined) {
     if (filters.assigneeId === null) {
-      fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"assigneeId"`)} IS NULL`);
+      scopePredicates.push(Prisma.sql`${Prisma.raw(`${prefix}"assigneeId"`)} IS NULL`);
     } else {
-      fragments.push(
-        Prisma.sql`AND ${Prisma.raw(`${prefix}"assigneeId"`)} = ${filters.assigneeId}`
+      scopePredicates.push(
+        Prisma.sql`${Prisma.raw(`${prefix}"assigneeId"`)} = ${filters.assigneeId}`
       );
     }
   }
 
-  // `Prisma.join([])` throws — return empty SQL when there are no filters
-  // so the call site can splice the fragment unconditionally.
-  return fragments.length > 0 ? Prisma.join(fragments, ' ') : Prisma.empty;
+  if (scopePredicates.length > 0) {
+    predicates.push(
+      filters.useOrScope
+        ? Prisma.sql`(${Prisma.join(scopePredicates, ' OR ')})`
+        : Prisma.sql`(${Prisma.join(scopePredicates, ' AND ')})`
+    );
+  }
+
+  // `Prisma.join([])` throws. Returning Prisma.empty lets callers compose
+  // this fragment unconditionally without creating a placeholder.
+  return predicates.length > 0 ? Prisma.sql`AND ${Prisma.join(predicates, ' AND ')}` : Prisma.empty;
 }
 
 // Business-hours constants moved to `./business-hours.ts` to break the
@@ -230,7 +241,7 @@ type DbAggregateMetrics = {
  * Calculates core SLA metrics using database aggregation for better performance at scale.
  * Uses PostgreSQL aggregate functions instead of fetching all rows to memory.
  *
- * @param whereClause - Prisma where clause for filtering incidents
+ * @param filters - Canonical SLA filters shared by Prisma and raw-SQL paths
  * @param start - Start date of the window
  * @param end - End date of the window
  * @param serviceTargetMap - Map of service IDs to their SLA targets
@@ -242,7 +253,7 @@ type DbAggregateMetrics = {
  * tenant-configurable follow-up.
  */
 async function calculateDbAggregateMetrics(
-  whereClause: Prisma.IncidentWhereInput,
+  filters: SLAMetricsFilter,
   start: Date,
   end: Date,
   serviceTargetMap: Map<string, { ackMinutes: number; resolveMinutes: number }>,
@@ -281,65 +292,11 @@ async function calculateDbAggregateMetrics(
     resolveTargetCase = `CASE ${resolveCases} ELSE ${defaultResolveMs} END`;
   }
 
-  // Build filter conditions for raw SQL using parameterized queries
-  // Using Prisma.sql for proper parameterization to prevent SQL injection and enable query plan caching
-  const serviceIdFilter = (whereClause as { serviceId?: string | { in: string[] } }).serviceId;
-  const serviceFilterSql = serviceIdFilter
-    ? typeof serviceIdFilter === 'string'
-      ? Prisma.sql`AND "serviceId" = ${serviceIdFilter}`
-      : Prisma.sql`AND "serviceId" = ANY(${serviceIdFilter.in || []}::text[])`
-    : Prisma.empty;
-
-  const urgencyFilter = (whereClause as { urgency?: string }).urgency;
-  const urgencyFilterSql = urgencyFilter
-    ? Prisma.sql`AND "urgency" = ${urgencyFilter}::"IncidentUrgency"`
-    : Prisma.empty;
-
-  const statusFilter = (whereClause as { status?: string }).status;
-  const statusFilterSql = statusFilter
-    ? Prisma.sql`AND "status" = ${statusFilter}::"IncidentStatus"`
-    : Prisma.empty;
-
-  const assigneeIdFilter = (whereClause as { assigneeId?: string | null }).assigneeId;
-  const assigneeFilterSql =
-    assigneeIdFilter !== undefined
-      ? assigneeIdFilter === null
-        ? Prisma.sql`AND "assigneeId" IS NULL`
-        : Prisma.sql`AND "assigneeId" = ${assigneeIdFilter}`
-      : Prisma.empty;
-
-  const visibilityFilter = (whereClause as { visibility?: string }).visibility;
-  const visibilityFilterSql =
-    visibilityFilter && visibilityFilter !== 'ALL'
-      ? Prisma.sql`AND "visibility" = ${visibilityFilter}::"IncidentVisibility"`
-      : Prisma.empty;
-
-  // Build aliased filter conditions for JOIN queries (using i. prefix for incident table)
-  const serviceFilterSqlAliased = serviceIdFilter
-    ? typeof serviceIdFilter === 'string'
-      ? Prisma.sql`AND i."serviceId" = ${serviceIdFilter}`
-      : Prisma.sql`AND i."serviceId" = ANY(${serviceIdFilter.in || []}::text[])`
-    : Prisma.empty;
-
-  const urgencyFilterSqlAliased = urgencyFilter
-    ? Prisma.sql`AND i."urgency" = ${urgencyFilter}::"IncidentUrgency"`
-    : Prisma.empty;
-
-  const statusFilterSqlAliased = statusFilter
-    ? Prisma.sql`AND i."status" = ${statusFilter}::"IncidentStatus"`
-    : Prisma.empty;
-
-  const assigneeFilterSqlAliased =
-    assigneeIdFilter !== undefined
-      ? assigneeIdFilter === null
-        ? Prisma.sql`AND i."assigneeId" IS NULL`
-        : Prisma.sql`AND i."assigneeId" = ${assigneeIdFilter}`
-      : Prisma.empty;
-
-  const visibilityFilterSqlAliased =
-    visibilityFilter && visibilityFilter !== 'ALL'
-      ? Prisma.sql`AND i."visibility" = ${visibilityFilter}::"IncidentVisibility"`
-      : Prisma.empty;
+  // Keep every aggregate surface aligned with the Prisma filter semantics.
+  // Constructing a second filter set from Prisma.IncidentWhereInput omitted
+  // relational team filters and diverged from `useOrScope` at scale.
+  const incidentFilterSql = buildIncidentFilterSql(filters);
+  const incidentFilterSqlAliased = buildIncidentFilterSql(filters, 'i');
 
   // Calculate business hours for after-hours detection
   // Business hours: Monday-Friday 8am-6pm in user's timezone
@@ -367,7 +324,7 @@ async function calculateDbAggregateMetrics(
         low_urgency_count: bigint;
         after_hours_count: bigint;
       }>
-    >`
+    >(Prisma.sql`
       SELECT
         COUNT(*) as total_incidents,
         COUNT(*) FILTER (WHERE "acknowledgedAt" IS NOT NULL) as acknowledged_count,
@@ -418,12 +375,8 @@ async function calculateDbAggregateMetrics(
       FROM "Incident"
       WHERE "createdAt" >= ${start}
         AND "createdAt" <= ${end}
-        ${serviceFilterSql}
-        ${urgencyFilterSql}
-        ${statusFilterSql}
-        ${assigneeFilterSql}
-        ${visibilityFilterSql}
-    `;
+        ${incidentFilterSql}
+    `);
 
     // Percentile query - separate for cleaner code and optional optimization
     const percentileResult = await prisma.$queryRaw<
@@ -433,7 +386,7 @@ async function calculateDbAggregateMetrics(
         mttr_p50_ms: number | null;
         mttr_p95_ms: number | null;
       }>
-    >`
+    >(Prisma.sql`
       SELECT
         PERCENTILE_CONT(0.5) WITHIN GROUP (
           ORDER BY GREATEST(0, EXTRACT(EPOCH FROM ("acknowledgedAt" - "createdAt")) * 1000)
@@ -450,12 +403,8 @@ async function calculateDbAggregateMetrics(
       FROM "Incident"
       WHERE "createdAt" >= ${start}
         AND "createdAt" <= ${end}
-        ${serviceFilterSql}
-        ${urgencyFilterSql}
-        ${statusFilterSql}
-        ${assigneeFilterSql}
-        ${visibilityFilterSql}
-    `;
+        ${incidentFilterSql}
+    `);
 
     // Event counts query — for escalation, reopen, auto-resolve rates.
     //
@@ -474,7 +423,7 @@ async function calculateDbAggregateMetrics(
         reopen_count: bigint;
         auto_resolve_count: bigint;
       }>
-    >`
+    >(Prisma.sql`
       SELECT
         COUNT(DISTINCT e."incidentId") FILTER (WHERE ${escalatedPredicate}) as escalation_count,
         COUNT(DISTINCT e."incidentId") FILTER (WHERE ${reopenedPredicate}) as reopen_count,
@@ -483,12 +432,8 @@ async function calculateDbAggregateMetrics(
       INNER JOIN "Incident" i ON e."incidentId" = i."id"
       WHERE i."createdAt" >= ${start}
         AND i."createdAt" <= ${end}
-        ${serviceFilterSqlAliased}
-        ${urgencyFilterSqlAliased}
-        ${statusFilterSqlAliased}
-        ${assigneeFilterSqlAliased}
-        ${visibilityFilterSqlAliased}
-    `;
+        ${incidentFilterSqlAliased}
+    `);
 
     const agg = aggregateResult[0];
     const pct = percentileResult[0];
@@ -942,7 +887,8 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
       : { teamId: Array.isArray(filters.teamId) ? { in: filters.teamId } : filters.teamId }
     : {};
 
-  const assigneeWhere = filters.assigneeId ? { assigneeId: filters.assigneeId } : null;
+  const assigneeWhere =
+    filters.assigneeId !== undefined ? { assigneeId: filters.assigneeId } : null;
   const statusWhere = filters.status ? { status: filters.status } : null;
   const urgencyWhere = filters.urgency ? { urgency: filters.urgency } : null;
   const visibilityWhere =
@@ -1062,6 +1008,29 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
   const fullIncidentFilterSql = buildIncidentFilterSql(filters);
 
   // Step 3: Parallel fetch - lightweight queries that work at any scale
+  const incidentMetricSelect = {
+    id: true,
+    title: true,
+    createdAt: true,
+    updatedAt: true,
+    status: true,
+    urgency: true,
+    assigneeId: true,
+    serviceId: true,
+    description: true,
+    acknowledgedAt: true,
+    resolvedAt: true,
+    service: {
+      select: {
+        id: true,
+        name: true,
+        region: true,
+        targetAckMinutes: true,
+        targetResolveMinutes: true,
+      },
+    },
+  } satisfies Prisma.IncidentSelect;
+
   const [
     activeIncidentsData,
     mutedStatusCounts,
@@ -1168,7 +1137,8 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     // doesn't contradict the metrics above it (team/urgency/status/
     // visibility/assignee).
     prisma
-      .$queryRaw<Array<{ date: string; count: bigint }>>`
+      .$queryRaw<Array<{ date: string; count: bigint }>>(
+        Prisma.sql`
       SELECT DATE("createdAt") as date, COUNT(*) as count
       FROM "Incident"
       WHERE "createdAt" >= ${heatmapStart}
@@ -1177,9 +1147,10 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
       GROUP BY DATE("createdAt")
       ORDER BY date
     `
+      )
       .catch(err => {
-        logger.warn('[SLA] Heatmap raw query failed, falling back to empty list', { error: err });
-        return [];
+        logger.warn('[SLA] Heatmap raw query failed; marking heatmap unavailable', { error: err });
+        return null;
       }),
     prisma.incident.groupBy({
       by: ['urgency'],
@@ -1206,28 +1177,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     // For small datasets, fetch all; for large datasets, limit to display needs
     prisma.incident.findMany({
       where: recentIncidentWhere,
-      select: {
-        id: true,
-        title: true,
-        createdAt: true,
-        updatedAt: true,
-        status: true,
-        urgency: true,
-        assigneeId: true,
-        serviceId: true,
-        description: true,
-        acknowledgedAt: true,
-        resolvedAt: true,
-        service: {
-          select: {
-            id: true,
-            name: true,
-            region: true,
-            targetAckMinutes: true,
-            targetResolveMinutes: true,
-          },
-        },
-      },
+      select: incidentMetricSelect,
       orderBy: { createdAt: 'desc' },
       // PERFORMANCE: Limit fetch for large datasets, fetch all for small
       take: useDbAggregation
@@ -1251,7 +1201,8 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
           ack_count: bigint;
           resolve_count: bigint;
         }>
-      >`
+      >(
+        Prisma.sql`
       SELECT
         COUNT(*) as total_count,
         COUNT(*) FILTER (WHERE "urgency" = 'HIGH'::"IncidentUrgency") as high_urgency_count,
@@ -1268,31 +1219,25 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
         AND "createdAt" < ${previousEnd}
         ${fullIncidentFilterSql}
     `
+      )
       .catch(err => {
-        logger.warn('[SLA] Previous period query failed, returning zeroed stats', { error: err });
-        return [
-          {
-            total_count: BigInt(0),
-            high_urgency_count: BigInt(0),
-            medium_urgency_count: BigInt(0),
-            low_urgency_count: BigInt(0),
-            avg_mtta_ms: null,
-            avg_mttr_ms: null,
-            ack_count: BigInt(0),
-            resolve_count: BigInt(0),
-          },
-        ];
+        logger.warn('[SLA] Previous period query failed; marking comparison unavailable', {
+          error: err,
+        });
+        return null;
       }),
   ]);
 
   // Convert heatmap aggregates to expected format
-  const heatmapIncidents = heatmapAggregates.map(row => ({
+  const heatmapAvailable = heatmapAggregates !== null;
+  const heatmapIncidents = (heatmapAggregates ?? []).map(row => ({
     createdAt: new Date(row.date),
     count: Number(row.count),
   }));
 
   // Process previous period aggregates
-  const prevAgg = previousPeriodAggregates[0];
+  const previousPeriodAvailable = previousPeriodAggregates !== null;
+  const prevAgg = previousPeriodAggregates?.[0];
   const previousIncidentsCount = Number(prevAgg?.total_count ?? 0);
   const prevHighUrgCount = Number(prevAgg?.high_urgency_count ?? 0);
   const prevMediumUrgCount = Number(prevAgg?.medium_urgency_count ?? 0);
@@ -1311,21 +1256,18 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
 
   // For small datasets, we use displayIncidentsRaw for all processing
   // For large datasets, we use DB aggregation + limited display incidents
-  const allRecentIncidents = displayIncidentsRaw;
+  let recentIncidents = displayIncidentsRaw;
 
   // Performance monitoring: Log query completion with timing
   const dbQueryDuration = Date.now() - queryStartTime;
   logger.debug('[SLA] Database queries completed', {
     duration: dbQueryDuration,
-    incidentCount: allRecentIncidents.length,
+    incidentCount: recentIncidents.length,
     totalIncidentCount,
     dateRange: { start: finalStart.toISOString(), end: finalEnd.toISOString() },
     retentionDays: retentionPolicy.incidentRetentionDays,
     useDbAggregation,
   });
-
-  // Use display incidents for UI rendering
-  const recentIncidents = allRecentIncidents;
 
   // Build service target map early for DB aggregation
   const serviceTargetMap = new Map<string, { ackMinutes: number; resolveMinutes: number }>();
@@ -1349,7 +1291,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
   let dbAggMetrics: DbAggregateMetrics | null = null;
   if (useDbAggregation) {
     dbAggMetrics = await calculateDbAggregateMetrics(
-      recentIncidentWhere,
+      filters,
       finalStart,
       finalEnd,
       serviceTargetMap,
@@ -1358,8 +1300,20 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
 
     // Check if DB aggregation failed (signaled by totalIncidents = -1)
     if (dbAggMetrics.totalIncidents === -1) {
-      logger.warn('[SLA] DB aggregation failed, falling back to in-memory for this request');
+      logger.warn('[SLA] DB aggregation failed; loading the complete filtered set for fallback');
       dbAggMetrics = null;
+      // The display query is intentionally paginated above. Reusing that
+      // truncated array for fallback silently published incorrect headline
+      // metrics. A raw-query failure is exceptional, so favor correctness and
+      // load the full filtered set through Prisma's structured query path.
+      recentIncidents = await prisma.incident.findMany({
+        where: recentIncidentWhere,
+        select: incidentMetricSelect,
+        orderBy: { createdAt: 'desc' },
+      });
+      logger.info('[SLA] Complete in-memory fallback dataset loaded', {
+        incidentCount: recentIncidents.length,
+      });
     }
   }
 
@@ -1675,12 +1629,16 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
 
   // Insights
   const insights: SLAMetrics['insights'] = [];
-  if (currentStats.count > prevStatsDetailed.count && prevStatsDetailed.count > 0) {
+  if (
+    previousPeriodAvailable &&
+    currentStats.count > prevStatsDetailed.count &&
+    prevStatsDetailed.count > 0
+  ) {
     insights.push({
       type: 'negative',
       text: `Incident volume up ${currentStats.count - prevStatsDetailed.count} vs previous period`,
     });
-  } else if (currentStats.count < prevStatsDetailed.count) {
+  } else if (previousPeriodAvailable && currentStats.count < prevStatsDetailed.count) {
     insights.push({
       type: 'positive',
       text: `Incident volume down ${Math.abs(currentStats.count - prevStatsDetailed.count)} vs previous period`,
@@ -1688,6 +1646,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
   }
 
   if (
+    previousPeriodAvailable &&
     currentStats.mtta !== null &&
     prevStatsDetailed.mtta !== null &&
     currentStats.mtta < prevStatsDetailed.mtta &&
@@ -1698,6 +1657,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
       text: `Response time improved by ${Math.round((1 - currentStats.mtta / prevStatsDetailed.mtta) * 100)}%`,
     });
   } else if (
+    previousPeriodAvailable &&
     currentStats.mtta !== null &&
     prevStatsDetailed.mtta !== null &&
     currentStats.mtta > prevStatsDetailed.mtta &&
@@ -2341,6 +2301,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     autoResolveRate: Math.round(autoResolveRate * 100) / 100,
 
     previousPeriod: {
+      available: previousPeriodAvailable,
       totalIncidents: prevStatsDetailed.count,
       highUrgencyCount: prevStatsDetailed.highUrg,
       // Medium/low previous-period counts come from the same aggregate
@@ -2413,6 +2374,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
           totalRecent
         : 0,
     heatmapData,
+    heatmapAvailable,
     currentShifts: currentShiftsData.map(s => ({
       id: s.id,
       userId: s.userId,
@@ -3275,6 +3237,7 @@ export async function calculateSLAMetricsFromRollups(
     // would require a second rollup query for [start - windowMs, start);
     // out of scope for this PR but flagged for follow-up.
     previousPeriod: {
+      available: false,
       totalIncidents: 0,
       highUrgencyCount: 0,
       mtta: null,
@@ -3306,6 +3269,7 @@ export async function calculateSLAMetricsFromRollups(
           (priorityFilter.has('P5') ? r.p5Incidents : 0)
         : r.totalIncidents,
     })),
+    heatmapAvailable: true,
     serviceMetrics: [],
     insights: [],
     currentShifts: [],

--- a/src/lib/sla.ts
+++ b/src/lib/sla.ts
@@ -58,6 +58,8 @@ export type SLAMetrics = {
   autoResolveRate: number;
 
   previousPeriod: {
+    /** False when the comparison query failed; consumers must not render a zero-data trend. */
+    available?: boolean;
     totalIncidents: number;
     highUrgencyCount: number;
     /** Optional for backwards-compat — pre-PR consumers may not read these. */
@@ -118,6 +120,8 @@ export type SLAMetrics = {
   recurringTitles: Array<{ title: string; count: number }>;
   eventsPerIncident: number;
   heatmapData: Array<{ date: string; count: number }>;
+  /** False when heatmap aggregation failed; an empty array alone may mean no incidents. */
+  heatmapAvailable?: boolean;
 
   activeIncidentSummaries?: Array<{
     id: string;

--- a/tests/lib/sla-server.test.ts
+++ b/tests/lib/sla-server.test.ts
@@ -464,3 +464,204 @@ describe('calculateSLAMetrics investigation metrics', () => {
     expect(metrics.mttk).toBeCloseTo(12.5, 2);
   });
 });
+
+describe('calculateSLAMetrics composed PostgreSQL queries', () => {
+  type CapturedSqlQuery = { sql: string; values: unknown[] };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T00:00:00Z'));
+    clearRetentionPolicyCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flattens canonical filters into every large-dataset raw query', async () => {
+    setupBaseMocks({
+      activeIncidents: [],
+      recentIncidents: [],
+      previousIncidents: [],
+      heatmapIncidents: [],
+      escalationEvents: [],
+    });
+
+    prismaMock.incident.count.mockReset().mockResolvedValueOnce(501).mockResolvedValueOnce(0);
+    prismaMock.$queryRaw.mockReset().mockImplementation(async (query: unknown) => {
+      const sql = String((query as Partial<CapturedSqlQuery>)?.sql ?? '');
+
+      if (sql.includes('total_incidents')) {
+        return [
+          {
+            total_incidents: BigInt(501),
+            acknowledged_count: BigInt(0),
+            resolved_count: BigInt(0),
+            avg_mtta_ms: null,
+            avg_mttr_ms: null,
+            ack_sla_met: BigInt(0),
+            ack_sla_breached: BigInt(0),
+            resolve_sla_met: BigInt(0),
+            resolve_sla_breached: BigInt(0),
+            high_urgency_count: BigInt(0),
+            medium_urgency_count: BigInt(0),
+            low_urgency_count: BigInt(0),
+            after_hours_count: BigInt(0),
+          },
+        ];
+      }
+      if (sql.includes('mtta_p50_ms')) {
+        return [
+          {
+            mtta_p50_ms: null,
+            mtta_p95_ms: null,
+            mttr_p50_ms: null,
+            mttr_p95_ms: null,
+          },
+        ];
+      }
+      if (sql.includes('escalation_count')) {
+        return [
+          {
+            escalation_count: BigInt(0),
+            reopen_count: BigInt(0),
+            auto_resolve_count: BigInt(0),
+          },
+        ];
+      }
+      if (sql.includes('total_count')) {
+        return [
+          {
+            total_count: BigInt(0),
+            high_urgency_count: BigInt(0),
+            medium_urgency_count: BigInt(0),
+            low_urgency_count: BigInt(0),
+            avg_mtta_ms: null,
+            avg_mttr_ms: null,
+            ack_count: BigInt(0),
+            resolve_count: BigInt(0),
+          },
+        ];
+      }
+      return [];
+    });
+
+    await calculateSLAMetrics({
+      windowDays: 1,
+      userTimeZone: 'UTC',
+      serviceId: ['service-a', 'service-b'],
+      teamId: ['team-a', 'team-b'],
+      assigneeId: 'user-a',
+      urgency: 'HIGH',
+      status: 'RESOLVED',
+      visibility: 'PRIVATE',
+      useOrScope: true,
+    });
+
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(5);
+    const queries = prismaMock.$queryRaw.mock.calls.map(([query]) => query as CapturedSqlQuery);
+
+    for (const query of queries) {
+      expect(query).toEqual(
+        expect.objectContaining({ sql: expect.any(String), values: expect.any(Array) })
+      );
+      // Production previously emitted the entire filter object as a lone
+      // PostgreSQL placeholder (`$3`/`$20`) in grammar position.
+      expect(query.sql).not.toMatch(/^\s*\?\s*$/m);
+    }
+
+    const heatmapQuery = queries.find(query => query.sql.includes('SELECT DATE("createdAt")'));
+    const aggregateQuery = queries.find(query => query.sql.includes('total_incidents'));
+    const eventQuery = queries.find(query => query.sql.includes('escalation_count'));
+
+    for (const query of [heatmapQuery, aggregateQuery, eventQuery]) {
+      expect(query).toBeDefined();
+      if (!query) throw new Error('Expected composed SLA query was not executed');
+      expect(query.sql).toContain('= ANY(?::text[])');
+      expect(query.sql).toContain('"teamId" = ANY(?::text[])');
+      expect(query.sql).toContain(' OR ');
+      expect(query.values).toContainEqual(['service-a', 'service-b']);
+      expect(query.values).toContainEqual(['team-a', 'team-b']);
+    }
+  });
+
+  it('marks comparison data unavailable when optional raw queries fail', async () => {
+    setupBaseMocks({
+      activeIncidents: [],
+      recentIncidents: [],
+      previousIncidents: [],
+      heatmapIncidents: [],
+      escalationEvents: [],
+    });
+
+    prismaMock.$queryRaw.mockReset().mockRejectedValue(new Error('transient database failure'));
+
+    const metrics = await calculateSLAMetrics({ windowDays: 1, userTimeZone: 'UTC' });
+
+    expect(metrics.previousPeriod.available).toBe(false);
+    expect(metrics.heatmapAvailable).toBe(false);
+    expect(metrics.heatmapData).toEqual([]);
+    expect(metrics.insights).toEqual([]);
+  });
+
+  it('loads the complete filtered set when database aggregation fails', async () => {
+    setupBaseMocks({
+      activeIncidents: [],
+      recentIncidents: [],
+      previousIncidents: [],
+      heatmapIncidents: [],
+      escalationEvents: [],
+    });
+
+    const fallbackIncident = {
+      id: 'fallback-incident',
+      title: 'Fallback incident',
+      description: null,
+      createdAt: new Date('2026-01-01T12:00:00Z'),
+      updatedAt: new Date('2026-01-01T12:30:00Z'),
+      status: 'OPEN',
+      urgency: 'HIGH',
+      assigneeId: null,
+      serviceId: 'service-a',
+      acknowledgedAt: new Date('2026-01-01T12:05:00Z'),
+      resolvedAt: null,
+      service: {
+        id: 'service-a',
+        name: 'Service A',
+        region: null,
+        targetAckMinutes: 15,
+        targetResolveMinutes: 120,
+      },
+    };
+
+    prismaMock.incident.count.mockReset().mockResolvedValueOnce(501).mockResolvedValueOnce(0);
+    prismaMock.incident.findMany.mockResolvedValueOnce([fallbackIncident]);
+    prismaMock.$queryRaw.mockReset().mockImplementation(async (query: unknown) => {
+      const sql = String((query as Partial<CapturedSqlQuery>)?.sql ?? '');
+      if (sql.includes('total_incidents')) throw new Error('aggregate query failed');
+      if (sql.includes('total_count')) {
+        return [
+          {
+            total_count: BigInt(0),
+            high_urgency_count: BigInt(0),
+            medium_urgency_count: BigInt(0),
+            low_urgency_count: BigInt(0),
+            avg_mtta_ms: null,
+            avg_mttr_ms: null,
+            ack_count: BigInt(0),
+            resolve_count: BigInt(0),
+          },
+        ];
+      }
+      return [];
+    });
+
+    const metrics = await calculateSLAMetrics({ windowDays: 1, userTimeZone: 'UTC' });
+
+    expect(prismaMock.incident.findMany).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ take: expect.anything() })
+    );
+    expect(metrics.highUrgencyCount).toBe(1);
+    expect(metrics.ackRate).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Production PostgreSQL logs showed the SLA engine still emitting complete `Prisma.Sql` fragments as bound values (`$3`, `$20`-`$24`) after PR #386. With 875 incidents, the large-dataset path repeatedly failed its heatmap, previous-period, and headline aggregate queries.

This change:

- composes every complete raw query with `Prisma.sql` before passing it to `$queryRaw`, avoiding tagged-template fragment identity issues in the bundled production runtime
- centralizes service, team, assignee, urgency, status, and visibility predicates in one canonical SQL builder
- preserves Prisma `useOrScope` semantics, including direct incident-team and service-team assignments
- applies the same filter contract to headline, percentile, event, heatmap, and previous-period queries
- uses a complete structured Prisma fetch if headline DB aggregation fails instead of calculating metrics from the truncated display page
- marks heatmap and previous-period data unavailable on query failure, preventing false zero trends and fabricated insights

## Production evidence

Observed after the prior deployment:

- 875 incidents, activating the `>500` aggregation path
- 269 PostgreSQL errors in roughly six minutes
- 224 syntax errors at `$3`
- 43 syntax errors at `$20`
- failures repeated every 5-10 seconds in heatmap, previous-period, and main aggregate statements

## Validation

- production build passed
- TypeScript passed
- focused SLA/SSE suites: 24/24 passed
- full unit suite: 1,269 passed, 4 skipped
- regression coverage verifies all five raw queries receive fully composed `Prisma.Sql` objects
- regression coverage verifies array binding, enum casts, team/service/assignee OR scope, unavailable-state behavior, and complete fallback loading
- pre-push checks passed

## Deployment verification

After deployment, verify PostgreSQL logs contain no new syntax errors near `$3` or `$20`, then exercise dashboard, analytics, widget SSE, and realtime SSE against the production dataset.
