### PR TITLE
fix(dashboard): clarify active incident counts

### DIFF
--- a/src/app/(app)/incidents/page.tsx
+++ b/src/app/(app)/incidents/page.tsx
@@ -98,7 +98,7 @@ export default async function IncidentsPage({
 
   // Aggregate status counts from groupBy result
   const statusCountMap = new Map(statusCounts.map(s => [s.status, s._count._all]));
-  const openCount = (statusCountMap.get('OPEN') || 0) + (statusCountMap.get('ACKNOWLEDGED') || 0);
+  const activeCount = (statusCountMap.get('OPEN') || 0) + (statusCountMap.get('ACKNOWLEDGED') || 0);
   const resolvedCount = statusCountMap.get('RESOLVED') || 0;
   const snoozedCount = statusCountMap.get('SNOOZED') || 0;
   const suppressedCount = statusCountMap.get('SUPPRESSED') || 0;
@@ -149,8 +149,8 @@ export default async function IncidentsPage({
             </Card>
             <Card className="bg-white/10 border-white/20 backdrop-blur">
               <CardContent className="p-3 md:p-4 text-center">
-                <div className="text-xl md:text-2xl font-extrabold text-red-200">{openCount}</div>
-                <div className="text-[10px] md:text-xs opacity-90">Open</div>
+                <div className="text-xl md:text-2xl font-extrabold text-red-200">{activeCount}</div>
+                <div className="text-[10px] md:text-xs opacity-90">Active</div>
               </CardContent>
             </Card>
             <Card className="bg-white/10 border-white/20 backdrop-blur">

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -278,17 +278,17 @@ export default async function Dashboard({
   const metricsTotalCount = slaMetrics.totalIncidents;
   const metricsOpenCount = slaMetrics.statusMix.find(s => s.status === 'OPEN')?.count ?? 0;
   const metricsResolvedCount = slaMetrics.statusMix.find(s => s.status === 'RESOLVED')?.count ?? 0;
+  const currentPeriodAcknowledged =
+    slaMetrics.statusMix.find(s => s.status === 'ACKNOWLEDGED')?.count ?? 0;
+  const metricsActiveCount = metricsOpenCount + currentPeriodAcknowledged;
   const unassignedCount = slaMetrics.unassignedActive;
 
   const allActiveIncidentsCount =
     slaMetrics.activeIncidents ??
     slaMetrics.activeCount ??
     slaMetrics.openCount + slaMetrics.acknowledgedCount;
-  const allOpenIncidentsCount = allActiveIncidentsCount;
   const allAcknowledgedCount = slaMetrics.acknowledgedCount;
   const currentCriticalActive = slaMetrics.criticalCount;
-  const currentPeriodAcknowledged =
-    slaMetrics.statusMix.find(s => s.status === 'ACKNOWLEDGED')?.count ?? 0;
   const mttaMinutes = slaMetrics.mttd;
 
   // Calculate system status
@@ -412,8 +412,9 @@ export default async function Dashboard({
       >
         <DashboardCommandCenter
           systemStatus={systemStatus}
-          allOpenIncidentsCount={allOpenIncidentsCount}
+          allActiveIncidentsCount={allActiveIncidentsCount}
           totalInRange={totalInRange}
+          metricsActiveCount={metricsActiveCount}
           metricsOpenCount={metricsOpenCount}
           metricsResolvedCount={metricsResolvedCount}
           unassignedCount={unassignedCount}

--- a/src/components/DashboardExport.tsx
+++ b/src/components/DashboardExport.tsx
@@ -17,7 +17,8 @@ type ExportProps = {
     endDate?: string;
   };
   metrics: {
-    totalOpen: number;
+    totalActive: number;
+    totalTriggered: number;
     totalResolved: number;
     totalAcknowledged: number;
     unassigned: number;
@@ -85,7 +86,8 @@ export default function DashboardExport({ incidents, filters, metrics }: ExportP
 
     // Metrics Summary
     csvRows.push('Metrics Summary:');
-    csvRows.push(`Open Incidents,${metrics.totalOpen}`);
+    csvRows.push(`Active Incidents,${metrics.totalActive}`);
+    csvRows.push(`Triggered Incidents,${metrics.totalTriggered}`);
     csvRows.push(`Resolved Incidents,${metrics.totalResolved}`);
     csvRows.push(`Acknowledged Incidents,${metrics.totalAcknowledged}`);
     csvRows.push(`Unassigned Incidents,${metrics.unassigned}`);

--- a/src/components/dashboard/DashboardCommandCenter.tsx
+++ b/src/components/dashboard/DashboardCommandCenter.tsx
@@ -17,8 +17,9 @@ type SystemStatus = {
 
 type DashboardCommandCenterProps = {
   systemStatus: SystemStatus;
-  allOpenIncidentsCount: number;
+  allActiveIncidentsCount: number;
   totalInRange: number;
+  metricsActiveCount: number;
   metricsOpenCount: number;
   metricsResolvedCount: number;
   unassignedCount: number;
@@ -34,8 +35,9 @@ type DashboardCommandCenterProps = {
 
 export default function DashboardCommandCenter({
   systemStatus,
-  allOpenIncidentsCount,
+  allActiveIncidentsCount,
   totalInRange,
+  metricsActiveCount,
   metricsOpenCount,
   metricsResolvedCount,
   unassignedCount,
@@ -89,9 +91,9 @@ export default function DashboardCommandCenter({
             >
               {systemStatus.label}
             </Badge>
-            {allOpenIncidentsCount > 0 && (
+            {allActiveIncidentsCount > 0 && (
               <span className="text-xs text-primary-foreground/80">
-                ({allOpenIncidentsCount} active)
+                ({allActiveIncidentsCount} active)
               </span>
             )}
             <Badge
@@ -126,7 +128,8 @@ export default function DashboardCommandCenter({
               incidents={incidents}
               filters={filters}
               metrics={{
-                totalOpen: metricsOpenCount,
+                totalActive: metricsActiveCount,
+                totalTriggered: metricsOpenCount,
                 totalResolved: metricsResolvedCount,
                 totalAcknowledged: currentPeriodAcknowledged,
                 unassigned: unassignedCount,
@@ -138,7 +141,14 @@ export default function DashboardCommandCenter({
 
       <div className="relative z-10 grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
         <MetricCard label="TOTAL" value={totalInRange} rangeLabel={rangeLabel} variant="hero" />
-        <MetricCard label="OPEN" value={metricsOpenCount} rangeLabel={rangeLabel} variant="hero" />
+        <MetricCard
+          label="ACTIVE"
+          value={metricsActiveCount}
+          rangeLabel={rangeLabel}
+          description={`${metricsOpenCount.toLocaleString()} Triggered · ${currentPeriodAcknowledged.toLocaleString()} Acknowledged`}
+          href="/incidents?filter=all_open"
+          variant="hero"
+        />
         <MetricCard
           label="RESOLVED"
           value={metricsResolvedCount}

--- a/src/components/dashboard/DashboardIncidentFilters.tsx
+++ b/src/components/dashboard/DashboardIncidentFilters.tsx
@@ -289,7 +289,7 @@ export default function DashboardIncidentFilters({
               </SelectTrigger>
               <SelectContent className="rounded-lg">
                 <SelectItem value="all">All statuses</SelectItem>
-                <SelectItem value="OPEN">Open</SelectItem>
+                <SelectItem value="OPEN">Triggered</SelectItem>
                 <SelectItem value="ACKNOWLEDGED">Acknowledged</SelectItem>
                 <SelectItem value="RESOLVED">Resolved</SelectItem>
                 <SelectItem value="SNOOZED">Snoozed</SelectItem>

--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useRef, memo } from 'react';
+import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
 type MetricCardProps = {
@@ -9,6 +10,8 @@ type MetricCardProps = {
   rangeLabel?: string;
   isDark?: boolean;
   variant?: 'default' | 'hero';
+  description?: string;
+  href?: string;
 };
 
 /**
@@ -83,6 +86,8 @@ const MetricCard = memo(function MetricCard({
   rangeLabel,
   isDark = false,
   variant = 'default',
+  description,
+  href,
 }: MetricCardProps) {
   // Parse value and determine if we should animate
   const { shouldAnimate, numericEnd, displayString } = React.useMemo(() => {
@@ -120,7 +125,7 @@ const MetricCard = memo(function MetricCard({
 
   const isHero = variant === 'hero';
 
-  return (
+  const card = (
     <div
       className={cn(
         'relative overflow-hidden text-center transition-all duration-300',
@@ -136,7 +141,7 @@ const MetricCard = memo(function MetricCard({
         isHero ? 'p-3 md:p-4' : 'p-6 sm:p-4'
       )}
       role="figure"
-      aria-label={`${label}: ${formattedDisplay}${rangeLabel ? ` ${rangeLabel}` : ''}`}
+      aria-label={`${label}: ${formattedDisplay}${description ? `. ${description}` : ''}${rangeLabel ? ` ${rangeLabel}` : ''}`}
     >
       {/* Accent bar for default variant */}
       {!isDark && !isHero && (
@@ -164,7 +169,29 @@ const MetricCard = memo(function MetricCard({
       >
         {label} {rangeLabel && <span className="opacity-80 text-[0.7rem]">{rangeLabel}</span>}
       </div>
+      {description && (
+        <div
+          className={cn(
+            'mt-1 text-[0.7rem] leading-tight relative z-10',
+            isDark || isHero ? 'text-white/75' : 'text-muted-foreground'
+          )}
+        >
+          {description}
+        </div>
+      )}
     </div>
+  );
+
+  if (!href) return card;
+
+  return (
+    <Link
+      href={href}
+      className="block rounded-lg no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+      aria-label={`View ${label.toLowerCase()} incidents`}
+    >
+      {card}
+    </Link>
   );
 });
 

--- a/src/components/incident/IncidentsFilters.tsx
+++ b/src/components/incident/IncidentsFilters.tsx
@@ -278,7 +278,9 @@ export default function IncidentsFilters({
           </div>
 
           <div className="space-y-1.5">
-            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">Status</Label>
+            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">
+              Status
+            </Label>
             <Select value={currentFilter} onValueChange={val => updateParams({ filter: val })}>
               <SelectTrigger className="h-9 bg-muted/30 focus:bg-background transition-colors text-sm">
                 <div className="flex items-center gap-2">
@@ -291,7 +293,7 @@ export default function IncidentsFilters({
                 <SelectItem value="all_open">
                   <div className="flex items-center gap-2">
                     <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
-                    <span>Open</span>
+                    <span>Active</span>
                   </div>
                 </SelectItem>
                 <SelectItem value="mine">
@@ -323,7 +325,9 @@ export default function IncidentsFilters({
           </div>
 
           <div className="space-y-1.5">
-            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">Team</Label>
+            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">
+              Team
+            </Label>
             <Select value={currentTeamId} onValueChange={val => updateParams({ teamId: val })}>
               <SelectTrigger className="h-9 bg-muted/30 focus:bg-background transition-colors text-sm">
                 <div className="flex items-center gap-2">
@@ -344,7 +348,9 @@ export default function IncidentsFilters({
           </div>
 
           <div className="space-y-1.5">
-            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">Urgency</Label>
+            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">
+              Urgency
+            </Label>
             <Select
               value={currentUrgency}
               onValueChange={val => updateParams({ urgency: val === 'all' ? 'all' : val })}
@@ -380,7 +386,9 @@ export default function IncidentsFilters({
           </div>
 
           <div className="space-y-1.5">
-            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">Sort</Label>
+            <Label className="text-[11px] font-semibold uppercase text-muted-foreground">
+              Sort
+            </Label>
             <Select
               value={currentSort}
               onValueChange={val => updateParams({ sort: val === 'newest' ? 'newest' : val })}

--- a/tests/components/metric-card.test.tsx
+++ b/tests/components/metric-card.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import MetricCard from '@/components/dashboard/MetricCard';
+
+describe('MetricCard', () => {
+  it('shows an operational breakdown and links to the matching incident filter', () => {
+    render(
+      <MetricCard
+        label="ACTIVE"
+        value={396}
+        description="187 Triggered · 209 Acknowledged"
+        href="/incidents?filter=all_open"
+        variant="hero"
+      />
+    );
+
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    expect(screen.getByText('187 Triggered · 209 Acknowledged')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View active incidents' })).toHaveAttribute(
+      'href',
+      '/incidents?filter=all_open'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Makes dashboard incident counts use clear operational language without changing the incident database state machine.

## Problem

The command-center header counted both `OPEN` and `ACKNOWLEDGED` incidents as active, while the hero card showed only strict database `OPEN` incidents. Because acknowledged incidents were not visible in the headline cards, the dashboard totals appeared inconsistent.

## Changes

- replace the dashboard `OPEN` hero card with `ACTIVE`;
- calculate Active as Triggered (`OPEN`) + Acknowledged;
- show the breakdown directly below the Active total;
- make the Active card link to the existing combined active-incidents filter;
- label strict database `OPEN` filters as `Triggered`;
- rename combined `OPEN` + `ACKNOWLEDGED` counts to `Active` on the incidents page;
- align CSV dashboard exports with Active, Triggered, and Acknowledged terminology;
- add component coverage for the breakdown and filter link.

## Compatibility

- no Prisma schema or migration changes;
- no incident status or lifecycle changes;
- no API contract changes;
- existing `all_open` URLs remain supported.

## Validation

- TypeScript: passed
- Targeted dashboard tests: 23 passed
- ESLint: no errors in changed files
