### PR TITLE
feat(incident): add prominent template selector and management link in creation modal

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -1168,6 +1168,6 @@ export async function getIncidentCreationContext() {
     users,
     teams,
     customFields,
-    templates: templates as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    templates,
   };
 }

--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -1127,3 +1127,47 @@ export async function updateIncidentVisibility(id: string, visibility: 'PUBLIC' 
   revalidatePath('/incidents');
   revalidatePath('/');
 }
+
+export async function getIncidentCreationContext() {
+  const { getUserPermissions } = await import('@/lib/rbac');
+  const permissions = await getUserPermissions();
+
+  const canCreateIncident = permissions.capabilities.some(
+    (capability: string) =>
+      capability === 'incident.create.all' || capability === 'incident.create.scoped'
+  );
+
+  if (!canCreateIncident) {
+    return {
+      canCreateIncident: false as const,
+      services: [],
+      users: [],
+      teams: [],
+      customFields: [],
+      templates: [],
+    };
+  }
+
+  const { getAllTemplates } = await import('./template-actions');
+
+  const [services, users, customFields, teams, templates] = await Promise.all([
+    prisma.service.findMany({ orderBy: { name: 'asc' } }),
+    prisma.user.findMany({
+      where: { status: 'ACTIVE' },
+      select: { id: true, name: true, email: true, avatarUrl: true },
+      orderBy: { name: 'asc' },
+    }),
+    prisma.customField.findMany({ orderBy: { order: 'asc' } }),
+    prisma.team.findMany({ orderBy: { name: 'asc' } }),
+    getAllTemplates(permissions.id),
+  ]);
+
+  return {
+    canCreateIncident: true as const,
+    services,
+    users,
+    teams,
+    customFields,
+    templates: templates as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  };
+}

