### PR TITLE
fix(events): reduce ingestion transaction contention

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -159,22 +159,6 @@ export async function processEvent(
     eventData.summary = `Alert from ${eventData.source}`;
   }
 
-  // This read previously used the global Prisma client from inside an
-  // interactive transaction, which could consume a second pool connection
-  // while the transaction held the first. The uncommitted current alert was
-  // never visible to that read, so preserve the same historical check outside
-  // the transaction and avoid nested pool pressure.
-  let isFlapping = false;
-  if (event_action === 'trigger') {
-    try {
-      const { checkAlertFlapping } = await import('./flapping');
-      const flappingResult = await checkAlertFlapping(dedup_key, serviceId);
-      isFlapping = flappingResult.isFlapping;
-    } catch (_) {
-      // Non-critical: if flapping check fails, proceed with normal incident creation
-    }
-  }
-
   const result = await runReadCommittedTransaction(async tx => {
     // 1. Validate serviceId exists (prevents orphaned incidents)
     const service = await tx.service.findUnique({
@@ -214,6 +198,21 @@ export async function processEvent(
         data: { dedupKey: dedup_key },
       });
       existingIncident.dedupKey = dedup_key;
+    }
+
+    // Run this after the advisory lock so a queued event observes alert
+    // history committed by earlier events for the same dedup key. Passing the
+    // transaction client avoids opening a second pooled connection while this
+    // interactive transaction is active.
+    let isFlapping = false;
+    if (event_action === 'trigger' && !existingIncident) {
+      try {
+        const { checkAlertFlapping } = await import('./flapping');
+        const flappingResult = await checkAlertFlapping(dedup_key, serviceId, undefined, tx);
+        isFlapping = flappingResult.isFlapping;
+      } catch (_) {
+        // Non-critical: if flapping check fails, proceed with normal incident creation
+      }
     }
 
     // 3. For acknowledge, skip alert creation if no matching incident
@@ -362,14 +361,17 @@ export async function processEvent(
         },
       });
 
-      logger.info(isFlapping ? 'event.incident_created_suppressed_flapping' : 'event.incident_created', {
-        incidentId: newIncident.id,
-        dedupKey: dedup_key,
-        source: eventData.source,
-        severity: eventData.severity,
-        urgency,
-        isFlapping,
-      });
+      logger.info(
+        isFlapping ? 'event.incident_created_suppressed_flapping' : 'event.incident_created',
+        {
+          incidentId: newIncident.id,
+          dedupKey: dedup_key,
+          source: eventData.source,
+          severity: eventData.severity,
+          urgency,
+          isFlapping,
+        }
+      );
 
       // Connect alert to incident
       await tx.alert.update({

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -19,7 +19,7 @@ export type EventPayload = {
 };
 
 import { createHash } from 'crypto';
-import { runSerializableTransaction } from './db-utils';
+import { runReadCommittedTransaction } from './db-utils';
 
 const MAX_DEDUP_KEY_LENGTH = 512;
 const MAX_STORED_ALERT_PAYLOAD_BYTES = 64 * 1024;
@@ -120,6 +120,22 @@ function boundedAlertPayload(eventData: EventPayload['payload']): Prisma.InputJs
   };
 }
 
