### PR TITLE
feat(errors): introduce typed application error contract

### DIFF
--- a/src/components/status-page/StatusPageSubscribe.tsx
+++ b/src/components/status-page/StatusPageSubscribe.tsx
@@ -8,6 +8,12 @@ interface StatusPageSubscribeProps {
     onSuccess?: () => void;
 }
 
+function getApiErrorMessage(payload: unknown): string | null {
+    if (!payload || typeof payload !== 'object' || !('error' in payload)) return null;
+    const message = (payload as { error?: unknown }).error;
+    return typeof message === 'string' && message.trim() ? message : null;
+}
+
 export default function StatusPageSubscribe({ statusPageId, onSuccess }: StatusPageSubscribeProps) {
     const [email, setEmail] = useState('');
     const [isPending, startTransition] = useTransition();
@@ -35,8 +41,17 @@ export default function StatusPageSubscribe({ statusPageId, onSuccess }: StatusP
                 });
 
                 if (!response.ok) {
-                    const data = await response.json();
-                    throw new Error(data.error || 'Failed to subscribe');
+                    // The API response contract owns the public error message. Do not
+                    // re-wrap it as an arbitrary Error because unmatched exception
+                    // messages are intentionally treated as untrusted by AppError.
+                    let message = 'Failed to subscribe';
+                    try {
+                        message = getApiErrorMessage(await response.json()) ?? message;
+                    } catch {
+                        // Malformed/non-JSON error responses fall back to generic copy.
+                    }
+                    setError(message);
+                    return;
                 }
 
                 setSuccess(true);
@@ -44,7 +59,7 @@ export default function StatusPageSubscribe({ statusPageId, onSuccess }: StatusP
                 if (onSuccess) {
                     onSuccess();
                 }
-            } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+            } catch (err: unknown) {
                 const { getUserFriendlyError } = await import('@/lib/user-friendly-errors');
                 setError(getUserFriendlyError(err) || 'Failed to subscribe');
             }
@@ -99,4 +114,3 @@ export default function StatusPageSubscribe({ statusPageId, onSuccess }: StatusP
         </form>
     );
 }
-

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,10 +1,32 @@
 import { NextResponse } from 'next/server';
 import { getUserFriendlyError } from './user-friendly-errors';
+import { isAppError, toPublicAppError, type AppError } from './errors';
 
