### PR TITLE
refactor(incidents): route bulk lifecycle through command engine

### DIFF
--- a/src/app/(app)/incidents/bulk-actions.ts
+++ b/src/app/(app)/incidents/bulk-actions.ts
@@ -5,6 +5,75 @@ import { revalidatePath } from 'next/cache';
 import { assertResponderOrAbove, getCurrentUser } from '@/lib/rbac';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { logger } from '@/lib/logger';
+import {
+  executeIncidentLifecycleBatch,
+  executeIncidentLifecycleTargetBatch,
+  type IncidentLifecycleCommand,
+  type IncidentLifecycleResult,
+} from '@/lib/incidents/lifecycle';
+
+type BulkLifecycleStatus = 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED';
+
+function changedIncidentIds(results: readonly IncidentLifecycleResult[]): string[] {
+  return results.filter(result => result.changed).map(result => result.incidentId);
+}
+
+type BulkLifecycleActor = { id: string; name?: string };
+
+async function runBulkLifecycleCommand(
+  incidentIds: string[],
+  command: IncidentLifecycleCommand,
+  actor: BulkLifecycleActor,
+  eventMessage: string,
+  extra: Partial<{
+    snoozedUntil: Date;
+    snoozeReason: string | null;
+  }> = {}
+): Promise<string[]> {
+  const results = await executeIncidentLifecycleBatch(
+    incidentIds.map(incidentId => ({
+      incidentId,
+      command,
+      source: 'BULK' as const,
+      actor,
+      eventMessage,
+      ...extra,
+    }))
+  );
+  return changedIncidentIds(results);
+}
+
+async function runBulkLifecycleTarget(
+  incidentIds: string[],
+  status: BulkLifecycleStatus,
+  actor: BulkLifecycleActor,
+  eventMessage: string
+): Promise<string[]> {
+  const results = await executeIncidentLifecycleTargetBatch(
+    incidentIds.map(incidentId => ({
+      incidentId,
+      status,
+      source: 'BULK' as const,
+      actor,
+      eventMessage,
+    }))
+  );
+  return changedIncidentIds(results);
+}
+
+async function loadIncidentsForLifecycleEffects(incidentIds: string[]) {
+  if (incidentIds.length === 0) return [];
+
+  return prisma.incident.findMany({
+    where: { id: { in: incidentIds } },
+    include: {
+      service: { select: { id: true, name: true } },
+      assignee: {
+        select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
+      },
+    },
+  });
+}
 
 export async function bulkAcknowledge(incidentIds: string[]) {
   if (!incidentIds || incidentIds.length === 0) {
@@ -19,48 +88,15 @@ export async function bulkAcknowledge(incidentIds: string[]) {
 
   try {
     const user = await getCurrentUser();
-    const changedIncidentIds = await prisma.$transaction(async tx => {
-      const eligible = await tx.incident.findMany({
-        where: {
-          id: { in: incidentIds },
-          status: { in: ['OPEN', 'ACKNOWLEDGED', 'SNOOZED', 'SUPPRESSED'] },
-        },
-        select: { id: true },
-      });
-      const eligibleIds = eligible.map(incident => incident.id);
-      if (eligibleIds.length === 0) return [];
+    const changedIds = await runBulkLifecycleCommand(
+      incidentIds,
+      'ACKNOWLEDGE',
+      { id: user.id, name: user.name ?? undefined },
+      `Bulk acknowledged${user ? ` by ${user.name}` : ''}`
+    );
 
-      await tx.incident.updateMany({
-        where: { id: { in: eligibleIds } },
-        data: {
-          status: 'ACKNOWLEDGED',
-          acknowledgedAt: new Date(),
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
-        },
-      });
-      await tx.incidentEvent.createMany({
-        data: eligibleIds.map(incidentId => ({
-          incidentId,
-          type: 'ACKNOWLEDGED',
-          message: `Bulk acknowledged${user ? ` by ${user.name}` : ''}`,
-        })),
-      });
-      return eligibleIds;
-    });
+    const incidents = await loadIncidentsForLifecycleEffects(changedIds);
 
-    // Notify only incidents that were actually eligible and changed.
-    const incidents = await prisma.incident.findMany({
-      where: { id: { in: changedIncidentIds } },
-      include: {
-        service: { select: { id: true, name: true } },
-        assignee: {
-          select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-        },
-      },
-    });
-
-    // Send notifications in parallel
     const { sendIncidentNotifications } = await import('@/lib/user-notifications');
     const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
     const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
@@ -84,11 +120,11 @@ export async function bulkAcknowledge(incidentIds: string[]) {
               acknowledgedAt: incident.acknowledgedAt?.toISOString() || new Date().toISOString(),
             }),
           ]);
-        } catch (e) {
+        } catch (error) {
           logger.error('Failed to send notifications for incident', {
             component: 'bulk-actions',
             action: 'acknowledge',
-            error: e,
+            error,
             incidentId: incident.id,
           });
         }
