### PR TITLE
feat(events): add durable event side-effect outbox

### DIFF
--- a/src/lib/__tests__/queue.test.ts
+++ b/src/lib/__tests__/queue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import prisma from '@/lib/prisma';
 import * as queue from '../jobs/queue';
 import { sendNotification as mockedSendNotification } from '@/lib/notifications';
+import { processEventSideEffect as mockedProcessEventSideEffect } from '@/lib/event-side-effects';
 
 type TestMock = ReturnType<typeof vi.fn>;
 
@@ -20,6 +21,7 @@ const prismaMock = prisma as unknown as {
   };
 };
 const sendNotificationMock = mockedSendNotification as unknown as TestMock;
+const processEventSideEffectMock = mockedProcessEventSideEffect as unknown as TestMock;
 
 vi.mock('@/lib/user-notifications', () => ({
   sendIncidentNotifications: vi.fn(),
@@ -44,6 +46,10 @@ vi.mock('@/lib/status-page-webhooks', () => ({
 
 vi.mock('@/lib/notifications', () => ({
   sendNotification: vi.fn(),
+}));
+
+vi.mock('@/lib/event-side-effects', () => ({
+  processEventSideEffect: vi.fn(),
 }));
 
 // Prisma mock object
@@ -159,5 +165,59 @@ describe('queue.processJob NOTIFICATION retries', () => {
     const updateCall = prismaMock.backgroundJob.update.mock.calls[0]?.[0];
     expect(updateCall).toBeTruthy();
     expect(updateCall.data.status).toBe('FAILED');
+  });
+});
+
+describe('queue.processJob SCHEDULED_TASK event side effects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.backgroundJob.update.mockResolvedValue({});
+  });
+
+  it('dispatches durable event side effects and marks the job completed', async () => {
+    processEventSideEffectMock.mockResolvedValue(undefined);
+    const payload = {
+      task: 'EVENT_SIDE_EFFECT',
+      effect: 'ACK_SLACK',
+      incidentId: 'inc-1',
+    };
+
+    const result = await queue.processJob({
+      id: 'job-side-effect',
+      type: 'SCHEDULED_TASK',
+      status: 'PROCESSING',
+      payload,
+      attempts: 1,
+      maxAttempts: 5,
+    });
+
+    expect(result).toBe(true);
+    expect(processEventSideEffectMock).toHaveBeenCalledWith(payload);
+    expect(prismaMock.backgroundJob.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'job-side-effect' },
+        data: expect.objectContaining({ status: 'COMPLETED' }),
+      })
+    );
+  });
+
+  it('fails unknown scheduled tasks without executing a side effect', async () => {
+    const result = await queue.processJob({
+      id: 'job-unknown',
+      type: 'SCHEDULED_TASK',
+      status: 'PROCESSING',
+      payload: { task: 'UNKNOWN_TASK' },
+      attempts: 1,
+      maxAttempts: 5,
+    });
+
+    expect(result).toBe(false);
+    expect(processEventSideEffectMock).not.toHaveBeenCalled();
+    expect(prismaMock.backgroundJob.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'job-unknown' },
+        data: expect.objectContaining({ status: 'FAILED' }),
+      })
+    );
   });
 });

--- a/src/lib/event-outbox.ts
+++ b/src/lib/event-outbox.ts
@@ -1,0 +1,91 @@
+import { Prisma } from '@prisma/client';
+
+export type EventOutboxAction = 'triggered' | 'resolved' | 'acknowledged';
+
+export type EventSideEffect =
+  | 'TRIGGER_WEBHOOK'
+  | 'TRIGGER_ESCALATION_NOTIFICATIONS'
+  | 'TRIGGER_WAR_ROOM'
+  | 'RESOLVE_WEBHOOK'
+  | 'RESOLVE_SLACK'
+  | 'RESOLVE_WAR_ROOM_ARCHIVE'
+  | 'ACK_SLACK';
+
+export type EventSideEffectLane = 'WEBHOOK' | 'ESCALATION' | 'WAR_ROOM' | 'SLACK';
+
+export interface EventSideEffectPayload {
+  task: 'EVENT_SIDE_EFFECT';
+  effect: EventSideEffect;
+  lane: EventSideEffectLane;
+  incidentId: string;
+  eventOrderAt: string;
+}
+
+export function getEventSideEffects(action: EventOutboxAction): readonly EventSideEffect[] {
+  switch (action) {
+    case 'triggered':
+      return ['TRIGGER_WEBHOOK', 'TRIGGER_ESCALATION_NOTIFICATIONS', 'TRIGGER_WAR_ROOM'];
+    case 'resolved':
+      return ['RESOLVE_WEBHOOK', 'RESOLVE_SLACK', 'RESOLVE_WAR_ROOM_ARCHIVE'];
+    case 'acknowledged':
+      return ['ACK_SLACK'];
+  }
+}
+
+function getEventSideEffectLane(effect: EventSideEffect): EventSideEffectLane {
+  switch (effect) {
+    case 'TRIGGER_WEBHOOK':
+    case 'RESOLVE_WEBHOOK':
+      return 'WEBHOOK';
+    case 'TRIGGER_ESCALATION_NOTIFICATIONS':
+      return 'ESCALATION';
+    case 'TRIGGER_WAR_ROOM':
+    case 'RESOLVE_WAR_ROOM_ARCHIVE':
+      return 'WAR_ROOM';
+    case 'RESOLVE_SLACK':
+    case 'ACK_SLACK':
+      return 'SLACK';
+  }
+}
+
+/**
+ * Persist event side-effects in the same database transaction as the incident
+ * state change. The existing SCHEDULED_TASK job type is intentionally used as
+ * the durable internal outbox envelope so self-hosted installs do not require
+ * Redis, Kafka, or another queueing service.
+ *
+ * A PostgreSQL clock timestamp is captured after the event's advisory lock is
+ * acquired. Workers use this value to preserve lifecycle order within a single
+ * incident/lane (for example created webhook before resolved webhook), while
+ * independent lanes remain free to execute concurrently.
+ */
+export async function enqueueEventSideEffects(
+  tx: Prisma.TransactionClient,
+  action: EventOutboxAction,
+  incidentId: string
+): Promise<void> {
+  const effects = getEventSideEffects(action);
+  if (effects.length === 0) return;
+
+  const [databaseClock] = await tx.$queryRaw<Array<{ now: Date }>>`
+    SELECT clock_timestamp() AS "now"
+  `;
+  const eventOrderAt = databaseClock?.now ?? new Date();
+  const eventOrderAtIso = eventOrderAt.toISOString();
+
+  await tx.backgroundJob.createMany({
+    data: effects.map(effect => ({
+      type: 'SCHEDULED_TASK',
+      status: 'PENDING',
+      scheduledAt: eventOrderAt,
+      maxAttempts: 5,
+      payload: {
+        task: 'EVENT_SIDE_EFFECT',
+        effect,
+        lane: getEventSideEffectLane(effect),
+        incidentId,
+        eventOrderAt: eventOrderAtIso,
+      } satisfies EventSideEffectPayload,
+    })),
+  });
+}

