### PR TITLE
fix(notifications): route lifecycle push/sms alerts to assignees and watchers only

### DIFF
--- a/src/lib/user-notifications.ts
+++ b/src/lib/user-notifications.ts
@@ -213,11 +213,7 @@ export async function sendUserNotification(
 
   // A deliberate quiet-hours suppression is a successful policy decision, not a
   // notification-provider failure. In-app was already created above.
-  if (
-    channelsUsed.length === 0 &&
-    errors.length === 0 &&
-    quietHoursBlockedChannels.size > 0
-  ) {
+  if (channelsUsed.length === 0 && errors.length === 0 && quietHoursBlockedChannels.size > 0) {
     logger.info('[UserNotification] External delivery suppressed by quiet hours', {
       incidentId,
       userId,
@@ -264,6 +260,7 @@ export async function sendIncidentNotifications(
             },
           },
           assignee: true,
+          watchers: true,
         },
       }));
 
@@ -274,11 +271,16 @@ export async function sendIncidentNotifications(
     const incidentRecord = incidentData;
 
     const errors: string[] = [];
-    const recipients: string[] = [];
+    const inAppRecipients: string[] = [];
 
     // Add assignee if exists
     if (incidentRecord.assigneeId) {
-      recipients.push(incidentRecord.assigneeId);
+      inAppRecipients.push(incidentRecord.assigneeId);
+    }
+
+    // Add explicit incident watchers if any
+    if (incidentRecord.watchers && Array.isArray(incidentRecord.watchers)) {
+      inAppRecipients.push(...incidentRecord.watchers.map((w: { userId: string }) => w.userId));
     }
 
     // Add service team members if team exists
@@ -286,11 +288,13 @@ export async function sendIncidentNotifications(
       const teamUserIds = incidentRecord.service.team.members.map(
         (m: { userId: string }) => m.userId
       );
-      recipients.push(...teamUserIds);
+      inAppRecipients.push(...teamUserIds);
     }
 
-    // Remove duplicates
-    const uniqueRecipients = [...new Set(recipients)].filter(id => !excludeUserIds.includes(id));
+    // Remove duplicates for In-App notifications
+    const uniqueInAppRecipients = [...new Set(inAppRecipients)].filter(
+      id => !excludeUserIds.includes(id)
+    );
 
     const eventTitle =
       eventType === 'triggered'
@@ -302,9 +306,9 @@ export async function sendIncidentNotifications(
             : 'Incident Updated';
     const eventMessage = `[${incidentRecord.service.name}] ${incidentRecord.title}`;
 
-    if (uniqueRecipients.length > 0) {
+    if (uniqueInAppRecipients.length > 0) {
       await createInAppNotifications({
-        userIds: uniqueRecipients,
+        userIds: uniqueInAppRecipients,
         type: 'INCIDENT',
         title: eventTitle,
         message: eventMessage,
@@ -313,10 +317,32 @@ export async function sendIncidentNotifications(
       });
     }
 
-    if (uniqueRecipients.length > 0) {
+    // Determine External Recipients (Push, SMS, WhatsApp, Email)
+    // 1. For 'triggered': if this function is called (i.e. service has no escalation policy),
+    //    alert the whole team and assignee so someone responds to the new incident.
+    // 2. For lifecycle events ('acknowledged', 'resolved', 'updated'):
+    //    only send disruptive personal device alerts (Push/SMS/WhatsApp/Email) to the active
+    //    Assignee and explicit Incident Watchers. Do NOT blast off-duty team members' personal phones.
+    let externalRecipients: string[] = [];
+    if (eventType === 'triggered') {
+      externalRecipients = uniqueInAppRecipients;
+    } else {
+      const directRecipients: string[] = [];
+      if (incidentRecord.assigneeId) {
+        directRecipients.push(incidentRecord.assigneeId);
+      }
+      if (incidentRecord.watchers && Array.isArray(incidentRecord.watchers)) {
+        directRecipients.push(...incidentRecord.watchers.map((w: { userId: string }) => w.userId));
+      }
+      externalRecipients = [...new Set(directRecipients)].filter(
+        id => !excludeUserIds.includes(id)
+      );
+    }
+
+    if (externalRecipients.length > 0) {
       // Batch fetch user notification preferences to avoid N+1 queries
       const users = await prisma.user.findMany({
-        where: { id: { in: uniqueRecipients } },
+        where: { id: { in: externalRecipients } },
         select: {
           id: true,
           emailNotificationsEnabled: true,
@@ -351,7 +377,7 @@ export async function sendIncidentNotifications(
 
       // Send notifications to each recipient based on their preferences
       const message = `[${incidentRecord.service.name}] Incident ${eventType}: ${incidentRecord.title}`;
-      const notificationPromises = uniqueRecipients.map(async userId => {
+      const notificationPromises = externalRecipients.map(async userId => {
         const user = userMap.get(userId);
         if (!user) {
           return { userId, success: false, error: 'User not found' };

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -165,7 +165,7 @@ describe('Notification System Tests', () => {
             ],
           },
         },
-      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      } as unknown as Awaited<ReturnType<typeof prisma.incident.findUnique>>);
 
       vi.mocked(prisma.user.findMany).mockResolvedValue([
         {
@@ -190,12 +190,14 @@ describe('Notification System Tests', () => {
           timeZone: 'UTC',
           quietHoursEnabled: false,
         },
-      ] as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      ] as unknown as Awaited<ReturnType<typeof prisma.user.findMany>>);
 
       const inAppModule = await import('@/lib/in-app-notifications');
       const inAppSpy = vi
         .spyOn(inAppModule, 'createInAppNotifications')
-        .mockResolvedValue([] as any);
+        .mockResolvedValue(
+          [] as unknown as Awaited<ReturnType<typeof inAppModule.createInAppNotifications>>
+        );
 
       const notifModule = await import('@/lib/notifications');
       const sendNotifSpy = vi

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -11,7 +11,7 @@
  * - Channel priority
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import prisma from '@/lib/prisma';
 import { sendServiceNotifications } from '@/lib/service-notifications';
 import { executeEscalation, resolveEscalationTarget } from '@/lib/escalation';
@@ -39,6 +39,7 @@ vi.mock('@/lib/prisma', () => ({
     notification: { create: vi.fn() },
     user: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
       create: vi.fn(),
     },
     onCallSchedule: { findUnique: vi.fn() },
@@ -100,7 +101,7 @@ describe('Notification System Tests', () => {
     });
   });
 
-  describe('Incident Notifications', () => {
+  describe('Incident Notifications & Lifecycle Routing', () => {
     it('should still trigger service notifications when there are no user recipients', async () => {
       const incidentId = 'inc-1';
       const serviceId = 'svc-1';
@@ -130,6 +131,99 @@ describe('Notification System Tests', () => {
       expect(serviceSpy).toHaveBeenCalledWith(incidentId, 'triggered');
       expect(result.success).toBe(true);
       serviceSpy.mockRestore();
+    });
+
+    it('should restrict external push/SMS alerts for acknowledged events to assignee and watchers, while team gets in-app notifications', async () => {
+      const incidentId = 'inc-2';
+      const serviceId = 'svc-2';
+      const assigneeUserId = 'user-assignee';
+      const watcherUserId = 'user-watcher';
+      const offDutyTeamMemberId = 'user-team-member';
+
+      vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+        id: incidentId,
+        title: 'DB Latency High',
+        urgency: 'HIGH',
+        serviceId,
+        assigneeId: assigneeUserId,
+        assignee: { id: assigneeUserId, name: 'Assignee User' },
+        watchers: [{ id: 'w-1', incidentId, userId: watcherUserId, role: 'FOLLOWER' }],
+        service: {
+          id: serviceId,
+          name: 'DB Service',
+          slackWebhookUrl: null,
+          serviceNotificationChannels: [],
+          team: {
+            id: 'team-1',
+            name: 'Backend Team',
+            members: [
+              { userId: assigneeUserId, user: { id: assigneeUserId, name: 'Assignee User' } },
+              {
+                userId: offDutyTeamMemberId,
+                user: { id: offDutyTeamMemberId, name: 'Off Duty Member' },
+              },
+            ],
+          },
+        },
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      vi.mocked(prisma.user.findMany).mockResolvedValue([
+        {
+          id: assigneeUserId,
+          emailNotificationsEnabled: false,
+          smsNotificationsEnabled: false,
+          pushNotificationsEnabled: true,
+          whatsappNotificationsEnabled: false,
+          phoneNumber: null,
+          email: 'assignee@example.com',
+          timeZone: 'UTC',
+          quietHoursEnabled: false,
+        },
+        {
+          id: watcherUserId,
+          emailNotificationsEnabled: false,
+          smsNotificationsEnabled: false,
+          pushNotificationsEnabled: true,
+          whatsappNotificationsEnabled: false,
+          phoneNumber: null,
+          email: 'watcher@example.com',
+          timeZone: 'UTC',
+          quietHoursEnabled: false,
+        },
+      ] as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const inAppModule = await import('@/lib/in-app-notifications');
+      const inAppSpy = vi
+        .spyOn(inAppModule, 'createInAppNotifications')
+        .mockResolvedValue([] as any);
+
+      const notifModule = await import('@/lib/notifications');
+      const sendNotifSpy = vi
+        .spyOn(notifModule, 'sendNotification')
+        .mockResolvedValue({ success: true, notificationId: 'notif-1' });
+
+      vi.spyOn(notificationProviders, 'isChannelAvailable').mockResolvedValue(true);
+
+      const result = await sendIncidentNotifications(incidentId, 'acknowledged');
+
+      expect(result.success).toBe(true);
+
+      // In-app notifications are delivered to assignee, watcher, and team members
+      expect(inAppSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userIds: expect.arrayContaining([assigneeUserId, watcherUserId, offDutyTeamMemberId]),
+          title: 'Incident Acknowledged',
+        })
+      );
+
+      // External personal notifications (PUSH/SMS) are sent ONLY to assignee and watcher, NOT off-duty team member
+      const notifiedUserIds = sendNotifSpy.mock.calls.map(call => call[1]);
+      expect(notifiedUserIds).toContain(assigneeUserId);
+      expect(notifiedUserIds).toContain(watcherUserId);
+      expect(notifiedUserIds).not.toContain(offDutyTeamMemberId);
+
+      inAppSpy.mockRestore();
+      sendNotifSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Description
Fixes an issue where lifecycle status transitions (`acknowledged`, `resolved`, `updated`) were broadcasting disruptive personal push notifications and SMS to all off-duty members of a service's team.

## Key Changes
- **Targeted Lifecycle Notifications**: Restricts disruptive external channels (Mobile Push, SMS, WhatsApp, Email) for `acknowledged`, `resolved`, and `updated` events exclusively to the direct **Incident Assignee** and explicit **Incident Watchers**.
- **Preserved In-App & Slack Visibility**: In-App notifications and Slack/Webhook integration channels continue to be delivered to all team members so the team has full passive visibility in the console and communication channels.
- **Incident Watchers Included**: Added `watchers` to the incident lookup in `sendIncidentNotifications` so subscribed stakeholders/followers always receive lifecycle updates.
- **Unit Tests**: Added automated tests verifying that external alerts are delivered only to assignees and watchers, and not to off-duty team members.

## Verification
- `npx tsc --noEmit` passed (0 errors)
- Full unit test suite (`npm run test:unit`) passed (175 test files, 1328 tests passed)
- Production build (`npm run build`) succeeded