### PR TITLE
fix(incidents): make lifecycle notifications idempotent

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -46,7 +46,7 @@ export async function updateIncidentStatus(
   } catch (error) {
     throw new Error(getUserFriendlyError(error));
   }
-  const currentIncident = await runSerializableTransaction(async tx => {
+  const transition = await runSerializableTransaction(async tx => {
     // Get current incident to check if we're setting acknowledgedAt for the first time
     const incident = await tx.incident.findUnique({
       where: { id },
@@ -59,7 +59,7 @@ export async function updateIncidentStatus(
     // A retry whose desired result already exists is successful even if its
     // expected source state is now stale because the first attempt committed.
     if (incident.status === status) {
-      return incident;
+      return { previousStatus: incident.status, changed: false };
     }
     if (expectedStatus && incident.status !== expectedStatus) {
       throw new Error(
@@ -173,8 +173,12 @@ export async function updateIncidentStatus(
       data: updateData,
     });
 
-    return incident;
+    return { previousStatus: incident.status, changed: true };
   });
+
+  if (!transition.changed) {
+    return;
+  }
 
   // Send service-level notifications for status changes
   // Uses user preferences for each recipient
@@ -184,7 +188,7 @@ export async function updateIncidentStatus(
       await sendIncidentNotifications(id, 'acknowledged');
     } else if (status === 'RESOLVED') {
       await sendIncidentNotifications(id, 'resolved');
-    } else if (status === 'OPEN' && currentIncident?.status !== 'OPEN') {
+    } else if (status === 'OPEN' && transition.previousStatus !== 'OPEN') {
       // Status changed to OPEN (e.g., from snoozed/acknowledged)
       await sendIncidentNotifications(id, 'updated');
     }
@@ -287,7 +291,7 @@ export async function resolveIncidentWithNote(id: string, resolution: string) {
   }
   const user = await getCurrentUser();
 
-  await runSerializableTransaction(async tx => {
+  const resolvedNow = await runSerializableTransaction(async tx => {
     // Get current incident to check if we're setting resolvedAt for the first time
     const currentIncident = await tx.incident.findUnique({ where: { id } });
     if (!currentIncident) {
@@ -296,7 +300,7 @@ export async function resolveIncidentWithNote(id: string, resolution: string) {
 
     // Idempotency check: If already resolved, prevent duplicate resolution notes
     if (currentIncident.status === 'RESOLVED') {
-      return;
+      return false;
     }
     await assertRequiredCustomFieldsPresent(tx, id);
 
@@ -341,7 +345,13 @@ export async function resolveIncidentWithNote(id: string, resolution: string) {
         },
       });
     }
+
+    return true;
   });
+
+  if (!resolvedNow) {
+    return;
+  }
 
   // Send service-level notifications for resolution
   // Uses user preferences for each recipient

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -19,7 +19,7 @@ export async function sendNotification(
   message: string,
   incident?: Incident & { service?: Service | null }
 ) {
-  // Check for duplicate pending/sent notification within debounce window (60s)
+  // Check for duplicate pending/sent notification with the same payload within debounce window (60s)
   if (typeof prisma.notification?.findFirst === 'function') {
     const debounceWindow = new Date(Date.now() - 60_000);
     const existingNotification = await prisma.notification.findFirst({
@@ -27,6 +27,7 @@ export async function sendNotification(
         incidentId,
         userId,
         channel,
+        message,
         status: { in: ['SENT', 'PENDING'] },
         createdAt: { gte: debounceWindow },
       },

--- a/tests/actions/incident-status-idempotency.test.ts
+++ b/tests/actions/incident-status-idempotency.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runSerializableTransaction: vi.fn(),
+  assertCanModifyIncident: vi.fn(),
+  getCurrentUser: vi.fn(),
+  sendIncidentNotifications: vi.fn(),
+  scheduleStatusPageNotification: vi.fn(),
+  archiveWarRoomChannel: vi.fn(),
+  postWarRoomUpdate: vi.fn(),
+  updateWarRoomTopic: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+vi.mock('@/lib/db-utils', () => ({
+  runSerializableTransaction: mocks.runSerializableTransaction,
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  assertCanModifyIncident: mocks.assertCanModifyIncident,
+  assertResponderOrAbove: vi.fn(),
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+vi.mock('@/lib/user-friendly-errors', () => ({
+  getUserFriendlyError: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock('@/lib/user-notifications', () => ({
+  sendIncidentNotifications: mocks.sendIncidentNotifications,
+}));
+
+vi.mock('@/lib/jobs/queue', () => ({
+  scheduleStatusPageNotification: mocks.scheduleStatusPageNotification,
+}));
+
+vi.mock('@/lib/chatops/war-room', () => ({
+  archiveWarRoomChannel: mocks.archiveWarRoomChannel,
+  postWarRoomUpdate: mocks.postWarRoomUpdate,
+  updateWarRoomTopic: mocks.updateWarRoomTopic,
+}));
+
+import { resolveIncidentWithNote, updateIncidentStatus } from '@/app/(app)/incidents/actions';
+
+describe('incident lifecycle action idempotency', () => {
+  const tx = {
+    incident: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    customField: {
+      findMany: vi.fn(),
+    },
+    incidentNote: {
+      create: vi.fn(),
+    },
+    incidentEvent: {
+      create: vi.fn(),
+    },
+  };
+
+  type TransactionCallback = (client: typeof tx) => unknown | Promise<unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.assertCanModifyIncident.mockResolvedValue(undefined);
+    mocks.getCurrentUser.mockResolvedValue({ id: 'user-1', name: 'Responder' });
+    mocks.sendIncidentNotifications.mockResolvedValue({ success: true });
+    mocks.scheduleStatusPageNotification.mockResolvedValue(undefined);
+    mocks.archiveWarRoomChannel.mockResolvedValue(undefined);
+    mocks.postWarRoomUpdate.mockResolvedValue(undefined);
+    mocks.updateWarRoomTopic.mockResolvedValue(undefined);
+    mocks.runSerializableTransaction.mockImplementation(async (callback: TransactionCallback) =>
+      callback(tx)
+    );
+  });
+
+  it('does not repeat side effects when ACK is retried after it already committed', async () => {
+    tx.incident.findUnique.mockResolvedValue({
+      status: 'ACKNOWLEDGED',
+      acknowledgedAt: new Date(),
+      resolvedAt: null,
+      currentEscalationStep: 0,
+    });
+
+    await updateIncidentStatus('inc-1', 'ACKNOWLEDGED', 'OPEN');
+
+    expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
+    expect(mocks.scheduleStatusPageNotification).not.toHaveBeenCalled();
+    expect(mocks.postWarRoomUpdate).not.toHaveBeenCalled();
+    expect(mocks.updateWarRoomTopic).not.toHaveBeenCalled();
+    expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('does not repeat resolution effects or notes when resolve-with-note is retried', async () => {
+    tx.incident.findUnique.mockResolvedValue({
+      id: 'inc-1',
+      status: 'RESOLVED',
+      resolvedAt: new Date(),
+    });
+
+    await resolveIncidentWithNote('inc-1', 'Resolved after database failover');
+
+    expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(tx.incidentNote.create).not.toHaveBeenCalled();
+    expect(tx.incidentEvent.create).not.toHaveBeenCalled();
+    expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
+    expect(mocks.scheduleStatusPageNotification).not.toHaveBeenCalled();
+    expect(mocks.archiveWarRoomChannel).not.toHaveBeenCalled();
+    expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('still runs lifecycle effects for a real status transition', async () => {
+    tx.incident.findUnique.mockResolvedValue({
+      status: 'OPEN',
+      acknowledgedAt: null,
+      resolvedAt: null,
+      currentEscalationStep: 0,
+    });
+    tx.incident.update.mockResolvedValue({});
+
+    await updateIncidentStatus('inc-1', 'ACKNOWLEDGED', 'OPEN');
+
+    expect(tx.incident.update).toHaveBeenCalledOnce();
+    expect(mocks.sendIncidentNotifications).toHaveBeenCalledWith('inc-1', 'acknowledged');
+    expect(mocks.scheduleStatusPageNotification).toHaveBeenCalledWith('inc-1', 'acknowledged');
+    expect(mocks.postWarRoomUpdate).toHaveBeenCalledOnce();
+    expect(mocks.updateWarRoomTopic).toHaveBeenCalledWith('inc-1', 'ACKNOWLEDGED');
+  });
+});

--- a/tests/lib/notifications.test.ts
+++ b/tests/lib/notifications.test.ts
@@ -3,10 +3,14 @@ import { sendNotification } from '@/lib/notifications';
 import prisma from '@/lib/prisma';
 import * as emailModule from '@/lib/email';
 
+type NotificationFindResult = Awaited<ReturnType<typeof prisma.notification.findFirst>>;
+type NotificationCreateResult = Awaited<ReturnType<typeof prisma.notification.create>>;
+type IncidentFindResult = Awaited<ReturnType<typeof prisma.incident.findUnique>>;
+
 vi.mock('@/lib/prisma', () => ({
   __esModule: true,
   default: {
-    notification: { create: vi.fn(), update: vi.fn() },
+    notification: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
     incident: { findUnique: vi.fn() },
     incidentEvent: { create: vi.fn() },
   },
@@ -54,6 +58,59 @@ describe('Notifications Library', () => {
         data: expect.objectContaining({ status: 'SENT' }),
       })
     );
+  });
+
+  it('should debounce an identical recent notification payload', async () => {
+    const message = '[API] Incident triggered: CPU high';
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue(
+      { id: 'notif-existing' } as unknown as NotificationFindResult
+    );
+
+    const result = await sendNotification('inc-1', 'user-1', 'EMAIL', message);
+
+    expect(result).toEqual({
+      success: true,
+      notificationId: 'notif-existing',
+      debounced: true,
+    });
+    expect(prisma.notification.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          incidentId: 'inc-1',
+          userId: 'user-1',
+          channel: 'EMAIL',
+          message,
+        }),
+      })
+    );
+    expect(prisma.notification.create).not.toHaveBeenCalled();
+    expect(emailModule.sendIncidentEmail).not.toHaveBeenCalled();
+  });
+
+  it('should not let a recent trigger notification suppress a resolved lifecycle message', async () => {
+    const resolvedMessage = '[API] Incident resolved: CPU high';
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.notification.create).mockResolvedValue(
+      { id: 'notif-resolved', attempts: 0 } as unknown as NotificationCreateResult
+    );
+    vi.mocked(prisma.incident.findUnique).mockResolvedValue(
+      {
+        id: 'inc-1',
+        status: 'RESOLVED',
+      } as unknown as IncidentFindResult
+    );
+    vi.mocked(emailModule.sendIncidentEmail).mockResolvedValue({ success: true });
+
+    const result = await sendNotification('inc-1', 'user-1', 'EMAIL', resolvedMessage);
+
+    expect(result.success).toBe(true);
+    expect(prisma.notification.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ message: resolvedMessage }),
+      })
+    );
+    expect(prisma.notification.create).toHaveBeenCalled();
+    expect(emailModule.sendIncidentEmail).toHaveBeenCalledWith('user-1', 'inc-1', 'resolved');
   });
 
   it('should route to WHATSAPP channel correctly', async () => {


### PR DESCRIPTION
## Summary

Fix two incident notification/idempotency bugs without changing escalation, on-call, DST, or incident lifecycle semantics.

### Fixes
- Treat repeated manual ACK/RESOLVE requests as successful no-ops after the desired state is already committed, so retries do not resend user notifications, status-page notifications, or ChatOps updates.
- Scope the 60-second notification debounce to the same notification message, so a recent `triggered` notification cannot suppress a legitimate `acknowledged` or `resolved` lifecycle notification on the same incident/user/channel.

### Tests
- duplicate ACK does not repeat side effects
- duplicate resolve-with-note does not repeat notes or lifecycle side effects
- genuine status transitions still execute lifecycle effects
- identical notification payloads still debounce
- different lifecycle messages are not suppressed by the debounce window

The PR is intentionally narrow and contains exactly one commit.