--- a/src/lib/event-side-effects.ts
+++ b/src/lib/event-side-effects.ts
@@ -1,0 +1,158 @@
+import prisma from './prisma';
+import { executeEscalation } from './notifications';
+import { notifySlackForIncident } from './slack';
+import { logger } from './logger';
+import type { EventSideEffectPayload } from './event-outbox';
+
+export function escalationNotificationRoute(result: {
+  escalated?: boolean;
+  reason?: string;
+}): 'service' | 'fallback' {
+  const reason = (result.reason || '').toLowerCase();
+  const policyOwnsResponderRouting =
+    result.escalated === true ||
+    reason.includes('scheduled') ||
+    reason.includes('already in progress');
+
+  return policyOwnsResponderRouting ? 'service' : 'fallback';
+}
+
+async function sendEventWebhook(
+  payload: EventSideEffectPayload,
+  eventType: 'incident.created' | 'incident.resolved'
+): Promise<void> {
+  const incident = await prisma.incident.findUnique({
+    where: { id: payload.incidentId },
+    include: {
+      service: { select: { id: true, name: true } },
+      assignee: {
+        select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
+      },
+    },
+  });
+
+  // Incident deletion makes the side-effect obsolete rather than retryable.
+  if (!incident) {
+    logger.info('event.outbox.incident_missing', { incidentId: payload.incidentId, eventType });
+    return;
+  }
+
+  const { triggerWebhooksForService } = await import('./status-page-webhooks');
+  const webhookPayload = {
+    id: incident.id,
+    title: incident.title,
+    description: incident.description,
+    // The job can run after a later incident transition has committed. Preserve
+    // the lifecycle state represented by this durable event rather than leaking
+    // a newer current status into an older webhook.
+    status: eventType === 'incident.created' ? 'OPEN' : 'RESOLVED',
+    urgency: incident.urgency,
+    priority: incident.priority,
+    service: {
+      id: incident.service.id,
+      name: incident.service.name,
+    },
+    assignee: incident.assignee,
+    createdAt: incident.createdAt.toISOString(),
+    ...(eventType === 'incident.resolved'
+      ? {
+          acknowledgedAt: incident.acknowledgedAt?.toISOString() || null,
+          resolvedAt: incident.resolvedAt?.toISOString() || payload.eventOrderAt,
+        }
+      : {}),
+  };
+
+  await triggerWebhooksForService(incident.serviceId, eventType, webhookPayload);
+}
+
+async function runTriggerEscalationAndNotifications(incidentId: string): Promise<void> {
+  const startedAt = performance.now();
+  let escalationResult: Awaited<ReturnType<typeof executeEscalation>>;
+
+  try {
+    escalationResult = await executeEscalation(incidentId);
+  } catch (error) {
+    // Preserve the previous fallback only for an escalation execution failure.
+    // Notification-provider failures below must escape to the durable queue so
+    // they are retried instead of immediately entering a second send path.
+    logger.error('event.outbox.escalation_failed', {
+      incidentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    const { sendServiceNotifications } = await import('./service-notifications');
+    await sendServiceNotifications(incidentId, 'triggered');
+    return;
+  }
+
+  const route = escalationNotificationRoute(escalationResult || {});
+
+  if (route === 'service') {
+    const { sendServiceNotifications } = await import('./service-notifications');
+    await sendServiceNotifications(incidentId, 'triggered');
+  } else {
+    const { sendIncidentNotifications } = await import('./user-notifications');
+    await sendIncidentNotifications(incidentId, 'triggered');
+  }
+
+  logger.info('event.outbox.notifications_sent', {
+    incidentId,
+    route,
+    latencyMs: performance.now() - startedAt,
+  });
+}
+
+export async function processEventSideEffect(payload: EventSideEffectPayload): Promise<void> {
+  if (
+    payload.task !== 'EVENT_SIDE_EFFECT' ||
+    !payload.effect ||
+    !payload.lane ||
+    !payload.incidentId ||
+    !payload.eventOrderAt
+  ) {
+    throw new Error('Invalid EVENT_SIDE_EFFECT payload');
+  }
+
+  switch (payload.effect) {
+    case 'TRIGGER_WEBHOOK':
+      await sendEventWebhook(payload, 'incident.created');
+      return;
+
+    case 'TRIGGER_ESCALATION_NOTIFICATIONS':
+      await runTriggerEscalationAndNotifications(payload.incidentId);
+      return;
+
+    case 'TRIGGER_WAR_ROOM': {
+      const { createIncidentWarRoom } = await import('./chatops/war-room');
+      const result = await createIncidentWarRoom(payload.incidentId);
+      if (result.success) {
+        logger.info('event.outbox.war_room_created', {
+          incidentId: payload.incidentId,
+          channelName: result.channelName,
+        });
+      }
+      return;
+    }
+
+    case 'RESOLVE_WEBHOOK':
+      await sendEventWebhook(payload, 'incident.resolved');
+      return;
+
+    case 'RESOLVE_SLACK':
+      await notifySlackForIncident(payload.incidentId, 'resolved');
+      return;
+
+    case 'RESOLVE_WAR_ROOM_ARCHIVE': {
+      const { archiveWarRoomChannel } = await import('./chatops/war-room');
+      await archiveWarRoomChannel(payload.incidentId);
+      return;
+    }
+
+    case 'ACK_SLACK':
+      await notifySlackForIncident(payload.incidentId, 'acknowledged');
+      return;
+  }
+
+  throw new Error(
+    `Unknown EVENT_SIDE_EFFECT effect: ${String((payload as { effect?: unknown }).effect)}`
+  );
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,9 +1,9 @@
 import { Prisma, IncidentUrgency } from '@prisma/client';
-import prisma from './prisma';
-import { executeEscalation } from './notifications';
-import { notifySlackForIncident } from './slack';
 import { logger } from './logger';
 import { EVENT_TRANSACTION_MAX_ATTEMPTS } from './config';
+import { createHash } from 'crypto';
+import { runReadCommittedTransaction } from './db-utils';
+import { enqueueEventSideEffects } from './event-outbox';
 
 export type EventSeverity = 'critical' | 'error' | 'warning' | 'info';
 
@@ -17,9 +17,6 @@ export type EventPayload = {
     custom_details?: unknown;
   };
 };
-
-import { createHash } from 'crypto';
-import { runReadCommittedTransaction } from './db-utils';
 
 const MAX_DEDUP_KEY_LENGTH = 512;
 const MAX_STORED_ALERT_PAYLOAD_BYTES = 64 * 1024;
@@ -332,6 +329,8 @@ export async function processEvent(
           },
         });
 
