### PR TITLE
feat(dashboard): add current muted incident summary and drill-down

### DIFF
--- a/docs/core-concepts/dashboard.md
+++ b/docs/core-concepts/dashboard.md
@@ -22,9 +22,11 @@ Shows the current actionable backlog: Triggered (`OPEN`) plus Acknowledged incid
 
 Dashboard scopes are explicit:
 
-- **Current** applies to Active, current urgency, and unassigned Active counts.
+- **Current** applies to Active, Muted, current urgency, and unassigned Active counts.
 - The displayed range applies to Total, Resolved, trends, MTTA, MTTR, and other historical analysis.
 - Retention can clip historical analysis but does not hide current Active incidents.
+
+The **Muted** card shows the current non-actionable backlog: Snoozed plus Suppressed incidents. Its drill-down preserves both states so the displayed total always matches the incident list.
 
 Each active incident includes:
 

--- a/docs/v1.5/core-concepts/dashboard.md
+++ b/docs/v1.5/core-concepts/dashboard.md
@@ -20,13 +20,13 @@ The top-level status is calculated from active incidents:
 | Degraded    | Active incidents exist, but none is High urgency |
 | Operational | No active incidents                              |
 
-“Active” refers to incident work that has not been resolved and excludes states that the current metric explicitly omits. Always open the filtered incident list before treating the badge as a full service-health diagnosis.
+“Active” means Triggered (`OPEN`) plus Acknowledged. Snoozed, Suppressed, and Resolved incidents are excluded. Always open the filtered incident list before treating the badge as a full service-health diagnosis.
 
 ## Command Center summary
 
-The header summarizes the selected range and current workload, including total incidents, active/open work, resolved and acknowledged counts, unassigned incidents, and High-urgency active incidents. A retention indicator appears when the requested history is clipped by the installation's retention policy.
+The header summarizes the selected range and current workload, including total incidents, Active work, Muted work, Resolved incidents, unassigned incidents, and High-urgency Active incidents. **Muted** is the current combined count of Snoozed plus Suppressed incidents and shows both values in its breakdown. A retention indicator appears when the requested history is clipped by the installation's retention policy.
 
