### PR TITLE
docs(v1.5): polish onboarding and install flow

### DIFF
--- a/docs/v1.5/getting-started/README.md
+++ b/docs/v1.5/getting-started/README.md
@@ -1,24 +1,28 @@
 ---
 order: 1
 title: Getting Started
-description: Fifteen minutes from Compose to a test page
+description: Get from a fresh OpsKnight install to your first verified incident in about 10 minutes.
 ---
 
 # Getting Started
 
-This is the **15-minute path**: Compose up, admin account, a service that can page you, one test incident. Use the other guides in this section when you need install variants or a fuller first-week setup.
+This is the shortest path from a fresh OpsKnight installation to a working incident flow.
 
-| Minutes | What you do                        | Done when                                   |
-| ------- | ---------------------------------- | ------------------------------------------- |
-| 0–5     | Run Compose and create the admin   | You can sign in at `http://localhost:3000`  |
-| 5–12    | Team → schedule → policy → service | The service routes to your current schedule |
-| 12–15   | Open a test incident               | It appears OPEN; you can acknowledge it     |
+By the end, you will have:
 
-Notifications (email/SMS/Slack) are optional for this path. Without a provider, the incident still exists; nobody is paged off-box.
+- a running OpsKnight instance;
+- an Admin account;
+- one team, schedule, escalation policy, and service;
+- one test incident that you acknowledge and resolve;
+- an optional Events API test using a real integration key.
 
----
+> Keep the first run simple. Notification providers, status pages, SSO, ChatOps, production monitoring integrations, and advanced deployment options can all be added after the core incident path works.
 
-## 1. Run OpsKnight (Compose)
+## Before you begin
+
+You need Docker with Compose support, Git, OpenSSL, and a local shell. For Helm, Kustomize, or from-source installs, use [Installation](./installation).
+
+## 1. Start OpsKnight
 
 ```bash
 git clone https://github.com/opsknight-labs/OpsKnight.git
@@ -26,12 +30,14 @@ cd OpsKnight
 cp env.example .env
 ```
 
-Generate the two secrets, then paste the output values into `.env` before you start:
+Generate the two required secrets:
 
 ```bash
 openssl rand -base64 32
 openssl rand -hex 32
 ```
+
+Add the generated values to `.env`:
 
 ```dotenv
 NEXTAUTH_URL=http://localhost:3000
@@ -40,83 +46,126 @@ NEXTAUTH_SECRET=PASTE_BASE64_OUTPUT
 ENCRYPTION_KEY=PASTE_64_HEX_CHARACTER_OUTPUT
 ```
 
-Dotenv files do not evaluate `$(...)` shell substitutions.
+Do not put shell substitutions such as `$(openssl ...)` directly in `.env`; dotenv files do not evaluate them.
 
-The Compose file constructs the application's container-only `DATABASE_URL` from `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`; you do not need to change the host-development `DATABASE_URL` example for this path.
+Start the stack:
 
 ```bash
 docker compose up -d
-open http://localhost:3000
 ```
 
-First boot sends you to `/setup`. Create the admin, **copy the generated password once**, then sign in.
+Open `http://localhost:3000`. On first boot, OpsKnight sends you to `/setup`. Create the first Admin, copy the generated temporary password when it is shown, and sign in.
 
-Helm, Kustomize, and from-source installs: [Installation](./installation). Env reference: [Configuration](./configuration).
+### Checkpoint
 
----
+You are done with this step when the OpsKnight dashboard loads successfully.
 
-## 2. Make something that can page
+## 2. Create the minimum incident-routing chain
 
-Stay on this machine. You do not need a second user for a first page.
+For the first test, use yourself as the responder. You do not need a second user or an external notification provider yet.
 
-1. **Teams** — create `Platform` and add yourself.
-2. **Schedules** — create `Platform primary`, add yourself on a 24×7 layer (or a short override covering now).
-3. **Policies** — create `Platform page`, one step: notify the schedule, a few minutes before the next step (you will ack before that).
-4. **Services** — create `Checkout API`, attach that policy.
+1. **Team** — create `Platform` and add yourself.
+2. **Schedule** — create `Platform Primary` and add yourself to a layer covering the current time.
+3. **Escalation Policy** — create `Platform Page` with one step targeting `Platform Primary`.
+4. **Service** — create `Checkout API`, owned by `Platform`, using `Platform Page`.
 