--- a/src/app/(app)/incidents/templates/page.tsx
+++ b/src/app/(app)/incidents/templates/page.tsx
@@ -13,7 +13,6 @@ import CreateIncidentButton, {
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/shadcn/dropdown-menu';
 

--- a/src/app/(app)/incidents/templates/page.tsx
+++ b/src/app/(app)/incidents/templates/page.tsx
@@ -7,6 +7,9 @@ import { Plus, Trash2, ArrowUpRight, Copy, MoreHorizontal, LayoutTemplate } from
 import { Button } from '@/components/ui/shadcn/button';
 import { Badge } from '@/components/ui/shadcn/badge';
 import { cn } from '@/lib/utils';
+import CreateIncidentButton, {
+  CreateIncidentMenuItem,
+} from '@/components/incident/CreateIncidentButton';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -199,15 +202,14 @@ export default async function TemplatesPage() {
 
                   {/* Action Buttons (Right Side) */}
                   <div className="flex items-center gap-1 self-start sm:self-center pl-2 border-l border-slate-100 ml-1">
-                    <Link href={`/incidents/create?template=${template.id}`}>
-                      <Button
-                        size="sm"
-                        className="h-8 shadow-sm bg-slate-900 text-white hover:bg-indigo-600 transition-colors"
-                      >
-                        Use Template
-                        <ArrowUpRight className="w-3.5 h-3.5 ml-1.5 opacity-70" />
-                      </Button>
-                    </Link>
+                    <CreateIncidentButton
+                      templateId={template.id}
+                      size="sm"
+                      className="h-8 shadow-sm bg-slate-900 text-white hover:bg-indigo-600 transition-colors"
+                    >
+                      Use Template
+                      <ArrowUpRight className="w-3.5 h-3.5 ml-1.5 opacity-70" />
+                    </CreateIncidentButton>
 
                     {canManageTemplates && template.createdById === permissions.id && (
                       <DropdownMenu>
@@ -221,12 +223,10 @@ export default async function TemplatesPage() {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          <Link href={`/incidents/create?template=${template.id}`}>
-                            <DropdownMenuItem>
-                              <Copy className="w-4 h-4 mr-2" />
-                              Use Template
-                            </DropdownMenuItem>
-                          </Link>
+                          <CreateIncidentMenuItem templateId={template.id}>
+                            <Copy className="w-4 h-4 mr-2" />
+                            Use Template
+                          </CreateIncidentMenuItem>
                           <form action={handleDelete}>
                             <input type="hidden" name="templateId" value={template.id} />
                             <ConfirmSubmitButton

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -22,6 +22,8 @@ import { logger } from '@/lib/logger';
 import SessionTimeoutWarning from '@/components/auth/SessionTimeoutWarning';
 import { activeIncidentStatuses } from '@/lib/incident-status';
 import { CAPABILITIES, hasCapability, isAppRole } from '@/lib/authorization';
+import { IncidentCreationModalProvider } from '@/contexts/IncidentCreationModalContext';
+import CreateIncidentModal from '@/components/incident/CreateIncidentModal';
 
 const isNextRedirectError = (error: unknown) => {
   if (!error || typeof error !== 'object') return false;
@@ -208,51 +210,54 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           currentUserName={userName}
         >
           <SidebarProvider>
-            <GlobalKeyboardHandlerWrapper />
-            <SkipLinks />
-            <div className="app-shell">
-              <Sidebar
-                userName={userName}
-                userEmail={userEmail}
-                userRole={userRole}
-                userAvatar={userAvatar}
-                userGender={userGender}
-                userId={userId}
-              />
-              <div className="content-shell">
-                <header className="fixed top-0 right-0 left-[var(--sidebar-width)] z-30 flex h-14 items-center gap-3 border-b bg-background px-4">
-                  <div className="flex items-center gap-4">
-                    <OperationalStatus
-                      tone={statusTone}
-                      label={statusLabel}
-                      detail={statusDetail}
-                      criticalCount={criticalOpenCount}
-                      mediumCount={mediumOpenCount}
-                      lowCount={lowOpenCount}
-                    />
-                    <TopbarBreadcrumbs />
-                  </div>
-                  <div className="flex flex-1 items-center justify-center px-4">
-                    <SidebarSearch />
-                  </div>
-                  <div className="flex items-center gap-4 ml-auto">
-                    <TopbarNotifications />
-                    <QuickActions canCreate={canCreate} />
-                    <TopbarUserMenu
-                      name={userName}
-                      email={userEmail}
-                      role={userRole}
-                      avatarUrl={userAvatar}
-                      gender={userGender}
-                      userId={userId}
-                    />
-                  </div>
-                </header>
-                <main id="main-content" className="page-shell pt-14">
-                  {children}
-                </main>
+            <IncidentCreationModalProvider>
+              <GlobalKeyboardHandlerWrapper />
+              <SkipLinks />
+              <div className="app-shell">
+                <Sidebar
+                  userName={userName}
+                  userEmail={userEmail}
+                  userRole={userRole}
+                  userAvatar={userAvatar}
+                  userGender={userGender}
+                  userId={userId}
+                />
+                <div className="content-shell">
+                  <header className="fixed top-0 right-0 left-[var(--sidebar-width)] z-30 flex h-14 items-center gap-3 border-b bg-background px-4">
+                    <div className="flex items-center gap-4">
+                      <OperationalStatus
+                        tone={statusTone}
+                        label={statusLabel}
+                        detail={statusDetail}
+                        criticalCount={criticalOpenCount}
+                        mediumCount={mediumOpenCount}
+                        lowCount={lowOpenCount}
+                      />
+                      <TopbarBreadcrumbs />
+                    </div>
+                    <div className="flex flex-1 items-center justify-center px-4">
+                      <SidebarSearch />
+                    </div>
+                    <div className="flex items-center gap-4 ml-auto">
+                      <TopbarNotifications />
+                      <QuickActions canCreate={canCreate} />
+                      <TopbarUserMenu
+                        name={userName}
+                        email={userEmail}
+                        role={userRole}
+                        avatarUrl={userAvatar}
+                        gender={userGender}
+                        userId={userId}
+                      />
+                    </div>
+                  </header>
+                  <main id="main-content" className="page-shell pt-14">
+                    {children}
+                  </main>
+                </div>
               </div>
-            </div>
+              <CreateIncidentModal />
+            </IncidentCreationModalProvider>
           </SidebarProvider>
         </UserAvatarProvider>
       </TimezoneProvider>

--- a/src/app/(app)/services/[id]/page.tsx
+++ b/src/app/(app)/services/[id]/page.tsx
@@ -21,13 +21,13 @@ import {
   Globe,
   Settings,
   Zap,
-  Plus,
 } from 'lucide-react';
 
 // Custom Components
 import IncidentList from '@/components/service/IncidentList';
 import Pagination from '@/components/service/Pagination';
 import DeleteServiceButton from '@/components/service/DeleteServiceButton';
+import CreateIncidentButton from '@/components/incident/CreateIncidentButton';
 
 const INCIDENTS_PER_PAGE = 20;
 
@@ -349,14 +349,7 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
                   : 'Viewing Resolved and Closed incidents.'}
               </p>
             </div>
-            {tab === 'incidents' && (
-              <Button className="gap-2" asChild>
-                <Link href={`/incidents/create?serviceId=${id}`}>
-                  <Plus className="h-4 w-4" />
-                  Create Incident
-                </Link>
-              </Button>
-            )}
+            {tab === 'incidents' && <CreateIncidentButton serviceId={id} className="gap-2" />}
           </div>
 
           <Card className="border-slate-200 shadow-sm overflow-hidden">

--- a/src/components/DashboardKeyboardShortcuts.tsx
+++ b/src/components/DashboardKeyboardShortcuts.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
 import KeyboardShortcuts from './KeyboardShortcuts';
 
 type DashboardKeyboardShortcutsProps = {
@@ -14,6 +15,7 @@ export default function DashboardKeyboardShortcuts({
   onExport,
 }: DashboardKeyboardShortcutsProps) {
   const router = useRouter();
+  const { openCreateIncident } = useCreateIncidentModal();
   const [showShortcuts, setShowShortcuts] = useState(false);
 
   useEffect(() => {
@@ -48,7 +50,7 @@ export default function DashboardKeyboardShortcuts({
       // New incident
       if (e.key === 'n' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        router.push('/incidents/create');
+        openCreateIncident();
       }
 
       // Quick navigation

--- a/src/components/DashboardKeyboardShortcuts.tsx
+++ b/src/components/DashboardKeyboardShortcuts.tsx
@@ -97,7 +97,7 @@ export default function DashboardKeyboardShortcuts({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [router, onRefresh, onExport]);
+  }, [router, onRefresh, onExport, openCreateIncident]);
 
   return (
     <>

--- a/src/components/GlobalKeyboardHandler.tsx
+++ b/src/components/GlobalKeyboardHandler.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
 
 type KeyboardHandlerProps = {
   onShortcutsToggle: () => void;
@@ -10,12 +11,14 @@ type KeyboardHandlerProps = {
 export default function GlobalKeyboardHandler({ onShortcutsToggle }: KeyboardHandlerProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const { openCreateIncident } = useCreateIncidentModal();
   const [gPressed, setGPressed] = useState(false);
 
   // Use refs to avoid re-attaching event listeners when state/callbacks change
   const gPressedRef = useRef(gPressed);
   const pathnameRef = useRef(pathname);
   const onShortcutsToggleRef = useRef(onShortcutsToggle);
+  const openCreateIncidentRef = useRef(openCreateIncident);
 
   // Keep refs in sync
   useEffect(() => {
@@ -29,6 +32,10 @@ export default function GlobalKeyboardHandler({ onShortcutsToggle }: KeyboardHan
   useEffect(() => {
     onShortcutsToggleRef.current = onShortcutsToggle;
   }, [onShortcutsToggle]);
+
+  useEffect(() => {
+    openCreateIncidentRef.current = openCreateIncident;
+  }, [openCreateIncident]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -120,7 +127,7 @@ export default function GlobalKeyboardHandler({ onShortcutsToggle }: KeyboardHan
         pathnameRef.current?.startsWith('/incidents')
       ) {
         e.preventDefault();
-        router.push('/incidents/create');
+        openCreateIncidentRef.current();
       }
     };
 

--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -45,6 +45,7 @@ type QuickActionsProps = {
 
 export default function QuickActions({ canCreate = true }: QuickActionsProps) {
   const router = useRouter();
+  const { openCreateIncident } = useCreateIncidentModal();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -150,7 +151,13 @@ export default function QuickActions({ canCreate = true }: QuickActionsProps) {
             <React.Fragment key={action.href}>
               {index === 2 && <DropdownMenuSeparator className="my-0.5 bg-border/60" />}
               <DropdownMenuItem
-                onClick={() => router.push(action.href)}
+                onClick={() => {
+                  if (action.label === 'New Incident') {
+                    openCreateIncident();
+                  } else {
+                    router.push(action.href);
+                  }
+                }}
                 className="group cursor-pointer focus:bg-muted/60 data-[highlighted]:bg-muted/60 rounded py-1 px-1.5"
               >
                 <div

--- a/src/components/SidebarSearch.tsx
+++ b/src/components/SidebarSearch.tsx
@@ -3,6 +3,7 @@
 import { logger } from '@/lib/logger';
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
 import { useModalState } from '@/hooks/useModalState';
 import { Command as CommandPrimitive } from 'cmdk';
 import {
@@ -145,6 +146,7 @@ export default function SidebarSearch() {
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const router = useRouter();
+  const { openCreateIncident } = useCreateIncidentModal();
 
   useEffect(() => {
     try {
@@ -239,7 +241,11 @@ export default function SidebarSearch() {
   const handleSelect = useCallback(
     (value: string, item?: any) => {
       if (item?.href) {
-        router.push(item.href);
+        if (item.href === '/incidents/create' || item.id === 'qa-create') {
+          openCreateIncident();
+        } else {
+          router.push(item.href);
+        }
         if (query.length >= 2) {
           saveRecentSearch(query, results.length);
         }
@@ -251,7 +257,7 @@ export default function SidebarSearch() {
         // Ensure it triggers search
       }
     },
-    [router, query, results.length, saveRecentSearch]
+    [router, openCreateIncident, query, results.length, saveRecentSearch]
   );
 
   const groupedResults = useMemo(() => {

--- a/src/components/dashboard/QuickActionsPanel.tsx
+++ b/src/components/dashboard/QuickActionsPanel.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import SidebarWidget, { WIDGET_ICON_BG } from '@/components/dashboard/SidebarWidget';
 import { Siren, BarChart2, Settings, Zap, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
 
 interface QuickActionsPanelProps {
   greeting: string;
@@ -11,24 +12,28 @@ interface QuickActionsPanelProps {
 }
 
 export default function QuickActionsPanel({ greeting, userName }: QuickActionsPanelProps) {
+  const { openCreateIncident } = useCreateIncidentModal();
   const actions = [
     {
-      href: '/incidents/create',
+      href: '#',
       label: 'Trigger Incident',
       icon: <Siren className="w-4 h-4" />,
       variant: 'primary' as const,
+      isModal: true,
     },
     {
       href: '/analytics',
       label: 'View Analytics',
       icon: <BarChart2 className="w-4 h-4" />,
       variant: 'secondary' as const,
+      isModal: false,
     },
     {
       href: '/services',
       label: 'Manage Services',
       icon: <Settings className="w-4 h-4" />,
       variant: 'secondary' as const,
+      isModal: false,
     },
   ];
 
@@ -40,34 +45,49 @@ export default function QuickActionsPanel({ greeting, userName }: QuickActionsPa
       subtitle="Quick actions"
     >
       <div className="space-y-2">
-        {actions.map((action, idx) => (
-          <Link
-            key={idx}
-            href={action.href}
-            className={cn(
-              "group flex items-center gap-3 p-2.5 rounded-lg border transition-colors",
-              action.variant === 'primary'
-                ? 'bg-primary text-primary-foreground border-primary hover:bg-primary/90'
-                : 'bg-white border-slate-100 text-slate-700 hover:border-slate-200 hover:bg-slate-50/50'
-            )}
-          >
-            <div className={cn(
-              "w-8 h-8 rounded-lg flex items-center justify-center shrink-0",
-              action.variant === 'primary'
-                ? 'bg-white/20'
-                : 'bg-slate-100 text-slate-500'
-            )}>
-              {action.icon}
-            </div>
-            <span className="flex-1 text-xs font-semibold">{action.label}</span>
-            <ChevronRight className={cn(
-              "w-3.5 h-3.5 shrink-0 transition-colors",
-              action.variant === 'primary'
-                ? 'text-white/50 group-hover:text-white/80'
-                : 'text-slate-300 group-hover:text-slate-500'
-            )} />
-          </Link>
-        ))}
+        {actions.map((action, idx) => {
+          const classes = cn(
+            'group flex items-center gap-3 p-2.5 rounded-lg border transition-colors w-full',
+            action.variant === 'primary'
+              ? 'bg-primary text-primary-foreground border-primary hover:bg-primary/90'
+              : 'bg-white border-slate-100 text-slate-700 hover:border-slate-200 hover:bg-slate-50/50'
+          );
+          const content = (
+            <>
+              <div
+                className={cn(
+                  'w-8 h-8 rounded-lg flex items-center justify-center shrink-0',
+                  action.variant === 'primary' ? 'bg-white/20' : 'bg-slate-100 text-slate-500'
+                )}
+              >
+                {action.icon}
+              </div>
+              <span className="flex-1 text-xs font-semibold text-left">{action.label}</span>
+              <ChevronRight
+                className={cn(
+                  'w-3.5 h-3.5 shrink-0 transition-colors',
+                  action.variant === 'primary'
+                    ? 'text-white/50 group-hover:text-white/80'
+                    : 'text-slate-300 group-hover:text-slate-500'
+                )}
+              />
+            </>
+          );
+
+          if (action.isModal) {
+            return (
+              <button key={idx} onClick={() => openCreateIncident()} className={classes}>
+                {content}
+              </button>
+            );
+          }
+
+          return (
+            <Link key={idx} href={action.href} className={classes}>
+              {content}
+            </Link>
+          );
+        })}
       </div>
     </SidebarWidget>
   );

--- a/src/components/incident/CreateIncidentButton.tsx
+++ b/src/components/incident/CreateIncidentButton.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React from 'react';
+import { Button } from '@/components/ui/shadcn/button';
+import { DropdownMenuItem } from '@/components/ui/shadcn/dropdown-menu';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
+import { Plus } from 'lucide-react';
+
+type CreateIncidentButtonProps = {
+  serviceId?: string;
+  templateId?: string;
+  children?: React.ReactNode;
+  variant?: 'default' | 'outline' | 'ghost' | 'secondary' | 'destructive' | 'link';
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  className?: string;
+};
+
+export default function CreateIncidentButton({
+  serviceId,
+  templateId,
+  children,
+  variant = 'default',
+  size = 'default',
+  className,
+}: CreateIncidentButtonProps) {
+  const { openCreateIncident } = useCreateIncidentModal();
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={className}
+      onClick={() => openCreateIncident({ serviceId, templateId })}
+    >
+      {children || (
+        <>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Incident
+        </>
+      )}
+    </Button>
+  );
+}
+
+export function CreateIncidentMenuItem({
+  serviceId,
+  templateId,
+  children,
+  className,
+}: {
+  serviceId?: string;
+  templateId?: string;
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  const { openCreateIncident } = useCreateIncidentModal();
+
+  return (
+    <DropdownMenuItem
+      className={className}
+      onClick={() => openCreateIncident({ serviceId, templateId })}
+    >
+      {children || (
+        <>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Incident
+        </>
+      )}
+    </DropdownMenuItem>
+  );
+}

--- a/src/components/incident/CreateIncidentModal.tsx
+++ b/src/components/incident/CreateIncidentModal.tsx
@@ -1,0 +1,898 @@
+'use client';
+
+import * as React from 'react';
+import { useState, useEffect, useActionState, useCallback, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useRouter } from 'next/navigation';
+import { createIncident, getIncidentCreationContext } from '@/app/(app)/incidents/actions';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
+import CustomFieldInput from '@/components/CustomFieldInput';
+import { Button } from '@/components/ui/shadcn/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/shadcn/form';
+import { Input } from '@/components/ui/shadcn/input';
+import { Textarea } from '@/components/ui/shadcn/textarea';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/shadcn/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/shadcn/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/shadcn/select';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '@/lib/utils';
+import {
+  Check,
+  ChevronsUpDown,
+  AlertTriangle,
+  AlertCircle,
+  Info,
+  Activity,
+  Hash,
+  Users,
+  Zap,
+  X,
+  Loader2,
+  LayoutTemplate,
+} from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcn/avatar';
+
+type Service = { id: string; name: string };
+type UserRecord = { id: string; name: string; email: string; avatarUrl?: string | null };
+type Team = { id: string; name: string };
+type Template = {
+  id: string;
+  name: string;
+  title: string;
+  descriptionText?: string | null;
+  defaultUrgency: 'HIGH' | 'MEDIUM' | 'LOW';
+  defaultPriority?: string | null;
+  defaultService?: { id: string; name: string } | null;
+};
+type CustomField = {
+  id: string;
+  name: string;
+  key: string;
+  type: 'TEXT' | 'NUMBER' | 'DATE' | 'SELECT' | 'BOOLEAN' | 'URL' | 'EMAIL';
+  required: boolean;
+  defaultValue?: string | null;
+  options?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+};
+
+type ContextData = {
+  canCreateIncident: boolean;
+  services: Service[];
+  users: UserRecord[];
+  teams: Team[];
+  customFields: CustomField[];
+  templates: Template[];
+};
+
+const formSchema = z.object({
+  title: z.string().min(5, { message: 'Title must be at least 5 characters.' }).max(255),
+  description: z.string().optional(),
+  serviceId: z
+    .string({ required_error: 'Please select a service.' })
+    .min(1, 'Please select a service.'),
+  urgency: z.enum(['HIGH', 'MEDIUM', 'LOW']),
+  priority: z.string().optional(),
+  assigneeId: z.string().optional(),
+  dedupKey: z.string().max(200).optional(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export default function CreateIncidentModal() {
+  const { isOpen, openOptions, closeCreateIncident } = useCreateIncidentModal();
+  const router = useRouter();
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const [contextData, setContextData] = useState<ContextData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | ''>('');
+  const [customFieldValues, setCustomFieldValues] = useState<Record<string, string>>({});
+  const [serviceOpen, setServiceOpen] = useState(false);
+  const [assigneeOpen, setAssigneeOpen] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      title: '',
+      description: '',
+      serviceId: '',
+      urgency: 'HIGH',
+      priority: '',
+      assigneeId: 'unassigned',
+      dedupKey: '',
+    },
+  });
+
+  const applyTemplate = useCallback(
+    (template: Template) => {
+      form.reset({
+        title: template.title,
+        description: template.descriptionText || '',
+        serviceId: template.defaultService?.id || '',
+        urgency: template.defaultUrgency,
+        priority: template.defaultPriority || '',
+        assigneeId: 'unassigned',
+        dedupKey: '',
+      });
+    },
+    [form]
+  );
+
+  // Fetch context data when modal opens
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+    setLoading(true);
+
+    getIncidentCreationContext()
+      .then(data => {
+        if (cancelled) return;
+        setContextData(data as ContextData);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  // Apply openOptions (serviceId / templateId) once context is loaded
+  useEffect(() => {
+    if (!contextData || !isOpen) return;
+
+    if (openOptions?.serviceId) {
+      form.setValue('serviceId', openOptions.serviceId);
+    }
+
+    if (openOptions?.templateId) {
+      setSelectedTemplateId(openOptions.templateId);
+      const template = contextData.templates.find((t: Template) => t.id === openOptions.templateId);
+      if (template) {
+        applyTemplate(template);
+      }
+    }
+  }, [contextData, isOpen, openOptions, form, applyTemplate]);
+
+  // Auto-focus title input when data is loaded
+  useEffect(() => {
+    if (isOpen && contextData && !loading) {
+      setTimeout(() => titleInputRef.current?.focus(), 100);
+    }
+  }, [isOpen, contextData, loading]);
+
+  // Reset form when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      form.reset();
+      setSelectedTemplateId('');
+      setCustomFieldValues({});
+      setContextData(null);
+    }
+  }, [isOpen, form]);
+
+  // Server Action State
+  const [state, formAction, isPending] = useActionState(
+    async (prevState: { id: string } | null, formData: FormData) => {
+      return await createIncident(formData);
+    },
+    null
+  );
+
+  // Handle successful creation
+  useEffect(() => {
+    if (state && state.id) {
+      closeCreateIncident();
+      router.push(`/incidents/${state.id}`);
+    }
+  }, [state, router, closeCreateIncident]);
+
+  // Custom submit handler to bridge RHF and Server Actions
+  const onSubmit = useCallback(
+    (data: FormValues) => {
+      const formData = new FormData();
+      formData.append('title', data.title);
+      formData.append('description', data.description || '');
+      formData.append('serviceId', data.serviceId);
+      formData.append('urgency', data.urgency);
+      if (data.priority) formData.append('priority', data.priority);
+      if (data.assigneeId && data.assigneeId !== 'unassigned') {
+        if (data.assigneeId.startsWith('team:')) {
+          formData.append('teamId', data.assigneeId.replace('team:', ''));
+        } else if (data.assigneeId.startsWith('user:')) {
+          formData.append('assigneeId', data.assigneeId.replace('user:', ''));
+        } else {
+          formData.append('assigneeId', data.assigneeId);
+        }
+      }
+      if (data.dedupKey) formData.append('dedupKey', data.dedupKey);
+
+      Object.entries(customFieldValues).forEach(([key, value]) => {
+        formData.append(`customField_${key}`, value);
+      });
+
+      React.startTransition(() => {
+        formAction(formData);
+      });
+    },
+    [customFieldValues, formAction]
+  );
+
+  // Keyboard shortcut: Cmd+Enter to submit
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        form.handleSubmit(onSubmit)();
+      }
+    },
+    [form, onSubmit]
+  );
+
+  const getInitials = (name: string) =>
+    name
+      .split(' ')
+      .map(n => n[0])
+      .join('')
+      .substring(0, 2)
+      .toUpperCase();
+
+  const services = contextData?.services || [];
+  const users = contextData?.users || [];
+  const teams = contextData?.teams || [];
+  const templates = contextData?.templates || [];
+  const customFields = contextData?.customFields || [];
+
+  return (
+    <DialogPrimitive.Root
+      open={isOpen}
+      onOpenChange={open => {
+        if (!open) closeCreateIncident();
+      }}
+    >
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-slate-950/60 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          className="fixed left-[50%] top-[50%] z-50 w-[92vw] max-w-3xl max-h-[88vh] translate-x-[-50%] translate-y-[-50%] rounded-2xl border border-border shadow-2xl bg-card/95 backdrop-blur-xl p-0 flex flex-col overflow-hidden gap-0 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+          onKeyDown={handleKeyDown}
+        >
+          {/* Decorative strip */}
+          <div className="h-1.5 w-full bg-gradient-to-r from-primary via-rose-500 to-amber-500 shrink-0" />
+
+          {/* Header */}
+          <div className="px-6 pt-5 pb-4 border-b border-border/40 shrink-0">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="flex items-center justify-center h-10 w-10 rounded-xl bg-primary/10 border border-primary/20">
+                  <Zap className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <DialogPrimitive.Title className="text-lg font-bold tracking-tight text-foreground">
+                    Create Incident
+                  </DialogPrimitive.Title>
+                  <DialogPrimitive.Description className="text-xs text-muted-foreground mt-0.5">
+                    Log a new incident and trigger response workflows.
+                  </DialogPrimitive.Description>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {/* Template Quick-Picker */}
+                {templates.length > 0 && (
+                  <Select
+                    value={selectedTemplateId}
+                    onValueChange={val => {
+                      setSelectedTemplateId(val);
+                      const template = templates.find((t: Template) => t.id === val);
+                      if (template) applyTemplate(template);
+                    }}
+                  >
+                    <SelectTrigger className="h-8 w-[180px] text-xs bg-muted/40 border-border/50">
+                      <LayoutTemplate className="h-3.5 w-3.5 mr-1.5 text-muted-foreground" />
+                      <SelectValue placeholder="Use template..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {templates.map((t: Template) => (
+                        <SelectItem key={t.id} value={t.id} className="text-xs">
+                          {t.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <DialogPrimitive.Close className="rounded-lg p-1.5 opacity-70 ring-offset-background transition-opacity hover:opacity-100 hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Close</span>
+                </DialogPrimitive.Close>
+              </div>
+            </div>
+          </div>
+
+          {/* Loading state */}
+          {loading && (
+            <div className="flex-1 flex items-center justify-center py-20">
+              <div className="flex flex-col items-center gap-3">
+                <Loader2 className="h-8 w-8 animate-spin text-primary/60" />
+                <p className="text-sm text-muted-foreground">Loading form data...</p>
+              </div>
+            </div>
+          )}
+
+          {/* Form body */}
+          {!loading && contextData && (
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
+                <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+                  {/* Intelligent Deduplication Info */}
+                  <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-3.5 flex gap-3 text-sm text-yellow-600 dark:text-yellow-500">
+                    <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <div className="space-y-1">
+                      <p className="font-semibold text-xs">Intelligent Merging Active</p>
+                      <p className="opacity-90 text-[11px]">
+                        If you use a <strong>Deduplication Key</strong> that matches an existing
+                        incident:
+                      </p>
+                      <ul className="list-disc pl-4 text-[11px] space-y-0.5 opacity-80 mt-1">
+                        <li>
+                          <strong>Open Incident:</strong> Your report will be added as a note to it.
+                        </li>
+                        <li>
+                          <strong>Recently Resolved:</strong> It will re-open the incident (if
+                          resolved &lt; 30m ago).
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+
+                  {/* Section 1: Core Content */}
+                  <div className="space-y-4">
+                    <FormField
+                      control={form.control}
+                      name="title"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormControl>
+                            <Input
+                              placeholder="What's broken? e.g. API Latency Spike in EU"
+                              className="text-base md:text-lg font-medium py-5 px-4 bg-background/50 border-input/50 focus:bg-background focus:ring-2 focus:ring-primary/20 transition-all duration-300 shadow-sm"
+                              {...field}
+                              ref={e => {
+                                field.ref(e);
+                                (
+                                  titleInputRef as React.MutableRefObject<HTMLInputElement | null>
+                                ).current = e;
+                              }}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="description"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormControl>
+                            <Textarea
+                              placeholder="Provide context... Impact, symptoms, triggered alerts."
+                              className="min-h-[80px] resize-y bg-background/50 border-input/50 focus:bg-background focus:ring-2 focus:ring-primary/20 transition-all duration-300 shadow-inner px-4 py-3 leading-relaxed text-sm"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  {/* Divider */}
+                  <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t border-border/40" />
+                    </div>
+                    <div className="relative flex justify-center text-xs uppercase">
+                      <span className="bg-card px-2 text-muted-foreground font-semibold tracking-widest text-[10px]">
+                        Context & Routing
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Section 2: Grid */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {/* Left Column: Routing */}
+                    <div className="space-y-5">
+                      {/* Service Selector */}
+                      <FormField
+                        control={form.control}
+                        name="serviceId"
+                        render={({ field }) => (
+                          <FormItem className="flex flex-col">
+                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1">
+                              Affected Service
+                            </FormLabel>
+                            <Popover open={serviceOpen} onOpenChange={setServiceOpen}>
+                              <PopoverTrigger asChild>
+                                <FormControl>
+                                  <Button
+                                    variant="outline"
+                                    role="combobox"
+                                    className={cn(
+                                      'w-full justify-between h-9 bg-background/50 hover:bg-background border-dashed border-input active:scale-[0.98] transition-all text-sm',
+                                      !field.value && 'text-muted-foreground'
+                                    )}
+                                  >
+                                    {field.value ? (
+                                      <span className="flex items-center gap-2 font-medium">
+                                        <Activity className="h-3.5 w-3.5 text-primary" />
+                                        {services.find(s => s.id === field.value)?.name}
+                                      </span>
+                                    ) : (
+                                      'Select service...'
+                                    )}
+                                    <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
+                                  </Button>
+                                </FormControl>
+                              </PopoverTrigger>
+                              <PopoverContent
+                                className="w-[var(--radix-popover-trigger-width)] p-0 shadow-xl border-border/50"
+                                align="start"
+                              >
+                                <Command>
+                                  <CommandInput placeholder="Search services..." className="h-9" />
+                                  <CommandList>
+                                    <CommandEmpty>No service found.</CommandEmpty>
+                                    <CommandGroup>
+                                      {services.map(service => (
+                                        <CommandItem
+                                          value={service.name}
+                                          key={service.id}
+                                          onSelect={() => {
+                                            form.setValue('serviceId', service.id);
+                                            setServiceOpen(false);
+                                          }}
+                                          className="flex items-center gap-2 py-2 cursor-pointer text-sm"
+                                        >
+                                          <Check
+                                            className={cn(
+                                              'mr-1.5 h-3 w-3',
+                                              service.id === field.value
+                                                ? 'opacity-100'
+                                                : 'opacity-0'
+                                            )}
+                                          />
+                                          <div className="h-2 w-2 rounded-full bg-green-500 mr-1.5" />
+                                          <span className="font-medium">{service.name}</span>
+                                        </CommandItem>
+                                      ))}
+                                    </CommandGroup>
+                                  </CommandList>
+                                </Command>
+                              </PopoverContent>
+                            </Popover>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      {/* Assignee Selector */}
+                      <FormField
+                        control={form.control}
+                        name="assigneeId"
+                        render={({ field }) => (
+                          <FormItem className="flex flex-col">
+                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1">
+                              Assignee
+                            </FormLabel>
+                            <Popover open={assigneeOpen} onOpenChange={setAssigneeOpen}>
+                              <PopoverTrigger asChild>
+                                <FormControl>
+                                  <Button
+                                    variant="outline"
+                                    role="combobox"
+                                    className={cn(
+                                      'w-full justify-between h-9 bg-background/50 hover:bg-background border-dashed border-input active:scale-[0.98] transition-all text-sm',
+                                      !field.value && 'text-muted-foreground'
+                                    )}
+                                  >
+                                    {field.value && field.value !== 'unassigned' ? (
+                                      <span className="flex items-center gap-2 font-medium">
+                                        {field.value.startsWith('team:') ? (
+                                          <>
+                                            <div className="h-5 w-5 rounded-md bg-indigo-100 text-indigo-600 flex items-center justify-center border border-indigo-200">
+                                              <Users className="h-3 w-3" />
+                                            </div>
+                                            {teams.find(t => `team:${t.id}` === field.value)?.name}
+                                          </>
+                                        ) : (
+                                          <>
+                                            <Avatar className="h-5 w-5 border border-slate-200">
+                                              <AvatarImage
+                                                src={
+                                                  users.find(
+                                                    u =>
+                                                      `user:${u.id}` === field.value ||
+                                                      u.id === field.value
+                                                  )?.avatarUrl || undefined
+                                                }
+                                              />
+                                              <AvatarFallback className="text-[9px] bg-primary/10 text-primary">
+                                                {getInitials(
+                                                  users.find(
+                                                    u =>
+                                                      `user:${u.id}` === field.value ||
+                                                      u.id === field.value
+                                                  )?.name || '?'
+                                                )}
+                                              </AvatarFallback>
+                                            </Avatar>
+                                            {
+                                              users.find(
+                                                u =>
+                                                  `user:${u.id}` === field.value ||
+                                                  u.id === field.value
+                                              )?.name
+                                            }
+                                          </>
+                                        )}
+                                      </span>
+                                    ) : (
+                                      <span className="flex items-center gap-2 text-muted-foreground italic">
+                                        <div className="h-5 w-5 rounded-full bg-muted flex items-center justify-center text-[10px] border border-border">
+                                          <Hash className="h-3 w-3" />
+                                        </div>
+                                        Auto-assign (via ELP)
+                                      </span>
+                                    )}
+                                    <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
+                                  </Button>
+                                </FormControl>
+                              </PopoverTrigger>
+                              <PopoverContent
+                                className="w-[300px] p-0 shadow-xl border-border/50"
+                                align="start"
+                              >
+                                <Command>
+                                  <CommandInput
+                                    placeholder="Search users or teams..."
+                                    className="h-9"
+                                  />
+                                  <CommandList>
+                                    <CommandEmpty>No assignee found.</CommandEmpty>
+                                    <CommandGroup heading="Suggestions">
+                                      <CommandItem
+                                        value="unassigned"
+                                        onSelect={() => {
+                                          form.setValue('assigneeId', 'unassigned');
+                                          setAssigneeOpen(false);
+                                        }}
+                                        className="flex items-center gap-2 cursor-pointer"
+                                      >
+                                        <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center text-[10px] border border-border">
+                                          <Hash className="h-3 w-3" />
+                                        </div>
+                                        <span>Auto-assign (via ELP)</span>
+                                        {field.value === 'unassigned' && (
+                                          <Check className="ml-auto h-3 w-3 opacity-100" />
+                                        )}
+                                      </CommandItem>
+                                    </CommandGroup>
+
+                                    {teams.length > 0 && (
+                                      <CommandGroup heading="Teams">
+                                        {teams.map(team => (
+                                          <CommandItem
+                                            key={team.id}
+                                            value={team.name}
+                                            onSelect={() => {
+                                              form.setValue('assigneeId', `team:${team.id}`);
+                                              setAssigneeOpen(false);
+                                            }}
+                                            className="flex items-center gap-2 cursor-pointer"
+                                          >
+                                            <div className="h-6 w-6 rounded-md bg-indigo-100 text-indigo-600 flex items-center justify-center border border-indigo-200">
+                                              <Users className="h-3.5 w-3.5" />
+                                            </div>
+                                            <span>{team.name}</span>
+                                            {field.value === `team:${team.id}` && (
+                                              <Check className="ml-auto h-3 w-3 opacity-100" />
+                                            )}
+                                          </CommandItem>
+                                        ))}
+                                      </CommandGroup>
+                                    )}
+
+                                    <CommandGroup heading="Users">
+                                      {users.map(user => (
+                                        <CommandItem
+                                          key={user.id}
+                                          value={user.name}
+                                          onSelect={() => {
+                                            form.setValue('assigneeId', `user:${user.id}`);
+                                            setAssigneeOpen(false);
+                                          }}
+                                          className="flex items-center gap-2 cursor-pointer"
+                                        >
+                                          <Avatar className="h-6 w-6 border border-slate-200">
+                                            <AvatarImage src={user.avatarUrl || undefined} />
+                                            <AvatarFallback className="text-[10px] bg-primary/10 text-primary font-bold">
+                                              {getInitials(user.name)}
+                                            </AvatarFallback>
+                                          </Avatar>
+                                          <span>{user.name}</span>
+                                          {(field.value === `user:${user.id}` ||
+                                            field.value === user.id) && (
+                                            <Check className="ml-auto h-3 w-3 opacity-100" />
+                                          )}
+                                        </CommandItem>
+                                      ))}
+                                    </CommandGroup>
+                                  </CommandList>
+                                </Command>
+                              </PopoverContent>
+                            </Popover>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+
+                    {/* Right Column: Impact */}
+                    <div className="space-y-5">
+                      {/* Urgency Cards */}
+                      <FormField
+                        control={form.control}
+                        name="urgency"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1 block">
+                              Urgency
+                            </FormLabel>
+                            <FormControl>
+                              <div className="grid grid-cols-3 gap-2.5">
+                                {[
+                                  {
+                                    value: 'LOW',
+                                    label: 'Low',
+                                    icon: Info,
+                                    color: 'text-emerald-600',
+                                    active:
+                                      'ring-2 ring-emerald-500 bg-emerald-500/5 shadow-[0_0_15px_-3px_rgba(16,185,129,0.3)]',
+                                  },
+                                  {
+                                    value: 'MEDIUM',
+                                    label: 'Medium',
+                                    icon: AlertCircle,
+                                    color: 'text-amber-600',
+                                    active:
+                                      'ring-2 ring-amber-500 bg-amber-500/5 shadow-[0_0_15px_-3px_rgba(245,158,11,0.3)]',
+                                  },
+                                  {
+                                    value: 'HIGH',
+                                    label: 'High',
+                                    icon: AlertTriangle,
+                                    color: 'text-rose-600',
+                                    active:
+                                      'ring-2 ring-rose-500 bg-rose-500/5 shadow-[0_0_15px_-3px_rgba(244,63,94,0.3)]',
+                                  },
+                                ].map(option => (
+                                  <div
+                                    key={option.value}
+                                    className={cn(
+                                      'group cursor-pointer rounded-xl border p-2.5 transition-all duration-300 relative overflow-hidden active:scale-95',
+                                      field.value === option.value
+                                        ? `border-transparent ${option.active}`
+                                        : 'border-input bg-background/50 hover:bg-accent hover:border-accent-foreground/30'
+                                    )}
+                                    onClick={() => field.onChange(option.value)}
+                                  >
+                                    {field.value === option.value && (
+                                      <div
+                                        className={cn(
+                                          'absolute inset-0 opacity-10 blur-xl',
+                                          option.color.replace('text-', 'bg-')
+                                        )}
+                                      />
+                                    )}
+                                    <div className="relative flex flex-col items-center gap-1.5">
+                                      <option.icon
+                                        className={cn(
+                                          'h-4 w-4 transition-transform duration-300 group-hover:scale-110',
+                                          option.color
+                                        )}
+                                      />
+                                      <span
+                                        className={cn(
+                                          'text-[10px] font-bold tracking-wide',
+                                          field.value === option.value
+                                            ? option.color
+                                            : 'text-muted-foreground'
+                                        )}
+                                      >
+                                        {option.label}
+                                      </span>
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      {/* Priority Selector */}
+                      <FormField
+                        control={form.control}
+                        name="priority"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1 block">
+                              Priority
+                            </FormLabel>
+                            <FormControl>
+                              <div className="flex items-center gap-1 p-1 bg-muted/40 rounded-lg border border-border/50">
+                                {['P1', 'P2', 'P3', 'P4', 'P5'].map(p => {
+                                  const isSelected = field.value === p;
+                                  return (
+                                    <div
+                                      key={p}
+                                      onClick={() => field.onChange(isSelected ? '' : p)}
+                                      className={cn(
+                                        'flex-1 cursor-pointer py-1.5 text-center rounded-md text-xs font-bold transition-all duration-200 select-none',
+                                        isSelected
+                                          ? 'bg-background shadow-sm text-foreground ring-1 ring-border'
+                                          : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
+                                      )}
+                                    >
+                                      {p}
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Advanced Options */}
+                  <div className="rounded-lg border bg-muted/20 px-4 py-3">
+                    <div className="flex flex-wrap gap-x-8 gap-y-4 items-center">
+                      <div className="flex-1 min-w-[240px]">
+                        <FormField
+                          control={form.control}
+                          name="dedupKey"
+                          render={({ field }) => (
+                            <FormItem className="space-y-1">
+                              <FormLabel className="text-[10px] uppercase font-bold text-muted-foreground flex items-center gap-1">
+                                <Hash className="h-3 w-3" /> Deduplication Key
+                              </FormLabel>
+                              <FormControl>
+                                <Input
+                                  {...field}
+                                  placeholder="auto-generated-if-empty"
+                                  className="h-8 text-xs bg-transparent border-transparent hover:border-input focus:border-primary focus:bg-background transition-colors placeholder:text-muted-foreground/50"
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
+                      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                        <Info className="h-3 w-3" />
+                        Notifications follow escalation and service rules automatically.
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Custom Fields */}
+                  {customFields.length > 0 && (
+                    <div className="pt-2 border-t border-dashed">
+                      <h3 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground mb-3 mt-2">
+                        Additional Fields
+                      </h3>
+                      <div className="grid grid-cols-2 gap-4">
+                        {customFields.map(field => (
+                          <div key={field.id}>
+                            <CustomFieldInput
+                              field={field}
+                              value={customFieldValues[field.id] || ''}
+                              onChange={value =>
+                                setCustomFieldValues({
+                                  ...customFieldValues,
+                                  [field.id]: value,
+                                })
+                              }
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Footer Actions */}
+                <div className="p-4 bg-muted/30 border-t flex justify-between items-center shrink-0">
+                  <div className="flex items-center gap-3">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={closeCreateIncident}
+                      className="text-muted-foreground hover:text-foreground hover:bg-background"
+                    >
+                      Cancel
+                    </Button>
+                    <span className="text-[10px] text-muted-foreground hidden sm:inline">
+                      <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px]">
+                        Esc
+                      </kbd>{' '}
+                      to close
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-[10px] text-muted-foreground hidden sm:inline">
+                      <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px]">
+                        ⌘
+                      </kbd>
+                      <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px] ml-0.5">
+                        Enter
+                      </kbd>{' '}
+                      to submit
+                    </span>
+                    <Button
+                      type="submit"
+                      size="sm"
+                      disabled={isPending}
+                      className={cn(
+                        'px-6 font-semibold shadow-lg transition-all duration-300',
+                        isPending ? 'opacity-80' : 'hover:shadow-primary/20 hover:scale-[1.02]'
+                      )}
+                    >
+                      {isPending ? (
+                        <span className="flex items-center gap-2">
+                          <Loader2 className="h-4 w-4 animate-spin" /> Creating...
+                        </span>
+                      ) : (
+                        'Create Incident'
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </form>
+            </Form>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/components/incident/CreateIncidentModal.tsx
+++ b/src/components/incident/CreateIncidentModal.tsx
@@ -73,7 +73,7 @@ type CustomField = {
   type: 'TEXT' | 'NUMBER' | 'DATE' | 'SELECT' | 'BOOLEAN' | 'URL' | 'EMAIL';
   required: boolean;
   defaultValue?: string | null;
-  options?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  options?: unknown;
 };
 
 type ContextData = {
@@ -99,14 +99,21 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>;
 
-export default function CreateIncidentModal() {
-  const { isOpen, openOptions, closeCreateIncident } = useCreateIncidentModal();
+function CreateIncidentModalContent({
+  onClose,
+  openOptions,
+}: {
+  onClose: () => void;
+  openOptions: { serviceId?: string; templateId?: string } | null;
+}) {
   const router = useRouter();
   const titleInputRef = useRef<HTMLInputElement>(null);
 
   const [contextData, setContextData] = useState<ContextData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [selectedTemplateId, setSelectedTemplateId] = useState<string | ''>('');
+  const [loading, setLoading] = useState(true);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>(
+    openOptions?.templateId || ''
+  );
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, string>>({});
   const [serviceOpen, setServiceOpen] = useState(false);
   const [assigneeOpen, setAssigneeOpen] = useState(false);
@@ -116,7 +123,7 @@ export default function CreateIncidentModal() {
     defaultValues: {
       title: '',
       description: '',
-      serviceId: '',
+      serviceId: openOptions?.serviceId || '',
       urgency: 'HIGH',
       priority: '',
       assigneeId: 'unassigned',
@@ -139,18 +146,24 @@ export default function CreateIncidentModal() {
     [form]
   );
 
-  // Fetch context data when modal opens
+  // Fetch context data on mount
   useEffect(() => {
-    if (!isOpen) return;
-
     let cancelled = false;
-    setLoading(true);
 
     getIncidentCreationContext()
       .then(data => {
         if (cancelled) return;
-        setContextData(data as ContextData);
+        const ctx = data as ContextData;
+        setContextData(ctx);
         setLoading(false);
+
+        // Pre-apply template if specified in openOptions
+        if (openOptions?.templateId) {
+          const matched = ctx.templates.find((t: Template) => t.id === openOptions.templateId);
+          if (matched) {
+            applyTemplate(matched);
+          }
+        }
       })
       .catch(() => {
         if (cancelled) return;
@@ -160,45 +173,19 @@ export default function CreateIncidentModal() {
     return () => {
       cancelled = true;
     };
-  }, [isOpen]);
+  }, [openOptions, applyTemplate]);
 
-  // Apply openOptions (serviceId / templateId) once context is loaded
+  // Auto-focus title input once data is loaded
   useEffect(() => {
-    if (!contextData || !isOpen) return;
-
-    if (openOptions?.serviceId) {
-      form.setValue('serviceId', openOptions.serviceId);
+    if (contextData && !loading) {
+      const timer = setTimeout(() => titleInputRef.current?.focus(), 100);
+      return () => clearTimeout(timer);
     }
-
-    if (openOptions?.templateId) {
-      setSelectedTemplateId(openOptions.templateId);
-      const template = contextData.templates.find((t: Template) => t.id === openOptions.templateId);
-      if (template) {
-        applyTemplate(template);
-      }
-    }
-  }, [contextData, isOpen, openOptions, form, applyTemplate]);
-
-  // Auto-focus title input when data is loaded
-  useEffect(() => {
-    if (isOpen && contextData && !loading) {
-      setTimeout(() => titleInputRef.current?.focus(), 100);
-    }
-  }, [isOpen, contextData, loading]);
-
-  // Reset form when modal closes
-  useEffect(() => {
-    if (!isOpen) {
-      form.reset();
-      setSelectedTemplateId('');
-      setCustomFieldValues({});
-      setContextData(null);
-    }
-  }, [isOpen, form]);
+  }, [contextData, loading]);
 
   // Server Action State
   const [state, formAction, isPending] = useActionState(
-    async (prevState: { id: string } | null, formData: FormData) => {
+    async (_prevState: { id: string } | null, formData: FormData) => {
       return await createIncident(formData);
     },
     null
@@ -206,11 +193,11 @@ export default function CreateIncidentModal() {
 
   // Handle successful creation
   useEffect(() => {
-    if (state && state.id) {
-      closeCreateIncident();
+    if (state?.id) {
+      onClose();
       router.push(`/incidents/${state.id}`);
     }
-  }, [state, router, closeCreateIncident]);
+  }, [state, router, onClose]);
 
   // Custom submit handler to bridge RHF and Server Actions
   const onSubmit = useCallback(
@@ -269,6 +256,625 @@ export default function CreateIncidentModal() {
   const customFields = contextData?.customFields || [];
 
   return (
+    <DialogPrimitive.Content
+      className="fixed left-[50%] top-[50%] z-50 w-[92vw] max-w-3xl max-h-[88vh] translate-x-[-50%] translate-y-[-50%] rounded-2xl border border-border shadow-2xl bg-card/95 backdrop-blur-xl p-0 flex flex-col overflow-hidden gap-0 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+      onKeyDown={handleKeyDown}
+    >
+      {/* Decorative strip */}
+      <div className="h-1.5 w-full bg-gradient-to-r from-primary via-rose-500 to-amber-500 shrink-0" />
+
+      {/* Header */}
+      <div className="px-6 pt-5 pb-4 border-b border-border/40 shrink-0">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center h-10 w-10 rounded-xl bg-primary/10 border border-primary/20">
+              <Zap className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <DialogPrimitive.Title className="text-lg font-bold tracking-tight text-foreground">
+                Create Incident
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="text-xs text-muted-foreground mt-0.5">
+                Log a new incident and trigger response workflows.
+              </DialogPrimitive.Description>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {/* Template Quick-Picker */}
+            {templates.length > 0 && (
+              <Select
+                value={selectedTemplateId}
+                onValueChange={val => {
+                  setSelectedTemplateId(val);
+                  const template = templates.find((t: Template) => t.id === val);
+                  if (template) applyTemplate(template);
+                }}
+              >
+                <SelectTrigger className="h-8 w-[180px] text-xs bg-muted/40 border-border/50">
+                  <LayoutTemplate className="h-3.5 w-3.5 mr-1.5 text-muted-foreground" />
+                  <SelectValue placeholder="Use template..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {templates.map((t: Template) => (
+                    <SelectItem key={t.id} value={t.id} className="text-xs">
+                      {t.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <DialogPrimitive.Close className="rounded-lg p-1.5 opacity-70 ring-offset-background transition-opacity hover:opacity-100 hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          </div>
+        </div>
+      </div>
+
+      {/* Loading state */}
+      {loading && (
+        <div className="flex-1 flex items-center justify-center py-20">
+          <div className="flex flex-col items-center gap-3">
+            <Loader2 className="h-8 w-8 animate-spin text-primary/60" />
+            <p className="text-sm text-muted-foreground">Loading form data...</p>
+          </div>
+        </div>
+      )}
+
+      {/* Form body */}
+      {!loading && contextData && (
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
+            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+              {/* Intelligent Deduplication Info */}
+              <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-3.5 flex gap-3 text-sm text-yellow-600 dark:text-yellow-500">
+                <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                <div className="space-y-1">
+                  <p className="font-semibold text-xs">Intelligent Merging Active</p>
+                  <p className="opacity-90 text-[11px]">
+                    If you use a <strong>Deduplication Key</strong> that matches an existing
+                    incident:
+                  </p>
+                  <ul className="list-disc pl-4 text-[11px] space-y-0.5 opacity-80 mt-1">
+                    <li>
+                      <strong>Open Incident:</strong> Your report will be added as a note to it.
+                    </li>
+                    <li>
+                      <strong>Recently Resolved:</strong> It will re-open the incident (if resolved
+                      &lt; 30m ago).
+                    </li>
+                  </ul>
+                </div>
+              </div>
+
+              {/* Section 1: Core Content */}
+              <div className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input
+                          placeholder="What's broken? e.g. API Latency Spike in EU"
+                          className="text-base md:text-lg font-medium py-5 px-4 bg-background/50 border-input/50 focus:bg-background focus:ring-2 focus:ring-primary/20 transition-all duration-300 shadow-sm"
+                          {...field}
+                          ref={e => {
+                            field.ref(e);
+                            (
+                              titleInputRef as React.MutableRefObject<HTMLInputElement | null>
+                            ).current = e;
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Provide context... Impact, symptoms, triggered alerts."
+                          className="min-h-[80px] resize-y bg-background/50 border-input/50 focus:bg-background focus:ring-2 focus:ring-primary/20 transition-all duration-300 shadow-inner px-4 py-3 leading-relaxed text-sm"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              {/* Divider */}
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t border-border/40" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground font-semibold tracking-widest text-[10px]">
+                    Context & Routing
+                  </span>
+                </div>
+              </div>
+
+              {/* Section 2: Grid */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {/* Left Column: Routing */}
+                <div className="space-y-5">
+                  {/* Service Selector */}
+                  <FormField
+                    control={form.control}
+                    name="serviceId"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-col">
+                        <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1">
+                          Affected Service
+                        </FormLabel>
+                        <Popover open={serviceOpen} onOpenChange={setServiceOpen}>
+                          <PopoverTrigger asChild>
+                            <FormControl>
+                              <Button
+                                variant="outline"
+                                role="combobox"
+                                className={cn(
+                                  'w-full justify-between h-9 bg-background/50 hover:bg-background border-dashed border-input active:scale-[0.98] transition-all text-sm',
+                                  !field.value && 'text-muted-foreground'
+                                )}
+                              >
+                                {field.value ? (
+                                  <span className="flex items-center gap-2 font-medium">
+                                    <Activity className="h-3.5 w-3.5 text-primary" />
+                                    {services.find(s => s.id === field.value)?.name}
+                                  </span>
+                                ) : (
+                                  'Select service...'
+                                )}
+                                <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
+                              </Button>
+                            </FormControl>
+                          </PopoverTrigger>
+                          <PopoverContent
+                            className="w-[var(--radix-popover-trigger-width)] p-0 shadow-xl border-border/50"
+                            align="start"
+                          >
+                            <Command>
+                              <CommandInput placeholder="Search services..." className="h-9" />
+                              <CommandList>
+                                <CommandEmpty>No service found.</CommandEmpty>
+                                <CommandGroup>
+                                  {services.map(service => (
+                                    <CommandItem
+                                      value={service.name}
+                                      key={service.id}
+                                      onSelect={() => {
+                                        form.setValue('serviceId', service.id);
+                                        setServiceOpen(false);
+                                      }}
+                                      className="flex items-center gap-2 py-2 cursor-pointer text-sm"
+                                    >
+                                      <Check
+                                        className={cn(
+                                          'mr-1.5 h-3 w-3',
+                                          service.id === field.value ? 'opacity-100' : 'opacity-0'
+                                        )}
+                                      />
+                                      <div className="h-2 w-2 rounded-full bg-green-500 mr-1.5" />
+                                      <span className="font-medium">{service.name}</span>
+                                    </CommandItem>
+                                  ))}
+                                </CommandGroup>
+                              </CommandList>
+                            </Command>
+                          </PopoverContent>
+                        </Popover>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Assignee Selector */}
+                  <FormField
+                    control={form.control}
+                    name="assigneeId"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-col">
+                        <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1">
+                          Assignee
+                        </FormLabel>
+                        <Popover open={assigneeOpen} onOpenChange={setAssigneeOpen}>
+                          <PopoverTrigger asChild>
+                            <FormControl>
+                              <Button
+                                variant="outline"
+                                role="combobox"
+                                className={cn(
+                                  'w-full justify-between h-9 bg-background/50 hover:bg-background border-dashed border-input active:scale-[0.98] transition-all text-sm',
+                                  !field.value && 'text-muted-foreground'
+                                )}
+                              >
+                                {field.value && field.value !== 'unassigned' ? (
+                                  <span className="flex items-center gap-2 font-medium">
+                                    {field.value.startsWith('team:') ? (
+                                      <>
+                                        <div className="h-5 w-5 rounded-md bg-indigo-100 text-indigo-600 flex items-center justify-center border border-indigo-200">
+                                          <Users className="h-3 w-3" />
+                                        </div>
+                                        {teams.find(t => `team:${t.id}` === field.value)?.name}
+                                      </>
+                                    ) : (
+                                      <>
+                                        <Avatar className="h-5 w-5 border border-slate-200">
+                                          <AvatarImage
+                                            src={
+                                              users.find(
+                                                u =>
+                                                  `user:${u.id}` === field.value ||
+                                                  u.id === field.value
+                                              )?.avatarUrl || undefined
+                                            }
+                                          />
+                                          <AvatarFallback className="text-[9px] bg-primary/10 text-primary">
+                                            {getInitials(
+                                              users.find(
+                                                u =>
+                                                  `user:${u.id}` === field.value ||
+                                                  u.id === field.value
+                                              )?.name || '?'
+                                            )}
+                                          </AvatarFallback>
+                                        </Avatar>
+                                        {
+                                          users.find(
+                                            u =>
+                                              `user:${u.id}` === field.value || u.id === field.value
+                                          )?.name
+                                        }
+                                      </>
+                                    )}
+                                  </span>
+                                ) : (
+                                  <span className="flex items-center gap-2 text-muted-foreground italic">
+                                    <div className="h-5 w-5 rounded-full bg-muted flex items-center justify-center text-[10px] border border-border">
+                                      <Hash className="h-3 w-3" />
+                                    </div>
+                                    Auto-assign (via ELP)
+                                  </span>
+                                )}
+                                <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
+                              </Button>
+                            </FormControl>
+                          </PopoverTrigger>
+                          <PopoverContent
+                            className="w-[300px] p-0 shadow-xl border-border/50"
+                            align="start"
+                          >
+                            <Command>
+                              <CommandInput
+                                placeholder="Search users or teams..."
+                                className="h-9"
+                              />
+                              <CommandList>
+                                <CommandEmpty>No assignee found.</CommandEmpty>
+                                <CommandGroup heading="Suggestions">
+                                  <CommandItem
+                                    value="unassigned"
+                                    onSelect={() => {
+                                      form.setValue('assigneeId', 'unassigned');
+                                      setAssigneeOpen(false);
+                                    }}
+                                    className="flex items-center gap-2 cursor-pointer"
+                                  >
+                                    <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center text-[10px] border border-border">
+                                      <Hash className="h-3 w-3" />
+                                    </div>
+                                    <span>Auto-assign (via ELP)</span>
+                                    {field.value === 'unassigned' && (
+                                      <Check className="ml-auto h-3 w-3 opacity-100" />
+                                    )}
+                                  </CommandItem>
+                                </CommandGroup>
+
+                                {teams.length > 0 && (
+                                  <CommandGroup heading="Teams">
+                                    {teams.map(team => (
+                                      <CommandItem
+                                        key={team.id}
+                                        value={team.name}
+                                        onSelect={() => {
+                                          form.setValue('assigneeId', `team:${team.id}`);
+                                          setAssigneeOpen(false);
+                                        }}
+                                        className="flex items-center gap-2 cursor-pointer"
+                                      >
+                                        <div className="h-6 w-6 rounded-md bg-indigo-100 text-indigo-600 flex items-center justify-center border border-indigo-200">
+                                          <Users className="h-3.5 w-3.5" />
+                                        </div>
+                                        <span>{team.name}</span>
+                                        {field.value === `team:${team.id}` && (
+                                          <Check className="ml-auto h-3 w-3 opacity-100" />
+                                        )}
+                                      </CommandItem>
+                                    ))}
+                                  </CommandGroup>
+                                )}
+
+                                <CommandGroup heading="Users">
+                                  {users.map(user => (
+                                    <CommandItem
+                                      key={user.id}
+                                      value={user.name}
+                                      onSelect={() => {
+                                        form.setValue('assigneeId', `user:${user.id}`);
+                                        setAssigneeOpen(false);
+                                      }}
+                                      className="flex items-center gap-2 cursor-pointer"
+                                    >
+                                      <Avatar className="h-6 w-6 border border-slate-200">
+                                        <AvatarImage src={user.avatarUrl || undefined} />
+                                        <AvatarFallback className="text-[10px] bg-primary/10 text-primary font-bold">
+                                          {getInitials(user.name)}
+                                        </AvatarFallback>
+                                      </Avatar>
+                                      <span>{user.name}</span>
+                                      {(field.value === `user:${user.id}` ||
+                                        field.value === user.id) && (
+                                        <Check className="ml-auto h-3 w-3 opacity-100" />
+                                      )}
+                                    </CommandItem>
+                                  ))}
+                                </CommandGroup>
+                              </CommandList>
+                            </Command>
+                          </PopoverContent>
+                        </Popover>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {/* Right Column: Impact */}
+                <div className="space-y-5">
+                  {/* Urgency Cards */}
+                  <FormField
+                    control={form.control}
+                    name="urgency"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1 block">
+                          Urgency
+                        </FormLabel>
+                        <FormControl>
+                          <div className="grid grid-cols-3 gap-2.5">
+                            {[
+                              {
+                                value: 'LOW',
+                                label: 'Low',
+                                icon: Info,
+                                color: 'text-emerald-600',
+                                active:
+                                  'ring-2 ring-emerald-500 bg-emerald-500/5 shadow-[0_0_15px_-3px_rgba(16,185,129,0.3)]',
+                              },
+                              {
+                                value: 'MEDIUM',
+                                label: 'Medium',
+                                icon: AlertCircle,
+                                color: 'text-amber-600',
+                                active:
+                                  'ring-2 ring-amber-500 bg-amber-500/5 shadow-[0_0_15px_-3px_rgba(245,158,11,0.3)]',
+                              },
+                              {
+                                value: 'HIGH',
+                                label: 'High',
+                                icon: AlertTriangle,
+                                color: 'text-rose-600',
+                                active:
+                                  'ring-2 ring-rose-500 bg-rose-500/5 shadow-[0_0_15px_-3px_rgba(244,63,94,0.3)]',
+                              },
+                            ].map(option => (
+                              <div
+                                key={option.value}
+                                className={cn(
+                                  'group cursor-pointer rounded-xl border p-2.5 transition-all duration-300 relative overflow-hidden active:scale-95',
+                                  field.value === option.value
+                                    ? `border-transparent ${option.active}`
+                                    : 'border-input bg-background/50 hover:bg-accent hover:border-accent-foreground/30'
+                                )}
+                                onClick={() => field.onChange(option.value)}
+                              >
+                                {field.value === option.value && (
+                                  <div
+                                    className={cn(
+                                      'absolute inset-0 opacity-10 blur-xl',
+                                      option.color.replace('text-', 'bg-')
+                                    )}
+                                  />
+                                )}
+                                <div className="relative flex flex-col items-center gap-1.5">
+                                  <option.icon
+                                    className={cn(
+                                      'h-4 w-4 transition-transform duration-300 group-hover:scale-110',
+                                      option.color
+                                    )}
+                                  />
+                                  <span
+                                    className={cn(
+                                      'text-[10px] font-bold tracking-wide',
+                                      field.value === option.value
+                                        ? option.color
+                                        : 'text-muted-foreground'
+                                    )}
+                                  >
+                                    {option.label}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Priority Selector */}
+                  <FormField
+                    control={form.control}
+                    name="priority"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1 block">
+                          Priority
+                        </FormLabel>
+                        <FormControl>
+                          <div className="flex items-center gap-1 p-1 bg-muted/40 rounded-lg border border-border/50">
+                            {['P1', 'P2', 'P3', 'P4', 'P5'].map(p => {
+                              const isSelected = field.value === p;
+                              return (
+                                <div
+                                  key={p}
+                                  onClick={() => field.onChange(isSelected ? '' : p)}
+                                  className={cn(
+                                    'flex-1 cursor-pointer py-1.5 text-center rounded-md text-xs font-bold transition-all duration-200 select-none',
+                                    isSelected
+                                      ? 'bg-background shadow-sm text-foreground ring-1 ring-border'
+                                      : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
+                                  )}
+                                >
+                                  {p}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
+
+              {/* Advanced Options */}
+              <div className="rounded-lg border bg-muted/20 px-4 py-3">
+                <div className="flex flex-wrap gap-x-8 gap-y-4 items-center">
+                  <div className="flex-1 min-w-[240px]">
+                    <FormField
+                      control={form.control}
+                      name="dedupKey"
+                      render={({ field }) => (
+                        <FormItem className="space-y-1">
+                          <FormLabel className="text-[10px] uppercase font-bold text-muted-foreground flex items-center gap-1">
+                            <Hash className="h-3 w-3" /> Deduplication Key
+                          </FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              placeholder="auto-generated-if-empty"
+                              className="h-8 text-xs bg-transparent border-transparent hover:border-input focus:border-primary focus:bg-background transition-colors placeholder:text-muted-foreground/50"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                  <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                    <Info className="h-3 w-3" />
+                    Notifications follow escalation and service rules automatically.
+                  </div>
+                </div>
+              </div>
+
+              {/* Custom Fields */}
+              {customFields.length > 0 && (
+                <div className="pt-2 border-t border-dashed">
+                  <h3 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground mb-3 mt-2">
+                    Additional Fields
+                  </h3>
+                  <div className="grid grid-cols-2 gap-4">
+                    {customFields.map(field => (
+                      <div key={field.id}>
+                        <CustomFieldInput
+                          field={field}
+                          value={customFieldValues[field.id] || ''}
+                          onChange={value =>
+                            setCustomFieldValues(prev => ({
+                              ...prev,
+                              [field.id]: value,
+                            }))
+                          }
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Footer Actions */}
+            <div className="p-4 bg-muted/30 border-t flex justify-between items-center shrink-0">
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={onClose}
+                  className="text-muted-foreground hover:text-foreground hover:bg-background"
+                >
+                  Cancel
+                </Button>
+                <span className="text-[10px] text-muted-foreground hidden sm:inline">
+                  <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px]">
+                    Esc
+                  </kbd>{' '}
+                  to close
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-[10px] text-muted-foreground hidden sm:inline">
+                  <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px]">
+                    ⌘
+                  </kbd>
+                  <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px] ml-0.5">
+                    Enter
+                  </kbd>{' '}
+                  to submit
+                </span>
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={isPending}
+                  className={cn(
+                    'px-6 font-semibold shadow-lg transition-all duration-300',
+                    isPending ? 'opacity-80' : 'hover:shadow-primary/20 hover:scale-[1.02]'
+                  )}
+                >
+                  {isPending ? (
+                    <span className="flex items-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Creating...
+                    </span>
+                  ) : (
+                    'Create Incident'
+                  )}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
+      )}
+    </DialogPrimitive.Content>
+  );
+}
+
+export default function CreateIncidentModal() {
+  const { isOpen, openOptions, closeCreateIncident } = useCreateIncidentModal();
+
+  return (
     <DialogPrimitive.Root
       open={isOpen}
       onOpenChange={open => {
@@ -277,621 +883,9 @@ export default function CreateIncidentModal() {
     >
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-slate-950/60 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <DialogPrimitive.Content
-          className="fixed left-[50%] top-[50%] z-50 w-[92vw] max-w-3xl max-h-[88vh] translate-x-[-50%] translate-y-[-50%] rounded-2xl border border-border shadow-2xl bg-card/95 backdrop-blur-xl p-0 flex flex-col overflow-hidden gap-0 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
-          onKeyDown={handleKeyDown}
-        >
-          {/* Decorative strip */}
-          <div className="h-1.5 w-full bg-gradient-to-r from-primary via-rose-500 to-amber-500 shrink-0" />
-
-          {/* Header */}
-          <div className="px-6 pt-5 pb-4 border-b border-border/40 shrink-0">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex items-center gap-3">
-                <div className="flex items-center justify-center h-10 w-10 rounded-xl bg-primary/10 border border-primary/20">
-                  <Zap className="h-5 w-5 text-primary" />
-                </div>
-                <div>
-                  <DialogPrimitive.Title className="text-lg font-bold tracking-tight text-foreground">
-                    Create Incident
-                  </DialogPrimitive.Title>
-                  <DialogPrimitive.Description className="text-xs text-muted-foreground mt-0.5">
-                    Log a new incident and trigger response workflows.
-                  </DialogPrimitive.Description>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                {/* Template Quick-Picker */}
-                {templates.length > 0 && (
-                  <Select
-                    value={selectedTemplateId}
-                    onValueChange={val => {
-                      setSelectedTemplateId(val);
-                      const template = templates.find((t: Template) => t.id === val);
-                      if (template) applyTemplate(template);
-                    }}
-                  >
-                    <SelectTrigger className="h-8 w-[180px] text-xs bg-muted/40 border-border/50">
-                      <LayoutTemplate className="h-3.5 w-3.5 mr-1.5 text-muted-foreground" />
-                      <SelectValue placeholder="Use template..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {templates.map((t: Template) => (
-                        <SelectItem key={t.id} value={t.id} className="text-xs">
-                          {t.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-                <DialogPrimitive.Close className="rounded-lg p-1.5 opacity-70 ring-offset-background transition-opacity hover:opacity-100 hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
-                  <X className="h-4 w-4" />
-                  <span className="sr-only">Close</span>
-                </DialogPrimitive.Close>
-              </div>
-            </div>
-          </div>
-
-          {/* Loading state */}
-          {loading && (
-            <div className="flex-1 flex items-center justify-center py-20">
-              <div className="flex flex-col items-center gap-3">
-                <Loader2 className="h-8 w-8 animate-spin text-primary/60" />
-                <p className="text-sm text-muted-foreground">Loading form data...</p>
-              </div>
-            </div>
-          )}
-
-          {/* Form body */}
-          {!loading && contextData && (
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
-                <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
-                  {/* Intelligent Deduplication Info */}
-                  <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-3.5 flex gap-3 text-sm text-yellow-600 dark:text-yellow-500">
-                    <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-                    <div className="space-y-1">
-                      <p className="font-semibold text-xs">Intelligent Merging Active</p>
-                      <p className="opacity-90 text-[11px]">
-                        If you use a <strong>Deduplication Key</strong> that matches an existing
-                        incident:
-                      </p>
-                      <ul className="list-disc pl-4 text-[11px] space-y-0.5 opacity-80 mt-1">
-                        <li>
-                          <strong>Open Incident:</strong> Your report will be added as a note to it.
-                        </li>
-                        <li>
-                          <strong>Recently Resolved:</strong> It will re-open the incident (if
-                          resolved &lt; 30m ago).
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-
-                  {/* Section 1: Core Content */}
-                  <div className="space-y-4">
-                    <FormField
-                      control={form.control}
-                      name="title"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormControl>
-                            <Input
-                              placeholder="What's broken? e.g. API Latency Spike in EU"
-                              className="text-base md:text-lg font-medium py-5 px-4 bg-background/50 border-input/50 focus:bg-background focus:ring-2 focus:ring-primary/20 transition-all duration-300 shadow-sm"
-                              {...field}
-                              ref={e => {
-                                field.ref(e);
-                                (
-                                  titleInputRef as React.MutableRefObject<HTMLInputElement | null>
-                                ).current = e;
-                              }}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <FormField
-                      control={form.control}
-                      name="description"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormControl>
-                            <Textarea
-                              placeholder="Provide context... Impact, symptoms, triggered alerts."
-                              className="min-h-[80px] resize-y bg-background/50 border-input/50 focus:bg-background focus:ring-2 focus:ring-primary/20 transition-all duration-300 shadow-inner px-4 py-3 leading-relaxed text-sm"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </div>
-
-                  {/* Divider */}
-                  <div className="relative">
-                    <div className="absolute inset-0 flex items-center">
-                      <span className="w-full border-t border-border/40" />
-                    </div>
-                    <div className="relative flex justify-center text-xs uppercase">
-                      <span className="bg-card px-2 text-muted-foreground font-semibold tracking-widest text-[10px]">
-                        Context & Routing
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Section 2: Grid */}
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    {/* Left Column: Routing */}
-                    <div className="space-y-5">
-                      {/* Service Selector */}
-                      <FormField
-                        control={form.control}
-                        name="serviceId"
-                        render={({ field }) => (
-                          <FormItem className="flex flex-col">
-                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1">
-                              Affected Service
-                            </FormLabel>
-                            <Popover open={serviceOpen} onOpenChange={setServiceOpen}>
-                              <PopoverTrigger asChild>
-                                <FormControl>
-                                  <Button
-                                    variant="outline"
-                                    role="combobox"
-                                    className={cn(
-                                      'w-full justify-between h-9 bg-background/50 hover:bg-background border-dashed border-input active:scale-[0.98] transition-all text-sm',
-                                      !field.value && 'text-muted-foreground'
-                                    )}
-                                  >
-                                    {field.value ? (
-                                      <span className="flex items-center gap-2 font-medium">
-                                        <Activity className="h-3.5 w-3.5 text-primary" />
-                                        {services.find(s => s.id === field.value)?.name}
-                                      </span>
-                                    ) : (
-                                      'Select service...'
-                                    )}
-                                    <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
-                                  </Button>
-                                </FormControl>
-                              </PopoverTrigger>
-                              <PopoverContent
-                                className="w-[var(--radix-popover-trigger-width)] p-0 shadow-xl border-border/50"
-                                align="start"
-                              >
-                                <Command>
-                                  <CommandInput placeholder="Search services..." className="h-9" />
-                                  <CommandList>
-                                    <CommandEmpty>No service found.</CommandEmpty>
-                                    <CommandGroup>
-                                      {services.map(service => (
-                                        <CommandItem
-                                          value={service.name}
-                                          key={service.id}
-                                          onSelect={() => {
-                                            form.setValue('serviceId', service.id);
-                                            setServiceOpen(false);
-                                          }}
-                                          className="flex items-center gap-2 py-2 cursor-pointer text-sm"
-                                        >
-                                          <Check
-                                            className={cn(
-                                              'mr-1.5 h-3 w-3',
-                                              service.id === field.value
-                                                ? 'opacity-100'
-                                                : 'opacity-0'
-                                            )}
-                                          />
-                                          <div className="h-2 w-2 rounded-full bg-green-500 mr-1.5" />
-                                          <span className="font-medium">{service.name}</span>
-                                        </CommandItem>
-                                      ))}
-                                    </CommandGroup>
-                                  </CommandList>
-                                </Command>
-                              </PopoverContent>
-                            </Popover>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {/* Assignee Selector */}
-                      <FormField
-                        control={form.control}
-                        name="assigneeId"
-                        render={({ field }) => (
-                          <FormItem className="flex flex-col">
-                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1">
-                              Assignee
-                            </FormLabel>
-                            <Popover open={assigneeOpen} onOpenChange={setAssigneeOpen}>
-                              <PopoverTrigger asChild>
-                                <FormControl>
-                                  <Button
-                                    variant="outline"
-                                    role="combobox"
-                                    className={cn(
-                                      'w-full justify-between h-9 bg-background/50 hover:bg-background border-dashed border-input active:scale-[0.98] transition-all text-sm',
-                                      !field.value && 'text-muted-foreground'
-                                    )}
-                                  >
-                                    {field.value && field.value !== 'unassigned' ? (
-                                      <span className="flex items-center gap-2 font-medium">
-                                        {field.value.startsWith('team:') ? (
-                                          <>
-                                            <div className="h-5 w-5 rounded-md bg-indigo-100 text-indigo-600 flex items-center justify-center border border-indigo-200">
-                                              <Users className="h-3 w-3" />
-                                            </div>
-                                            {teams.find(t => `team:${t.id}` === field.value)?.name}
-                                          </>
-                                        ) : (
-                                          <>
-                                            <Avatar className="h-5 w-5 border border-slate-200">
-                                              <AvatarImage
-                                                src={
-                                                  users.find(
-                                                    u =>
-                                                      `user:${u.id}` === field.value ||
-                                                      u.id === field.value
-                                                  )?.avatarUrl || undefined
-                                                }
-                                              />
-                                              <AvatarFallback className="text-[9px] bg-primary/10 text-primary">
-                                                {getInitials(
-                                                  users.find(
-                                                    u =>
-                                                      `user:${u.id}` === field.value ||
-                                                      u.id === field.value
-                                                  )?.name || '?'
-                                                )}
-                                              </AvatarFallback>
-                                            </Avatar>
-                                            {
-                                              users.find(
-                                                u =>
-                                                  `user:${u.id}` === field.value ||
-                                                  u.id === field.value
-                                              )?.name
-                                            }
-                                          </>
-                                        )}
-                                      </span>
-                                    ) : (
-                                      <span className="flex items-center gap-2 text-muted-foreground italic">
-                                        <div className="h-5 w-5 rounded-full bg-muted flex items-center justify-center text-[10px] border border-border">
-                                          <Hash className="h-3 w-3" />
-                                        </div>
-                                        Auto-assign (via ELP)
-                                      </span>
-                                    )}
-                                    <ChevronsUpDown className="ml-2 h-3 w-3 shrink-0 opacity-50" />
-                                  </Button>
-                                </FormControl>
-                              </PopoverTrigger>
-                              <PopoverContent
-                                className="w-[300px] p-0 shadow-xl border-border/50"
-                                align="start"
-                              >
-                                <Command>
-                                  <CommandInput
-                                    placeholder="Search users or teams..."
-                                    className="h-9"
-                                  />
-                                  <CommandList>
-                                    <CommandEmpty>No assignee found.</CommandEmpty>
-                                    <CommandGroup heading="Suggestions">
-                                      <CommandItem
-                                        value="unassigned"
-                                        onSelect={() => {
-                                          form.setValue('assigneeId', 'unassigned');
-                                          setAssigneeOpen(false);
-                                        }}
-                                        className="flex items-center gap-2 cursor-pointer"
-                                      >
-                                        <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center text-[10px] border border-border">
-                                          <Hash className="h-3 w-3" />
-                                        </div>
-                                        <span>Auto-assign (via ELP)</span>
-                                        {field.value === 'unassigned' && (
-                                          <Check className="ml-auto h-3 w-3 opacity-100" />
-                                        )}
-                                      </CommandItem>
-                                    </CommandGroup>
-
-                                    {teams.length > 0 && (
-                                      <CommandGroup heading="Teams">
-                                        {teams.map(team => (
-                                          <CommandItem
-                                            key={team.id}
-                                            value={team.name}
-                                            onSelect={() => {
-                                              form.setValue('assigneeId', `team:${team.id}`);
-                                              setAssigneeOpen(false);
-                                            }}
-                                            className="flex items-center gap-2 cursor-pointer"
-                                          >
-                                            <div className="h-6 w-6 rounded-md bg-indigo-100 text-indigo-600 flex items-center justify-center border border-indigo-200">
-                                              <Users className="h-3.5 w-3.5" />
-                                            </div>
-                                            <span>{team.name}</span>
-                                            {field.value === `team:${team.id}` && (
-                                              <Check className="ml-auto h-3 w-3 opacity-100" />
-                                            )}
-                                          </CommandItem>
-                                        ))}
-                                      </CommandGroup>
-                                    )}
-
-                                    <CommandGroup heading="Users">
-                                      {users.map(user => (
-                                        <CommandItem
-                                          key={user.id}
-                                          value={user.name}
-                                          onSelect={() => {
-                                            form.setValue('assigneeId', `user:${user.id}`);
-                                            setAssigneeOpen(false);
-                                          }}
-                                          className="flex items-center gap-2 cursor-pointer"
-                                        >
-                                          <Avatar className="h-6 w-6 border border-slate-200">
-                                            <AvatarImage src={user.avatarUrl || undefined} />
-                                            <AvatarFallback className="text-[10px] bg-primary/10 text-primary font-bold">
-                                              {getInitials(user.name)}
-                                            </AvatarFallback>
-                                          </Avatar>
-                                          <span>{user.name}</span>
-                                          {(field.value === `user:${user.id}` ||
-                                            field.value === user.id) && (
-                                            <Check className="ml-auto h-3 w-3 opacity-100" />
-                                          )}
-                                        </CommandItem>
-                                      ))}
-                                    </CommandGroup>
-                                  </CommandList>
-                                </Command>
-                              </PopoverContent>
-                            </Popover>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-
-                    {/* Right Column: Impact */}
-                    <div className="space-y-5">
-                      {/* Urgency Cards */}
-                      <FormField
-                        control={form.control}
-                        name="urgency"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1 block">
-                              Urgency
-                            </FormLabel>
-                            <FormControl>
-                              <div className="grid grid-cols-3 gap-2.5">
-                                {[
-                                  {
-                                    value: 'LOW',
-                                    label: 'Low',
-                                    icon: Info,
-                                    color: 'text-emerald-600',
-                                    active:
-                                      'ring-2 ring-emerald-500 bg-emerald-500/5 shadow-[0_0_15px_-3px_rgba(16,185,129,0.3)]',
-                                  },
-                                  {
-                                    value: 'MEDIUM',
-                                    label: 'Medium',
-                                    icon: AlertCircle,
-                                    color: 'text-amber-600',
-                                    active:
-                                      'ring-2 ring-amber-500 bg-amber-500/5 shadow-[0_0_15px_-3px_rgba(245,158,11,0.3)]',
-                                  },
-                                  {
-                                    value: 'HIGH',
-                                    label: 'High',
-                                    icon: AlertTriangle,
-                                    color: 'text-rose-600',
-                                    active:
-                                      'ring-2 ring-rose-500 bg-rose-500/5 shadow-[0_0_15px_-3px_rgba(244,63,94,0.3)]',
-                                  },
-                                ].map(option => (
-                                  <div
-                                    key={option.value}
-                                    className={cn(
-                                      'group cursor-pointer rounded-xl border p-2.5 transition-all duration-300 relative overflow-hidden active:scale-95',
-                                      field.value === option.value
-                                        ? `border-transparent ${option.active}`
-                                        : 'border-input bg-background/50 hover:bg-accent hover:border-accent-foreground/30'
-                                    )}
-                                    onClick={() => field.onChange(option.value)}
-                                  >
-                                    {field.value === option.value && (
-                                      <div
-                                        className={cn(
-                                          'absolute inset-0 opacity-10 blur-xl',
-                                          option.color.replace('text-', 'bg-')
-                                        )}
-                                      />
-                                    )}
-                                    <div className="relative flex flex-col items-center gap-1.5">
-                                      <option.icon
-                                        className={cn(
-                                          'h-4 w-4 transition-transform duration-300 group-hover:scale-110',
-                                          option.color
-                                        )}
-                                      />
-                                      <span
-                                        className={cn(
-                                          'text-[10px] font-bold tracking-wide',
-                                          field.value === option.value
-                                            ? option.color
-                                            : 'text-muted-foreground'
-                                        )}
-                                      >
-                                        {option.label}
-                                      </span>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {/* Priority Selector */}
-                      <FormField
-                        control={form.control}
-                        name="priority"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-[10px] uppercase tracking-wide text-foreground/70 font-bold mb-1.5 pl-1 block">
-                              Priority
-                            </FormLabel>
-                            <FormControl>
-                              <div className="flex items-center gap-1 p-1 bg-muted/40 rounded-lg border border-border/50">
-                                {['P1', 'P2', 'P3', 'P4', 'P5'].map(p => {
-                                  const isSelected = field.value === p;
-                                  return (
-                                    <div
-                                      key={p}
-                                      onClick={() => field.onChange(isSelected ? '' : p)}
-                                      className={cn(
-                                        'flex-1 cursor-pointer py-1.5 text-center rounded-md text-xs font-bold transition-all duration-200 select-none',
-                                        isSelected
-                                          ? 'bg-background shadow-sm text-foreground ring-1 ring-border'
-                                          : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
-                                      )}
-                                    >
-                                      {p}
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </div>
-
-                  {/* Advanced Options */}
-                  <div className="rounded-lg border bg-muted/20 px-4 py-3">
-                    <div className="flex flex-wrap gap-x-8 gap-y-4 items-center">
-                      <div className="flex-1 min-w-[240px]">
-                        <FormField
-                          control={form.control}
-                          name="dedupKey"
-                          render={({ field }) => (
-                            <FormItem className="space-y-1">
-                              <FormLabel className="text-[10px] uppercase font-bold text-muted-foreground flex items-center gap-1">
-                                <Hash className="h-3 w-3" /> Deduplication Key
-                              </FormLabel>
-                              <FormControl>
-                                <Input
-                                  {...field}
-                                  placeholder="auto-generated-if-empty"
-                                  className="h-8 text-xs bg-transparent border-transparent hover:border-input focus:border-primary focus:bg-background transition-colors placeholder:text-muted-foreground/50"
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
-                      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                        <Info className="h-3 w-3" />
-                        Notifications follow escalation and service rules automatically.
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Custom Fields */}
-                  {customFields.length > 0 && (
-                    <div className="pt-2 border-t border-dashed">
-                      <h3 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground mb-3 mt-2">
-                        Additional Fields
-                      </h3>
-                      <div className="grid grid-cols-2 gap-4">
-                        {customFields.map(field => (
-                          <div key={field.id}>
-                            <CustomFieldInput
-                              field={field}
-                              value={customFieldValues[field.id] || ''}
-                              onChange={value =>
-                                setCustomFieldValues({
-                                  ...customFieldValues,
-                                  [field.id]: value,
-                                })
-                              }
-                            />
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* Footer Actions */}
-                <div className="p-4 bg-muted/30 border-t flex justify-between items-center shrink-0">
-                  <div className="flex items-center gap-3">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={closeCreateIncident}
-                      className="text-muted-foreground hover:text-foreground hover:bg-background"
-                    >
-                      Cancel
-                    </Button>
-                    <span className="text-[10px] text-muted-foreground hidden sm:inline">
-                      <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px]">
-                        Esc
-                      </kbd>{' '}
-                      to close
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span className="text-[10px] text-muted-foreground hidden sm:inline">
-                      <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px]">
-                        ⌘
-                      </kbd>
-                      <kbd className="font-mono bg-muted border border-border/50 px-1 rounded text-[9px] ml-0.5">
-                        Enter
-                      </kbd>{' '}
-                      to submit
-                    </span>
-                    <Button
-                      type="submit"
-                      size="sm"
-                      disabled={isPending}
-                      className={cn(
-                        'px-6 font-semibold shadow-lg transition-all duration-300',
-                        isPending ? 'opacity-80' : 'hover:shadow-primary/20 hover:scale-[1.02]'
-                      )}
-                    >
-                      {isPending ? (
-                        <span className="flex items-center gap-2">
-                          <Loader2 className="h-4 w-4 animate-spin" /> Creating...
-                        </span>
-                      ) : (
-                        'Create Incident'
-                      )}
-                    </Button>
-                  </div>
-                </div>
-              </form>
-            </Form>
-          )}
-        </DialogPrimitive.Content>
+        {isOpen && (
+          <CreateIncidentModalContent onClose={closeCreateIncident} openOptions={openOptions} />
+        )}
       </DialogPrimitive.Portal>
     </DialogPrimitive.Root>
   );

--- a/src/components/incident/CreateIncidentModal.tsx
+++ b/src/components/incident/CreateIncidentModal.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { createIncident, getIncidentCreationContext } from '@/app/(app)/incidents/actions';
 import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
 import CustomFieldInput from '@/components/CustomFieldInput';
@@ -51,6 +52,8 @@ import {
   X,
   Loader2,
   LayoutTemplate,
+  ArrowUpRight,
+  Sparkles,
 } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcn/avatar';
 
@@ -60,6 +63,7 @@ type Team = { id: string; name: string };
 type Template = {
   id: string;
   name: string;
+  description?: string | null;
   title: string;
   descriptionText?: string | null;
   defaultUrgency: 'HIGH' | 'MEDIUM' | 'LOW';
@@ -254,6 +258,7 @@ function CreateIncidentModalContent({
   const teams = contextData?.teams || [];
   const templates = contextData?.templates || [];
   const customFields = contextData?.customFields || [];
+  const activeTemplate = templates.find(t => t.id === selectedTemplateId);
 
   return (
     <DialogPrimitive.Content
@@ -280,29 +285,6 @@ function CreateIncidentModalContent({
             </div>
           </div>
           <div className="flex items-center gap-2">
-            {/* Template Quick-Picker */}
-            {templates.length > 0 && (
-              <Select
-                value={selectedTemplateId}
-                onValueChange={val => {
-                  setSelectedTemplateId(val);
-                  const template = templates.find((t: Template) => t.id === val);
-                  if (template) applyTemplate(template);
-                }}
-              >
-                <SelectTrigger className="h-8 w-[180px] text-xs bg-muted/40 border-border/50">
-                  <LayoutTemplate className="h-3.5 w-3.5 mr-1.5 text-muted-foreground" />
-                  <SelectValue placeholder="Use template..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {templates.map((t: Template) => (
-                    <SelectItem key={t.id} value={t.id} className="text-xs">
-                      {t.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
             <DialogPrimitive.Close className="rounded-lg p-1.5 opacity-70 ring-offset-background transition-opacity hover:opacity-100 hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
               <X className="h-4 w-4" />
               <span className="sr-only">Close</span>
@@ -316,7 +298,7 @@ function CreateIncidentModalContent({
         <div className="flex-1 flex items-center justify-center py-20">
           <div className="flex flex-col items-center gap-3">
             <Loader2 className="h-8 w-8 animate-spin text-primary/60" />
-            <p className="text-sm text-muted-foreground">Loading form data...</p>
+            <p className="text-sm text-muted-foreground">Loading incident context...</p>
           </div>
         </div>
       )}
@@ -326,6 +308,124 @@ function CreateIncidentModalContent({
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
             <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+              {/* Template Picker & Helper */}
+              <div className="rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-3.5 space-y-2.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <LayoutTemplate className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
+                    <span className="text-xs font-bold uppercase tracking-wider text-foreground">
+                      Start with a Template
+                    </span>
+                    <span className="text-[11px] text-muted-foreground">(Optional)</span>
+                  </div>
+                  <Link
+                    href="/incidents/templates"
+                    onClick={onClose}
+                    className="text-[11px] font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 inline-flex items-center gap-1 hover:underline"
+                  >
+                    Manage Templates
+                    <ArrowUpRight className="h-3 w-3" />
+                  </Link>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={selectedTemplateId || 'none'}
+                    onValueChange={val => {
+                      if (val === 'none') {
+                        setSelectedTemplateId('');
+                        form.reset({
+                          title: '',
+                          description: '',
+                          serviceId: openOptions?.serviceId || '',
+                          urgency: 'HIGH',
+                          priority: '',
+                          assigneeId: 'unassigned',
+                          dedupKey: '',
+                        });
+                      } else {
+                        setSelectedTemplateId(val);
+                        const template = templates.find((t: Template) => t.id === val);
+                        if (template) applyTemplate(template);
+                      }
+                    }}
+                  >
+                    <SelectTrigger className="flex-1 h-9 text-xs bg-background border-border/70 shadow-sm">
+                      <SelectValue placeholder="Select a template or start from scratch..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem
+                        value="none"
+                        className="text-xs font-medium text-muted-foreground"
+                      >
+                        ✨ No template (start from scratch)
+                      </SelectItem>
+                      {templates.map((t: Template) => (
+                        <SelectItem key={t.id} value={t.id} className="text-xs">
+                          <div className="flex items-center gap-2 py-0.5">
+                            <span className="font-semibold text-foreground">{t.name}</span>
+                            {t.defaultService && (
+                              <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground">
+                                {t.defaultService.name}
+                              </span>
+                            )}
+                            <span
+                              className={cn(
+                                'text-[9px] uppercase font-bold px-1.5 py-0.2 rounded',
+                                t.defaultUrgency === 'HIGH'
+                                  ? 'bg-red-50 text-red-700 dark:bg-red-950/50 dark:text-red-300'
+                                  : t.defaultUrgency === 'MEDIUM'
+                                    ? 'bg-amber-50 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300'
+                                    : 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300'
+                              )}
+                            >
+                              {t.defaultUrgency}
+                            </span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+
+                  {selectedTemplateId && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-9 px-2.5 text-xs text-muted-foreground hover:text-foreground"
+                      onClick={() => {
+                        setSelectedTemplateId('');
+                        form.reset({
+                          title: '',
+                          description: '',
+                          serviceId: openOptions?.serviceId || '',
+                          urgency: 'HIGH',
+                          priority: '',
+                          assigneeId: 'unassigned',
+                          dedupKey: '',
+                        });
+                      }}
+                    >
+                      Clear
+                    </Button>
+                  )}
+                </div>
+
+                {/* Active Template Applied Banner */}
+                {activeTemplate && (
+                  <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-indigo-500/10 border border-indigo-500/20 text-xs">
+                    <Sparkles className="h-3.5 w-3.5 text-indigo-600 dark:text-indigo-400 shrink-0" />
+                    <p className="text-[11px] text-foreground font-medium truncate">
+                      Applied template{' '}
+                      <strong className="text-indigo-700 dark:text-indigo-300">
+                        {activeTemplate.name}
+                      </strong>
+                      {activeTemplate.description ? ` — ${activeTemplate.description}` : ''}
+                    </p>
+                  </div>
+                )}
+              </div>
+
               {/* Intelligent Deduplication Info */}
               <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-3.5 flex gap-3 text-sm text-yellow-600 dark:text-yellow-500">
                 <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />

--- a/src/components/incident/IncidentsFilters.tsx
+++ b/src/components/incident/IncidentsFilters.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useTransition } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useCreateIncidentModal } from '@/contexts/IncidentCreationModalContext';
 import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
 import {
@@ -55,6 +56,7 @@ export default function IncidentsFilters({
   canCreateIncident = false,
 }: IncidentsFiltersProps) {
   const router = useRouter();
+  const { openCreateIncident } = useCreateIncidentModal();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
@@ -132,7 +134,7 @@ export default function IncidentsFilters({
                 size="sm"
                 className="h-7 px-3 text-xs"
                 onClick={() => {
-                  router.push('/incidents/create');
+                  openCreateIncident();
                 }}
               >
                 Create incident

--- a/src/components/service/IncidentList.tsx
+++ b/src/components/service/IncidentList.tsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/shadcn/button';
+import CreateIncidentButton from '@/components/incident/CreateIncidentButton';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -157,9 +158,7 @@ function IncidentList({ incidents, serviceId }: IncidentListProps) {
         <p className="text-slate-500 max-w-sm mb-6">
           This service is running smoothly with no recorded incidents.
         </p>
-        <Button asChild>
-          <Link href={`/incidents/create?serviceId=${serviceId}`}>Create Incident</Link>
-        </Button>
+        <CreateIncidentButton serviceId={serviceId} />
       </div>
     );
   }

--- a/src/contexts/IncidentCreationModalContext.tsx
+++ b/src/contexts/IncidentCreationModalContext.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+type OpenOptions = {
+  serviceId?: string;
+  templateId?: string;
+};
+
+type IncidentCreationModalContextType = {
+  isOpen: boolean;
+  openOptions: OpenOptions | null;
+  openCreateIncident: (options?: OpenOptions) => void;
+  closeCreateIncident: () => void;
+};
+
+const defaultContextValue: IncidentCreationModalContextType = {
+  isOpen: false,
+  openOptions: null,
+  openCreateIncident: () => {},
+  closeCreateIncident: () => {},
+};
+
+const IncidentCreationModalContext =
+  createContext<IncidentCreationModalContextType>(defaultContextValue);
+
+export function IncidentCreationModalProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [openOptions, setOpenOptions] = useState<OpenOptions | null>(null);
+
+  const openCreateIncident = useCallback((options?: OpenOptions) => {
+    setOpenOptions(options || null);
+    setIsOpen(true);
+  }, []);
+
+  const closeCreateIncident = useCallback(() => {
+    setIsOpen(false);
+    setOpenOptions(null);
+  }, []);
+
+  return (
+    <IncidentCreationModalContext.Provider
+      value={{ isOpen, openOptions, openCreateIncident, closeCreateIncident }}
+    >
+      {children}
+    </IncidentCreationModalContext.Provider>
+  );
+}
+
+export function useCreateIncidentModal() {
+  return useContext(IncidentCreationModalContext);
+}

--- a/tests/unit/incident-creation-modal.test.tsx
+++ b/tests/unit/incident-creation-modal.test.tsx
@@ -80,6 +80,19 @@ describe('Incident Creation Modal System', () => {
       expect(screen.getByTestId('modal-state').textContent).toBe('open');
       expect(screen.getByTestId('service-id').textContent).toBe('srv-999');
     });
+
+    it('triggers openCreateIncident with templateId on click', () => {
+      render(
+        <IncidentCreationModalProvider>
+          <TestConsumer />
+          <CreateIncidentButton templateId="tmpl-888">Use Template Button</CreateIncidentButton>
+        </IncidentCreationModalProvider>
+      );
+
+      fireEvent.click(screen.getByText('Use Template Button'));
+      expect(screen.getByTestId('modal-state').textContent).toBe('open');
+      expect(screen.getByTestId('template-id').textContent).toBe('tmpl-888');
+    });
   });
 
   describe('CreateIncidentMenuItem', () => {

--- a/tests/unit/incident-creation-modal.test.tsx
+++ b/tests/unit/incident-creation-modal.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import {
+  IncidentCreationModalProvider,
+  useCreateIncidentModal,
+} from '@/contexts/IncidentCreationModalContext';
+import CreateIncidentButton, {
+  CreateIncidentMenuItem,
+} from '@/components/incident/CreateIncidentButton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/shadcn/dropdown-menu';
+
+function TestConsumer() {
+  const { isOpen, openOptions, openCreateIncident, closeCreateIncident } = useCreateIncidentModal();
+
+  return (
+    <div>
+      <div data-testid="modal-state">{isOpen ? 'open' : 'closed'}</div>
+      <div data-testid="service-id">{openOptions?.serviceId || 'none'}</div>
+      <div data-testid="template-id">{openOptions?.templateId || 'none'}</div>
+      <button onClick={() => openCreateIncident()}>Open Default</button>
+      <button onClick={() => openCreateIncident({ serviceId: 'srv-123', templateId: 'tmpl-456' })}>
+        Open With Options
+      </button>
+      <button onClick={() => closeCreateIncident()}>Close</button>
+    </div>
+  );
+}
+
+describe('Incident Creation Modal System', () => {
+  describe('IncidentCreationModalContext', () => {
+    it('manages open/close state and options correctly', () => {
+      render(
+        <IncidentCreationModalProvider>
+          <TestConsumer />
+        </IncidentCreationModalProvider>
+      );
+
+      expect(screen.getByTestId('modal-state').textContent).toBe('closed');
+      expect(screen.getByTestId('service-id').textContent).toBe('none');
+      expect(screen.getByTestId('template-id').textContent).toBe('none');
+
+      // Open default
+      fireEvent.click(screen.getByText('Open Default'));
+      expect(screen.getByTestId('modal-state').textContent).toBe('open');
+      expect(screen.getByTestId('service-id').textContent).toBe('none');
+
+      // Close
+      fireEvent.click(screen.getByText('Close'));
+      expect(screen.getByTestId('modal-state').textContent).toBe('closed');
+
+      // Open with options
+      fireEvent.click(screen.getByText('Open With Options'));
+      expect(screen.getByTestId('modal-state').textContent).toBe('open');
+      expect(screen.getByTestId('service-id').textContent).toBe('srv-123');
+      expect(screen.getByTestId('template-id').textContent).toBe('tmpl-456');
+    });
+
+    it('falls back gracefully when hook used outside provider', () => {
+      render(<TestConsumer />);
+      expect(screen.getByTestId('modal-state').textContent).toBe('closed');
+      expect(screen.getByTestId('service-id').textContent).toBe('none');
+    });
+  });
+
+  describe('CreateIncidentButton', () => {
+    it('renders and triggers openCreateIncident on click', () => {
+      render(
+        <IncidentCreationModalProvider>
+          <TestConsumer />
+          <CreateIncidentButton serviceId="srv-999">Trigger Custom</CreateIncidentButton>
+        </IncidentCreationModalProvider>
+      );
+
+      fireEvent.click(screen.getByText('Trigger Custom'));
+      expect(screen.getByTestId('modal-state').textContent).toBe('open');
+      expect(screen.getByTestId('service-id').textContent).toBe('srv-999');
+    });
+  });
+
+  describe('CreateIncidentMenuItem', () => {
+    it('triggers openCreateIncident with templateId when clicked', () => {
+      render(
+        <IncidentCreationModalProvider>
+          <TestConsumer />
+          <DropdownMenu open={true}>
+            <DropdownMenuTrigger>Open Menu</DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <CreateIncidentMenuItem templateId="tmpl-777">
+                Use Template Menu
+              </CreateIncidentMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </IncidentCreationModalProvider>
+      );
+
+      fireEvent.click(screen.getByText('Use Template Menu'));
+      expect(screen.getByTestId('modal-state').textContent).toBe('open');
+      expect(screen.getByTestId('template-id').textContent).toBe('tmpl-777');
+    });
+  });
+});


### PR DESCRIPTION
## Description
Enhances the global incident creation modal with a prominent template selector, instant pre-filling, active template details banner, and direct management link.

## Key Changes
- **Dedicated Template Picker**: Prominent 'Start with a Template' card directly at the top of the creation modal with template descriptions, default service, and urgency badges.
- **One-Click Pre-Fill & Reset**: Instant pre-filling of Title, Description, Service, Urgency, and Priority with a 'Clear' button to return to scratch.
- **Active Template Banner**: Visual feedback showing which template is currently applied.
- **Manage Templates Link**: Quick jump to `/incidents/templates` to create or configure templates.
- **Unit Tests**: Added test coverage for template selection via button and menu item.

## Verification
- `npm run test:unit` passed (175 test files, 1328 tests passed)
- Production build (`npm run build`) succeeded