### PR TITLE
feat(auth): allow users to create incidents for team services

### DIFF
--- a/src/app/(app)/incidents/actions.core.test.ts
+++ b/src/app/(app)/incidents/actions.core.test.ts
@@ -5,6 +5,7 @@ import prisma from '@/lib/prisma';
 // Mock dependencies
 vi.mock('@/lib/rbac', () => ({
   assertResponderOrAbove: vi.fn().mockResolvedValue(true),
+  assertCanCreateIncidentForService: vi.fn().mockResolvedValue(true),
   assertCanModifyIncident: vi.fn().mockResolvedValue(true),
   getCurrentUser: vi.fn().mockResolvedValue({ id: 'user-1', name: 'Test User' }),
 }));

--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -4,7 +4,12 @@ import prisma from '@/lib/prisma';
 import { runSerializableTransaction } from '@/lib/db-utils';
 import { revalidatePath } from 'next/cache';
 import { IncidentStatus, IncidentUrgency } from '@prisma/client';
-import { getCurrentUser, assertResponderOrAbove, assertCanModifyIncident } from '@/lib/rbac';
+import {
+  getCurrentUser,
+  assertResponderOrAbove,
+  assertCanModifyIncident,
+  assertCanCreateIncidentForService,
+} from '@/lib/rbac';
 import { getUserFriendlyError } from '@/lib/user-friendly-errors';
 import { logger } from '@/lib/logger';
 