-Detail and screenshots: [First Steps](./first-steps).
+```text
+user → team → schedule → escalation policy → service
+```
 
----
+### Checkpoint
 
-## 3. Fire a test incident
+Open `Checkout API` and verify the expected owning team and escalation policy are attached. For a production-ready setup with multiple responders, notification channels, overrides, ownership, and escalation testing, continue with [First Steps](./first-steps).
 
-**In the UI**
+## 3. Create and verify your first incident
 
-1. **Incidents** → **Create Incident**
-2. Title `Test page`, service `Checkout API`, urgency High
-3. Create
+1. Open **Incidents** → **Create Incident**.
+2. Set the title to `TEST: Checkout API incident`.
+3. Select `Checkout API`.
+4. Set urgency to **High**.
+5. Create the incident.
 
-You should see status `OPEN` and a timeline entry. Click **Acknowledge**, then **Resolve**.
+Verify that the incident appears as `OPEN`, the timeline records the lifecycle, and the expected escalation target is shown. Select **Acknowledge**, then **Resolve**, and add a short resolution note.
 
-**Optional: Events API** (after you add an integration key on the service)
+### Checkpoint
+
+Your core OpsKnight flow is working when one incident moves successfully through:
+
+```text
+OPEN → ACKNOWLEDGED → RESOLVED
+```
+
+## 4. Verify inbound event ingestion
+
+This step is optional for the first UI test, but recommended before connecting a real monitoring system.
+
+Open `Checkout API` → **Integrations**, create an **Events API** integration, and copy its integration key into secure temporary storage.
+
+Trigger an incident:
 
 ```bash
-curl -X POST http://localhost:3000/api/events \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Token token=YOUR_INTEGRATION_KEY" \
-  -d '{
+curl --request POST "http://localhost:3000/api/events" \
+  --header "Authorization: Token token=YOUR_INTEGRATION_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
     "event_action": "trigger",
-    "dedup_key": "getting-started-test-1",
+    "dedup_key": "getting-started/checkout-api",
     "payload": {
-      "summary": "Test page from getting started",
-      "severity": "critical",
-      "source": "getting-started"
+      "summary": "TEST: Checkout API alert",
+      "source": "getting-started",
+      "severity": "critical"
     }
   }'
 ```
 
-See [Events API](../api/events).
+Resolve the same incident by reusing the integration key and `dedup_key`:
 
----
+```bash
+curl --request POST "http://localhost:3000/api/events" \
+  --header "Authorization: Token token=YOUR_INTEGRATION_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "event_action": "resolve",
+    "dedup_key": "getting-started/checkout-api",
+    "payload": {
+      "summary": "TEST: Checkout API recovered",
+      "source": "getting-started",
+      "severity": "info"
+    }
+  }'
+```
 
-## 4. Confirm the install
+The trigger and resolve events should affect the same incident rather than create two independent incidents. See the [Events API](../api/events) for the complete contract.
+
+## 5. Check application health
 
 ```bash
 curl -s http://localhost:3000/api/health
 ```
 
-Expect `"status":"healthy"` (or `"degraded"` only if a non-database check failed). If the UI never loads, [Troubleshooting](../troubleshooting).
+A healthy local installation should report `"status":"healthy"`. A `"degraded"` result means the application is running but at least one non-database health check needs attention.
 
----
+If the UI does not load or the health endpoint fails, use [Troubleshooting](../troubleshooting).
 
-## After the first page
+## What to configure next
 
-| Next job                                          | Guide                                                        |
-| ------------------------------------------------- | ------------------------------------------------------------ |
-| Email / SMS / Slack so a real page leaves the box | [Notifications](../administration/notifications)             |
-| One public/private status page                    | [Status page](../core-concepts/status-page)                  |
-| Slack war rooms (this version)                    | [Slack ChatOps](../integrations/communication/slack-chatops) |
-| Ingest from monitoring                            | [Integrations](../integrations)                              |
-| OIDC SSO (not SAML)                               | [OIDC](../security/oidc-setup)                               |
+| Goal | Continue with |
+| --- | --- |
+| Page responders outside the browser | [Notifications](../administration/notifications) |
+| Connect monitoring | [Integrations](../integrations) |
+| Build a multi-person on-call rotation | [First Steps](./first-steps) |
+| Publish incident communication | [Status Page](../core-concepts/status-page) |
+| Add Slack incident collaboration | [Slack ChatOps](../integrations/communication/slack-chatops) |
+| Configure OIDC SSO | [OIDC](../security/oidc-setup) |
+| Prepare a production deployment | [Deployment](../deployment) |
 
