### PR TITLE
fix(dashboard): align Command Center metric cards

### DIFF
--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -25,28 +25,30 @@ const useCountUp = (end: number, duration = 800) => {
   const [count, setCount] = useState(0);
   const animationRef = useRef<number | null>(null);
   const prevEndRef = useRef<number>(end);
+  const countRef = useRef(0);
 
   useEffect(() => {
-    // Guard against invalid values
-    if (!Number.isFinite(end) || end < 0) {
-      setCount(0);
-      return;
-    }
+    const updateCount = (value: number) => {
+      countRef.current = value;
+      setCount(value);
+    };
 
     // Skip animation if value hasn't changed
-    if (prevEndRef.current === end && count === end) {
+    if (prevEndRef.current === end && countRef.current === end) {
       return;
     }
     prevEndRef.current = end;
 
-    // For zero, just set immediately
-    if (end === 0) {
-      setCount(0);
-      return;
+    // Keep state updates inside the animation callback rather than synchronously in the effect.
+    if (!Number.isFinite(end) || end <= 0) {
+      animationRef.current = requestAnimationFrame(() => updateCount(0));
+      return () => {
+        if (animationRef.current !== null) cancelAnimationFrame(animationRef.current);
+      };
     }
 
     let startTime: number | null = null;
-    const startValue = count;
+    const startValue = countRef.current;
 
     const animate = (timestamp: number) => {
       if (!startTime) startTime = timestamp;
@@ -57,13 +59,13 @@ const useCountUp = (end: number, duration = 800) => {
       const ease = 1 - Math.pow(1 - progress, 4);
 
       const newCount = Math.round(startValue + (end - startValue) * ease);
-      setCount(newCount);
+      updateCount(newCount);
 
       if (progress < 1) {
         animationRef.current = requestAnimationFrame(animate);
       } else {
         // Ensure we end exactly at the target
-        setCount(end);
+        updateCount(end);
       }
     };
 
@@ -75,7 +77,7 @@ const useCountUp = (end: number, duration = 800) => {
         animationRef.current = null;
       }
     };
-  }, [end, duration, count]);
+  }, [end, duration]);
 
   return count;
 };
@@ -140,7 +142,7 @@ const MetricCard = memo(function MetricCard({
   const card = (
     <div
       className={cn(
-        'relative overflow-hidden text-center transition-all duration-300',
+        'relative h-full overflow-hidden text-center transition-all duration-300',
         isHero
           ? 'rounded-lg'
           : 'group rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/5 via-white to-primary/5 shadow-sm hover:shadow-md',
@@ -150,7 +152,7 @@ const MetricCard = memo(function MetricCard({
           : isHero
             ? 'bg-white/10 border border-white/20 backdrop-blur text-primary-foreground shadow-sm hover:bg-white/15'
             : '',
-        isHero ? 'p-3 md:p-4' : 'p-6 sm:p-4'
+        isHero ? 'flex min-h-32 flex-col justify-center p-3 md:p-4' : 'p-6 sm:p-4'
       )}
       role="figure"
       aria-label={`${label}: ${formattedDisplay}${description ? `. ${description}` : ''}${rangeLabel ? ` ${rangeLabel}` : ''}`}
@@ -218,7 +220,7 @@ const MetricCard = memo(function MetricCard({
   return (
     <Link
       href={href}
-      className="block rounded-lg no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+      className="block h-full rounded-lg no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
       aria-label={`View ${label.toLowerCase()} incidents`}
     >
       {card}

--- a/tests/components/metric-card.test.tsx
+++ b/tests/components/metric-card.test.tsx
@@ -16,10 +16,10 @@ describe('MetricCard', () => {
 
     expect(screen.getByText('ACTIVE')).toBeInTheDocument();
     expect(screen.getByText('187 Triggered · 209 Acknowledged')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'View active incidents' })).toHaveAttribute(
-      'href',
-      '/incidents?filter=all_open'
-    );
+    const link = screen.getByRole('link', { name: 'View active incidents' });
+    expect(link).toHaveAttribute('href', '/incidents?filter=all_open');
+    expect(link).toHaveClass('h-full');
+    expect(screen.getByRole('figure')).toHaveClass('h-full', 'min-h-32');
   });
 
   it('shows the muted breakdown and links to the combined muted filter', () => {


### PR DESCRIPTION
## Summary\n\nMakes all five Command Center metric cards use an equal height, including cards with breakdown text. Content remains vertically centered across desktop and responsive grid layouts.\n\nAlso removes the synchronous state update from the count-up effect so the touched component passes the strict React lint rule.\n\n## Validation\n\n- `npx eslint src/components/dashboard/MetricCard.tsx --max-warnings 0`\n- `npx tsc --noEmit`\n- `npx vitest run tests/components/metric-card.test.tsx`\n- `git diff --check`