+async function lockEventDedupKeys(
+  tx: Prisma.TransactionClient,
+  serviceId: string,
+  candidateDedupKeys: string[]
+): Promise<void> {
+  // Serialize only requests that can address the same logical incident. Include
+  // legacy keys during rolling upgrades and use deterministic lock ordering.
+  const lockKeys = Array.from(
+    new Set(candidateDedupKeys.map(key => JSON.stringify([serviceId, key])))
+  ).sort();
+
+  for (const lockKey of lockKeys) {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`;
+  }
+}
+
 export async function processEvent(
   payload: EventPayload,
   serviceId: string,
@@ -143,7 +159,23 @@ export async function processEvent(
     eventData.summary = `Alert from ${eventData.source}`;
   }
 
-  const result = await runSerializableTransaction(async tx => {
+  // This read previously used the global Prisma client from inside an
+  // interactive transaction, which could consume a second pool connection
+  // while the transaction held the first. The uncommitted current alert was
+  // never visible to that read, so preserve the same historical check outside
+  // the transaction and avoid nested pool pressure.
+  let isFlapping = false;
+  if (event_action === 'trigger') {
+    try {
+      const { checkAlertFlapping } = await import('./flapping');
+      const flappingResult = await checkAlertFlapping(dedup_key, serviceId);
+      isFlapping = flappingResult.isFlapping;
+    } catch (_) {
+      // Non-critical: if flapping check fails, proceed with normal incident creation
+    }
+  }
+
+  const result = await runReadCommittedTransaction(async tx => {
     // 1. Validate serviceId exists (prevents orphaned incidents)
     const service = await tx.service.findUnique({
       where: { id: serviceId },
@@ -158,6 +190,11 @@ export async function processEvent(
       });
       throw new Error(`Service not found: ${serviceId}. Integration may be misconfigured.`);
     }
+
+    // ReadCommitted removes broad Serializable predicate conflicts. A
+    // transaction-scoped advisory lock preserves the find-then-create
+    // deduplication boundary for events targeting the same service/key.
+    await lockEventDedupKeys(tx, serviceId, candidateDedupKeys);
 
     // 2. Find existing open incident with this dedup_key BEFORE creating alert
     // This prevents alert orphaning when resolve/acknowledge has no matching incident
@@ -313,18 +350,6 @@ export async function processEvent(
         ? truncateString(rawDescription, MAX_DESCRIPTION_LENGTH)
         : null;
 
-      // Flapping detection: check rapid state oscillations before creating a new incident
-      // Done outside the transaction since it reads Alert rows that were just committed
-      // (the current alert was created above in the same tx, so we use a non-tx prisma read)
-      let isFlapping = false;
-      try {
-        const { checkAlertFlapping } = await import('./flapping');
-        const flappingResult = await checkAlertFlapping(dedup_key, serviceId);
-        isFlapping = flappingResult.isFlapping;
-      } catch (_) {
-        // Non-critical: if flapping check fails, proceed with normal incident creation
-      }
-
       const newIncident = await tx.incident.create({
         data: {
           title: sanitizedTitle,
@@ -448,7 +473,7 @@ export async function processEvent(
       source: eventData.source,
     });
     return { action: 'ignored', reason: `Unknown event action: ${event_action}` };
-  });
+  }, EVENT_TRANSACTION_MAX_ATTEMPTS);
 
   if (result.action === 'triggered' && result.incident) {
     // Trigger status page webhooks for incident.created event

--- a/src/lib/flapping.ts
+++ b/src/lib/flapping.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import prisma from './prisma';
 import { logger } from './logger';
 
@@ -25,12 +26,13 @@ const DEFAULT_CONFIG: FlappingConfig = {
 export async function checkAlertFlapping(
   dedupKey: string,
   serviceId: string,
-  config: FlappingConfig = DEFAULT_CONFIG
+  config: FlappingConfig = DEFAULT_CONFIG,
+  db: Pick<Prisma.TransactionClient, 'alert'> = prisma
 ): Promise<{ isFlapping: boolean; transitionCount: number }> {
   try {
     const windowStart = new Date(Date.now() - config.windowSeconds * 1000);
 
-    const recentAlerts = await prisma.alert.findMany({
+    const recentAlerts = await db.alert.findMany({
       where: {
         dedupKey,
         serviceId,

--- a/tests/integration/event-resilience.test.ts
+++ b/tests/integration/event-resilience.test.ts
@@ -32,9 +32,10 @@ describeIfRealDB('Event Ingestion Resilience Tests', { timeout: 30000 }, () => {
   });
 
   describe('Incident Deduplication Race Conditions', () => {
-    it('should create exactly one incident when receiving multiple identical trigger events simultaneously', async () => {
+    it('should create exactly one incident when receiving identical trigger events concurrently', async () => {
       const service = await createTestService('Deduplication Service');
       const dedupKey = `test-dedup-${Date.now()}`;
+      const eventCount = 10;
 
       const payload: EventPayload = {
         event_action: 'trigger',
@@ -46,20 +47,22 @@ describeIfRealDB('Event Ingestion Resilience Tests', { timeout: 30000 }, () => {
         },
       };
 
-      // Process events in rapid succession but not exact-simultaneity
-      // to allow local DB to handle serializable isolation without flaky timeouts.
-      // The processEvent still uses Serializable isolation and will retry internally.
-      const results = [];
-      for (let i = 0; i < 5; i++) {
-        results.push(await processEvent(payload, service.id, 'test-integration-id'));
-      }
+      // This is intentionally true concurrency. Event ingestion uses
+      // ReadCommitted isolation plus a transaction-scoped advisory lock for the
+      // service/dedup key so unrelated keys can progress independently while
+      // the find-then-create deduplication boundary remains race-safe.
+      const results = await Promise.all(
+        Array.from({ length: eventCount }, () =>
+          processEvent(payload, service.id, 'test-integration-id')
+        )
+      );
 
       // Verify results
       const triggeredCount = results.filter(r => r.action === 'triggered').length;
       const deduplicatedCount = results.filter(r => r.action === 'deduplicated').length;
 
       expect(triggeredCount).toBe(1);
-      expect(deduplicatedCount).toBe(4);
+      expect(deduplicatedCount).toBe(eventCount - 1);
 
       // Verify DB state
       const scopedDedupKey = `test-integration-id:${dedupKey}`;
@@ -72,7 +75,7 @@ describeIfRealDB('Event Ingestion Resilience Tests', { timeout: 30000 }, () => {
       const alerts = await testPrisma.alert.findMany({
         where: { dedupKey: scopedDedupKey, serviceId: service.id },
       });
-      expect(alerts).toHaveLength(5);
+      expect(alerts).toHaveLength(eventCount);
 
       const incident = await testPrisma.incident.findFirst({
         where: { dedupKey: scopedDedupKey, serviceId: service.id },


### PR DESCRIPTION
## Summary

Reduces the confirmed `P2034` / `P2028` contention in high-concurrency event ingestion without changing Helm, Kustomize, deployment topology, or Docker Compose behavior.

## Root cause

`processEvent()` was using a broad `Serializable` interactive transaction even though the shared DB helper explicitly recommends `ReadCommitted` for high-frequency event ingestion. Under concurrent event traffic this creates avoidable serialization failures between unrelated dedup keys.

The same transaction also called `checkAlertFlapping()` through the global Prisma client while the interactive transaction was still open. That could hold one pooled connection for the transaction while requesting a second connection for the flapping read, amplifying pool pressure and contributing to `P2028` transaction-start failures.

## Fix

- switch event ingestion from `runSerializableTransaction` to `runReadCommittedTransaction`;
- use `EVENT_TRANSACTION_MAX_ATTEMPTS` (default 5) for the ingestion transaction;
- preserve dedup correctness with PostgreSQL transaction-scoped advisory locks keyed by `(serviceId, dedupKey)`;
- include the legacy unscoped dedup key in lock acquisition during rolling-upgrade compatibility;
- acquire multiple candidate locks in deterministic sorted order to avoid lock-order deadlocks;
- run flapping detection through the transaction client after the dedup advisory lock, avoiding a second pool connection while ensuring queued events observe committed alert history.

## Correctness boundary

Only events that can address the same logical incident are serialized. Different service/dedup-key combinations can progress concurrently under `ReadCommitted`.

The advisory lock protects the existing find-then-create deduplication path, so concurrent identical trigger events still create exactly one active incident and attach all alerts to it.

## Regression coverage

The existing event resilience integration test now runs 10 identical trigger events with real `Promise.all()` concurrency instead of sequential calls and asserts:

- exactly 1 `triggered` result;
- 9 `deduplicated` results;
- exactly 1 incident;
- all 10 alerts linked to that incident.

Existing trigger → acknowledge → resolve lifecycle and duplicate-resolve coverage remain intact.

## Scope

Application/database transaction behavior only.

No changes to:

- PR #382;
- Helm;
- Kustomize;
- HPA;
- PgBouncer configuration;
- Docker Compose manifests;
- Prisma schema or migrations;
- notification semantics.

## Validation still required

After CI is green, rerun the short ingestion benchmark used to expose the issue:

- 100 RPS for 60 seconds;
- 200 distributed integration keys;
- capture `202` / `429` / `5xx`;
- capture `P2034` / `P2028` counts;
- verify active-incident dedup correctness;
- capture PostgreSQL CPU/connections and transaction latency.

The goal is to verify the application-level contention fix before considering larger async/outbox changes.