-There is **no voice** channel. Microsoft Teams and Google Chat are webhook formats, not Slack-style rooms.
+## First-run acceptance checklist
+
+- [ ] OpsKnight starts and the Admin can sign in.
+- [ ] The service has the expected team and escalation policy.
+- [ ] A manual incident can be opened, acknowledged, and resolved.
+- [ ] An Events API trigger reaches the correct service.
+- [ ] Reusing the same `dedup_key` for resolve updates the same incident.
+- [ ] `/api/health` reports the expected state.
+
+Once these checks pass, the core incident path is ready and you can layer on production integrations, notification providers, and operational controls.

--- a/docs/v1.5/getting-started/first-steps.md
+++ b/docs/v1.5/getting-started/first-steps.md
@@ -1,130 +1,123 @@
 ---
-title: First steps
-description: Complete a first-week setup with users, team ownership, on-call coverage, paging, integrations, and operational verification.
+title: First Steps
+description: Turn the verified first incident into a production-ready team, paging, integration, and communication setup.
 order: 3
 ---
 
-# First steps
+# First Steps
 
-The [Getting Started](README.md) page is the 15-minute Compose path. This guide is the longer first-week setup for a real team: accounts, ownership, on-call rotation, escalation, notifications, integration ingest, status communication, and operating checks.
+Use this guide after completing [Getting Started](./README). Getting Started proves the shortest core path. This guide turns that working path into a setup suitable for a real team.
+
+Use synthetic names and a non-production service until paging, routing, and public communication are verified.
 
 ## What you will build
 
 ```text
-active users → team → schedule → escalation policy → service
-                                                  ↘ integration → incident
-service + policy + providers → tested responder notification
+responders → team → schedule → escalation policy → service
+                                             ↘ integration → incident
+service + policy + providers → verified responder notification
 ```
 
-Use synthetic names and a non-production service until the workflow is verified.
-
-## 1. Secure the first Admin
+## 1. Secure administration
 
 On a new installation, `/setup` is available only while no user exists.
 
-1. Enter the first Admin's name and email.
-2. Select **Generate Admin Credentials**.
-3. Copy the generated temporary password; it is shown once.
-4. Sign in at `/login`.
-5. Open **Settings → Security**, change the password, and store recovery information securely.
+After creating the first Admin:
 
-Create a second Admin before production so administration does not depend on one account.
+1. Sign in with the generated temporary password.
+2. Open **Settings → Security** and change it.
+3. Store recovery information securely.
+4. Create a second Admin before production so administration does not depend on one account.
 
-## 2. Configure a notification provider
+Use Admin access for workspace governance, not simply to make paging work.
 
-In-app notifications work without a third-party provider, but they are not sufficient for dependable on-call paging.
+## 2. Configure an external notification provider
+
+In-app notifications are useful for validation, but production on-call paging should use at least one external provider.
 
 1. Open **Settings → Notification Providers**.
-2. Configure at least one provider—email is a practical first test.
-3. Save and enable it.
-4. Open your personal **Settings → Notifications** and enable the matching channel.
-5. Add the required phone/device data for SMS, WhatsApp, or push.
+2. Configure and enable a provider. Email is a practical first test.
+3. Open your personal **Settings → Notifications**.
+4. Enable the matching channel and add any required destination data.
+5. Do not treat a successful provider save as proof of delivery; verify delivery with a test incident later in this guide.
 
-The provider card's save result is not a delivery test. You will verify it with a test incident later. See [Notifications](../administration/notifications.md).
+See [Notifications](../administration/notifications).
 
 ## 3. Invite responders
 
 1. Open **Users**.
 2. Invite at least one additional person as **Responder**.
-3. Copy the invitation link and deliver it through a secure channel.
-4. Have the user set a password, sign in, configure a timezone, and enable a notification channel.
+3. Deliver the invitation link through an appropriate secure channel.
+4. Have the responder sign in, set a password, select a timezone, and enable a notification channel.
 