@@ -97,7 +133,7 @@ export async function bulkAcknowledge(incidentIds: string[]) {
 
     revalidatePath('/incidents');
     revalidatePath('/');
-    return { success: true, count: changedIncidentIds.length };
+    return { success: true, count: changedIds.length };
   } catch (error) {
     logger.error('Bulk acknowledge failed', { component: 'bulk-actions', error, incidentIds });
     return { success: false, error: 'Failed to acknowledge incidents' };
@@ -117,37 +153,15 @@ export async function bulkResolve(incidentIds: string[]) {
 
   try {
     const user = await getCurrentUser();
-    await prisma.$transaction(async tx => {
-      await tx.incident.updateMany({
-        where: { id: { in: incidentIds } },
-        data: {
-          status: 'RESOLVED',
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
-          resolvedAt: new Date(),
-        },
-      });
-      await tx.incidentEvent.createMany({
-        data: incidentIds.map(incidentId => ({
-          incidentId,
-          type: 'MANUAL_RESOLVED',
-          message: `Bulk resolved${user ? ` by ${user.name}` : ''}`,
-        })),
-      });
-    });
+    const changedIds = await runBulkLifecycleCommand(
+      incidentIds,
+      'RESOLVE',
+      { id: user.id, name: user.name ?? undefined },
+      `Bulk resolved${user ? ` by ${user.name}` : ''}`
+    );
 
-    // Fetch all incidents in a single query for notifications and webhooks
-    const incidents = await prisma.incident.findMany({
-      where: { id: { in: incidentIds } },
-      include: {
-        service: { select: { id: true, name: true } },
-        assignee: {
-          select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-        },
-      },
-    });
+    const incidents = await loadIncidentsForLifecycleEffects(changedIds);
 
-    // Send notifications & archive war-room channels in parallel
     const { sendIncidentNotifications } = await import('@/lib/user-notifications');
     const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
     const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
@@ -159,10 +173,10 @@ export async function bulkResolve(incidentIds: string[]) {
           await Promise.all([
             sendIncidentNotifications(incident.id, 'resolved'),
             notifyStatusPageSubscribers(incident.id, 'resolved'),
-            archiveWarRoomChannel(incident.id).catch(err =>
+            archiveWarRoomChannel(incident.id).catch(error =>
               logger.warn('[ChatOps] Failed to archive war-room channel on bulk resolve', {
                 incidentId: incident.id,
-                error: err,
+                error,
               })
             ),
             triggerWebhooksForService(incident.serviceId, 'incident.resolved', {
@@ -178,11 +192,11 @@ export async function bulkResolve(incidentIds: string[]) {
               resolvedAt: incident.resolvedAt?.toISOString() || new Date().toISOString(),
             }),
           ]);
-        } catch (e) {
+        } catch (error) {
           logger.error('Failed to send notifications for incident', {
             component: 'bulk-actions',
             action: 'resolve',
-            error: e,
+            error,
             incidentId: incident.id,
           });
         }
@@ -191,7 +205,7 @@ export async function bulkResolve(incidentIds: string[]) {
 
     revalidatePath('/incidents');
     revalidatePath('/');
-    return { success: true, count: incidentIds.length };
+    return { success: true, count: changedIds.length };
   } catch (error) {
     logger.error('Bulk resolve failed', { component: 'bulk-actions', error, incidentIds });
     return { success: false, error: 'Failed to resolve incidents' };
@@ -233,7 +247,6 @@ export async function bulkReassign(incidentIds: string[], assigneeId: string) {
       });
     });
 
-    // Fetch all incidents in a single query for notifications and webhooks
     const incidents = await prisma.incident.findMany({
       where: { id: { in: incidentIds } },
       include: {
@@ -244,7 +257,6 @@ export async function bulkReassign(incidentIds: string[], assigneeId: string) {
       },
     });
 
-    // Send notifications in parallel
     const { sendIncidentNotifications } = await import('@/lib/user-notifications');
     const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
 
@@ -265,11 +277,11 @@ export async function bulkReassign(incidentIds: string[], assigneeId: string) {
               createdAt: incident.createdAt.toISOString(),
             }),
           ]);
-        } catch (e) {
+        } catch (error) {
           logger.error('Failed to send notifications for incident', {
             component: 'bulk-actions',
             action: 'reassign',
-            error: e,
+            error,
             incidentId: incident.id,
           });
         }