+        await enqueueEventSideEffects(tx, 'resolved', resolvedIncident.id);
+
         logger.info('event.out_of_order_resolved', {
           incidentId: resolvedIncident.id,
           dedupKey: dedup_key,
@@ -389,9 +388,10 @@ export async function processEvent(
         },
       });
 
-      // Note: Webhook triggering happens outside transaction to avoid blocking
-      // If the incident is suppressed due to flapping, return 'suppressed' action
-      // so the caller skips escalation dispatch
+      if (!isFlapping) {
+        await enqueueEventSideEffects(tx, 'triggered', newIncident.id);
+      }
+
       return {
         action: isFlapping ? ('suppressed' as const) : ('triggered' as const),
         incident: newIncident,
@@ -426,6 +426,8 @@ export async function processEvent(
         },
       });
 
+      await enqueueEventSideEffects(tx, 'resolved', resolvedIncident.id);
+
       logger.info('event.incident_resolved', {
         incidentId: resolvedIncident.id,
         dedupKey: dedup_key,
@@ -459,6 +461,8 @@ export async function processEvent(
         },
       });
 
+      await enqueueEventSideEffects(tx, 'acknowledged', ackIncident.id);
+
       logger.info('event.incident_acknowledged', {
         incidentId: ackIncident.id,
         dedupKey: dedup_key,
@@ -477,229 +481,10 @@ export async function processEvent(
     return { action: 'ignored', reason: `Unknown event action: ${event_action}` };
   }, EVENT_TRANSACTION_MAX_ATTEMPTS);
 
-  if (result.action === 'triggered' && result.incident) {
-    // Trigger status page webhooks for incident.created event
-    try {
-      const { triggerWebhooksForService } = await import('./status-page-webhooks');
-      const incidentWithService = await prisma.incident.findUnique({
-        where: { id: result.incident.id },
-        include: {
-          service: { select: { id: true, name: true } },
-          assignee: {
-            select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-          },
-        },
-      });
-
-      if (incidentWithService) {
-        // Await externally visible side effects so process teardown cannot
-        // silently discard them after the response is returned.
-        const webhookStart = performance.now();
-        await triggerWebhooksForService(result.incident.serviceId, 'incident.created', {
-          id: incidentWithService.id,
-          title: incidentWithService.title,
-          description: incidentWithService.description,
-          status: incidentWithService.status,
-          urgency: incidentWithService.urgency,
-          priority: incidentWithService.priority,
-          service: {
-            id: incidentWithService.service.id,
-            name: incidentWithService.service.name,
-          },
-          assignee: incidentWithService.assignee,
-          createdAt: incidentWithService.createdAt.toISOString(),
-        })
-          .then(() => {
-            logger.info('api.event.webhook_trigger_success', {
-              latencyMs: performance.now() - webhookStart,
-              incidentId: result.incident.id,
-            });
-          })
-          .catch(err => {
-            logger.error('api.event.webhook_trigger_failed', {
-              error: err instanceof Error ? err.message : String(err),
-              latencyMs: performance.now() - webhookStart,
-            });
-          });
-      }
-    } catch (e) {
-      logger.error('api.event.webhook_trigger_error', {
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
-
-    // Execute escalation policy, then choose the correct notification path.
-    const notifyStart = performance.now();
-    await executeEscalation(result.incident.id)
-      .then(escalationResult => {
-        const route = escalationNotificationRoute(escalationResult || {});
-
-        if (route === 'service') {
-          return import('./service-notifications')
-            .then(({ sendServiceNotifications }) => {
-              return sendServiceNotifications(result.incident.id, 'triggered')
-                .then(() => {
-                  logger.info('api.event.notifications_sent', {
-                    latencyMs: performance.now() - notifyStart,
-                    incidentId: result.incident.id,
-                  });
-                })
-                .catch(error => {
-                  logger.error('Service notification failed', {
-                    incidentId: result.incident.id,
-                    error: error instanceof Error ? error.message : 'Unknown error',
-                    latencyMs: performance.now() - notifyStart,
-                  });
-                });
-            })
-            .catch(e => logger.error('Failed to load service-notifications', { error: e }));
-        } else {
-          // Fallback only when the policy cannot provide responders. Scheduled
-          // steps retain their configured delay and do not page the whole team.
-          return import('./user-notifications')
-            .then(({ sendIncidentNotifications }) => {
-              return sendIncidentNotifications(result.incident.id, 'triggered')
-                .then(() => {
-                  logger.info('api.event.user_notifications_sent', {
-                    latencyMs: performance.now() - notifyStart,
-                    incidentId: result.incident.id,
-                  });
-                })
-                .catch(error => {
-                  logger.error('User notification failed', {
-                    incidentId: result.incident.id,
-                    error: error instanceof Error ? error.message : 'Unknown error',
-                    latencyMs: performance.now() - notifyStart,
-                  });
-                });
-            })
-            .catch(e => logger.error('Failed to load user-notifications', { error: e }));
-        }
-      })
-      .catch(error => {
-        logger.error('Escalation failed', {
-          incidentId: result.incident.id,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-
-        return import('./service-notifications')
-          .then(({ sendServiceNotifications }) => {
-            return sendServiceNotifications(result.incident.id, 'triggered').catch(err => {
-              logger.error('Service notification failed', {
-                incidentId: result.incident.id,
-                error: err instanceof Error ? err.message : 'Unknown error',
-                latencyMs: performance.now() - notifyStart,
-              });
-            });
-          })
-          .catch(e => logger.error('Failed to load service-notifications', { error: e }));
-      });
-
-    // ChatOps: Auto-create war-room channel for qualifying incidents.
-    await import('./chatops/war-room')
-      .then(({ createIncidentWarRoom }) => {
-        return createIncidentWarRoom(result.incident.id)
-          .then(warRoomResult => {
-            if (warRoomResult.success) {
-              logger.info('chatops.war_room_created', {
-                incidentId: result.incident.id,
-                channelName: warRoomResult.channelName,
-              });
-            }
-          })
-          .catch(err => {
-            logger.error('chatops.war_room_creation_failed', {
-              incidentId: result.incident.id,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
-      })
-      .catch(e => logger.error('Failed to load chatops/war-room', { error: e }));
-  }
-
-  if (result.action === 'resolved' && result.incident) {
-    // Trigger status page webhooks for incident.resolved event
-    try {
-      const { triggerWebhooksForService } = await import('./status-page-webhooks');
-      const incidentWithService = await prisma.incident.findUnique({
-        where: { id: result.incident.id },
-        include: {
-          service: { select: { id: true, name: true } },
-          assignee: {
-            select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-          },
-        },
-      });
-
-      if (incidentWithService) {
-        await triggerWebhooksForService(result.incident.serviceId, 'incident.resolved', {
-          id: incidentWithService.id,
-          title: incidentWithService.title,
-          description: incidentWithService.description,
-          status: incidentWithService.status,
-          urgency: incidentWithService.urgency,
-          priority: incidentWithService.priority,
-          service: {
-            id: incidentWithService.service.id,
-            name: incidentWithService.service.name,
-          },
-          assignee: incidentWithService.assignee,
-          createdAt: incidentWithService.createdAt.toISOString(),
-          acknowledgedAt: incidentWithService.acknowledgedAt?.toISOString() || null,
-          resolvedAt: incidentWithService.resolvedAt?.toISOString() || null,
-        }).catch(err => {
-          logger.error('api.event.webhook_trigger_failed', {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-      }
-    } catch (e) {
-      logger.error('api.event.webhook_trigger_error', {
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
-
-    await notifySlackForIncident(result.incident.id, 'resolved').catch(error => {
-      logger.error('Slack notification failed', {
-        incidentId: result.incident.id,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    });
-
-    // ChatOps: Archive war-room channel on resolve.
-    await import('./chatops/war-room')
-      .then(({ archiveWarRoomChannel }) => {
-        return archiveWarRoomChannel(result.incident.id).catch(err => {
-          logger.error('chatops.war_room_archive_failed', {
-            incidentId: result.incident.id,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-      })
-      .catch(e => logger.error('Failed to load chatops/war-room', { error: e }));
-  }
-
-  if (result.action === 'acknowledged' && result.incident) {
-    await notifySlackForIncident(result.incident.id, 'acknowledged').catch(error => {
-      logger.error('Slack notification failed', {
-        incidentId: result.incident.id,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    });
-  }
-
+  // External side-effects are persisted above in the same transaction and are
+  // executed by the durable PostgreSQL job worker. The API no longer waits for
+  // webhook, notification, Slack, or ChatOps network calls before returning.
   return result;
 }
 
-export function escalationNotificationRoute(result: {
-  escalated?: boolean;
-  reason?: string;
-}): 'service' | 'fallback' {
-  const reason = (result.reason || '').toLowerCase();
-  const policyOwnsResponderRouting =
-    result.escalated === true ||
-    reason.includes('scheduled') ||
-    reason.includes('already in progress');
-
-  return policyOwnsResponderRouting ? 'service' : 'fallback';
-}
+export { escalationNotificationRoute } from './event-side-effects';

--- a/src/lib/jobs/queue.ts
+++ b/src/lib/jobs/queue.ts
@@ -2,7 +2,7 @@
  * PostgreSQL-based Job Queue System
  *
  * This implementation uses PostgreSQL instead of Redis/BullMQ.
- * Jobs are stored in the BackgroundJob table and processed by cron jobs.
+ * Jobs are stored in the BackgroundJob table and processed by workers/schedulers.
  *
  * Benefits:
  * - No additional infrastructure (Redis) needed
@@ -138,6 +138,12 @@ export async function getPendingJobs(limit: number = 50): Promise<any[]> {
 /**
  * Atomically claim pending jobs for processing.
  * Uses SKIP LOCKED to avoid concurrent workers claiming the same jobs.
+ *
+ * EVENT_SIDE_EFFECT jobs add one more boundary: a later lifecycle event in the
+ * same incident/lane cannot be claimed while an older job in that lane is
+ * pending or processing. This preserves created -> acknowledged -> resolved
+ * ordering for dependent external systems without serializing independent
+ * webhook, Slack, escalation, and war-room lanes.
  */
 export async function claimPendingJobs(limit: number = 50, type?: JobType): Promise<any[]> {
   // Recover abandoned jobs that exceeded maxAttempts while in PROCESSING
@@ -155,18 +161,45 @@ export async function claimPendingJobs(limit: number = 50, type?: JobType): Prom
     )
     .catch(err => logger.warn('[Queue] Failed to sweep zombie processing jobs', { error: err }));
 
-  const typeFilter = type ? Prisma.sql`AND "type" = ${type}::"JobType"` : Prisma.empty;
+  const typeFilter = type
+    ? Prisma.sql`AND candidate."type" = ${type}::"JobType"`
+    : Prisma.empty;
   const jobs = await prisma.$queryRaw<any[]>( // eslint-disable-line @typescript-eslint/no-explicit-any
     Prisma.sql`
       WITH cte AS (
-        SELECT "id"
-        FROM "BackgroundJob"
-        WHERE ("status" = 'PENDING' OR ("status" = 'PROCESSING' AND ("startedAt" IS NULL OR "startedAt" < NOW() - INTERVAL '10 minutes')))
-          AND "scheduledAt" <= NOW()
-          AND "attempts" < "maxAttempts"
+        SELECT candidate."id"
+        FROM "BackgroundJob" AS candidate
+        WHERE (
+            candidate."status" = 'PENDING'
+            OR (
+              candidate."status" = 'PROCESSING'
+              AND (
+                candidate."startedAt" IS NULL
+                OR candidate."startedAt" < NOW() - INTERVAL '10 minutes'
+              )
+            )
+          )
+          AND candidate."scheduledAt" <= NOW()
+          AND candidate."attempts" < candidate."maxAttempts"
           ${typeFilter}
-        ORDER BY "scheduledAt" ASC
-        FOR UPDATE SKIP LOCKED
+          AND (
+            candidate."type" <> 'SCHEDULED_TASK'::"JobType"
+            OR candidate."payload"->>'task' IS DISTINCT FROM 'EVENT_SIDE_EFFECT'
+            OR NOT EXISTS (
+              SELECT 1
+              FROM "BackgroundJob" AS older
+              WHERE older."type" = 'SCHEDULED_TASK'::"JobType"
+                AND older."status" IN ('PENDING', 'PROCESSING')
+                AND older."payload"->>'task' = 'EVENT_SIDE_EFFECT'
+                AND older."payload"->>'incidentId' = candidate."payload"->>'incidentId'
+                AND older."payload"->>'lane' = candidate."payload"->>'lane'
+                AND older."id" <> candidate."id"
+                AND (older."payload"->>'eventOrderAt')::timestamptz
+                  < (candidate."payload"->>'eventOrderAt')::timestamptz
+            )
+          )
+        ORDER BY candidate."scheduledAt" ASC, candidate."createdAt" ASC
+        FOR UPDATE OF candidate SKIP LOCKED
         LIMIT ${limit}
       )
       UPDATE "BackgroundJob"
@@ -396,6 +429,25 @@ export async function processJob(job: any): Promise<boolean> {
             }
           );
         }
+        await markJobCompleted(job.id);
+        return true;
+      }
+
+      case 'SCHEDULED_TASK': {
+        if (job.payload?.task !== 'EVENT_SIDE_EFFECT') {
+          await prisma.backgroundJob.update({
+            where: { id: job.id },
+            data: {
+              status: 'FAILED',
+              failedAt: new Date(),
+              error: `Unknown scheduled task: ${job.payload?.task || 'missing task'}`,
+            },
+          });
+          return false;
+        }
+
+        const { processEventSideEffect } = await import('../event-side-effects');
+        await processEventSideEffect(job.payload);
         await markJobCompleted(job.id);
         return true;
       }

--- a/src/lib/runtime-role.ts
+++ b/src/lib/runtime-role.ts
@@ -12,10 +12,11 @@ const DEFAULT_PROCESS_ROLE: OpsKnightProcessRole = 'integrated';
 /**
  * Resolve the role for this process.
  *
- * The default deliberately preserves the pre-worker-plane runtime: every
- * application process starts the existing distributed cron scheduler. New
- * deployments can opt into separated web/scheduler/worker responsibilities
- * without forcing a flag-day migration on existing installations.
+ * The default preserves the single-process self-hosted runtime while also
+ * running the durable job worker in-process. This keeps Docker Compose and
+ * other integrated installs low-latency without requiring a separate worker
+ * container, while split deployments can continue to isolate web, scheduler,
+ * and worker responsibilities.
  */
 export function getOpsKnightProcessRole(
   value: string | undefined = process.env.OPSKNIGHT_PROCESS_ROLE
@@ -38,7 +39,7 @@ export function getOpsKnightProcessRole(
 export function getRuntimeResponsibilities(role: OpsKnightProcessRole): RuntimeResponsibilities {
   switch (role) {
     case 'integrated':
-      return { startScheduler: true, startJobWorker: false };
+      return { startScheduler: true, startJobWorker: true };
     case 'web':
       return { startScheduler: false, startJobWorker: false };
     case 'scheduler':

--- a/tests/integration/event-outbox.test.ts
+++ b/tests/integration/event-outbox.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { processEvent, type EventPayload } from '@/lib/events';
+import { claimPendingJobs } from '@/lib/jobs/queue';
+import { resetDatabase, createTestService, testPrisma } from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+type SideEffectPayload = {
+  task?: string;
+  effect?: string;
+  lane?: string;
+  incidentId?: string;
+  eventOrderAt?: string;
+};
+
+describeIfRealDB('Event Transactional Outbox', { timeout: 30000 }, () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  it('commits trigger side-effects as durable jobs with the incident', async () => {
+    const service = await createTestService('Outbox Trigger Service');
+    const payload: EventPayload = {
+      event_action: 'trigger',
+      dedup_key: `outbox-trigger-${Date.now()}`,
+      payload: {
+        summary: 'Outbox trigger incident',
+        source: 'outbox-test',
+        severity: 'critical',
+      },
+    };
+
+    const result = await processEvent(payload, service.id, 'outbox-integration');
+    expect(result.action).toBe('triggered');
+
+    const jobs = await testPrisma.backgroundJob.findMany({
+      where: { type: 'SCHEDULED_TASK' },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    expect(jobs).toHaveLength(3);
+    expect(jobs.every(job => job.status === 'PENDING')).toBe(true);
+    expect(jobs.every(job => job.maxAttempts === 5)).toBe(true);
+    expect(jobs.map(job => (job.payload as SideEffectPayload).effect).sort()).toEqual(
+      ['TRIGGER_ESCALATION_NOTIFICATIONS', 'TRIGGER_WAR_ROOM', 'TRIGGER_WEBHOOK'].sort()
+    );
+    expect(
+      jobs.every(job => (job.payload as SideEffectPayload).incidentId === result.incident?.id)
+    ).toBe(true);
+    expect(jobs.every(job => Boolean((job.payload as SideEffectPayload).lane))).toBe(true);
+    expect(jobs.every(job => Boolean((job.payload as SideEffectPayload).eventOrderAt))).toBe(true);
+  });
+
+  it('does not enqueue duplicate side-effects for a deduplicated trigger', async () => {
+    const service = await createTestService('Outbox Dedup Service');
+    const payload: EventPayload = {
+      event_action: 'trigger',
+      dedup_key: `outbox-dedup-${Date.now()}`,
+      payload: {
+        summary: 'Repeated trigger',
+        source: 'outbox-test',
+        severity: 'error',
+      },
+    };
+
+    const first = await processEvent(payload, service.id, 'outbox-integration');
+    const second = await processEvent(payload, service.id, 'outbox-integration');
+
+    expect(first.action).toBe('triggered');
+    expect(second.action).toBe('deduplicated');
+    expect(await testPrisma.backgroundJob.count({ where: { type: 'SCHEDULED_TASK' } })).toBe(3);
+  });
+
+  it('enqueues action-specific jobs for acknowledge and resolve', async () => {
+    const service = await createTestService('Outbox Lifecycle Service');
+    const dedupKey = `outbox-lifecycle-${Date.now()}`;
+    const basePayload = {
+      dedup_key: dedupKey,
+      payload: {
+        summary: 'Outbox lifecycle incident',
+        source: 'outbox-test',
+        severity: 'warning' as const,
+      },
+    };
+
+    const triggered = await processEvent(
+      { ...basePayload, event_action: 'trigger' },
+      service.id,
+      'outbox-integration'
+    );
+    expect(triggered.action).toBe('triggered');
+
+    const acknowledged = await processEvent(
+      { ...basePayload, event_action: 'acknowledge' },
+      service.id,
+      'outbox-integration'
+    );
+    expect(acknowledged.action).toBe('acknowledged');
+
+    const resolved = await processEvent(
+      { ...basePayload, event_action: 'resolve' },
+      service.id,
+      'outbox-integration'
+    );
+    expect(resolved.action).toBe('resolved');
+
+    const jobs = await testPrisma.backgroundJob.findMany({
+      where: { type: 'SCHEDULED_TASK' },
+    });
+    const effects = jobs.map(job => (job.payload as SideEffectPayload).effect);
+
+    expect(jobs).toHaveLength(7);
+    expect(effects.filter(effect => effect === 'ACK_SLACK')).toHaveLength(1);
+    expect(effects.filter(effect => effect === 'RESOLVE_WEBHOOK')).toHaveLength(1);
+    expect(effects.filter(effect => effect === 'RESOLVE_SLACK')).toHaveLength(1);
+    expect(effects.filter(effect => effect === 'RESOLVE_WAR_ROOM_ARCHIVE')).toHaveLength(1);
+  });
+
+  it('claims later lifecycle work only after older jobs in the same lane complete', async () => {
+    const service = await createTestService('Outbox Ordering Service');
+    const dedupKey = `outbox-ordering-${Date.now()}`;
+    const basePayload = {
+      dedup_key: dedupKey,
+      payload: {
+        summary: 'Ordered lifecycle incident',
+        source: 'outbox-test',
+        severity: 'critical' as const,
+      },
+    };
+
+    expect(
+      (
+        await processEvent(
+          { ...basePayload, event_action: 'trigger' },
+          service.id,
+          'outbox-integration'
+        )
+      ).action
+    ).toBe('triggered');
+    expect(
+      (
+        await processEvent(
+          { ...basePayload, event_action: 'resolve' },
+          service.id,
+          'outbox-integration'
+        )
+      ).action
+    ).toBe('resolved');
+
+    const firstClaim = await claimPendingJobs(20, 'SCHEDULED_TASK');
+    const firstEffects = firstClaim.map(job => (job.payload as SideEffectPayload).effect);
+
+    expect(firstEffects).toContain('TRIGGER_WEBHOOK');
+    expect(firstEffects).toContain('TRIGGER_WAR_ROOM');
+    expect(firstEffects).toContain('TRIGGER_ESCALATION_NOTIFICATIONS');
+    expect(firstEffects).toContain('RESOLVE_SLACK');
+    expect(firstEffects).not.toContain('RESOLVE_WEBHOOK');
+    expect(firstEffects).not.toContain('RESOLVE_WAR_ROOM_ARCHIVE');
+
+    const completedLaneJobs = firstClaim
+      .filter(job => {
+        const effect = (job.payload as SideEffectPayload).effect;
+        return effect === 'TRIGGER_WEBHOOK' || effect === 'TRIGGER_WAR_ROOM';
+      })
+      .map(job => job.id);
+
+    await testPrisma.backgroundJob.updateMany({
+      where: { id: { in: completedLaneJobs } },
+      data: { status: 'COMPLETED', completedAt: new Date() },
+    });
+
+    const secondClaim = await claimPendingJobs(20, 'SCHEDULED_TASK');
+    const secondEffects = secondClaim.map(job => (job.payload as SideEffectPayload).effect);
+    expect(secondEffects).toContain('RESOLVE_WEBHOOK');
+    expect(secondEffects).toContain('RESOLVE_WAR_ROOM_ARCHIVE');
+  });
+
+  it('does not leave outbox jobs when event transaction fails', async () => {
+    const payload: EventPayload = {
+      event_action: 'trigger',
+      dedup_key: `outbox-rollback-${Date.now()}`,
+      payload: {
+        summary: 'Should roll back',
+        source: 'outbox-test',
+        severity: 'critical',
+      },
+    };
+
+    await expect(processEvent(payload, 'missing-service', 'outbox-integration')).rejects.toThrow(
+      /Service not found/
+    );
+    expect(await testPrisma.backgroundJob.count({ where: { type: 'SCHEDULED_TASK' } })).toBe(0);
+  });
+});

--- a/tests/lib/event-side-effects.test.ts
+++ b/tests/lib/event-side-effects.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeEscalation as mockedExecuteEscalation } from '@/lib/notifications';
+import { sendServiceNotifications as mockedSendServiceNotifications } from '@/lib/service-notifications';
+import { sendIncidentNotifications as mockedSendIncidentNotifications } from '@/lib/user-notifications';
+import { triggerWebhooksForService as mockedTriggerWebhooksForService } from '@/lib/status-page-webhooks';
+import prisma from '@/lib/prisma';
+import { processEventSideEffect } from '@/lib/event-side-effects';
+import type { EventSideEffectPayload } from '@/lib/event-outbox';
+
+type TestMock = ReturnType<typeof vi.fn>;
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/notifications', () => ({
+  executeEscalation: vi.fn(),
+}));
+
+vi.mock('@/lib/service-notifications', () => ({
+  sendServiceNotifications: vi.fn(),
+}));
+
+vi.mock('@/lib/user-notifications', () => ({
+  sendIncidentNotifications: vi.fn(),
+}));
+
+vi.mock('@/lib/status-page-webhooks', () => ({
+  triggerWebhooksForService: vi.fn(),
+}));
+
+vi.mock('@/lib/slack', () => ({
+  notifySlackForIncident: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    incident: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/chatops/war-room', () => ({
+  createIncidentWarRoom: vi.fn(),
+  archiveWarRoomChannel: vi.fn(),
+}));
+
+const executeEscalationMock = mockedExecuteEscalation as unknown as TestMock;
+const sendServiceNotificationsMock = mockedSendServiceNotifications as unknown as TestMock;
+const sendIncidentNotificationsMock = mockedSendIncidentNotifications as unknown as TestMock;
+const triggerWebhooksForServiceMock = mockedTriggerWebhooksForService as unknown as TestMock;
+const prismaMock = prisma as unknown as { incident: { findUnique: TestMock } };
+
+function payload(
+  effect: EventSideEffectPayload['effect'],
+  lane: EventSideEffectPayload['lane'] = 'ESCALATION'
+): EventSideEffectPayload {
+  return {
+    task: 'EVENT_SIDE_EFFECT',
+    effect,
+    lane,
+    incidentId: 'inc-1',
+    eventOrderAt: new Date().toISOString(),
+  };
+}
+
+describe('event durable side effects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses service notification fallback only when escalation execution fails', async () => {
+    executeEscalationMock.mockRejectedValue(new Error('escalation unavailable'));
+    sendServiceNotificationsMock.mockResolvedValue(undefined);
+
+    await expect(
+      processEventSideEffect(payload('TRIGGER_ESCALATION_NOTIFICATIONS'))
+    ).resolves.toBeUndefined();
+
+    expect(sendServiceNotificationsMock).toHaveBeenCalledTimes(1);
+    expect(sendIncidentNotificationsMock).not.toHaveBeenCalled();
+  });
+
+  it('lets notification-provider failure escape so the durable job retries', async () => {
+    executeEscalationMock.mockResolvedValue({
+      escalated: false,
+      reason: 'No escalation policy configured',
+    });
+    sendIncidentNotificationsMock.mockRejectedValue(new Error('provider unavailable'));
+
+    await expect(
+      processEventSideEffect(payload('TRIGGER_ESCALATION_NOTIFICATIONS'))
+    ).rejects.toThrow('provider unavailable');
+
+    expect(sendIncidentNotificationsMock).toHaveBeenCalledTimes(1);
+    expect(sendServiceNotificationsMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps created webhook lifecycle state even if the incident has since resolved', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue({
+      id: 'inc-1',
+      title: 'Incident',
+      description: null,
+      status: 'RESOLVED',
+      urgency: 'HIGH',
+      priority: 'P1',
+      serviceId: 'svc-1',
+      service: { id: 'svc-1', name: 'Service' },
+      assignee: null,
+      createdAt: new Date('2026-08-26T12:00:00Z'),
+      acknowledgedAt: null,
+      resolvedAt: new Date('2026-08-26T12:01:00Z'),
+    });
+    triggerWebhooksForServiceMock.mockResolvedValue(undefined);
+
+    await processEventSideEffect(payload('TRIGGER_WEBHOOK', 'WEBHOOK'));
+
+    expect(triggerWebhooksForServiceMock).toHaveBeenCalledWith(
+      'svc-1',
+      'incident.created',
+      expect.objectContaining({ status: 'OPEN' })
+    );
+  });
+
+  it('rejects an unknown effect instead of silently completing it', async () => {
+    const invalid = {
+      ...payload('ACK_SLACK', 'SLACK'),
+      effect: 'UNKNOWN_EFFECT',
+    } as unknown as EventSideEffectPayload;
+
+    await expect(processEventSideEffect(invalid)).rejects.toThrow(/Unknown EVENT_SIDE_EFFECT effect/);
+  });
+});

--- a/tests/lib/runtime-role.test.ts
+++ b/tests/lib/runtime-role.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { getOpsKnightProcessRole, getRuntimeResponsibilities } from '@/lib/runtime-role';
 
 describe('runtime process roles', () => {
-  it('preserves the existing integrated runtime by default', () => {
+  it('preserves the integrated runtime by default and processes durable jobs in-process', () => {
     expect(getOpsKnightProcessRole(undefined)).toBe('integrated');
     expect(getRuntimeResponsibilities('integrated')).toEqual({
       startScheduler: true,
-      startJobWorker: false,
+      startJobWorker: true,
     });
   });
 


### PR DESCRIPTION
Moves event side-effects to OpsKnight's existing PostgreSQL BackgroundJob queue. Event transactions atomically enqueue SCHEDULED_TASK / EVENT_SIDE_EFFECT jobs for webhooks, escalation/notifications, Slack, and ChatOps, then return without waiting on external network work. Integrated mode starts the existing bounded job worker in-process so Docker Compose/single-process installs need no extra service. Adds real-DB outbox coverage and queue/runtime tests. No Helm, Kustomize, HPA, PgBouncer, Docker Compose manifest, or schema changes. Draft only; do not merge until CI and short 100 RPS validation are green.