-Use **User** for standard read-oriented access, **Responder** for incident/on-call work, and **Admin** for workspace governance. Do not give Admin access merely to make paging work.
+Use **User** for standard read-oriented access, **Responder** for incident/on-call work, and **Admin** for workspace governance.
 
 ## 4. Create the owning team
 
-1. Open **Teams** and create a uniquely named team, such as `Platform Engineering`.
+1. Open **Teams** and create a team such as `Platform Engineering`.
 2. Add active responders.
-3. Assign at least two appropriate Team Owners.
+3. Assign appropriate Team Owners.
 4. Optionally select a Team Lead.
-5. Confirm `Receive team notifications` is enabled for people expected to receive team-targeted pages.
+5. Confirm that people expected to receive team-targeted pages are configured to receive team notifications.
 
-Application roles and team roles are separate. See [Teams](../core-concepts/teams.md).
+Application roles and team roles are separate concepts. See [Teams](../core-concepts/teams).
 
-## 5. Create and verify the schedule
+## 5. Create and verify the on-call schedule
 
-Create the schedule before the policy so it is available as a policy target.
+Create the schedule before the escalation policy so it is available as a policy target.
 
 1. Open **Schedules** and create `Platform Primary On-Call`.
-2. Select the team's authoritative IANA timezone, for example `America/New_York`.
-3. Add a `Primary Rotation` layer with a current start time and rotation length such as `168` hours for weekly handoff.
+2. Select the team's authoritative IANA timezone.
+3. Add a primary rotation layer covering the current time.
 4. Add responders in rotation order.
-5. Inspect the timeline, calendar, current on-call user, and next handoff.
-6. Create a short test override, verify it changes effective coverage, then remove it.
+5. Inspect the current on-call responder and next handoff.
+6. Create a short test override, verify effective coverage changes, then remove it.
 
-Do not continue with an empty layer, expired layer, coverage warning, or unexpected current user. See [On-call schedules](../core-concepts/schedules.md).
+Do not continue with an empty layer, expired layer, coverage warning, or unexpected current responder. See [On-call schedules](../core-concepts/schedules).
 
 ## 6. Create the escalation policy
 
-Only an application Admin can manage policies.
+Create `Platform Service Escalation` with a simple staged path. For example:
 
-1. Open **Escalation Policies** and create `Platform Service Escalation`.
-2. Add these example steps:
+| Step | Target | Delay | Purpose |
+| --- | --- | ---: | --- |
+| 1 | `Platform Primary On-Call` schedule | 0 min | Page the current primary immediately. |
+| 2 | Backup responder | 5 min | Cover a missed acknowledgement. |
+| 3 | `Platform Engineering` team | 10 min | Broaden escalation. |
 
-| Step | Target                              |      Delay | Purpose                                         |
-| ---- | ----------------------------------- | ---------: | ----------------------------------------------- |
-| 1    | `Platform Primary On-Call` schedule |  0 minutes | Notify current primary immediately.             |
-| 2    | Backup Responder user               |  5 minutes | Cover a missed acknowledgement or schedule gap. |
-| 3    | `Platform Engineering` team         | 10 minutes | Broader escalation.                             |
-
-3. Confirm the displayed order and delays.
-
-The delay belongs to the step and is the wait before that step runs. Policies do not repeat after the final step in v1.4. The current add-step UI uses user notification preferences; it does not expose a new per-step channel selector. See [Escalation policies](../core-concepts/escalation-policies.md).
+Confirm the displayed order and delays before attaching the policy to a production service. See [Escalation policies](../core-concepts/escalation-policies).
 
 ## 7. Create the service
 
-1. Open **Services** and select **Create New Service**.
-2. Use a unique name such as `Payment API - Docs Test`.
+1. Open **Services** → **Create New Service**.
+2. Use a clear name such as `Payment API - Validation`.
 3. Select the owning team and escalation policy.
 4. Optionally choose region and SLA tier.
-5. Create the service, then open **Settings** to verify ownership and policy.
+5. Create the service and verify the ownership and policy from its settings.
 
-The tier label does not set the service's acknowledgement/resolution target minutes in the v1.4 settings UI. See [Services](../core-concepts/services.md).
+See [Services](../core-concepts/services).
 
-## 8. Run a manual incident test
+## 8. Verify paging with a manual incident
 
-Coordinate the test with all recipients.
+Coordinate the test with all recipients before sending external pages.
 