@@ -475,15 +480,15 @@ export async function updateIncidentPriority(id: string, priority: string | null
 }
 
 export async function createIncident(formData: FormData) {
-  try {
-    await assertResponderOrAbove();
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
   const title = formData.get('title') as string;
   const description = formData.get('description') as string;
   const urgency = parseIncidentUrgency(formData.get('urgency') as string);
   const serviceId = formData.get('serviceId') as string;
+  try {
+    await assertCanCreateIncidentForService(serviceId);
+  } catch (error) {
+    throw new Error(getUserFriendlyError(error));
+  }
   const priority = formData.get('priority') as string | null;
   const dedupKey = formData.get('dedupKey') as string | null;
   const assigneeId = formData.get('assigneeId') as string | null;

--- a/src/app/(app)/incidents/create/page.tsx
+++ b/src/app/(app)/incidents/create/page.tsx
@@ -26,7 +26,9 @@ export default async function CreateIncidentPage({
 
   const templates = await getAllTemplates(permissions.id);
 
-  const canCreateIncident = permissions.isResponderOrAbove;
+  const canCreateIncident = permissions.capabilities.some(
+    capability => capability === 'incident.create.all' || capability === 'incident.create.scoped'
+  );
 
   if (!canCreateIncident) {
     return (

--- a/src/app/(app)/incidents/page.tsx
+++ b/src/app/(app)/incidents/page.tsx
@@ -56,7 +56,9 @@ export default async function IncidentsPage({
   const skip = (currentPage - 1) * ITEMS_PER_PAGE;
 
   const permissions = await getUserPermissions();
-  const canCreateIncident = permissions.isResponderOrAbove;
+  const canCreateIncident = permissions.capabilities.some(
+    capability => capability === 'incident.create.all' || capability === 'incident.create.scoped'
+  );
 
   const currentUser = await prisma.user.findUnique({
     where: { id: permissions.id },

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -12,6 +12,8 @@ export type AppRole = (typeof APP_ROLES)[number];
 export const CAPABILITIES = {
   ADMIN_MANAGE: 'admin.manage',
   OPERATIONS_MANAGE: 'operations.manage',
+  INCIDENT_CREATE_ALL: 'incident.create.all',
+  INCIDENT_CREATE_SCOPED: 'incident.create.scoped',
   INCIDENT_READ_ALL: 'incident.read.all',
   INCIDENT_READ_SCOPED: 'incident.read.scoped',
   INCIDENT_EXPORT: 'incident.export',
@@ -51,6 +53,7 @@ export function isWriteApiScope(scope: ApiScope): boolean {
 const ADMIN_CAPABILITIES = new Set<Capability>(Object.values(CAPABILITIES));
 const RESPONDER_CAPABILITIES = new Set<Capability>([
   CAPABILITIES.OPERATIONS_MANAGE,
+  CAPABILITIES.INCIDENT_CREATE_ALL,
   CAPABILITIES.INCIDENT_READ_ALL,
   CAPABILITIES.INCIDENT_EXPORT,
   CAPABILITIES.INCIDENT_SENSITIVE_READ,
@@ -71,6 +74,7 @@ const AUDITOR_CAPABILITIES = new Set<Capability>([
   CAPABILITIES.REPORT_EXPORT,
 ]);
 const USER_CAPABILITIES = new Set<Capability>([
+  CAPABILITIES.INCIDENT_CREATE_SCOPED,
   CAPABILITIES.INCIDENT_READ_SCOPED,
   CAPABILITIES.SERVICE_READ_SCOPED,
   CAPABILITIES.METRICS_READ_SCOPED,

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -175,6 +175,24 @@ export async function assertCanReadServiceMetrics(opts: {
   return user;
 }
 
+export async function assertCanCreateIncidentForService(serviceId: string) {
+  const user = await getCurrentUser();
+  if (hasCapability(user.role as AppRole, CAPABILITIES.INCIDENT_CREATE_ALL)) return user;
+  if (!hasCapability(user.role as AppRole, CAPABILITIES.INCIDENT_CREATE_SCOPED)) {
+    throw new AuthorizationError(
+      'Unauthorized. Incident creation access required.',
+      CAPABILITIES.INCIDENT_CREATE_SCOPED
+    );
+  }
+  const service = await prisma.service.findFirst({
+    where: { id: serviceId, team: { members: { some: { userId: user.id } } } },
+    select: { id: true },
+  });
+  if (!service)
+    throw new Error('Unauthorized. You can only create incidents for your team services.');
+  return user;
+}
+
 export async function getUserPermissions() {
   try {
     const user = await getCurrentUser();

--- a/tests/lib/authorization.test.ts
+++ b/tests/lib/authorization.test.ts
@@ -37,6 +37,8 @@ describe('central authorization contract', () => {
   });
 
   it('keeps User access scoped', () => {
+    expect(hasCapability('USER', CAPABILITIES.INCIDENT_CREATE_SCOPED)).toBe(true);
+    expect(hasCapability('USER', CAPABILITIES.INCIDENT_CREATE_ALL)).toBe(false);
     expect(hasCapability('USER', CAPABILITIES.INCIDENT_READ_SCOPED)).toBe(true);
     expect(hasCapability('USER', CAPABILITIES.SERVICE_READ_SCOPED)).toBe(true);
     expect(hasCapability('USER', CAPABILITIES.INCIDENT_READ_ALL)).toBe(false);

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -6,6 +6,7 @@ import { processJob } from '@/lib/jobs/queue';
 
 vi.mock('@/lib/rbac', () => ({
   assertResponderOrAbove: vi.fn().mockResolvedValue(undefined),
+  assertCanCreateIncidentForService: vi.fn().mockResolvedValue(undefined),
   assertCanModifyIncident: vi.fn().mockResolvedValue(undefined),
   getCurrentUser: vi.fn().mockResolvedValue({ id: 'user-1', name: 'Alex' }),
 }));

--- a/tests/lib/rbac.test.ts
+++ b/tests/lib/rbac.test.ts
@@ -9,6 +9,7 @@ import {
   getUserPermissions,
   assertCanModifyIncident,
   assertCanModifyService,
+  assertCanCreateIncidentForService,
 } from '@/lib/rbac';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
@@ -35,6 +36,7 @@ vi.mock('@/lib/prisma', () => ({
     },
     service: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
     },
     teamMember: {
       findFirst: vi.fn(),
@@ -267,6 +269,47 @@ describe('RBAC Functions', () => {
       } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
       expect(await assertCanModifyService(serviceId)).toEqual(mockUser);
+    });
+
+    it('should allow ADMIN to create incident for any service', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockAdmin.email } });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAdmin as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(await assertCanCreateIncidentForService(serviceId)).toEqual(mockAdmin);
+    });
+
+    it('should allow RESPONDER to create incident for any service', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockResponder.email } });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockResponder as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(await assertCanCreateIncidentForService(serviceId)).toEqual(mockResponder);
+    });
+
+    it('should allow USER to create incident for their team service', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockUser.email } });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.service.findFirst).mockResolvedValue({ id: serviceId } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(await assertCanCreateIncidentForService(serviceId)).toEqual(mockUser);
+    });
+
+    it('should reject USER from creating incident for non-team service', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockUser.email } });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.service.findFirst).mockResolvedValue(null);
+
+      await expect(assertCanCreateIncidentForService(serviceId)).rejects.toThrow(
+        'Unauthorized. You can only create incidents for your team services.'
+      );
+    });
+
+    it('should reject AUDITOR from creating incidents', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockAuditor.email } });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAuditor as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      await expect(assertCanCreateIncidentForService(serviceId)).rejects.toThrow(
+        'Unauthorized. Incident creation access required.'
+      );
     });
   });
 });


### PR DESCRIPTION
Adds the scoped incident.create capability for Users. Server-side enforcement permits creation only for services owned by a team the User belongs to; Responders and Admins retain global creation, while Auditors remain read-only. Typecheck and focused tests pass.