-Selecting a summary link opens the corresponding incident view.
+Selecting a summary link opens the corresponding incident view. The Muted link uses the combined muted filter, so its incident list matches the card total.
 
 ## Filter the incident preview
 

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -219,6 +219,8 @@ export default async function Dashboard({
         activeCount: 0,
         openCount: 0,
         acknowledgedCount: 0,
+        snoozedCount: 0,
+        suppressedCount: 0,
         resolvedCount: 0,
         criticalCount: 0,
         highUrgencyCount: 0,
@@ -281,6 +283,9 @@ export default async function Dashboard({
   const metricsResolvedCount = slaMetrics.statusMix.find(s => s.status === 'RESOLVED')?.count ?? 0;
   const currentAcknowledgedCount = slaMetrics.acknowledgedCount;
   const currentActiveCount = currentTriggeredCount + currentAcknowledgedCount;
+  const currentSnoozedCount = slaMetrics.snoozedCount;
+  const currentSuppressedCount = slaMetrics.suppressedCount;
+  const currentMutedCount = currentSnoozedCount + currentSuppressedCount;
   const unassignedCount = slaMetrics.unassignedActive;
 
   const allActiveIncidentsCount =
@@ -415,6 +420,9 @@ export default async function Dashboard({
           totalInRange={totalInRange}
           currentActiveCount={currentActiveCount}
           currentTriggeredCount={currentTriggeredCount}
+          currentMutedCount={currentMutedCount}
+          currentSnoozedCount={currentSnoozedCount}
+          currentSuppressedCount={currentSuppressedCount}
           metricsResolvedCount={metricsResolvedCount}
           unassignedCount={unassignedCount}
           rangeLabel={getRangeLabel(range)}

--- a/src/components/DashboardExport.tsx
+++ b/src/components/DashboardExport.tsx
@@ -19,6 +19,9 @@ type ExportProps = {
   metrics: {
     totalActive: number;
     totalTriggered: number;
+    totalMuted: number;
+    totalSnoozed: number;
+    totalSuppressed: number;
     totalResolved: number;
     totalAcknowledged: number;
     unassigned: number;
@@ -89,6 +92,9 @@ export default function DashboardExport({ incidents, filters, metrics }: ExportP
     csvRows.push(`Active Incidents (current),${metrics.totalActive}`);
     csvRows.push(`Triggered Incidents (current),${metrics.totalTriggered}`);
     csvRows.push(`Acknowledged Incidents (current),${metrics.totalAcknowledged}`);
+    csvRows.push(`Muted Incidents (current),${metrics.totalMuted}`);
+    csvRows.push(`Snoozed Incidents (current),${metrics.totalSnoozed}`);
+    csvRows.push(`Suppressed Incidents (current),${metrics.totalSuppressed}`);
     csvRows.push(`Unassigned Active Incidents (current),${metrics.unassigned}`);
     csvRows.push(`Resolved Incidents (selected period),${metrics.totalResolved}`);
     csvRows.push('');

--- a/src/components/dashboard/DashboardCommandCenter.tsx
+++ b/src/components/dashboard/DashboardCommandCenter.tsx
@@ -21,6 +21,9 @@ type DashboardCommandCenterProps = {
   totalInRange: number;
   currentActiveCount: number;
   currentTriggeredCount: number;
+  currentMutedCount: number;
+  currentSnoozedCount: number;
+  currentSuppressedCount: number;
   metricsResolvedCount: number;
   unassignedCount: number;
   rangeLabel: string;
@@ -39,6 +42,9 @@ export default function DashboardCommandCenter({
   totalInRange,
   currentActiveCount,
   currentTriggeredCount,
+  currentMutedCount,
+  currentSnoozedCount,
+  currentSuppressedCount,
   metricsResolvedCount,
   unassignedCount,
   rangeLabel,
@@ -130,6 +136,9 @@ export default function DashboardCommandCenter({
               metrics={{
                 totalActive: currentActiveCount,
                 totalTriggered: currentTriggeredCount,
+                totalMuted: currentMutedCount,
+                totalSnoozed: currentSnoozedCount,
+                totalSuppressed: currentSuppressedCount,
                 totalResolved: metricsResolvedCount,
                 totalAcknowledged: currentAcknowledgedCount,
                 unassigned: unassignedCount,
@@ -139,7 +148,7 @@ export default function DashboardCommandCenter({
         </div>
       </div>
 
-      <div className="relative z-10 grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
+      <div className="relative z-10 grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-3 md:gap-4">
         <MetricCard label="TOTAL" value={totalInRange} rangeLabel={rangeLabel} variant="hero" />
         <MetricCard
           label="ACTIVE"
@@ -147,6 +156,14 @@ export default function DashboardCommandCenter({
           rangeLabel="(CURRENT)"
           description={`${currentTriggeredCount.toLocaleString()} Triggered · ${currentAcknowledgedCount.toLocaleString()} Acknowledged`}
           href="/incidents?filter=all_open"
+          variant="hero"
+        />
+        <MetricCard
+          label="MUTED"
+          value={currentMutedCount}
+          rangeLabel="(CURRENT)"
+          description={`${currentSnoozedCount.toLocaleString()} Snoozed · ${currentSuppressedCount.toLocaleString()} Suppressed`}
+          href="/incidents?filter=muted"
           variant="hero"
         />
         <MetricCard

--- a/src/components/incident/IncidentsFilters.tsx
+++ b/src/components/incident/IncidentsFilters.tsx
@@ -333,6 +333,12 @@ export default function IncidentsFilters({
                     <span>Resolved</span>
                   </div>
                 </SelectItem>
+                <SelectItem value="muted">
+                  <div className="flex items-center gap-2">
+                    <div className="h-1.5 w-1.5 rounded-full bg-violet-500" />
+                    <span>Muted (Snoozed + Suppressed)</span>
+                  </div>
+                </SelectItem>
                 <SelectItem value="snoozed">
                   <div className="flex items-center gap-2">
                     <div className="h-1.5 w-1.5 rounded-full bg-yellow-500" />

--- a/src/lib/incidents-query.ts
+++ b/src/lib/incidents-query.ts
@@ -1,10 +1,11 @@
 import type { IncidentStatus, IncidentUrgency, Prisma } from '@prisma/client';
-import { activeIncidentStatuses } from './incident-status';
+import { activeIncidentStatuses, mutedIncidentStatuses } from './incident-status';
 
 export type IncidentListFilter =
   | 'all'
   | 'mine'
   | 'all_open'
+  | 'muted'
   | 'open'
   | 'acknowledged'
   | 'resolved'
@@ -16,6 +17,7 @@ const incidentFilters: IncidentListFilter[] = [
   'all',
   'mine',
   'all_open',
+  'muted',
   'open',
   'acknowledged',
   'resolved',
@@ -82,6 +84,8 @@ export function buildIncidentWhere({
     where.status = { in: activeIncidentStatuses() };
   } else if (filter === 'all_open') {
     where.status = { in: activeIncidentStatuses() };
+  } else if (filter === 'muted') {
+    where.status = { in: mutedIncidentStatuses() };
   } else if (filter === 'open') {
     where.status = 'OPEN';
   } else if (filter === 'acknowledged') {

--- a/tests/components/metric-card.test.tsx
+++ b/tests/components/metric-card.test.tsx
@@ -21,4 +21,23 @@ describe('MetricCard', () => {
       '/incidents?filter=all_open'
     );
   });
+
+  it('shows the muted breakdown and links to the combined muted filter', () => {
+    render(
+      <MetricCard
+        label="MUTED"
+        value={118}
+        description="75 Snoozed · 43 Suppressed"
+        href="/incidents?filter=muted"
+        variant="hero"
+      />
+    );
+
+    expect(screen.getByText('MUTED')).toBeInTheDocument();
+    expect(screen.getByText('75 Snoozed · 43 Suppressed')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View muted incidents' })).toHaveAttribute(
+      'href',
+      '/incidents?filter=muted'
+    );
+  });
 });

--- a/tests/lib/incident-links.test.ts
+++ b/tests/lib/incident-links.test.ts
@@ -14,6 +14,10 @@ describe('buildIncidentListHref', () => {
     );
   });
 
+  it('builds the combined muted incident drill-down', () => {
+    expect(buildIncidentListHref({ filter: 'muted' })).toBe('/incidents?filter=muted');
+  });
+
   it('supports mobile service drill-downs', () => {
     expect(
       buildIncidentListHref({ basePath: '/m/incidents', filter: 'all_open', serviceId: 'svc-1' })

--- a/tests/lib/incidents-query.test.ts
+++ b/tests/lib/incidents-query.test.ts
@@ -17,7 +17,14 @@ describe('incidents-query helpers', () => {
     expect(normalizeIncidentFilter('mine')).toBe('mine');
     expect(normalizeIncidentFilter('acknowledged')).toBe('acknowledged');
     expect(normalizeIncidentFilter('open')).toBe('open');
+    expect(normalizeIncidentFilter('muted')).toBe('muted');
     expect(normalizeIncidentSort('updated')).toBe('updated');
+  });
+
+  it('builds the combined muted filter from snoozed and suppressed states', () => {
+    expect(buildIncidentWhere({ filter: 'muted' })).toEqual({
+      status: { in: ['SNOOZED', 'SUPPRESSED'] },
+    });
   });
 
   it('builds acknowledged and open filters correctly', () => {


### PR DESCRIPTION
## Summary

Adds a **Muted** block to the Command Center so operators can see the current non-actionable incident backlog without mixing it into Active work.

## Metric definition

- **Muted** = Snoozed + Suppressed
- the card is explicitly labeled **Current**
- the card shows the Snoozed and Suppressed breakdown
- selecting it opens one combined muted incident list

## Changes

- add the Muted hero card and responsive five-card layout;
- add the canonical `muted` incident-list filter;
- expose Muted in the Incidents filter menu;
- include Muted, Snoozed, and Suppressed current counts in dashboard CSV exports;
- reuse existing SLA snapshot counts, so no extra database query is introduced;
- update current and v1.5 Command Center documentation;
- add regression tests for the card, URL, and combined query semantics.

## Compatibility

- no database schema or migration changes;
- no incident lifecycle changes;
- no additional dashboard query;
- Active remains Triggered + Acknowledged;
- Docker Compose and Kubernetes behavior is unchanged.

## Validation

- TypeScript: passed
- Unit suite: 172 files passed; 1,298 tests passed; 4 skipped
- Focused UI/query tests: passed
- Production build: passed (100 routes)
- Documentation links: passed
- Documentation capability contract: passed
- Full mixed suite: 1,311 tests passed; one DB-lock integration test could not run locally because PostgreSQL was unavailable
- `git diff --check`: passed