-1. Open **Incidents → Create incident**.
+1. Open **Incidents → Create Incident**.
 2. Enter `TEST: Payment API response workflow`.
-3. Select the test service, High urgency, and private visibility.
+3. Select the validation service, High urgency, and private visibility.
 4. Create the incident.
-5. Verify the incident timeline shows the first policy step and the expected current on-call user receives an in-app and configured external notification.
-6. Let the second step execute once and verify its timing.
-7. Acknowledge the incident and confirm no later step runs.
-8. Add a note, assign/reassign it, then resolve with a resolution note.
-9. Review Notification History and the event timeline.
+5. Verify the expected responder receives the configured notification.
+6. Allow the second escalation step to execute once and verify timing.
+7. Acknowledge the incident and confirm later escalation stops.
+8. Add a note, assign or reassign the incident, then resolve it with a resolution note.
+9. Review Notification History and the incident timeline.
 
-If the test fails, keep the service out of production routing and use [Troubleshooting](../troubleshooting.md).
+If notification delivery or escalation behavior is not correct, keep the service out of production routing until the problem is resolved.
 
-## 9. Add an inbound integration
+## 9. Verify inbound integration routing
 
-1. Open **Service → Integrations**.
-2. Select **Events API** for the simplest contract test or choose the production monitoring provider.
-3. Enter a descriptive integration name and create it.
-4. Copy the generated integration/routing key into secret storage.
+Open the service's **Integrations** page and create an **Events API** integration or the monitoring integration you intend to use.
 
-Test Events API ingest:
+For a contract test, send a trigger:
 
 ```bash
 curl --request POST "https://YOUR_OPSKNIGHT_HOST/api/events" \
@@ -132,16 +125,16 @@ curl --request POST "https://YOUR_OPSKNIGHT_HOST/api/events" \
   --header "Content-Type: application/json" \
   --data '{
     "event_action": "trigger",
-    "dedup_key": "first-week/payment-api",
+    "dedup_key": "first-steps/payment-api",
     "payload": {
       "summary": "TEST: integration routing",
-      "source": "first-week-check",
+      "source": "first-steps-check",
       "severity": "warning"
     }
   }'
 ```
 
-Confirm it creates a Medium-urgency incident for the correct service. Send a resolve with the same integration key and `dedup_key`:
+Confirm it reaches the correct service. Resolve it with the same integration key and `dedup_key`:
 
 ```bash
 curl --request POST "https://YOUR_OPSKNIGHT_HOST/api/events" \
@@ -149,57 +142,51 @@ curl --request POST "https://YOUR_OPSKNIGHT_HOST/api/events" \
   --header "Content-Type: application/json" \
   --data '{
     "event_action": "resolve",
-    "dedup_key": "first-week/payment-api",
+    "dedup_key": "first-steps/payment-api",
     "payload": {
       "summary": "TEST: integration routing recovered",
-      "source": "first-week-check",
+      "source": "first-steps-check",
       "severity": "info"
     }
   }'
 ```
 
-See the [Events API](../api/events.md) and [Integration catalog](../integrations/README.md).
+Confirm trigger and resolve operate on the same incident. See the [Events API](../api/events).
 
 ## 10. Configure public communication intentionally
 
-If you need a status page:
+If you need a public status page:
 
 1. Open **Settings → Status Page**.
 2. Add only approved services.
-3. Review every privacy field.
-4. Keep the page disabled while testing its preview.
-5. Enable it, then inspect `/status` signed out and from outside your network.
+3. Review privacy and visibility fields.
+4. Keep the page disabled while validating the preview.
+5. Enable it only after verifying the public view while signed out.
 
-Use a private synthetic incident to prove excluded data stays private, then a public synthetic incident to verify the approved display. See [Status page](../core-concepts/status-page.md).
+Use private synthetic incidents to prove excluded data stays private before testing approved public communication. See [Status page](../core-concepts/status-page).
 
-## 11. Establish operating ownership
+## 11. Assign operational ownership
 
-Before production, assign owners for:
+Before production, assign explicit owners for:
 
-- user onboarding/offboarding and Admin continuity;
+- user onboarding, offboarding, and Admin continuity;
 - schedule coverage and override review;
 - provider credentials and delivery failures;
