### PR TITLE
fix(sla): prevent duplicate SLA breach notifications and redundant shift handoffs

### DIFF
--- a/src/lib/oncall-handoff.ts
+++ b/src/lib/oncall-handoff.ts
@@ -31,19 +31,23 @@ export async function processUpcomingShiftReminders(
       const currentUserId = currentOnCallMap.get(shift.scheduleId);
       // Only remind if the responder is taking over or shift is starting
       if (currentUserId !== shift.userId) {
-        const minutesUntilStart = Math.max(1, Math.round((shift.start.getTime() - now.getTime()) / 60000));
+        const minutesUntilStart = Math.max(
+          1,
+          Math.round((shift.start.getTime() - now.getTime()) / 60000)
+        );
 
         // Deduplicate in-app notification within the last 45 minutes
-        const recentNotification = typeof prisma.inAppNotification?.findFirst === 'function'
-          ? await prisma.inAppNotification.findFirst({
-              where: {
-                userId: shift.userId,
-                type: 'SCHEDULE',
-                entityId: shift.scheduleId,
-                createdAt: { gte: new Date(now.getTime() - 45 * 60 * 1000) },
-              },
-            })
-          : null;
+        const recentNotification =
+          typeof prisma.inAppNotification?.findFirst === 'function'
+            ? await prisma.inAppNotification.findFirst({
+                where: {
+                  userId: shift.userId,
+                  type: 'SCHEDULE',
+                  entityId: shift.scheduleId,
+                  createdAt: { gte: new Date(now.getTime() - 45 * 60 * 1000) },
+                },
+              })
+            : null;
 
         if (!recentNotification) {
           await createInAppNotifications({
@@ -122,7 +126,12 @@ export async function processShiftRotations(now: Date = new Date()): Promise<Shi
             select: { id: true, title: true, status: true, assigneeId: true },
           });
 
-          for (const incident of activeIncidents) {
+          // Only reassign incidents that are not already assigned to the incoming responder
+          const incidentsToReassign = activeIncidents.filter(
+            incident => incident.assigneeId !== currentShift.userId
+          );
+
+          for (const incident of incidentsToReassign) {
             // Reassign to incoming responder
             await prisma.incident.update({
               where: { id: incident.id },
@@ -141,13 +150,13 @@ export async function processShiftRotations(now: Date = new Date()): Promise<Shi
             result.incidentsReassigned++;
           }
 
-          // Send handoff summary digest to incoming responder
-          if (activeIncidents.length > 0) {
+          // Send handoff summary digest to incoming responder only if incidents were reassigned
+          if (incidentsToReassign.length > 0) {
             await createInAppNotifications({
               userIds: [currentShift.userId],
               type: 'INCIDENT',
               title: 'Shift Handoff: Active Incidents',
-              message: `You took over on-call for "${currentShift.schedule.name}" with ${activeIncidents.length} active incident(s).`,
+              message: `You took over on-call for "${currentShift.schedule.name}" with ${incidentsToReassign.length} active incident(s).`,
               entityType: 'SCHEDULE',
               entityId: currentShift.scheduleId,
             });

--- a/src/lib/sla-breach-monitor.ts
+++ b/src/lib/sla-breach-monitor.ts
@@ -141,15 +141,15 @@ export async function checkSLABreaches(
             incidentId: { in: incidentIds },
             OR: [
               // Breach events are deduplicated for the full lifetime of the open incident
-              { message: { startsWith: '🚨 SLA ACK Breached' } },
-              { message: { startsWith: '🚨 SLA RESOLVE Breached' } },
+              { message: { contains: 'SLA ACK Breached', mode: 'insensitive' } },
+              { message: { contains: 'SLA RESOLVE Breached', mode: 'insensitive' } },
               // Warning events are deduplicated within the recent threshold window
               {
-                message: { startsWith: '⏰ SLA ACK Warning' },
+                message: { contains: 'SLA ACK Warning', mode: 'insensitive' },
                 createdAt: { gte: new Date(now.getTime() - maxThreshold) },
               },
               {
-                message: { startsWith: '⚠️ SLA RESOLVE Warning' },
+                message: { contains: 'SLA RESOLVE Warning', mode: 'insensitive' },
                 createdAt: { gte: new Date(now.getTime() - maxThreshold) },
               },
             ],
@@ -160,13 +160,12 @@ export async function checkSLABreaches(
 
   const recentWarningMap = new Set<string>();
   for (const evt of recentWarningEvents) {
-    if (evt.message.startsWith('🚨 SLA ACK Breached'))
-      recentWarningMap.add(`${evt.incidentId}:ack:breached`);
-    if (evt.message.startsWith('⏰ SLA ACK Warning'))
-      recentWarningMap.add(`${evt.incidentId}:ack:warning`);
-    if (evt.message.startsWith('🚨 SLA RESOLVE Breached'))
+    const msg = (evt.message || '').toUpperCase();
+    if (msg.includes('SLA ACK BREACHED')) recentWarningMap.add(`${evt.incidentId}:ack:breached`);
+    if (msg.includes('SLA ACK WARNING')) recentWarningMap.add(`${evt.incidentId}:ack:warning`);
+    if (msg.includes('SLA RESOLVE BREACHED'))
       recentWarningMap.add(`${evt.incidentId}:resolve:breached`);
-    if (evt.message.startsWith('⚠️ SLA RESOLVE Warning'))
+    if (msg.includes('SLA RESOLVE WARNING'))
       recentWarningMap.add(`${evt.incidentId}:resolve:warning`);
   }
 
@@ -278,6 +277,7 @@ export async function checkSLABreaches(
             await prisma.incidentEvent.create({
               data: {
                 incidentId: incident.id,
+                type: isBreached ? 'ESCALATED' : 'COMMENT',
                 message: isBreached
                   ? `🚨 SLA RESOLVE Breached: target was ${resolveTargetMinutes} min`
                   : `⚠️ SLA RESOLVE Warning: ${Math.max(1, Math.round(resolveRemainingMs / 60000))} min remaining`,

--- a/tests/lib/oncall-handoff.test.ts
+++ b/tests/lib/oncall-handoff.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { processShiftRotations } from '@/lib/oncall-handoff';
+
+// Mock prisma
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    escalationPolicy: {
+      findMany: vi.fn(),
+    },
+    incident: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    incidentEvent: {
+      create: vi.fn(),
+    },
+    inAppNotification: {
+      findFirst: vi.fn(),
+      createMany: vi.fn(),
+    },
+  },
+}));
+
+// Mock oncall-shifts
+vi.mock('@/lib/oncall-shifts', () => ({
+  getActiveOnCallShifts: vi.fn(),
+}));
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock in-app-notifications
+vi.mock('@/lib/in-app-notifications', () => ({
+  createInAppNotifications: vi.fn().mockResolvedValue([]),
+}));
+
+describe('oncall-handoff', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+  });
+
+  describe('processShiftRotations', () => {
+    it('reassigns active incidents when shift rotates and incident is assigned to outgoing user', async () => {
+      const { default: prisma } = await import('@/lib/prisma');
+      const { getActiveOnCallShifts } = await import('@/lib/oncall-shifts');
+
+      const now = new Date('2026-08-26T06:31:00Z');
+
+      // Past shift (5m ago) was User A, current shift is User B
+      vi.mocked(getActiveOnCallShifts).mockImplementation(async (time: Date = new Date()) => {
+        if (time.getTime() < now.getTime()) {
+          return [
+            {
+              scheduleId: 'sched-1',
+              userId: 'user-a',
+              schedule: { name: 'Devops Schedule' },
+              user: { name: 'User A' },
+            } as any,
+          ];
+        }
+        return [
+          {
+            scheduleId: 'sched-1',
+            userId: 'user-b',
+            schedule: { name: 'Devops Schedule' },
+            user: { name: 'User B' },
+          } as any,
+        ];
+      });
+
+      vi.mocked(prisma.escalationPolicy.findMany).mockResolvedValue([
+        { id: 'ep-1', services: [{ id: 'svc-1' }] } as any,
+      ]);
+
+      vi.mocked(prisma.incident.findMany).mockResolvedValue([
+        { id: 'inc-1', title: 'Open issue', status: 'OPEN', assigneeId: 'user-a' } as any,
+      ]);
+
+      const result = await processShiftRotations(now);
+
+      expect(result.rotationsProcessed).toBe(1);
+      expect(result.incidentsReassigned).toBe(1);
+      expect(prisma.incident.update).toHaveBeenCalledWith({
+        where: { id: 'inc-1' },
+        data: { assigneeId: 'user-b' },
+      });
+      expect(prisma.incidentEvent.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT create duplicate reassignment or timeline events if incident is already assigned to incoming responder', async () => {
+      const { default: prisma } = await import('@/lib/prisma');
+      const { getActiveOnCallShifts } = await import('@/lib/oncall-shifts');
+
+      const now = new Date('2026-08-26T06:33:00Z');
+
+      // Cron running 2 minutes later: shift rotation lookback still sees transition, but incident is already User B
+      vi.mocked(getActiveOnCallShifts).mockImplementation(async (time: Date = new Date()) => {
+        if (time.getTime() < now.getTime()) {
+          return [
+            {
+              scheduleId: 'sched-1',
+              userId: 'user-a',
+              schedule: { name: 'Devops Schedule' },
+              user: { name: 'User B' },
+            } as any,
+          ];
+        }
+        return [
+          {
+            scheduleId: 'sched-1',
+            userId: 'user-b',
+            schedule: { name: 'Devops Schedule' },
+            user: { name: 'User B' },
+          } as any,
+        ];
+      });
+
+      vi.mocked(prisma.escalationPolicy.findMany).mockResolvedValue([
+        { id: 'ep-1', services: [{ id: 'svc-1' }] } as any,
+      ]);
+
+      // Incident is already assigned to user-b
+      vi.mocked(prisma.incident.findMany).mockResolvedValue([
+        { id: 'inc-1', title: 'Open issue', status: 'OPEN', assigneeId: 'user-b' } as any,
+      ]);
+
+      const result = await processShiftRotations(now);
+
+      expect(result.rotationsProcessed).toBe(1);
+      expect(result.incidentsReassigned).toBe(0);
+      expect(prisma.incident.update).not.toHaveBeenCalled();
+      expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/lib/oncall-handoff.test.ts
+++ b/tests/lib/oncall-handoff.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { processShiftRotations } from '@/lib/oncall-handoff';
+import type { DynamicOnCallShift } from '@/lib/oncall-shifts';
 
 // Mock prisma
 vi.mock('@/lib/prisma', () => ({
@@ -58,30 +59,36 @@ describe('oncall-handoff', () => {
         if (time.getTime() < now.getTime()) {
           return [
             {
+              id: 'shift-1',
               scheduleId: 'sched-1',
               userId: 'user-a',
-              schedule: { name: 'Devops Schedule' },
-              user: { name: 'User A' },
-            } as any,
+              schedule: { id: 'sched-1', name: 'Devops Schedule' },
+              user: { id: 'user-a', name: 'User A' },
+              start: new Date(now.getTime() - 60 * 60 * 1000),
+              end: now,
+            } as unknown as DynamicOnCallShift,
           ];
         }
         return [
           {
+            id: 'shift-2',
             scheduleId: 'sched-1',
             userId: 'user-b',
-            schedule: { name: 'Devops Schedule' },
-            user: { name: 'User B' },
-          } as any,
+            schedule: { id: 'sched-1', name: 'Devops Schedule' },
+            user: { id: 'user-b', name: 'User B' },
+            start: now,
+            end: new Date(now.getTime() + 60 * 60 * 1000),
+          } as unknown as DynamicOnCallShift,
         ];
       });
 
       vi.mocked(prisma.escalationPolicy.findMany).mockResolvedValue([
-        { id: 'ep-1', services: [{ id: 'svc-1' }] } as any,
-      ]);
+        { id: 'ep-1', services: [{ id: 'svc-1' }] },
+      ] as unknown as Awaited<ReturnType<typeof prisma.escalationPolicy.findMany>>);
 
       vi.mocked(prisma.incident.findMany).mockResolvedValue([
-        { id: 'inc-1', title: 'Open issue', status: 'OPEN', assigneeId: 'user-a' } as any,
-      ]);
+        { id: 'inc-1', title: 'Open issue', status: 'OPEN', assigneeId: 'user-a' },
+      ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
 
       const result = await processShiftRotations(now);
 
@@ -105,31 +112,37 @@ describe('oncall-handoff', () => {
         if (time.getTime() < now.getTime()) {
           return [
             {
+              id: 'shift-1',
               scheduleId: 'sched-1',
               userId: 'user-a',
-              schedule: { name: 'Devops Schedule' },
-              user: { name: 'User B' },
-            } as any,
+              schedule: { id: 'sched-1', name: 'Devops Schedule' },
+              user: { id: 'user-a', name: 'User A' },
+              start: new Date(now.getTime() - 60 * 60 * 1000),
+              end: new Date(now.getTime() - 2 * 60 * 1000),
+            } as unknown as DynamicOnCallShift,
           ];
         }
         return [
           {
+            id: 'shift-2',
             scheduleId: 'sched-1',
             userId: 'user-b',
-            schedule: { name: 'Devops Schedule' },
-            user: { name: 'User B' },
-          } as any,
+            schedule: { id: 'sched-1', name: 'Devops Schedule' },
+            user: { id: 'user-b', name: 'User B' },
+            start: new Date(now.getTime() - 2 * 60 * 1000),
+            end: new Date(now.getTime() + 60 * 60 * 1000),
+          } as unknown as DynamicOnCallShift,
         ];
       });
 
       vi.mocked(prisma.escalationPolicy.findMany).mockResolvedValue([
-        { id: 'ep-1', services: [{ id: 'svc-1' }] } as any,
-      ]);
+        { id: 'ep-1', services: [{ id: 'svc-1' }] },
+      ] as unknown as Awaited<ReturnType<typeof prisma.escalationPolicy.findMany>>);
 
       // Incident is already assigned to user-b
       vi.mocked(prisma.incident.findMany).mockResolvedValue([
-        { id: 'inc-1', title: 'Open issue', status: 'OPEN', assigneeId: 'user-b' } as any,
-      ]);
+        { id: 'inc-1', title: 'Open issue', status: 'OPEN', assigneeId: 'user-b' },
+      ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
 
       const result = await processShiftRotations(now);
 

--- a/tests/lib/sla-breach-monitor.test.ts
+++ b/tests/lib/sla-breach-monitor.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/prisma', () => ({
     },
     incidentEvent: {
       findFirst: vi.fn(),
+      findMany: vi.fn(),
       create: vi.fn(),
     },
   },
@@ -30,9 +31,11 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 describe('sla-breach-monitor', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    const { default: prisma } = await import('@/lib/prisma');
+    vi.mocked(prisma.incidentEvent.findMany).mockResolvedValue([]);
   });
 
   describe('checkSLABreaches', () => {
@@ -158,6 +161,47 @@ describe('sla-breach-monitor', () => {
       const result = await checkSLABreaches();
 
       expect(result.warnings).toHaveLength(0);
+    });
+
+    it('deduplicates SLA ACK and RESOLVE breach events when already logged', async () => {
+      const { default: prisma } = await import('@/lib/prisma');
+
+      const now = new Date('2026-01-05T12:00:00Z');
+      vi.setSystemTime(now);
+
+      // Incident created 3 hours ago (both 15m ack and 120m resolve targets breached)
+      const createdAt = new Date(now.getTime() - 180 * 60 * 1000);
+
+      vi.mocked(prisma.incident.findMany).mockResolvedValue([
+        {
+          id: 'inc-1',
+          title: 'Breached Incident',
+          serviceId: 'svc-1',
+          urgency: 'HIGH',
+          status: 'OPEN',
+          createdAt,
+          acknowledgedAt: null,
+          service: {
+            id: 'svc-1',
+            name: 'Test Service',
+            targetAckMinutes: 15,
+            targetResolveMinutes: 120,
+            serviceNotifyOnSlaBreach: true,
+          },
+        },
+      ] as any);
+
+      // Existing breach events in DB
+      vi.mocked(prisma.incidentEvent.findMany).mockResolvedValue([
+        { incidentId: 'inc-1', message: '🚨 SLA ACK Breached: target was 15 min' },
+        { incidentId: 'inc-1', message: '🚨 SLA RESOLVE Breached: target was 120 min' },
+      ] as any);
+
+      const result = await checkSLABreaches();
+
+      // No new warnings or duplicate events created
+      expect(result.warnings).toHaveLength(0);
+      expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/lib/sla-breach-monitor.test.ts
+++ b/tests/lib/sla-breach-monitor.test.ts
@@ -81,8 +81,8 @@ describe('sla-breach-monitor', () => {
             slackWebhookUrl: null,
             serviceNotifyOnSlaBreach: true,
           },
-        } as any,
-      ] as any);
+        },
+      ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
 
       const result = await checkSLABreaches();
 
@@ -122,7 +122,7 @@ describe('sla-breach-monitor', () => {
             serviceNotifyOnSlaBreach: true,
           },
         },
-      ] as any);
+      ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
 
       const result = await checkSLABreaches();
 
@@ -156,7 +156,7 @@ describe('sla-breach-monitor', () => {
             slackWebhookUrl: null,
           },
         },
-      ] as any);
+      ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
 
       const result = await checkSLABreaches();
 
@@ -189,13 +189,13 @@ describe('sla-breach-monitor', () => {
             serviceNotifyOnSlaBreach: true,
           },
         },
-      ] as any);
+      ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
 
       // Existing breach events in DB
       vi.mocked(prisma.incidentEvent.findMany).mockResolvedValue([
         { incidentId: 'inc-1', message: '🚨 SLA ACK Breached: target was 15 min' },
         { incidentId: 'inc-1', message: '🚨 SLA RESOLVE Breached: target was 120 min' },
-      ] as any);
+      ] as unknown as Awaited<ReturnType<typeof prisma.incidentEvent.findMany>>);
 
       const result = await checkSLABreaches();
 


### PR DESCRIPTION
### Summary of Changes

Fixes timeline flooding and duplicate automation events:

1. **SLA Breach Event Deduplication**:
   - In `src/lib/sla-breach-monitor.ts`, replaced fragile emoji `startsWith` queries with case-insensitive `contains` pattern matching on `IncidentEvent.message` to reliably find existing breach and warning events.
   - Standardized event parsing in `recentWarningMap` to ensure breach events are recognized across all unicode representations.
   - Explicitly assigned `type: isBreached ? 'ESCALATED' : 'COMMENT'` on resolve breach events.

2. **Shift Rotation Handoff Idempotency**:
   - In `src/lib/oncall-handoff.ts`, filtered active incidents to only reassign when `incident.assigneeId !== currentShift.userId`.
   - Prevents duplicate `ASSIGNMENT` timeline events and redundant handoff notifications during successive cron ticks within the 5-minute transition window.

3. **Automated Test Coverage**:
   - Added unit test suite in `tests/lib/oncall-handoff.test.ts` verifying exactly-once reassignment.
   - Added deduplication test cases in `tests/lib/sla-breach-monitor.test.ts`.

### Verification
- 150 test files, 1279 tests passed.
- Clean `tsc --noEmit` type checking.
- Production build passed.