-export function jsonError(message: string, status: number, meta?: Record<string, unknown>) {
-  // Convert technical errors to user-friendly messages
-  const friendlyMessage = getUserFriendlyError(message);
-  return NextResponse.json({ error: friendlyMessage, meta }, { status });
+export function jsonError(
+  error: string | AppError | unknown,
+  status?: number,
+  meta?: Record<string, unknown>
+) {
+  if (isAppError(error)) {
+    const publicError = toPublicAppError(error);
+
+    return NextResponse.json(
+      {
+        // Preserve the existing string field for backward compatibility while
+        // exposing stable machine-readable semantics to new clients.
+        error: publicError.message,
+        code: publicError.code,
+        action: publicError.action,
+        retryable: publicError.retryable,
+        fields: publicError.fields,
+        meta,
+      },
+      { status: error.status }
+    );
+  }
+
+  const friendlyMessage = getUserFriendlyError(error);
+  return NextResponse.json({ error: friendlyMessage, meta }, { status: status ?? 500 });
 }
 
 export function jsonOk<T>(payload: T, status: number = 200, headers?: HeadersInit) {

--- a/src/lib/errors/app-error.ts
+++ b/src/lib/errors/app-error.ts
@@ -1,4 +1,10 @@
-import { ERROR_REGISTRY, isAppErrorCode, type AppErrorCode, type ErrorExposure } from './registry';
+import {
+  ERROR_REGISTRY,
+  isAppErrorCode,
+  type AppErrorCode,
+  type ErrorDefinition,
+  type ErrorExposure,
+} from './registry';
 
 export type ErrorField = {
   field: string;
@@ -38,7 +44,7 @@ export class AppError extends Error {
   readonly cause?: unknown;
 
   constructor(options: AppErrorOptions) {
-    const definition = ERROR_REGISTRY[options.code];
+    const definition: ErrorDefinition = ERROR_REGISTRY[options.code];
     const userMessage = options.userMessage ?? definition.userMessage;
 
     super(userMessage);

--- a/src/lib/errors/app-error.ts
+++ b/src/lib/errors/app-error.ts
@@ -1,0 +1,102 @@
+import { ERROR_REGISTRY, isAppErrorCode, type AppErrorCode, type ErrorExposure } from './registry';
+
+export type ErrorField = {
+  field: string;
+  code?: string;
+  message: string;
+};
+
+export type AppErrorOptions = {
+  code: AppErrorCode;
+  status?: number;
+  userMessage?: string;
+  action?: string;
+  fields?: ErrorField[];
+  retryable?: boolean;
+  details?: Record<string, unknown>;
+  cause?: unknown;
+  exposure?: ErrorExposure;
+};
+
+export type PublicAppError = {
+  code: AppErrorCode;
+  message: string;
+  action?: string;
+  retryable: boolean;
+  fields?: ErrorField[];
+};
+
+export class AppError extends Error {
+  readonly code: AppErrorCode;
+  readonly status: number;
+  readonly userMessage: string;
+  readonly action?: string;
+  readonly fields?: ErrorField[];
+  readonly retryable: boolean;
+  readonly details?: Record<string, unknown>;
+  readonly exposure: ErrorExposure;
+  readonly cause?: unknown;
+
+  constructor(options: AppErrorOptions) {
+    const definition = ERROR_REGISTRY[options.code];
+    const userMessage = options.userMessage ?? definition.userMessage;
+
+    super(userMessage);
+    this.name = 'AppError';
+    this.code = options.code;
+    this.status = options.status ?? definition.status;
+    this.userMessage = userMessage;
+    this.action = options.action ?? definition.action;
+    this.fields = options.fields;
+    this.retryable = options.retryable ?? definition.retryable ?? false;
+    this.details = options.details;
+    this.exposure = options.exposure ?? definition.exposure ?? 'public';
+    this.cause = options.cause;
+
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function isAppError(error: unknown): error is AppError {
+  return error instanceof AppError;
+}
+
+export function normalizeError(error: unknown): AppError {
+  if (isAppError(error)) return error;
+
+  // Compatibility for existing typed errors (for example AuthorizationError)
+  // while domains migrate onto AppError directly.
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as Error & { code?: unknown }).code;
+    if (isAppErrorCode(code)) {
+      const status =
+        'status' in error && typeof (error as Error & { status?: unknown }).status === 'number'
+          ? (error as Error & { status: number }).status
+          : undefined;
+
+      return new AppError({
+        code,
+        status,
+        userMessage: error.message || undefined,
+        cause: error,
+      });
+    }
+  }
+
+  return new AppError({
+    code: 'INTERNAL_ERROR',
+    cause: error,
+  });
+}
+
+export function toPublicAppError(error: unknown): PublicAppError {
+  const appError = normalizeError(error);
+
+  return {
+    code: appError.code,
+    message: appError.userMessage,
+    action: appError.action,
+    retryable: appError.retryable,
+    fields: appError.fields,
+  };
+}

--- a/src/lib/errors/app-error.ts
+++ b/src/lib/errors/app-error.ts
@@ -14,7 +14,6 @@ export type ErrorField = {
 
 export type AppErrorOptions = {
   code: AppErrorCode;
-  status?: number;
   userMessage?: string;
   action?: string;
   fields?: ErrorField[];
@@ -50,7 +49,9 @@ export class AppError extends Error {
     super(userMessage);
     this.name = 'AppError';
     this.code = options.code;
-    this.status = options.status ?? definition.status;
+    // HTTP semantics are registry-owned for first-class AppError instances.
+    // Callers cannot create the same machine code with conflicting statuses.
+    this.status = definition.status;
     this.userMessage = userMessage;
     this.action = options.action ?? definition.action;
     this.fields = options.fields;
@@ -71,18 +72,13 @@ export function normalizeError(error: unknown): AppError {
   if (isAppError(error)) return error;
 
   // Compatibility for existing typed errors (for example AuthorizationError)
-  // while domains migrate onto AppError directly.
+  // while domains migrate onto AppError directly. Once a legacy code maps to
+  // the registry, the registry owns its HTTP status as well.
   if (error instanceof Error && 'code' in error) {
     const code = (error as Error & { code?: unknown }).code;
     if (isAppErrorCode(code)) {
-      const status =
-        'status' in error && typeof (error as Error & { status?: unknown }).status === 'number'
-          ? (error as Error & { status: number }).status
-          : undefined;
-
       return new AppError({
         code,
-        status,
         userMessage: error.message || undefined,
         cause: error,
       });
@@ -97,6 +93,19 @@ export function normalizeError(error: unknown): AppError {
 
 export function toPublicAppError(error: unknown): PublicAppError {
   const appError = normalizeError(error);
+
+  // `internal` is an enforceable serialization boundary, not metadata.
+  // Never expose caller-supplied message/action/fields for an internal error.
+  if (appError.exposure === 'internal') {
+    const definition: ErrorDefinition = ERROR_REGISTRY.INTERNAL_ERROR;
+    return {
+      code: 'INTERNAL_ERROR',
+      message: definition.userMessage,
+      action: definition.action,
+      retryable: definition.retryable ?? false,
+      fields: undefined,
+    };
+  }
 
   return {
     code: appError.code,

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,0 +1,4 @@
+export { AppError, isAppError, normalizeError, toPublicAppError } from './app-error';
+export type { AppErrorOptions, ErrorField, PublicAppError } from './app-error';
+export { ERROR_REGISTRY, isAppErrorCode } from './registry';
+export type { AppErrorCode, ErrorCategory, ErrorDefinition, ErrorExposure } from './registry';

--- a/src/lib/errors/registry.ts
+++ b/src/lib/errors/registry.ts
@@ -1,0 +1,123 @@
+export type ErrorCategory =
+  | 'authentication'
+  | 'authorization'
+  | 'validation'
+  | 'not_found'
+  | 'conflict'
+  | 'rate_limit'
+  | 'dependency'
+  | 'network'
+  | 'internal';
+
+export type ErrorExposure = 'public' | 'authenticated' | 'internal';
+
+export type ErrorDefinition = {
+  status: number;
+  category: ErrorCategory;
+  userMessage: string;
+  action?: string;
+  retryable?: boolean;
+  exposure?: ErrorExposure;
+};
+
+export const ERROR_REGISTRY = {
+  INTERNAL_ERROR: {
+    status: 500,
+    category: 'internal',
+    userMessage: 'An unexpected error occurred. Please try again. If the problem persists, contact support.',
+    action: 'Try again. If the problem continues, contact support.',
+    retryable: true,
+    exposure: 'internal',
+  },
+  VALIDATION_FAILED: {
+    status: 400,
+    category: 'validation',
+    userMessage: 'Please check your input and try again.',
+    retryable: false,
+    exposure: 'public',
+  },
+  INVALID_JSON: {
+    status: 400,
+    category: 'validation',
+    userMessage: 'The request body contains invalid JSON.',
+    action: 'Correct the request body and try again.',
+    retryable: false,
+    exposure: 'public',
+  },
+  AUTHENTICATION_REQUIRED: {
+    status: 401,
+    category: 'authentication',
+    userMessage: 'Authentication is required to continue.',
+    action: 'Sign in and try again.',
+    retryable: false,
+    exposure: 'public',
+  },
+  AUTHORIZATION_DENIED: {
+    status: 403,
+    category: 'authorization',
+    userMessage: 'You do not have permission to perform this action.',
+    action: 'Contact an administrator if you believe you should have access.',
+    retryable: false,
+    exposure: 'public',
+  },
+  RESOURCE_NOT_FOUND: {
+    status: 404,
+    category: 'not_found',
+    userMessage: 'The requested item could not be found.',
+    retryable: false,
+    exposure: 'public',
+  },
+  RATE_LIMIT_EXCEEDED: {
+    status: 429,
+    category: 'rate_limit',
+    userMessage: 'Too many requests were received.',
+    action: 'Wait briefly before trying again.',
+    retryable: true,
+    exposure: 'public',
+  },
+  INCIDENT_REQUIRED_FIELDS_MISSING: {
+    status: 400,
+    category: 'validation',
+    userMessage: 'Some required incident information is missing.',
+    action: 'Complete the required fields and try again.',
+    retryable: false,
+    exposure: 'public',
+  },
+  INCIDENT_TRANSITION_CONFLICT: {
+    status: 409,
+    category: 'conflict',
+    userMessage: 'The incident status changed before this action completed.',
+    action: 'Refresh the incident and try again.',
+    retryable: true,
+    exposure: 'public',
+  },
+  SCHEDULE_LAYER_USER_DUPLICATE: {
+    status: 409,
+    category: 'conflict',
+    userMessage: 'This responder is already assigned to this schedule layer.',
+    action: 'Remove the existing assignment before adding another.',
+    retryable: false,
+    exposure: 'public',
+  },
+  SERVICE_ACCESS_DENIED: {
+    status: 403,
+    category: 'authorization',
+    userMessage: 'You do not have access to this service.',
+    retryable: false,
+    exposure: 'public',
+  },
+  NOTIFICATION_PROVIDER_UNAVAILABLE: {
+    status: 503,
+    category: 'dependency',
+    userMessage: 'The notification provider is temporarily unavailable.',
+    action: 'Try again shortly.',
+    retryable: true,
+    exposure: 'public',
+  },
+} as const satisfies Record<string, ErrorDefinition>;
+
+export type AppErrorCode = keyof typeof ERROR_REGISTRY;
+
+export function isAppErrorCode(value: unknown): value is AppErrorCode {
+  return typeof value === 'string' && value in ERROR_REGISTRY;
+}

--- a/src/lib/server-action-helpers.ts
+++ b/src/lib/server-action-helpers.ts
@@ -1,16 +1,15 @@
 /**
  * Helper utilities for server actions to provide consistent error handling
- * and user-friendly error messages
+ * and user-friendly error messages.
  */
 
-import { getUserFriendlyError } from './user-friendly-errors';
 import { isRedirectError } from 'next/dist/client/components/redirect-error';
+import { isAppError } from './errors';
+import { getUserFriendlyError } from './user-friendly-errors';
 
 /**
- * Wraps a server action with error handling that converts errors to user-friendly messages
- *
- * @param action - The server action function to wrap
- * @returns A wrapped function that catches errors and returns user-friendly messages
+ * Wraps a server action with error handling that converts legacy errors to
+ * user-friendly messages while preserving typed AppError identity.
  */
 export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(action: T): T {
   // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -27,7 +26,12 @@ export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(ac
       )
         throw error;
 
-      // If it's already a state object with error, return it
+      // Typed application errors already contain safe public messaging and
+      // machine-readable identity. Do not flatten them back into plain Error.
+      if (isAppError(error)) throw error;
+
+      // If it's already a state object with error, return it using the legacy
+      // string contract until individual server actions adopt structured state.
       if (error && typeof error === 'object' && 'error' in error) {
         return {
           ...error,
@@ -35,18 +39,13 @@ export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(ac
         };
       }
 
-      // Convert error to user-friendly message
-      const friendlyMessage = getUserFriendlyError(error);
-
-      // If action returns a state object, wrap error in state format
-      // Otherwise, throw the friendly error
-      throw new Error(friendlyMessage);
+      throw new Error(getUserFriendlyError(error));
     }
   }) as T;
 }
 
 /**
- * Creates an error state object for form actions
+ * Creates an error state object for form actions.
  */
 export function createErrorState(error: unknown): { error: string } {
   return {
@@ -55,7 +54,7 @@ export function createErrorState(error: unknown): { error: string } {
 }
 
 /**
- * Creates a success state object for form actions
+ * Creates a success state object for form actions.
  */
 export function createSuccessState<T = Record<string, never>>(data?: T): { success: true } & T {
   return {

--- a/src/lib/user-friendly-errors.ts
+++ b/src/lib/user-friendly-errors.ts
@@ -1,34 +1,16 @@
 /**
- * User-friendly error message translations
- * Converts technical error messages to user-friendly ones
+ * User-friendly error message translations.
+ *
+ * @deprecated New domain code should throw AppError with a stable error code.
+ * This helper remains as a compatibility bridge while legacy string callers migrate.
  */
+import { isAppError } from './errors';
 
-export function getUserFriendlyError(error: string | Error | unknown): string {
-  // Handle Event objects specifically (they stringify to "[object Event]")
-  if (error && typeof error === 'object' && 'type' in error && 'target' in error) {
-    return 'An unexpected error occurred. Please try again.';
-  }
+const GENERIC_ERROR = 'An unexpected error occurred. Please try again.';
 
-  // Handle Error instances
-  if (error instanceof Error) {
-    // return error.message || 'An unexpected error occurred.';
-    error = error.message || 'An unexpected error occurred.';
-  }
-
-  // Handle strings
-  // if (typeof error === 'string') {
-  //   return error;
-  // }
-
-  // Handle objects that stringify to "[object ...]"
-  const errorString = String(error);
-  if (errorString.startsWith('[object ') && errorString.endsWith(']')) {
-    return 'An unexpected error occurred. Please try again.';
-  }
-
-  const errorMessage = errorString;
-
-  // Database/Prisma errors
+function translateLegacyMessage(errorMessage: string): string | undefined {
+  // Database/Prisma errors. These are legacy compatibility rules only; new
+  // code should map structured Prisma error codes at the domain boundary.
   if (errorMessage.includes('Unique constraint')) {
     if (errorMessage.includes('email')) {
       return 'A user with this email already exists. Please use a different email address.';
@@ -47,7 +29,6 @@ export function getUserFriendlyError(error: string | Error | unknown): string {
     return 'The item you are trying to update does not exist. It may have been deleted.';
   }
 
-  // Validation errors
   if (errorMessage.includes('required')) {
     return 'Please fill in all required fields.';
   }
@@ -56,7 +37,6 @@ export function getUserFriendlyError(error: string | Error | unknown): string {
     return 'Please check your input and try again.';
   }
 
-  // Authorization errors
   if (errorMessage.includes('Unauthorized') || errorMessage.includes('unauthorized')) {
     return 'You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
   }
@@ -65,7 +45,6 @@ export function getUserFriendlyError(error: string | Error | unknown): string {
     return 'The requested item could not be found. It may have been deleted or you may not have access to it.';
   }
 
-  // Network/API errors
   if (errorMessage.includes('fetch') || errorMessage.includes('network')) {
     return 'Unable to connect to the server. Please check your internet connection and try again.';
   }
@@ -74,17 +53,41 @@ export function getUserFriendlyError(error: string | Error | unknown): string {
     return 'The request took too long to complete. Please try again.';
   }
 
-  // Generic fallback
   if (errorMessage.includes('Internal Server Error') || errorMessage.includes('500')) {
     return 'An unexpected error occurred. Please try again. If the problem persists, contact support.';
   }
 
-  // Return original if no match found
-  return errorMessage;
+  return undefined;
+}
+
+export function getUserFriendlyError(error: string | Error | unknown): string {
+  if (isAppError(error)) {
+    return error.userMessage;
+  }
+
+  // Handle Event objects specifically (they stringify to "[object Event]").
+  if (error && typeof error === 'object' && 'type' in error && 'target' in error) {
+    return GENERIC_ERROR;
+  }
+
+  // Unexpected Error instances are untrusted. Preserve translations for known
+  // legacy errors, but never expose an unmatched exception message to users.
+  if (error instanceof Error) {
+    return translateLegacyMessage(error.message) ?? GENERIC_ERROR;
+  }
+
+  const errorString = String(error);
+  if (errorString.startsWith('[object ') && errorString.endsWith(']')) {
+    return GENERIC_ERROR;
+  }
+
+  // Plain strings are still treated as intentionally user-facing legacy input.
+  // New code should use AppError instead so semantic meaning does not depend on text.
+  return translateLegacyMessage(errorString) ?? errorString;
 }
 
 /**
- * Get a user-friendly success message for common actions
+ * Get a user-friendly success message for common actions.
  */
 export function getSuccessMessage(action: string, entity: string): string {
   const messages: Record<string, string> = {
@@ -99,5 +102,3 @@ export function getSuccessMessage(action: string, entity: string): string {
 
   return messages[action.toLowerCase()] || `${action} completed successfully.`;
 }
-
-

--- a/tests/lib/api-response.test.ts
+++ b/tests/lib/api-response.test.ts
@@ -1,19 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { jsonOk, jsonError } from '@/lib/api-response';
+import { AppError, ERROR_REGISTRY } from '@/lib/errors';
 
 describe('API Response Utilities', () => {
   describe('jsonOk', () => {
     it('should return successful JSON response with data', () => {
       const data = { message: 'Success', id: '123' };
       const response = jsonOk(data);
-      
+
       expect(response.status).toBe(200);
     });
 
     it('should include correct headers', () => {
       const response = jsonOk({ test: true });
       const headers = response.headers;
-      
+
       expect(headers.get('Content-Type')).toBe('application/json');
     });
 
@@ -21,14 +22,14 @@ describe('API Response Utilities', () => {
       const data = { message: 'Success', count: 42 };
       const response = jsonOk(data);
       const body = await response.json();
-      
+
       expect(body).toEqual(data);
     });
 
     it('should handle null data', async () => {
       const response = jsonOk(null);
       const body = await response.json();
-      
+
       expect(body).toBeNull();
     });
 
@@ -36,13 +37,13 @@ describe('API Response Utilities', () => {
       const data = [1, 2, 3];
       const response = jsonOk(data);
       const body = await response.json();
-      
+
       expect(body).toEqual(data);
     });
 
     it('should allow custom status code', () => {
       const response = jsonOk({ created: true }, 201);
-      
+
       expect(response.status).toBe(201);
     });
 
@@ -58,13 +59,13 @@ describe('API Response Utilities', () => {
   describe('jsonError', () => {
     it('should return error response with status and message', () => {
       const response = jsonError('Something went wrong', 500);
-      
+
       expect(response.status).toBe(500);
     });
 
     it('should return error response with custom status', () => {
       const response = jsonError('Not found', 404);
-      
+
       expect(response.status).toBe(404);
     });
 
@@ -72,7 +73,7 @@ describe('API Response Utilities', () => {
       const errorMessage = 'Custom error message';
       const response = jsonError(errorMessage, 400);
       const body = await response.json();
-      
+
       expect(body.error).toBeDefined();
       expect(typeof body.error).toBe('string');
     });
@@ -81,18 +82,82 @@ describe('API Response Utilities', () => {
       const meta = { field: 'email', code: 'VALIDATION_ERROR' };
       const response = jsonError('Validation failed', 400, meta);
       const body = await response.json();
-      
+
       expect(body.meta).toEqual(meta);
     });
 
     it('should handle different status codes', () => {
       const statusCodes = [400, 401, 403, 404, 500];
-      
+
       statusCodes.forEach(status => {
         const response = jsonError('Error', status);
         expect(response.status).toBe(status);
       });
     });
+
+    it('uses the registry HTTP status for AppError even when a conflicting status is supplied', async () => {
+      const error = new AppError({
+        code: 'RESOURCE_NOT_FOUND',
+        userMessage: 'Incident not found.',
+      });
+
+      const response = jsonError(error, 500);
+      const body = await response.json();
+
+      expect(response.status).toBe(ERROR_REGISTRY.RESOURCE_NOT_FOUND.status);
+      expect(response.status).toBe(404);
+      expect(body.error).toBe('Incident not found.');
+      expect(body.code).toBe('RESOURCE_NOT_FOUND');
+    });
+
+    it('preserves the legacy error string field for typed errors', async () => {
+      const error = new AppError({ code: 'VALIDATION_FAILED' });
+      const response = jsonError(error);
+      const body = await response.json();
+
+      expect(body.error).toBe(ERROR_REGISTRY.VALIDATION_FAILED.userMessage);
+      expect(body.code).toBe('VALIDATION_FAILED');
+    });
+
+    it('keeps plain string compatibility', async () => {
+      const response = jsonError('Custom legacy message', 422);
+      const body = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(body.error).toBe('Custom legacy message');
+    });
+
+    it('normalizes an unknown Error to a generic 500 without leaking its message', async () => {
+      const response = jsonError(new Error('postgres-secret-connection-string'));
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('An unexpected error occurred. Please try again.');
+      expect(JSON.stringify(body)).not.toContain('postgres-secret-connection-string');
+    });
+
+    it('enforces internal exposure at the API boundary', async () => {
+      const error = new AppError({
+        code: 'INTERNAL_ERROR',
+        userMessage: 'secret-provider-response',
+        action: 'expose-secret-action',
+        fields: [{ field: 'token', message: 'secret-field-value' }],
+        details: { token: 'secret-details-token' },
+      });
+
+      const response = jsonError(error);
+      const body = await response.json();
+      const serialized = JSON.stringify(body);
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe(ERROR_REGISTRY.INTERNAL_ERROR.userMessage);
+      expect(body.code).toBe('INTERNAL_ERROR');
+      expect(body.action).toBe(ERROR_REGISTRY.INTERNAL_ERROR.action);
+      expect(body.fields).toBeUndefined();
+      expect(serialized).not.toContain('secret-provider-response');
+      expect(serialized).not.toContain('expose-secret-action');
+      expect(serialized).not.toContain('secret-field-value');
+      expect(serialized).not.toContain('secret-details-token');
+    });
   });
 });
-

--- a/tests/lib/app-errors.test.ts
+++ b/tests/lib/app-errors.test.ts
@@ -36,6 +36,19 @@ describe('AppError', () => {
     expect(error.userMessage).toBe('This responder is already assigned to Layer 1.');
   });
 
+  it('keeps registry status authoritative even when runtime input contains a status property', () => {
+    const legacyShapedOptions = {
+      code: 'RESOURCE_NOT_FOUND' as const,
+      status: 500,
+    };
+
+    const error = new AppError(legacyShapedOptions);
+
+    expect(error.code).toBe('RESOURCE_NOT_FOUND');
+    expect(error.status).toBe(ERROR_REGISTRY.RESOURCE_NOT_FOUND.status);
+    expect(error.status).toBe(404);
+  });
+
   it('normalizes unknown exceptions to a safe internal error', () => {
     const source = new Error('postgres://user:secret@db.internal/opsknight');
     const error = normalizeError(source);
@@ -79,6 +92,36 @@ describe('AppError', () => {
       fields: undefined,
     });
     expect(JSON.stringify(publicError)).not.toContain('do-not-expose');
+  });
+
+  it('enforces internal exposure and cannot leak caller-supplied public data', () => {
+    const error = new AppError({
+      code: 'INTERNAL_ERROR',
+      userMessage: 'secret-provider-response',
+      action: 'send-secret-token',
+      fields: [
+        {
+          field: 'token',
+          message: 'secret-field-value',
+        },
+      ],
+      details: { token: 'secret-details-token' },
+    });
+
+    const publicError = toPublicAppError(error);
+    const serialized = JSON.stringify(publicError);
+
+    expect(publicError).toEqual({
+      code: 'INTERNAL_ERROR',
+      message: ERROR_REGISTRY.INTERNAL_ERROR.userMessage,
+      action: ERROR_REGISTRY.INTERNAL_ERROR.action,
+      retryable: true,
+      fields: undefined,
+    });
+    expect(serialized).not.toContain('secret-provider-response');
+    expect(serialized).not.toContain('send-secret-token');
+    expect(serialized).not.toContain('secret-field-value');
+    expect(serialized).not.toContain('secret-details-token');
   });
 
   it('supports structured validation fields', () => {

--- a/tests/lib/app-errors.test.ts
+++ b/tests/lib/app-errors.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AppError,
+  ERROR_REGISTRY,
+  normalizeError,
+  toPublicAppError,
+} from '@/lib/errors';
+
+describe('AppError', () => {
+  it('derives stable defaults from the error registry', () => {
+    const error = new AppError({
+      code: 'SCHEDULE_LAYER_USER_DUPLICATE',
+      details: { scheduleId: 'schedule-1', layerId: 'layer-1', userId: 'user-1' },
+    });
+
+    expect(error.code).toBe('SCHEDULE_LAYER_USER_DUPLICATE');
+    expect(error.status).toBe(409);
+    expect(error.userMessage).toBe(ERROR_REGISTRY.SCHEDULE_LAYER_USER_DUPLICATE.userMessage);
+    expect(error.action).toBe(ERROR_REGISTRY.SCHEDULE_LAYER_USER_DUPLICATE.action);
+    expect(error.retryable).toBe(false);
+    expect(error.details).toEqual({
+      scheduleId: 'schedule-1',
+      layerId: 'layer-1',
+      userId: 'user-1',
+    });
+  });
+
+  it('supports contextual public messages without changing machine identity', () => {
+    const error = new AppError({
+      code: 'SCHEDULE_LAYER_USER_DUPLICATE',
+      userMessage: 'This responder is already assigned to Layer 1.',
+    });
+
+    expect(error.code).toBe('SCHEDULE_LAYER_USER_DUPLICATE');
+    expect(error.status).toBe(409);
+    expect(error.userMessage).toBe('This responder is already assigned to Layer 1.');
+  });
+
+  it('normalizes unknown exceptions to a safe internal error', () => {
+    const source = new Error('postgres://user:secret@db.internal/opsknight');
+    const error = normalizeError(source);
+
+    expect(error.code).toBe('INTERNAL_ERROR');
+    expect(error.status).toBe(500);
+    expect(error.userMessage).not.toContain('secret');
+    expect(error.cause).toBe(source);
+  });
+
+  it('preserves compatible existing typed errors during migration', () => {
+    const legacyTypedError = Object.assign(new Error('Access denied by policy.'), {
+      code: 'AUTHORIZATION_DENIED' as const,
+      status: 403,
+    });
+
+    const error = normalizeError(legacyTypedError);
+
+    expect(error.code).toBe('AUTHORIZATION_DENIED');
+    expect(error.status).toBe(403);
+    expect(error.userMessage).toBe('Access denied by policy.');
+    expect(error.cause).toBe(legacyTypedError);
+  });
+
+  it('keeps internal details out of the public serializer', () => {
+    const error = new AppError({
+      code: 'NOTIFICATION_PROVIDER_UNAVAILABLE',
+      details: {
+        provider: 'slack',
+        token: 'do-not-expose',
+      },
+    });
+
+    const publicError = toPublicAppError(error);
+
+    expect(publicError).toEqual({
+      code: 'NOTIFICATION_PROVIDER_UNAVAILABLE',
+      message: ERROR_REGISTRY.NOTIFICATION_PROVIDER_UNAVAILABLE.userMessage,
+      action: ERROR_REGISTRY.NOTIFICATION_PROVIDER_UNAVAILABLE.action,
+      retryable: true,
+      fields: undefined,
+    });
+    expect(JSON.stringify(publicError)).not.toContain('do-not-expose');
+  });
+
+  it('supports structured validation fields', () => {
+    const error = new AppError({
+      code: 'VALIDATION_FAILED',
+      fields: [
+        {
+          field: 'title',
+          code: 'required',
+          message: 'Title is required.',
+        },
+      ],
+    });
+
+    expect(toPublicAppError(error).fields).toEqual([
+      {
+        field: 'title',
+        code: 'required',
+        message: 'Title is required.',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces the first compatibility-safe foundation for replacing OpsKnight's substring-driven error handling with stable machine-readable application errors.

### What changed

- adds a typed `AppError` contract with stable `code`, registry-owned HTTP status, user message, corrective action, field errors, retryability, internal details, cause, and exposure
- adds a central typed error registry with initial cross-domain codes
- adds safe normalization and public serialization that intentionally excludes internal `details`
- enforces `exposure: 'internal'` at serialization: caller-supplied message/action/fields are replaced by the canonical safe `INTERNAL_ERROR` definition
- makes HTTP status authoritative from the registry for first-class `AppError` instances; callers cannot override status independently from code
- updates `jsonError()` to understand typed errors while preserving the existing string `error` field for API compatibility
- updates server-action handling to preserve `AppError` identity instead of flattening it back into a plain `Error`
- keeps `getUserFriendlyError()` only as a deprecated legacy bridge; typed errors bypass substring translation
- hardens unexpected `Error` handling so unmatched exception messages are no longer exposed directly
- adds focused unit and API-boundary tests for registry defaults, status/code consistency, contextual messages, unknown exceptions, migration compatibility, exposure enforcement, detail redaction, structured fields, and `jsonError()` compatibility

## Compatibility / rollout

This is intentionally the foundation PR, not a repository-wide migration. Existing string callers continue to work. Individual domains can now migrate incrementally to `AppError` without a breaking API response change.

Known legacy typed errors whose codes are already in the registry are normalized onto the registry's HTTP semantics while retaining their existing message temporarily for migration compatibility.

The next migrations should move authorization, incidents, schedules, services, and provider errors onto concrete codes, then remove the legacy substring bridge once coverage is high enough.

## Security

- unknown exception messages are normalized to `INTERNAL_ERROR`
- public serialization does not expose `details` or causes
- `internal` exposure is an enforced boundary, not metadata: custom internal messages, actions, fields, and detail values cannot cross the public serializer/API boundary
- first-class error code and HTTP status cannot diverge through caller overrides

## Tests

Coverage includes:

- registry-derived defaults and status ownership
- attempted runtime status override rejection
- internal exposure cannot leak custom `userMessage`, action, fields, or details
- typed `jsonError()` uses registry status and preserves the legacy `error` string field
- plain string `jsonError()` remains backward compatible
- unknown `Error` through `jsonError()` returns a generic 500 without leaking the exception message
- structured validation fields remain available for public errors

## Commit history

Kept intentionally small: the original implementation, one TypeScript metadata correction, and one focused merge-blocking hardening commit (`fix(errors): enforce public error exposure contract`).