-- each service and inbound integration;
-- status-page communication and subscribers;
+- services and inbound integrations;
+- status-page communication;
 - backups, upgrades, retention, audit review, and security response.
 
-## First-week acceptance checklist
+## Production-readiness checklist
 
-- [ ] Two active Admins can sign in and manage the workspace.
-- [ ] Responders completed invitation and configured timezone/channels.
+- [ ] Two Admins can administer the workspace.
+- [ ] Responders have completed onboarding and configured timezone and notification channels.
 - [ ] Team ownership and notification participation are correct.
-- [ ] Schedule has continuous expected coverage and a tested override.
-- [ ] Policy reaches schedule, backup, and team targets at expected times.
-- [ ] Manual incident acknowledge/resolve stops later escalation.
+- [ ] Schedule coverage is continuous and an override has been tested.
+- [ ] Escalation reaches the expected targets at the expected times.
+- [ ] Acknowledging an incident stops later escalation.
 - [ ] Events API trigger and resolve reuse one incident.
-- [ ] Notification History shows expected success/failure detail.
-- [ ] Service ownership, SLA labels/limits, integrations, and status-page exposure are reviewed.
-- [ ] Backup, upgrade, retention, and security owners are named.
+- [ ] External notification delivery has been verified with a real test.
+- [ ] Service ownership, integrations, and public exposure have been reviewed.
+- [ ] Backup, upgrade, retention, and security responsibilities have owners.
 
-## Continue learning
-
-- [Core concepts](../core-concepts/README.md)
-- [Deployment](../deployment/README.md)
-- [Administration](../administration/README.md)
-- [Security](../security/README.md)
-- [Mobile](../mobile/README.md)
+Once this checklist passes, move the validated service and integrations into production use.

--- a/docs/v1.5/getting-started/installation.md
+++ b/docs/v1.5/getting-started/installation.md
@@ -1,178 +1,93 @@
 ---
-order: 1
 title: Installation
-description: Install OpsKnight with Docker Compose, Helm, Kustomize, or a Node.js development checkout and verify the complete incident path.
+description: Choose the shortest install path for evaluation or the deployment path that matches production needs.
+order: 2
 ---
 
 # Installation
 
-For the fastest evaluation, use Docker Compose. For production, choose the deployment method whose database, secrets, ingress, monitoring, backup, upgrade, and recovery lifecycle your team can own.
+Use the installation method that matches what you are trying to prove.
 
-If you want the shortest end-to-end tutorial, follow [Getting started](./README). This page covers installation choices and source development.
+For a first evaluation, prefer Docker Compose. It has the fewest moving parts and is the path used by [Getting Started](./README).
 
-## Choose a method
+## Choose an install path
 