@@ -344,38 +356,19 @@ export async function bulkSnooze(
   }
 
   try {
-    const snoozedUntil = new Date(Date.now() + durationMinutes * 60 * 1000);
-
-    // Update all selected incidents
-    await prisma.incident.updateMany({
-      where: {
-        id: { in: incidentIds },
-        status: { notIn: ['RESOLVED'] }, // Don't snooze resolved incidents
-      },
-      data: {
-        status: 'SNOOZED',
-        snoozedUntil,
-        snoozeReason: reason,
-        escalationStatus: 'PAUSED',
-        nextEscalationAt: null,
-      },
-    });
-
-    // Log events for each incident (batch create)
     const user = await getCurrentUser();
+    const snoozedUntil = new Date(Date.now() + durationMinutes * 60 * 1000);
     const userTimeZone = getUserTimeZone(user ?? undefined);
-    await prisma.incidentEvent
-      .createMany({
-        data: incidentIds.map(incidentId => ({
-          incidentId,
-          message: `Bulk snoozed until ${formatDateTime(snoozedUntil, userTimeZone, { format: 'datetime' })}${reason ? `: ${reason}` : ''}${user ? ` by ${user.name}` : ''}`,
-        })),
-        skipDuplicates: true,
-      })
-      .catch(() => {}); // Ignore errors if incident was already resolved
+    const changedIds = await runBulkLifecycleCommand(
+      incidentIds,
+      'SNOOZE',
+      { id: user.id, name: user.name ?? undefined },
+      `Bulk snoozed until ${formatDateTime(snoozedUntil, userTimeZone, { format: 'datetime' })}${reason ? `: ${reason}` : ''}${user ? ` by ${user.name}` : ''}`,
+      { snoozedUntil, snoozeReason: reason }
+    );
 
     revalidatePath('/incidents');
-    return { success: true, count: incidentIds.length };
+    return { success: true, count: changedIds.length };
   } catch (error) {
     logger.error('Bulk snooze failed', {
       component: 'bulk-actions',
@@ -399,35 +392,16 @@ export async function bulkUnsnooze(incidentIds: string[]) {
   }
 
   try {
-    // Update all selected incidents
-    await prisma.incident.updateMany({
-      where: {
-        id: { in: incidentIds },
-        status: 'SNOOZED',
-      },
-      data: {
-        status: 'OPEN',
-        snoozedUntil: null,
-        snoozeReason: null,
-        escalationStatus: 'ESCALATING',
-        nextEscalationAt: new Date(),
-      },
-    });
-
-    // Log events for each incident (batch create)
     const user = await getCurrentUser();
-    await prisma.incidentEvent
-      .createMany({
-        data: incidentIds.map(incidentId => ({
-          incidentId,
-          message: `Bulk unsnoozed${user ? ` by ${user.name}` : ''}`,
-        })),
-        skipDuplicates: true,
-      })
-      .catch(() => {}); // Ignore errors if incident wasn't snoozed
+    const changedIds = await runBulkLifecycleCommand(
+      incidentIds,
+      'UNSNOOZE',
+      { id: user.id, name: user.name ?? undefined },
+      `Bulk unsnoozed${user ? ` by ${user.name}` : ''}`
+    );
 
     revalidatePath('/incidents');
-    return { success: true, count: incidentIds.length };
+    return { success: true, count: changedIds.length };
   } catch (error) {
     logger.error('Bulk unsnooze failed', { component: 'bulk-actions', error, incidentIds });
     return { success: false, error: 'Failed to unsnooze incidents' };
@@ -446,33 +420,16 @@ export async function bulkSuppress(incidentIds: string[]) {
   }
 
   try {
-    // Update all selected incidents
-    await prisma.incident.updateMany({
-      where: {
-        id: { in: incidentIds },
-        status: { notIn: ['RESOLVED'] }, // Don't suppress resolved incidents
-      },
-      data: {
-        status: 'SUPPRESSED',
-        escalationStatus: 'PAUSED',
-        nextEscalationAt: null,
-      },
-    });
-
-    // Log events for each incident (batch create)
     const user = await getCurrentUser();
-    await prisma.incidentEvent
-      .createMany({
-        data: incidentIds.map(incidentId => ({
-          incidentId,
-          message: `Bulk suppressed${user ? ` by ${user.name}` : ''}`,
-        })),
-        skipDuplicates: true,
-      })
-      .catch(() => {}); // Ignore errors if incident was already resolved
+    const changedIds = await runBulkLifecycleCommand(
+      incidentIds,
+      'SUPPRESS',
+      { id: user.id, name: user.name ?? undefined },
+      `Bulk suppressed${user ? ` by ${user.name}` : ''}`
+    );
 
     revalidatePath('/incidents');
-    return { success: true, count: incidentIds.length };
+    return { success: true, count: changedIds.length };
   } catch (error) {
     logger.error('Bulk suppress failed', { component: 'bulk-actions', error, incidentIds });
     return { success: false, error: 'Failed to suppress incidents' };
@@ -491,33 +448,16 @@ export async function bulkUnsuppress(incidentIds: string[]) {
   }
 
   try {
-    // Update all selected incidents
-    await prisma.incident.updateMany({
-      where: {
-        id: { in: incidentIds },
-        status: 'SUPPRESSED',
-      },
-      data: {
-        status: 'OPEN',
-        escalationStatus: 'ESCALATING',
-        nextEscalationAt: new Date(),
-      },
-    });
-
-    // Log events for each incident (batch create)
     const user = await getCurrentUser();
-    await prisma.incidentEvent
-      .createMany({
-        data: incidentIds.map(incidentId => ({
-          incidentId,
-          message: `Bulk unsuppressed${user ? ` by ${user.name}` : ''}`,
-        })),
-        skipDuplicates: true,
-      })
-      .catch(() => {}); // Ignore errors if incident wasn't suppressed
+    const changedIds = await runBulkLifecycleCommand(
+      incidentIds,
+      'UNSUPPRESS',
+      { id: user.id, name: user.name ?? undefined },
+      `Bulk unsuppressed${user ? ` by ${user.name}` : ''}`
+    );
 
     revalidatePath('/incidents');
-    return { success: true, count: incidentIds.length };
+    return { success: true, count: changedIds.length };
   } catch (error) {
     logger.error('Bulk unsuppress failed', { component: 'bulk-actions', error, incidentIds });
     return { success: false, error: 'Failed to unsuppress incidents' };
@@ -536,7 +476,6 @@ export async function bulkUpdateUrgency(incidentIds: string[], urgency: 'HIGH' |
   }
 
   try {
-    // Update all selected incidents
     await prisma.incident.updateMany({
       where: {
         id: { in: incidentIds },
@@ -544,7 +483,6 @@ export async function bulkUpdateUrgency(incidentIds: string[], urgency: 'HIGH' |
       data: { urgency },
     });
 
-    // Log events for each incident (batch create)
     const user = await getCurrentUser();
     await prisma.incidentEvent.createMany({
       data: incidentIds.map(incidentId => ({
@@ -566,10 +504,7 @@ export async function bulkUpdateUrgency(incidentIds: string[], urgency: 'HIGH' |
   }
 }
 
-export async function bulkUpdateStatus(
-  incidentIds: string[],
-  status: 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED'
-) {
+export async function bulkUpdateStatus(incidentIds: string[], status: BulkLifecycleStatus) {
   if (!incidentIds || incidentIds.length === 0) {
     return { success: false, error: 'No incidents selected' };
   }
@@ -581,106 +516,19 @@ export async function bulkUpdateStatus(
   }
 
   try {
-    if (status === 'OPEN') {
-      const incidents = await prisma.incident.findMany({
-        where: { id: { in: incidentIds } },
-        select: {
-          id: true,
-          status: true,
-          currentEscalationStep: true,
-          acknowledgedAt: true,
-          resolvedAt: true,
-          service: {
-            select: {
-              policy: {
-                select: {
-                  steps: {
-                    orderBy: { stepOrder: 'asc' },
-                    select: { delayMinutes: true },
-                  },
-                },
-              },
-            },
-          },
-        },
-      });
-
-      for (const incident of incidents) {
-        let nextEscalationAt: Date | null = new Date();
-        if (incident.status === 'ACKNOWLEDGED') {
-          const stepIndex = incident.currentEscalationStep ?? 0;
-          const steps = incident.service?.policy?.steps ?? [];
-          const step = steps.find((_, index) => index === stepIndex);
-          const delayMinutes = step?.delayMinutes ?? 0;
-          nextEscalationAt = new Date(Date.now() + delayMinutes * 60 * 1000);
-        }
-
-        await prisma.incident.update({
-          where: { id: incident.id },
-          data: {
-            status,
-            escalationStatus: 'ESCALATING',
-            nextEscalationAt,
-            acknowledgedAt:
-              incident.status === 'ACKNOWLEDGED' || incident.status === 'RESOLVED'
-                ? null
-                : incident.acknowledgedAt,
-            resolvedAt: incident.status === 'RESOLVED' ? null : incident.resolvedAt,
-            currentEscalationStep:
-              incident.status === 'RESOLVED' ? 0 : incident.currentEscalationStep,
-          },
-        });
-      }
-    } else {
-      const updateData: any = { status }; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-      if (status === 'ACKNOWLEDGED') {
-        updateData.acknowledgedAt = new Date();
-        updateData.escalationStatus = 'COMPLETED';
-        updateData.nextEscalationAt = null;
-      } else if (status === 'RESOLVED') {
-        updateData.resolvedAt = new Date();
-        updateData.escalationStatus = 'COMPLETED';
-        updateData.nextEscalationAt = null;
-      } else if (status === 'SNOOZED' || status === 'SUPPRESSED') {
-        updateData.escalationStatus = 'PAUSED';
-        updateData.nextEscalationAt = null;
-      }
-
-      await prisma.incident.updateMany({
-        where: {
-          id: { in: incidentIds },
-        },
-        data: updateData,
-      });
-    }
-
-    // Log events for each incident (batch create)
     const user = await getCurrentUser();
-    await prisma.incidentEvent.createMany({
-      data: incidentIds.map(incidentId => ({
-        incidentId,
-        message: `Bulk status updated to ${status}${user ? ` by ${user.name}` : ''}`,
-      })),
-    });
+    const changedIds = await runBulkLifecycleTarget(
+      incidentIds,
+      status,
+      { id: user.id, name: user.name ?? undefined },
+      `Bulk status updated to ${status}${user ? ` by ${user.name}` : ''}`
+    );
 
-    // Fetch all incidents in a single query for notifications and webhooks
-    const incidents = await prisma.incident.findMany({
-      where: { id: { in: incidentIds } },
-      include: {
-        service: { select: { id: true, name: true } },
-        assignee: {
-          select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-        },
-      },
-    });
-
-    // Send notifications in parallel
+    const incidents = await loadIncidentsForLifecycleEffects(changedIds);
     const { sendIncidentNotifications } = await import('@/lib/user-notifications');
     const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
     const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
 
-    // Determine event type once
     let eventType = 'incident.updated';
     if (status === 'RESOLVED') eventType = 'incident.resolved';
     else if (status === 'ACKNOWLEDGED') eventType = 'incident.acknowledged';
@@ -702,10 +550,10 @@ export async function bulkUpdateStatus(
             notificationPromises.push(
               sendIncidentNotifications(incident.id, 'resolved'),
               notifyStatusPageSubscribers(incident.id, 'resolved'),
-              archiveWarRoomChannel(incident.id).catch(err =>
+              archiveWarRoomChannel(incident.id).catch(error =>
                 logger.warn('[ChatOps] Failed to archive war-room channel on bulk status update', {
                   incidentId: incident.id,
-                  error: err,
+                  error,
                 })
               )
             );
@@ -730,11 +578,11 @@ export async function bulkUpdateStatus(
           );
 
           await Promise.all(notificationPromises);
-        } catch (e) {
+        } catch (error) {
           logger.error('Failed to send notifications for incident', {
             component: 'bulk-actions',
             action: 'status-update',
-            error: e,
+            error,
             incidentId: incident.id,
             status,
           });
@@ -743,7 +591,7 @@ export async function bulkUpdateStatus(
     );
 
     revalidatePath('/incidents');
-    return { success: true, count: incidentIds.length };
+    return { success: true, count: changedIds.length };
   } catch (error) {
     logger.error('Bulk status update failed', {
       component: 'bulk-actions',

--- a/tests/lib/bulk-actions.test.ts
+++ b/tests/lib/bulk-actions.test.ts
@@ -1,14 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   bulkAcknowledge,
   bulkResolve,
-  bulkUpdateUrgency,
+  bulkSnooze,
   bulkUpdateStatus,
+  bulkUpdateUrgency,
 } from '@/app/(app)/incidents/bulk-actions';
 import prisma from '@/lib/prisma';
-import { getCurrentUser, assertResponderOrAbove } from '@/lib/rbac';
+import { assertResponderOrAbove, getCurrentUser } from '@/lib/rbac';
+import {
+  executeIncidentLifecycleBatch,
+  executeIncidentLifecycleTargetBatch,
+} from '@/lib/incidents/lifecycle';
 
-// Mock dependencies
 vi.mock('@/lib/prisma', () => {
   const incident = {
     updateMany: vi.fn(),
@@ -26,13 +30,8 @@ vi.mock('@/lib/prisma', () => {
       async (callback: (tx: { incident: typeof incident; incidentEvent: typeof incidentEvent }) => unknown) =>
         callback({ incident, incidentEvent })
     ),
-    auditLog: {
-      create: vi.fn(),
-    },
-    systemSettings: {
-      findUnique: vi.fn(),
-      upsert: vi.fn(),
-    },
+    auditLog: { create: vi.fn() },
+    systemSettings: { findUnique: vi.fn(), upsert: vi.fn() },
   };
   return { __esModule: true, default: client };
 });
@@ -40,6 +39,11 @@ vi.mock('@/lib/prisma', () => {
 vi.mock('@/lib/rbac', () => ({
   getCurrentUser: vi.fn(),
   assertResponderOrAbove: vi.fn(),
+}));
+
+vi.mock('@/lib/incidents/lifecycle', () => ({
+  executeIncidentLifecycleBatch: vi.fn(),
+  executeIncidentLifecycleTargetBatch: vi.fn(),
 }));
 
 vi.mock('next/cache', () => ({
@@ -56,136 +60,204 @@ describe('Bulk Actions', () => {
       email: 'test@example.com',
       role: 'RESPONDER',
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
   });
 
   describe('bulkAcknowledge', () => {
-    it('should acknowledge multiple incidents', async () => {
+    it('routes acknowledgement through the lifecycle batch engine', async () => {
       const incidentIds = ['incident-1', 'incident-2'];
-      vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 2 });
-      vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 2 });
-      vi.mocked(prisma.incident.findMany)
-        .mockResolvedValueOnce(
-          incidentIds.map(id => ({ id })) as unknown as Awaited<
-            ReturnType<typeof prisma.incident.findMany>
-          >
-        )
-        .mockResolvedValueOnce([]);
+      vi.mocked(executeIncidentLifecycleBatch).mockResolvedValue([
+        {
+          incidentId: 'incident-1',
+          command: 'ACKNOWLEDGE',
+          source: 'BULK',
+          previousStatus: 'OPEN',
+          status: 'ACKNOWLEDGED',
+          changed: true,
+        },
+        {
+          incidentId: 'incident-2',
+          command: 'ACKNOWLEDGE',
+          source: 'BULK',
+          previousStatus: 'ACKNOWLEDGED',
+          status: 'ACKNOWLEDGED',
+          changed: false,
+        },
+      ]);
 
       const result = await bulkAcknowledge(incidentIds);
 
-      expect(result.success).toBe(true);
-      expect(result.count).toBe(2);
-      expect(prisma.incident.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: incidentIds } },
-        data: {
-          status: 'ACKNOWLEDGED',
-          acknowledgedAt: expect.any(Date),
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
-        },
+      expect(result).toEqual({ success: true, count: 1 });
+      expect(executeIncidentLifecycleBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          incidentId: 'incident-1',
+          command: 'ACKNOWLEDGE',
+          source: 'BULK',
+          actor: { id: 'user-1', name: 'Test User' },
+        }),
+        expect.objectContaining({
+          incidentId: 'incident-2',
+          command: 'ACKNOWLEDGE',
+          source: 'BULK',
+          actor: { id: 'user-1', name: 'Test User' },
+        }),
+      ]);
+      expect(prisma.incident.updateMany).not.toHaveBeenCalled();
+      expect(prisma.incident.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: { in: ['incident-1'] } } })
+      );
+    });
+
+    it('returns an error if no incidents are selected', async () => {
+      await expect(bulkAcknowledge([])).resolves.toEqual({
+        success: false,
+        error: 'No incidents selected',
       });
+      expect(executeIncidentLifecycleBatch).not.toHaveBeenCalled();
     });
 
-    it('should return error if no incidents selected', async () => {
-      const result = await bulkAcknowledge([]);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('No incidents selected');
-    });
-
-    it('should return error if unauthorized', async () => {
+    it('returns an authorization error before invoking lifecycle commands', async () => {
       vi.mocked(assertResponderOrAbove).mockRejectedValue(new Error('Unauthorized'));
 
       const result = await bulkAcknowledge(['incident-1']);
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Unauthorized');
+      expect(result).toEqual({ success: false, error: 'Unauthorized' });
+      expect(executeIncidentLifecycleBatch).not.toHaveBeenCalled();
     });
   });
 
   describe('bulkResolve', () => {
-    it('should resolve multiple incidents', async () => {
-      const incidentIds = ['incident-1', 'incident-2'];
-      vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 2 });
-      vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 2 });
-      vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
-
-      const result = await bulkResolve(incidentIds);
-
-      expect(result.success).toBe(true);
-      expect(result.count).toBe(2);
-      expect(prisma.incident.updateMany).toHaveBeenCalledWith({
-        where: {
-          id: { in: incidentIds },
-        },
-        data: {
+    it('routes resolution through lifecycle validation and only counts changed incidents', async () => {
+      vi.mocked(executeIncidentLifecycleBatch).mockResolvedValue([
+        {
+          incidentId: 'incident-1',
+          command: 'RESOLVE',
+          source: 'BULK',
+          previousStatus: 'ACKNOWLEDGED',
           status: 'RESOLVED',
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
-          resolvedAt: expect.any(Date),
+          changed: true,
         },
-      });
+        {
+          incidentId: 'incident-2',
+          command: 'RESOLVE',
+          source: 'BULK',
+          previousStatus: 'RESOLVED',
+          status: 'RESOLVED',
+          changed: false,
+        },
+      ]);
+
+      const result = await bulkResolve(['incident-1', 'incident-2']);
+
+      expect(result).toEqual({ success: true, count: 1 });
+      expect(executeIncidentLifecycleBatch).toHaveBeenCalledWith([
+        expect.objectContaining({ incidentId: 'incident-1', command: 'RESOLVE', source: 'BULK' }),
+        expect.objectContaining({ incidentId: 'incident-2', command: 'RESOLVE', source: 'BULK' }),
+      ]);
+      expect(prisma.incident.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('does not bypass lifecycle required-field validation', async () => {
+      vi.mocked(executeIncidentLifecycleBatch).mockRejectedValue(
+        new Error('Complete required custom fields before resolving: Root Cause')
+      );
+
+      const result = await bulkResolve(['incident-1']);
+
+      expect(result).toEqual({ success: false, error: 'Failed to resolve incidents' });
+      expect(prisma.incident.updateMany).not.toHaveBeenCalled();
     });
   });
 
-  describe('bulkUpdateUrgency', () => {
-    it('should update urgency for multiple incidents', async () => {
-      const incidentIds = ['incident-1', 'incident-2'];
-      vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 2 });
-      vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 2 });
-
-      const result = await bulkUpdateUrgency(incidentIds, 'HIGH');
-
-      expect(result.success).toBe(true);
-      expect(result.count).toBe(2);
-      expect(prisma.incident.updateMany).toHaveBeenCalledWith({
-        where: {
-          id: { in: incidentIds },
+  describe('bulkSnooze', () => {
+    it('routes snooze metadata through the semantic lifecycle command', async () => {
+      vi.mocked(executeIncidentLifecycleBatch).mockResolvedValue([
+        {
+          incidentId: 'incident-1',
+          command: 'SNOOZE',
+          source: 'BULK',
+          previousStatus: 'OPEN',
+          status: 'SNOOZED',
+          changed: true,
         },
-        data: { urgency: 'HIGH' },
-      });
+      ]);
+
+      const result = await bulkSnooze(['incident-1'], 30, 'maintenance');
+
+      expect(result).toEqual({ success: true, count: 1 });
+      expect(executeIncidentLifecycleBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          incidentId: 'incident-1',
+          command: 'SNOOZE',
+          source: 'BULK',
+          snoozeReason: 'maintenance',
+          snoozedUntil: expect.any(Date),
+        }),
+      ]);
+      expect(prisma.incident.updateMany).not.toHaveBeenCalled();
     });
   });
 
   describe('bulkUpdateStatus', () => {
-    it('should update status to ACKNOWLEDGED with timestamp', async () => {
-      const incidentIds = ['incident-1'];
-      vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 1 });
-      vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 1 });
-      vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
-
-      const result = await bulkUpdateStatus(incidentIds, 'ACKNOWLEDGED');
-
-      expect(result.success).toBe(true);
-      expect(prisma.incident.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: incidentIds } },
-        data: {
-          status: 'ACKNOWLEDGED',
-          acknowledgedAt: expect.any(Date),
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
+    it('delegates OPEN to target-status translation so source state selects the semantic command', async () => {
+      vi.mocked(executeIncidentLifecycleTargetBatch).mockResolvedValue([
+        {
+          incidentId: 'incident-1',
+          command: 'REOPEN',
+          source: 'BULK',
+          previousStatus: 'RESOLVED',
+          status: 'OPEN',
+          changed: true,
         },
-      });
+      ]);
+
+      const result = await bulkUpdateStatus(['incident-1'], 'OPEN');
+
+      expect(result).toEqual({ success: true, count: 1 });
+      expect(executeIncidentLifecycleTargetBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          incidentId: 'incident-1',
+          status: 'OPEN',
+          source: 'BULK',
+          actor: { id: 'user-1', name: 'Test User' },
+        }),
+      ]);
+      expect(prisma.incident.updateMany).not.toHaveBeenCalled();
     });
 
-    it('should update status to RESOLVED with proper data', async () => {
-      const incidentIds = ['incident-1'];
-      vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 1 });
-      vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 1 });
-      vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
-
-      const result = await bulkUpdateStatus(incidentIds, 'RESOLVED');
-
-      expect(result.success).toBe(true);
-      expect(prisma.incident.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: incidentIds } },
-        data: {
-          status: 'RESOLVED',
-          resolvedAt: expect.any(Date),
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
+    it('does not write acknowledgement timestamps directly for generic status updates', async () => {
+      vi.mocked(executeIncidentLifecycleTargetBatch).mockResolvedValue([
+        {
+          incidentId: 'incident-1',
+          command: 'ACKNOWLEDGE',
+          source: 'BULK',
+          previousStatus: 'OPEN',
+          status: 'ACKNOWLEDGED',
+          changed: true,
         },
+      ]);
+
+      await bulkUpdateStatus(['incident-1'], 'ACKNOWLEDGED');
+
+      expect(executeIncidentLifecycleTargetBatch).toHaveBeenCalled();
+      expect(prisma.incident.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('bulkUpdateUrgency', () => {
+    it('keeps non-lifecycle bulk updates on their existing direct path', async () => {
+      vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 2 });
+      vi.mocked(prisma.incidentEvent.createMany).mockResolvedValue({ count: 2 });
+
+      const result = await bulkUpdateUrgency(['incident-1', 'incident-2'], 'HIGH');
+
+      expect(result).toEqual({ success: true, count: 2 });
+      expect(prisma.incident.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['incident-1', 'incident-2'] } },
+        data: { urgency: 'HIGH' },
       });
+      expect(executeIncidentLifecycleBatch).not.toHaveBeenCalled();
+      expect(executeIncidentLifecycleTargetBatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -34,40 +34,70 @@ vi.mock('next/cache', () => ({
 describe('incident flow safeguards', () => {
   const prismaMock = prisma as any;
 
+  function lifecycleSnapshot(
+    overrides: Partial<{
+      status: 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED';
+      acknowledgedAt: Date | null;
+      resolvedAt: Date | null;
+      currentEscalationStep: number | null;
+      snoozedUntil: Date | null;
+      snoozeReason: string | null;
+    }> = {}
+  ) {
+    return {
+      status: 'OPEN',
+      acknowledgedAt: null,
+      resolvedAt: null,
+      currentEscalationStep: 0,
+      snoozedUntil: null,
+      snoozeReason: null,
+      service: { policy: { steps: [{ delayMinutes: 0 }] } },
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.customField = { findMany: vi.fn().mockResolvedValue([]) };
     prismaMock.$transaction.mockImplementation(async (cb: any) => cb(prismaMock));
     prismaMock.incident.findMany.mockReset().mockResolvedValue([]);
+    prismaMock.incidentEvent.create = vi.fn().mockResolvedValue({});
     prismaMock.incidentEvent.createMany = vi.fn().mockResolvedValue({ count: 0 });
   });
 
-  it('bulk acknowledge stops escalation', async () => {
-    prismaMock.incident.updateMany.mockResolvedValue({ count: 2 });
-    prismaMock.incident.findMany
-      .mockResolvedValueOnce([{ id: 'inc-1' }, { id: 'inc-2' }])
-      .mockResolvedValueOnce([]);
+  it('bulk acknowledge stops escalation through the lifecycle engine', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue(lifecycleSnapshot());
+    prismaMock.incident.update.mockResolvedValue({});
 
     await bulkAcknowledge(['inc-1', 'inc-2']);
 
-    expect(prismaMock.incident.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
-        }),
-      })
-    );
+    expect(prismaMock.incident.update).toHaveBeenCalledTimes(2);
+    for (const [call] of prismaMock.incident.update.mock.calls) {
+      expect(call).toEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'ACKNOWLEDGED',
+            acknowledgedAt: expect.any(Date),
+            escalationStatus: 'COMPLETED',
+            nextEscalationAt: null,
+          }),
+        })
+      );
+    }
   });
 
-  it('bulk status ACKNOWLEDGED stops escalation', async () => {
-    prismaMock.incident.updateMany.mockResolvedValue({ count: 1 });
+  it('bulk status ACKNOWLEDGED stops escalation through the lifecycle engine', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue(lifecycleSnapshot());
+    prismaMock.incident.update.mockResolvedValue({});
 
     await bulkUpdateStatus(['inc-3'], 'ACKNOWLEDGED');
 
-    expect(prismaMock.incident.updateMany).toHaveBeenCalledWith(
+    expect(prismaMock.incident.update).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: { id: 'inc-3' },
         data: expect.objectContaining({
+          status: 'ACKNOWLEDGED',
+          acknowledgedAt: expect.any(Date),
           escalationStatus: 'COMPLETED',
           nextEscalationAt: null,
         }),
@@ -75,30 +105,35 @@ describe('incident flow safeguards', () => {
     );
   });
 
-  it('bulk reopen clears resolved state and resets escalation step', async () => {
-    prismaMock.incident.findMany.mockResolvedValue([
-      {
-        id: 'inc-4',
+  it('bulk reopen clears resolved state, resets escalation, and preserves first acknowledgement', async () => {
+    const acknowledgedAt = new Date('2026-08-27T10:00:00.000Z');
+    prismaMock.incident.findUnique.mockResolvedValue(
+      lifecycleSnapshot({
         status: 'RESOLVED',
         currentEscalationStep: 2,
-        acknowledgedAt: new Date(),
-        resolvedAt: new Date(),
-        service: { policy: { steps: [{ delayMinutes: 0 }] } },
-      },
-    ]);
+        acknowledgedAt,
+        resolvedAt: new Date('2026-08-27T10:30:00.000Z'),
+      })
+    );
     prismaMock.incident.update.mockResolvedValue({});
 
     await bulkUpdateStatus(['inc-4'], 'OPEN');
 
     expect(prismaMock.incident.update).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: { id: 'inc-4' },
         data: expect.objectContaining({
+          status: 'OPEN',
           resolvedAt: null,
-          acknowledgedAt: null,
           currentEscalationStep: 0,
+          escalationStatus: 'ESCALATING',
+          nextEscalationAt: expect.any(Date),
         }),
       })
     );
+
+    const updateData = prismaMock.incident.update.mock.calls[0][0].data;
+    expect(updateData).not.toHaveProperty('acknowledgedAt');
   });
 
   it('auto-unsnooze job resumes escalation', async () => {


### PR DESCRIPTION
## Summary

Routes bulk incident lifecycle mutations through the centralized lifecycle command engine introduced in #409.

## What changed

- bulk acknowledge and resolve now execute semantic lifecycle commands instead of writing status/timestamps/escalation fields directly
- bulk snooze/unsnooze and suppress/unsuppress now use the same lifecycle command contract as single-incident operations
- generic bulk status updates delegate to target-status translation, so `OPEN` becomes the correct semantic command per source state (`REOPEN`, `UNACKNOWLEDGE`, `UNSNOOZE`, or `UNSUPPRESS`)
- lifecycle timestamps and escalation state are no longer owned by `bulk-actions.ts`
- post-commit notifications/webhooks run only for incidents whose lifecycle state actually changed
- non-lifecycle bulk operations such as urgency, priority, and reassignment keep their existing direct paths
- incident-flow safeguard tests now exercise the real lifecycle engine instead of asserting removed direct Prisma writes

## Invariants fixed

- bulk ACK can no longer overwrite the first `acknowledgedAt` SLA timestamp
- bulk `OPEN` can no longer clear acknowledgement history
- bulk resolve now inherits required-custom-field validation from the lifecycle engine
- duplicate/retried lifecycle operations inherit lifecycle-engine no-op semantics
- reopen/resume behavior is source-state aware instead of treating every transition to `OPEN` identically
- reopen clears `resolvedAt` and resets escalation to step 0 while preserving the historical first acknowledgement timestamp

## Transaction semantics

Bulk lifecycle commands use the lifecycle batch helpers, so lifecycle mutations are all-or-nothing within the batch. Invalid transitions or required-field failures roll back the batch rather than partially applying lifecycle state.

## Tests

Updates bulk-action tests to assert lifecycle-engine delegation, changed-only counts, required-field validation propagation, semantic `OPEN` routing, snooze metadata routing, and that non-lifecycle bulk updates remain outside the lifecycle engine.

Updates `incident-flow.test.ts` to keep its safeguard coverage at the new architecture boundary: ACK still stops escalation, generic ACK still stops escalation, and reopen resets resolved/escalation state without erasing first-ACK history.

## Scope

No lifecycle engine rules are changed here. This PR is adoption only.

## Commit history

Two focused commits, three changed files: implementation/tests plus a follow-up safeguard-test alignment after CI exposed stale direct-Prisma assertions.