-| Method                       | Intended use                                                       | Next guide                             |
-| ---------------------------- | ------------------------------------------------------------------ | -------------------------------------- |
-| Docker Compose               | Evaluation, development, or an accepted single-host topology.      | [Docker Compose](../deployment/docker) |
-| Helm                         | Values-driven Kubernetes release managed by a platform team.       | [Helm](../deployment/helm)             |
-| Kustomize                    | Raw Kubernetes manifests with reviewed environment overlays.       | [Kustomize](../deployment/kustomize)   |
-| Node.js development checkout | Application development and local testing, not a packaged release. | [From source](#install-from-source)    |
+| Goal | Recommended path |
+| --- | --- |
+| Evaluate OpsKnight locally | Docker Compose |
+| Validate Kubernetes behavior | Kustomize profile |
+| Operate with configurable Kubernetes packaging | Helm |
+| Develop OpsKnight itself | From source |
 
-All methods require PostgreSQL. The published Compose and Kubernetes examples use PostgreSQL 15; the project declares PostgreSQL 14+ support. The production image and source package use Node.js 20 (`>=20 <21`).
+Do not start with a production-style Kubernetes deployment if your only goal is to understand the incident workflow. Prove the application path first, then introduce infrastructure complexity.
 
-## Install with Docker Compose
+## Docker Compose
 
-### 1. Prepare the repository and secrets
+Clone the repository and create a local environment file:
 
 ```bash
 git clone https://github.com/opsknight-labs/OpsKnight.git
 cd OpsKnight
 cp env.example .env
+```
+
+Generate the required application secrets:
+
+```bash
 openssl rand -base64 32
 openssl rand -hex 32
 ```
 
-Edit `.env` and paste the generated values. Dotenv files do not evaluate `$(...)` shell substitutions.
+Set at least:
 
 ```dotenv
-POSTGRES_USER=opsknight
-POSTGRES_PASSWORD=replace-with-a-long-database-password
-POSTGRES_DB=opsknight_db
-NEXTAUTH_URL=http://localhost:3000
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-NEXTAUTH_SECRET=replace-with-the-base64-output
-ENCRYPTION_KEY=replace-with-the-64-hex-character-output
-APP_PORT=3000
-```
-
-For a production origin, use the exact public HTTPS URL for both URL settings and store the secrets outside the repository. Keep `ENCRYPTION_KEY` stable and backed up; it is required to decrypt stored provider credentials.
-
-### 2. Render, start, and inspect
-
-```bash
-docker compose config
-docker compose pull
-docker compose up -d
-docker compose ps
-docker compose logs --tail=200 opsknight-app
-curl --fail 'http://localhost:3000/api/health?mode=readiness'
-```
-
-The Compose stack runs the application plus PostgreSQL 15 in the `opsknight_postgres_data` named volume. The application startup attempts database migrations. Inspect migration logs even when the container is running, because startup can continue after repeated migration failure.
-
-### 3. Bootstrap the first Admin
-
-Open `http://localhost:3000`. When no users exist, OpsKnight redirects to `/setup`.
-
-1. Enter the first Admin's name and email.
-2. Create the account.
-3. Copy the generated password; it is shown once.
-4. Sign in, change the generated password, and create a second Admin.
-
-Setup stops accepting another bootstrap after the first user exists.
-
-### 4. Verify a product workflow
-
-Do not stop at the login page:
-
-1. Create a team, schedule, escalation policy, and service.
-2. Create a controlled incident for that service.
-3. Confirm the expected assignment/escalation state.
-4. Acknowledge and resolve it.
-5. After configuring a provider, verify an external notification and its history.
-
-The [15-minute getting-started path](./README) gives the exact UI sequence.
-
-## Install on Kubernetes
-
-Use one packaging path:
-
-- [Helm](../deployment/helm) for the chart at `helm/opsknight`.
-- [Kustomize](../deployment/kustomize) for overlays based on `k8s/kustomization.yaml`.
-
-Both checked-in defaults contain example or placeholder values. Before applying, pin an image, replace every secret, configure the exact public HTTPS origin, choose an owned PostgreSQL topology, render/server-dry-run resources, and define backup/recovery. See [Kubernetes deployment](../deployment/kubernetes) for the shared runtime and scaling boundaries.
-
-## Install from source
-
-Use this path for contribution and development. It is not a substitute for the tested production image/entrypoint.
-
-### Prerequisites
-
-- Node.js 20 and npm.
-- PostgreSQL 14+ reachable from the host.
-- Build tools required by Node dependencies on your operating system.
-
-### Set up the application
-
-```bash
-git clone https://github.com/opsknight-labs/OpsKnight.git
-cd OpsKnight
-npm ci
-cp env.example .env
-openssl rand -base64 32
-openssl rand -hex 32
-```
-
-Edit `.env`. For PostgreSQL exposed from Compose to the development host, the hostname is `localhost`, not the container-only `opsknight-db` name:
-
-```dotenv
-DATABASE_URL=postgresql://opsknight:YOUR_PASSWORD@localhost:5432/opsknight_db?sslmode=prefer
 NEXTAUTH_URL=http://localhost:3000
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXTAUTH_SECRET=PASTE_BASE64_OUTPUT
 ENCRYPTION_KEY=PASTE_64_HEX_CHARACTER_OUTPUT
 ```
 
-Create or select a disposable development database, then:
+Then start OpsKnight:
 
 ```bash
-npx prisma validate
-npx prisma generate
-npx prisma migrate deploy
-npm run dev
+docker compose up -d
 ```
 
-Open `http://localhost:3000`, bootstrap the Admin, and run the same controlled incident workflow. Production builds use `npm run build`; use the packaged deployment guides for an operated installation.
+Open `http://localhost:3000` and complete `/setup`.
 
-## Common installation failures
+For the complete first-run workflow, return to [Getting Started](./README).
 
-### PostgreSQL is unhealthy or unreachable
+## Kubernetes
+
+OpsKnight includes Kubernetes deployment assets for environments that need separate runtime roles, horizontal web scaling, and database connection management.
+
+Before production use:
+
+- use a persistent PostgreSQL deployment appropriate for your environment;
+- configure secrets through your platform's secret-management mechanism rather than committing them;
+- set the public application URLs to the externally reachable HTTPS address;
+- verify web, worker, and scheduler roles are healthy;
+- test ingress, DNS, TLS, storage, and backup behavior independently of the application;
+- run a synthetic incident after deployment to verify the entire path.
+
+Use the [Deployment](../deployment) documentation for the specific profile and operational details.
+
+## From source
+
+Use a source install when developing OpsKnight or debugging application behavior.
+
+Follow the repository's development prerequisites and environment example rather than treating a development server as a production deployment.
+
+## Verify any installation
+
+After startup, check the application health endpoint:
 
 ```bash
-docker compose ps
-docker compose logs --tail=200 opsknight-db
-docker compose exec -T opsknight-db \
-  pg_isready -U "${POSTGRES_USER:-opsknight}" -d "${POSTGRES_DB:-opsknight_db}"
+curl -s http://localhost:3000/api/health
 ```
 
-Check database credentials, hostname, port, disk/volume state, TLS requirements, and application migration logs. Inside the application container, `localhost` refers to that container, not PostgreSQL.
+Then create a synthetic incident. Infrastructure health alone does not prove that service ownership, escalation, event ingestion, and incident lifecycle behavior are configured correctly.
 
-### Port 3000 is already used
+## Next step
 
-Set a different host port without changing the container port:
-
-```dotenv
-APP_PORT=3001
-NEXTAUTH_URL=http://localhost:3001
-NEXT_PUBLIC_APP_URL=http://localhost:3001
-```
-
-Recreate the application and open port 3001.
-
-### Login redirects repeatedly
-
-The browser origin must exactly match `NEXTAUTH_URL`, including scheme and port. Behind a proxy, forward the original host and scheme. Keep the same `NEXTAUTH_SECRET` across restarts/replicas; replacing it invalidates existing sessions and does not fix an origin mismatch.
-
-### You need a clean disposable database
-
-Do not use `docker compose down -v` as a routine troubleshooting command: `-v` deletes the named PostgreSQL volume. For a disposable install only, first confirm the Compose project/volume target and that no data or backup is needed. Production recovery must use the [backup and restore](../deployment/backup-restore) runbook.
-
-## Next steps
-
-- [First steps](./first-steps) — first-week configuration.
-- [Configuration reference](./configuration) — supported environment behavior.
-- [Authentication](../administration/authentication) — bootstrap, OIDC, sessions, and recovery.
-- [Monitoring](../deployment/monitoring) — readiness, logs, and synthetic validation.
-- [Upgrade and rollback](../deployment/upgrade-rollback) — controlled release workflow.
-- [Troubleshooting](../troubleshooting) — application and integration diagnosis.
+Continue with [Getting Started](./README) and verify one complete incident lifecycle before adding optional integrations or production controls.


### PR DESCRIPTION
## Summary

Polishes the existing v1.5 onboarding in the application repository so a new evaluator reaches a verified incident quickly, then graduates into production readiness.

## What changed

- streamlines `docs/v1.5/getting-started/README.md` around a clear first-run path with checkpoints
- separates the fast core-flow validation from the fuller production-readiness workflow in `first-steps.md`
- simplifies installation guidance so readers choose Compose, Kubernetes, or source installs based on their actual goal
- keeps all reference links inside the existing v1.5 documentation tree
- preserves advanced configuration/reference material outside the critical first-run path

## Documentation structure

The flow now follows progressive disclosure:

1. start OpsKnight
2. build the minimum routing chain
3. verify OPEN → ACKNOWLEDGED → RESOLVED
4. verify Events API trigger/resolve deduplication
5. check application health
6. add paging, integrations, status communication, and production controls

## Commits

This PR intentionally contains three focused documentation commits:

1. streamline first-run onboarding
2. separate production-readiness flow
3. clarify install paths and verification

## Validation

- changes are limited to `docs/v1.5/getting-started/`
- no v1.4 or website-repository content is changed
- existing v1.5 API, integration, security, deployment, core-concept, and troubleshooting references are used
- commands remain copy/paste oriented for the Compose path

No application runtime behavior is changed.