### PR TITLE
refactor(auth): adopt centralized policy across core APIs

### DIFF
--- a/docs/v1.5/security/authorization.md
+++ b/docs/v1.5/security/authorization.md
@@ -19,6 +19,14 @@ OpsKnight has workspace-wide application roles and independent team-scoped roles
 
 The implementation uses a central capability registry in `src/lib/authorization.ts`. Server guards enforce capabilities and then apply resource scope where required. UI checks are usability hints only; server enforcement remains authoritative.
 
+## Policy contract and adapters
+
+`src/lib/authorization-policy.ts` is the shared decision contract. Callers provide a normalized actor, an action, and—when required—a resource. It returns an allow/deny decision with global or resource scope and a stable denial reason.
+
+Browser sessions and API keys use the same role capabilities and resource rules for reading, creating, acknowledging, annotating, and managing incidents. `authorization-actors.ts` resolves the user's current database role, status, and team memberships; API-key actors additionally carry key scopes. A key is allowed only when both its scope and its owner's current permission allow the action. Disabled, invited, missing, or downgraded owners fail closed.
+
+Collection endpoints use filters generated from the same policy contract. Incident filters include assignee, watcher, public service-team, and public assigned-team access while preventing team membership alone from exposing private incidents. Avoid introducing route-local role comparisons or independent Prisma authorization filters.
+
 ## Resource checks for a User
 
 The central v1.5 checks allow a regular `USER` to:

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { processEvent, EventPayload } from '@/lib/events';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { EventSchema } from '@/lib/validation';
@@ -10,28 +10,10 @@ import {
   IntegrationBodyTooLargeError,
   readIntegrationBody,
 } from '@/lib/integrations/request-security';
-import { CAPABILITIES, hasCapability } from '@/lib/authorization';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
+import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 120;
-
-async function getApiUserContext(apiKeyUserId: string) {
-  const user = await prisma.user.findUnique({
-    where: { id: apiKeyUserId },
-    select: {
-      id: true,
-      role: true,
-      teamMemberships: { select: { teamId: true } },
-    },
-  });
-
-  if (!user) return null;
-
-  return {
-    id: user.id,
-    role: user.role,
-    teamIds: user.teamMemberships.map(membership => membership.teamId),
-  };
-}
 
 async function postEvent(req: NextRequest) {
   try {
@@ -39,8 +21,7 @@ async function postEvent(req: NextRequest) {
     const authHeader = req.headers.get('Authorization');
     let integrationId: string | null = null;
     let serviceId: string | null = null;
-    let apiKeyScopes: string[] | null = null;
-    let apiKeyUserId: string | null = null;
+    let apiKeyIdentity: Awaited<ReturnType<typeof authenticateApiKey>> = null;
     let apiKeyId: string | null = null;
 
     if (authHeader?.startsWith('Token token=')) {
@@ -59,8 +40,7 @@ async function postEvent(req: NextRequest) {
       if (!apiKey) {
         return jsonError('Unauthorized. Missing or invalid API key.', 401);
       }
-      apiKeyScopes = apiKey.scopes;
-      apiKeyUserId = apiKey.userId;
+      apiKeyIdentity = apiKey;
       apiKeyId = apiKey.id;
     }
 
@@ -84,8 +64,15 @@ async function postEvent(req: NextRequest) {
     const dedupKey = parsed.data.dedup_key;
 
     if (!serviceId) {
-      if (!hasApiScopes(apiKeyScopes, ['events:write'])) {
-        return jsonError('API key missing scope: events:write.', 403);
+      if (!apiKeyIdentity) {
+        return jsonError('Unauthorized. API key user not found.', 401);
+      }
+      const actor = await resolveApiKeyActor(apiKeyIdentity);
+      if (!actor) {
+        return jsonError('Unauthorized. API key user not found.', 401);
+      }
+      if (!authorize({ actor, action: AUTHORIZATION_ACTIONS.EVENT_CREATE }).allowed) {
+        return jsonError('Forbidden. API key owner cannot create events.', 403);
       }
       const candidate = body.service_id || body.serviceId;
       if (!candidate || typeof candidate !== 'string') {
@@ -95,14 +82,13 @@ async function postEvent(req: NextRequest) {
       if (!service) {
         return jsonError('Service not found.', 404);
       }
-      if (!apiKeyUserId) {
-        return jsonError('Unauthorized. API key user not found.', 401);
-      }
-      const apiUser = await getApiUserContext(apiKeyUserId);
-      if (!apiUser) {
-        return jsonError('Unauthorized. API key user not found.', 401);
-      }
-      if (!hasCapability(apiUser.role, CAPABILITIES.OPERATIONS_MANAGE)) {
+      if (
+        !authorize({
+          actor,
+          action: AUTHORIZATION_ACTIONS.EVENT_CREATE,
+          resource: { type: 'service', teamId: service.teamId },
+        }).allowed
+      ) {
         return jsonError('Forbidden. API key owner cannot create events.', 403);
       }
       serviceId = service.id;

--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -1,44 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { IncidentPatchSchema } from '@/lib/validation';
 import { logger } from '@/lib/logger';
 import { scheduleStatusPageNotification } from '@/lib/jobs/queue';
-import { CAPABILITIES, hasCapability } from '@/lib/authorization';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
+import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
 
 type IncidentStatus = 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED';
 type IncidentUrgency = 'LOW' | 'MEDIUM' | 'HIGH';
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 60;
 
-async function getApiUserContext(apiKeyUserId: string) {
-  const user = await prisma.user.findUnique({
-    where: { id: apiKeyUserId },
-    select: {
-      id: true,
-      role: true,
-      teamMemberships: { select: { teamId: true } },
-    },
-  });
-
-  if (!user) return null;
-
-  return {
-    id: user.id,
-    role: user.role,
-    teamIds: user.teamMemberships.map(membership => membership.teamId),
-  };
-}
-
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const apiKey = await authenticateApiKey(req);
   if (!apiKey) {
     return jsonError('Unauthorized. Missing or invalid API key.', 401);
-  }
-  if (!hasApiScopes(apiKey.scopes, ['incidents:read'])) {
-    return jsonError('API key missing scope: incidents:read.', 403);
   }
 
   const rate = await checkRateLimit(
@@ -54,9 +33,12 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     );
   }
 
-  const apiUser = await getApiUserContext(apiKey.userId);
-  if (!apiUser) {
+  const actor = await resolveApiKeyActor(apiKey);
+  if (!actor) {
     return jsonError('Unauthorized. API key user not found.', 401);
+  }
+  if (!authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ }).allowed) {
+    return jsonError('Forbidden. Incident access denied.', 403);
   }
 
   const { id } = await params;
@@ -64,6 +46,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     where: { id },
     include: {
       service: { select: { id: true, name: true, teamId: true } },
+      watchers: { select: { userId: true } },
       assignee: {
         select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
       },
@@ -74,17 +57,27 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     return jsonError('Incident not found.', 404);
   }
 
-  if (!hasCapability(apiUser.role, CAPABILITIES.INCIDENT_READ_ALL)) {
-    const teamId = incident.service?.teamId || null;
-    const hasTeamMembership = teamId ? apiUser.teamIds.includes(teamId) : false;
-    if (incident.assignee?.id !== apiUser.id && !hasTeamMembership) {
-      return jsonError('Forbidden. Incident access denied.', 403);
-    }
-  }
+  const decision = authorize({
+    actor,
+    action: AUTHORIZATION_ACTIONS.INCIDENT_READ,
+    resource: {
+      type: 'incident',
+      assigneeId: incident.assigneeId,
+      watcherIds: incident.watchers.map(watcher => watcher.userId),
+      visibility: incident.visibility,
+      serviceTeamId: incident.service?.teamId,
+      assignedTeamId: incident.teamId,
+    },
+  });
+  if (!decision.allowed) return jsonError('Forbidden. Incident access denied.', 403);
 
-  const responseIncident = incident.service
-    ? { ...incident, service: { id: incident.service.id, name: incident.service.name } }
-    : incident;
+  const { watchers: _watchers, ...visibleIncident } = incident;
+  const responseIncident = visibleIncident.service
+    ? {
+        ...visibleIncident,
+        service: { id: visibleIncident.service.id, name: visibleIncident.service.name },
+      }
+    : visibleIncident;
 
   return jsonOk({ incident: responseIncident }, 200);
 }
@@ -93,9 +86,6 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const apiKey = await authenticateApiKey(req);
   if (!apiKey) {
     return jsonError('Unauthorized. Missing or invalid API key.', 401);
-  }
-  if (!hasApiScopes(apiKey.scopes, ['incidents:write'])) {
-    return jsonError('API key missing scope: incidents:write.', 403);
   }
 
   const rate = await checkRateLimit(
@@ -111,11 +101,11 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     );
   }
 
-  const apiUser = await getApiUserContext(apiKey.userId);
-  if (!apiUser) {
+  const actor = await resolveApiKeyActor(apiKey);
+  if (!actor) {
     return jsonError('Unauthorized. API key user not found.', 401);
   }
-  if (!hasCapability(apiUser.role, CAPABILITIES.OPERATIONS_MANAGE)) {
+  if (!authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_MANAGE }).allowed) {
     return jsonError('Forbidden. API key owner cannot manage incidents.', 403);
   }
 

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { IncidentCreateSchema } from '@/lib/validation';
 import { logger } from '@/lib/logger';
 import { executeEscalation } from '@/lib/escalation';
 import { scheduleStatusPageNotification } from '@/lib/jobs/queue';
-import { CAPABILITIES, hasCapability } from '@/lib/authorization';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
+import { incidentReadWhere } from '@/lib/authorization-filters';
+import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
 
 function parseLimit(value: string | null) {
   const limit = Number(value);
@@ -19,32 +21,10 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 60;
 const RATE_LIMIT_BURST = 120; // short burst protection
 
-async function getApiUserContext(apiKeyUserId: string) {
-  const user = await prisma.user.findUnique({
-    where: { id: apiKeyUserId },
-    select: {
-      id: true,
-      role: true,
-      teamMemberships: { select: { teamId: true } },
-    },
-  });
-
-  if (!user) return null;
-
-  return {
-    id: user.id,
-    role: user.role,
-    teamIds: user.teamMemberships.map(membership => membership.teamId),
-  };
-}
-
 export async function GET(req: NextRequest) {
   const apiKey = await authenticateApiKey(req);
   if (!apiKey) {
     return jsonError('Unauthorized. Missing or invalid API key.', 401);
-  }
-  if (!hasApiScopes(apiKey.scopes, ['incidents:read'])) {
-    return jsonError('API key missing scope: incidents:read.', 403);
   }
 
   const rate = await checkRateLimit(
@@ -60,19 +40,20 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  const apiUser = await getApiUserContext(apiKey.userId);
-  if (!apiUser) {
+  const actor = await resolveApiKeyActor(apiKey);
+  if (!actor) {
     return jsonError('Unauthorized. API key user not found.', 401);
   }
 
   const { searchParams } = new URL(req.url);
   const limit = parseLimit(searchParams.get('limit'));
 
-  const accessFilter = hasCapability(apiUser.role, CAPABILITIES.INCIDENT_READ_ALL)
-    ? undefined
-    : {
-        OR: [{ assigneeId: apiUser.id }, { service: { teamId: { in: apiUser.teamIds } } }],
-      };
+  let accessFilter;
+  try {
+    accessFilter = incidentReadWhere(actor);
+  } catch {
+    return jsonError('Forbidden. Incident access denied.', 403);
+  }
 
   const incidents = await prisma.incident.findMany({
     where: accessFilter,
@@ -97,9 +78,6 @@ export async function POST(req: NextRequest) {
   if (!apiKey) {
     return jsonError('Unauthorized. Missing or invalid API key.', 401);
   }
-  if (!hasApiScopes(apiKey.scopes, ['incidents:write'])) {
-    return jsonError('API key missing scope: incidents:write.', 403);
-  }
 
   const rate = await checkRateLimit(
     `api:${apiKey.id}:incidents:post`,
@@ -122,12 +100,12 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const apiUser = await getApiUserContext(apiKey.userId);
-  if (!apiUser) {
+  const actor = await resolveApiKeyActor(apiKey);
+  if (!actor) {
     return jsonError('Unauthorized. API key user not found.', 401);
   }
-  if (!hasCapability(apiUser.role, CAPABILITIES.OPERATIONS_MANAGE)) {
-    return jsonError('Forbidden. API key owner cannot manage incidents.', 403);
+  if (!authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_CREATE }).allowed) {
+    return jsonError('Forbidden. Incident creation access denied.', 403);
   }
 
   let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -154,6 +132,12 @@ export async function POST(req: NextRequest) {
   if (!service) {
     return jsonError('Service not found.', 404);
   }
+  const decision = authorize({
+    actor,
+    action: AUTHORIZATION_ACTIONS.INCIDENT_CREATE,
+    resource: { type: 'service', teamId: service.teamId },
+  });
+  if (!decision.allowed) return jsonError('Forbidden. Service access denied.', 403);
 
   // Use include in create() to fetch relations in single query instead of separate findUnique
   const incident = await prisma.incident.create({

--- a/src/app/api/schedules/[id]/oncall/route.ts
+++ b/src/app/api/schedules/[id]/oncall/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { resolveEscalationTarget } from '@/lib/escalation';
 import { logger } from '@/lib/logger';
 import { checkApiKeyRateLimit } from '@/lib/api-rate-limit';
 import { getScheduleApiScope } from '@/lib/schedule-api-auth';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -13,12 +14,6 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       return NextResponse.json(
         { error: 'Unauthorized. Missing or invalid API key.' },
         { status: 401 }
-      );
-    }
-    if (!hasApiScopes(apiKey.scopes, ['schedules:read'])) {
-      return NextResponse.json(
-        { error: 'API key missing scope: schedules:read.' },
-        { status: 403 }
       );
     }
     const rate = await checkApiKeyRateLimit('schedules:oncall', apiKey.id, 60);
@@ -32,7 +27,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     const { id } = await params;
 
     // Verify schedule exists
-    const scheduleScope = await getScheduleApiScope(apiKey.userId);
+    const actor = await resolveApiKeyActor(apiKey);
+    if (!actor) return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+    let scheduleScope;
+    try {
+      scheduleScope = getScheduleApiScope(actor);
+    } catch {
+      return NextResponse.json({ error: 'Forbidden. Schedule access denied.' }, { status: 403 });
+    }
     const schedule = await prisma.onCallSchedule.findFirst({
       where: { id, ...scheduleScope },
       select: { id: true },

--- a/src/app/api/schedules/[id]/route.ts
+++ b/src/app/api/schedules/[id]/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { logger } from '@/lib/logger';
 import { checkApiKeyRateLimit } from '@/lib/api-rate-limit';
 import { getScheduleApiScope } from '@/lib/schedule-api-auth';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -12,12 +13,6 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       return NextResponse.json(
         { error: 'Unauthorized. Missing or invalid API key.' },
         { status: 401 }
-      );
-    }
-    if (!hasApiScopes(apiKey.scopes, ['schedules:read'])) {
-      return NextResponse.json(
-        { error: 'API key missing scope: schedules:read.' },
-        { status: 403 }
       );
     }
     const rate = await checkApiKeyRateLimit('schedules', apiKey.id);
@@ -29,7 +24,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     }
 
     const { id } = await params;
-    const scheduleScope = await getScheduleApiScope(apiKey.userId);
+    const actor = await resolveApiKeyActor(apiKey);
+    if (!actor) return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+    let scheduleScope;
+    try {
+      scheduleScope = getScheduleApiScope(actor);
+    } catch {
+      return NextResponse.json({ error: 'Forbidden. Schedule access denied.' }, { status: 403 });
+    }
     const schedule = await prisma.onCallSchedule.findFirst({
       where: { id, ...scheduleScope },
       select: {

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { logger } from '@/lib/logger';
 import { checkApiKeyRateLimit } from '@/lib/api-rate-limit';
 import { getScheduleApiScope } from '@/lib/schedule-api-auth';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
 
 function parseLimit(value: string | null) {
   const limit = Number(value);
@@ -20,12 +21,6 @@ export async function GET(req: NextRequest) {
         { status: 401 }
       );
     }
-    if (!hasApiScopes(apiKey.scopes, ['schedules:read'])) {
-      return NextResponse.json(
-        { error: 'API key missing scope: schedules:read.' },
-        { status: 403 }
-      );
-    }
     const rate = await checkApiKeyRateLimit('schedules', apiKey.id);
     if (!rate.allowed) {
       return NextResponse.json(
@@ -36,7 +31,14 @@ export async function GET(req: NextRequest) {
 
     const { searchParams } = new URL(req.url);
     const limit = parseLimit(searchParams.get('limit'));
-    const scheduleScope = await getScheduleApiScope(apiKey.userId);
+    const actor = await resolveApiKeyActor(apiKey);
+    if (!actor) return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+    let scheduleScope;
+    try {
+      scheduleScope = getScheduleApiScope(actor);
+    } catch {
+      return NextResponse.json({ error: 'Forbidden. Schedule access denied.' }, { status: 403 });
+    }
 
     const schedules = await prisma.onCallSchedule.findMany({
       where: scheduleScope,

--- a/src/app/api/services/[id]/route.ts
+++ b/src/app/api/services/[id]/route.ts
@@ -1,17 +1,15 @@
 import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { jsonError, jsonOk } from '@/lib/api-response';
-import { CAPABILITIES, hasCapability } from '@/lib/authorization';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
+import { serviceReadWhere } from '@/lib/authorization-filters';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const apiKey = await authenticateApiKey(req);
     if (!apiKey) {
       return jsonError('Unauthorized. Missing or invalid API key.', 401);
-    }
-    if (!hasApiScopes(apiKey.scopes, ['services:read'])) {
-      return jsonError('API key missing scope: services:read.', 403);
     }
 
     const { checkRateLimit } = await import('@/lib/rate-limit');
@@ -24,15 +22,16 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       });
     }
     const { id } = await params;
-    const apiUser = await prisma.user.findUnique({
-      where: { id: apiKey.userId },
-      select: { role: true, status: true, teamMemberships: { select: { teamId: true } } },
-    });
-    if (!apiUser || apiUser.status !== 'ACTIVE') return jsonError('Unauthorized.', 401);
-    const hasGlobalRead = hasCapability(apiUser.role, CAPABILITIES.SERVICE_READ_ALL);
-    const teamIds = apiUser.teamMemberships.map(membership => membership.teamId);
+    const actor = await resolveApiKeyActor(apiKey);
+    if (!actor) return jsonError('Unauthorized.', 401);
+    let accessFilter;
+    try {
+      accessFilter = serviceReadWhere(actor);
+    } catch {
+      return jsonError('Forbidden. Service access denied.', 403);
+    }
     const service = await prisma.service.findFirst({
-      where: { id, ...(hasGlobalRead ? {} : { teamId: { in: teamIds } }) },
+      where: { id, ...accessFilter },
       select: {
         id: true,
         name: true,

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
-import { authenticateApiKey, hasApiScopes } from '@/lib/api-auth';
+import { authenticateApiKey } from '@/lib/api-auth';
 import { jsonError, jsonOk } from '@/lib/api-response';
-import { CAPABILITIES, hasCapability } from '@/lib/authorization';
+import { resolveApiKeyActor } from '@/lib/authorization-actors';
+import { serviceReadWhere } from '@/lib/authorization-filters';
 
 function parseLimit(value: string | null) {
   const limit = Number(value);
@@ -16,9 +17,6 @@ export async function GET(req: NextRequest) {
     if (!apiKey) {
       return jsonError('Unauthorized. Missing or invalid API key.', 401);
     }
-    if (!hasApiScopes(apiKey.scopes, ['services:read'])) {
-      return jsonError('API key missing scope: services:read.', 403);
-    }
 
     const { checkRateLimit } = await import('@/lib/rate-limit');
     const rate = await checkRateLimit(`api:${apiKey.id}:services:list`, 60, 60_000);
@@ -31,16 +29,17 @@ export async function GET(req: NextRequest) {
     }
     const { searchParams } = new URL(req.url);
     const limit = parseLimit(searchParams.get('limit'));
-    const apiUser = await prisma.user.findUnique({
-      where: { id: apiKey.userId },
-      select: { role: true, status: true, teamMemberships: { select: { teamId: true } } },
-    });
-    if (!apiUser || apiUser.status !== 'ACTIVE') return jsonError('Unauthorized.', 401);
-    const hasGlobalRead = hasCapability(apiUser.role, CAPABILITIES.SERVICE_READ_ALL);
-    const teamIds = apiUser.teamMemberships.map(membership => membership.teamId);
+    const actor = await resolveApiKeyActor(apiKey);
+    if (!actor) return jsonError('Unauthorized.', 401);
+    let accessFilter;
+    try {
+      accessFilter = serviceReadWhere(actor);
+    } catch {
+      return jsonError('Forbidden. Service access denied.', 403);
+    }
 
     const services = await prisma.service.findMany({
-      where: hasGlobalRead ? {} : { teamId: { in: teamIds } },
+      where: accessFilter,
       orderBy: { createdAt: 'desc' },
       take: limit,
       select: {

--- a/src/lib/authorization-actors.ts
+++ b/src/lib/authorization-actors.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+
+import prisma from '@/lib/prisma';
+import { isAppRole } from '@/lib/authorization';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
+
+type ApiKeyIdentity = { id: string; userId: string; scopes: string[] };
+
+export async function resolveUserActor(userId: string): Promise<AuthorizationActor | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      role: true,
+      status: true,
+      teamMemberships: { select: { teamId: true } },
+    },
+  });
+  if (!user || !isAppRole(user.role)) return null;
+  return {
+    id: user.id,
+    role: user.role,
+    status: user.status,
+    teamIds: user.teamMemberships.map(membership => membership.teamId),
+  };
+}
+
+export async function resolveApiKeyActor(
+  apiKey: ApiKeyIdentity
+): Promise<AuthorizationActor | null> {
+  const actor = await resolveUserActor(apiKey.userId);
+  if (!actor) return null;
+  return { ...actor, apiKey: { id: apiKey.id, scopes: apiKey.scopes } };
+}

--- a/src/lib/authorization-filters.ts
+++ b/src/lib/authorization-filters.ts
@@ -1,0 +1,46 @@
+import type { Prisma } from '@prisma/client';
+import { AuthorizationError, CAPABILITIES } from '@/lib/authorization';
+import {
+  AUTHORIZATION_ACTIONS,
+  authorize,
+  type AuthorizationActor,
+} from '@/lib/authorization-policy';
+
+export function incidentReadWhere(actor: AuthorizationActor): Prisma.IncidentWhereInput {
+  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ });
+  if (!decision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Incident access denied.',
+      CAPABILITIES.INCIDENT_READ_SCOPED
+    );
+  }
+  if (decision.scope === 'global') return {};
+  return {
+    OR: [
+      { assigneeId: actor.id },
+      { watchers: { some: { userId: actor.id } } },
+      {
+        AND: [
+          { visibility: 'PUBLIC' },
+          {
+            OR: [
+              { teamId: { in: [...actor.teamIds] } },
+              { service: { teamId: { in: [...actor.teamIds] } } },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function serviceReadWhere(actor: AuthorizationActor): Prisma.ServiceWhereInput {
+  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.SERVICE_READ });
+  if (!decision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Service access denied.',
+      CAPABILITIES.SERVICE_READ_SCOPED
+    );
+  }
+  return decision.scope === 'global' ? {} : { teamId: { in: [...actor.teamIds] } };
+}

--- a/src/lib/authorization-policy.ts
+++ b/src/lib/authorization-policy.ts
@@ -1,0 +1,186 @@
+import {
+  API_SCOPES,
+  CAPABILITIES,
+  hasCapability,
+  type ApiScope,
+  type AppRole,
+  type Capability,
+} from '@/lib/authorization';
+
+export const AUTHORIZATION_ACTIONS = {
+  INCIDENT_READ: 'incident.read',
+  INCIDENT_CREATE: 'incident.create',
+  INCIDENT_ACKNOWLEDGE: 'incident.acknowledge',
+  INCIDENT_NOTE: 'incident.note',
+  INCIDENT_MANAGE: 'incident.manage',
+  EVENT_CREATE: 'event.create',
+  SERVICE_READ: 'service.read',
+  SCHEDULE_READ: 'schedule.read',
+} as const;
+
+export type AuthorizationAction =
+  (typeof AUTHORIZATION_ACTIONS)[keyof typeof AUTHORIZATION_ACTIONS];
+
+export type AuthorizationActor = {
+  id: string;
+  role: AppRole;
+  status: 'ACTIVE' | 'INVITED' | 'DISABLED';
+  teamIds: readonly string[];
+  apiKey?: { id: string; scopes: readonly string[] };
+};
+
+export type AuthorizationResource =
+  | {
+      type: 'incident';
+      assigneeId?: string | null;
+      watcherIds?: readonly string[];
+      visibility?: 'PUBLIC' | 'PRIVATE';
+      serviceTeamId?: string | null;
+      assignedTeamId?: string | null;
+    }
+  | { type: 'service'; teamId?: string | null }
+  | { type: 'schedule'; participantIds?: readonly string[]; relatedTeamIds?: readonly string[] };
+
+type IncidentResource = Extract<AuthorizationResource, { type: 'incident' }>;
+type ServiceResource = Extract<AuthorizationResource, { type: 'service' }>;
+type ScheduleResource = Extract<AuthorizationResource, { type: 'schedule' }>;
+
+type AuthorizationResourceByAction = {
+  [AUTHORIZATION_ACTIONS.INCIDENT_READ]: IncidentResource;
+  [AUTHORIZATION_ACTIONS.INCIDENT_CREATE]: ServiceResource;
+  [AUTHORIZATION_ACTIONS.INCIDENT_ACKNOWLEDGE]: IncidentResource;
+  [AUTHORIZATION_ACTIONS.INCIDENT_NOTE]: IncidentResource;
+  [AUTHORIZATION_ACTIONS.INCIDENT_MANAGE]: IncidentResource;
+  [AUTHORIZATION_ACTIONS.EVENT_CREATE]: ServiceResource;
+  [AUTHORIZATION_ACTIONS.SERVICE_READ]: ServiceResource;
+  [AUTHORIZATION_ACTIONS.SCHEDULE_READ]: ScheduleResource;
+};
+
+export type AuthorizationRequest<A extends AuthorizationAction = AuthorizationAction> = {
+  actor: AuthorizationActor;
+  action: A;
+  resource?: AuthorizationResourceByAction[A];
+};
+
+export type AuthorizationDecision =
+  | { allowed: true; scope: 'global' | 'resource' }
+  | {
+      allowed: false;
+      reason: 'ACTOR_INACTIVE' | 'MISSING_SCOPE' | 'MISSING_CAPABILITY' | 'RESOURCE_OUT_OF_SCOPE';
+      requiredCapability: Capability;
+      requiredScope?: ApiScope;
+    };
+
+type ActionPolicy = {
+  global: Capability;
+  scoped?: Capability;
+  apiScope?: ApiScope;
+};
+
+const ACTION_POLICIES = new Map<AuthorizationAction, ActionPolicy>([
+  [
+    AUTHORIZATION_ACTIONS.INCIDENT_READ,
+    {
+      global: CAPABILITIES.INCIDENT_READ_ALL,
+      scoped: CAPABILITIES.INCIDENT_READ_SCOPED,
+      apiScope: API_SCOPES.INCIDENTS_READ,
+    },
+  ],
+  [
+    AUTHORIZATION_ACTIONS.INCIDENT_CREATE,
+    {
+      global: CAPABILITIES.INCIDENT_CREATE_ALL,
+      scoped: CAPABILITIES.INCIDENT_CREATE_SCOPED,
+      apiScope: API_SCOPES.INCIDENTS_WRITE,
+    },
+  ],
+  [
+    AUTHORIZATION_ACTIONS.INCIDENT_MANAGE,
+    {
+      global: CAPABILITIES.OPERATIONS_MANAGE,
+      apiScope: API_SCOPES.INCIDENTS_WRITE,
+    },
+  ],
+  [
+    AUTHORIZATION_ACTIONS.INCIDENT_ACKNOWLEDGE,
+    {
+      global: CAPABILITIES.OPERATIONS_MANAGE,
+      scoped: CAPABILITIES.INCIDENT_ACKNOWLEDGE_SCOPED,
+      apiScope: API_SCOPES.INCIDENTS_WRITE,
+    },
+  ],
+  [
+    AUTHORIZATION_ACTIONS.INCIDENT_NOTE,
+    {
+      global: CAPABILITIES.OPERATIONS_MANAGE,
+      scoped: CAPABILITIES.INCIDENT_NOTE_SCOPED,
+      apiScope: API_SCOPES.INCIDENTS_WRITE,
+    },
+  ],
+  [
+    AUTHORIZATION_ACTIONS.EVENT_CREATE,
+    {
+      global: CAPABILITIES.OPERATIONS_MANAGE,
+      apiScope: API_SCOPES.EVENTS_WRITE,
+    },
+  ],
+  [
+    AUTHORIZATION_ACTIONS.SERVICE_READ,
+    {
+      global: CAPABILITIES.SERVICE_READ_ALL,
+      scoped: CAPABILITIES.SERVICE_READ_SCOPED,
+      apiScope: API_SCOPES.SERVICES_READ,
+    },
+  ],
+  [
+    AUTHORIZATION_ACTIONS.SCHEDULE_READ,
+    {
+      global: CAPABILITIES.SCHEDULE_READ_ALL,
+      scoped: CAPABILITIES.SCHEDULE_READ_SCOPED,
+      apiScope: API_SCOPES.SCHEDULES_READ,
+    },
+  ],
+]);
+
+function isResourceInScope(actor: AuthorizationActor, resource: AuthorizationResource): boolean {
+  const teams = new Set(actor.teamIds);
+  if (resource.type === 'service') return Boolean(resource.teamId && teams.has(resource.teamId));
+  if (resource.type === 'schedule') {
+    return (
+      resource.participantIds?.includes(actor.id) === true ||
+      resource.relatedTeamIds?.some(teamId => teams.has(teamId)) === true
+    );
+  }
+  if (resource.assigneeId === actor.id || resource.watcherIds?.includes(actor.id)) return true;
+  if (resource.visibility !== 'PUBLIC') return false;
+  return Boolean(
+    (resource.serviceTeamId && teams.has(resource.serviceTeamId)) ||
+    (resource.assignedTeamId && teams.has(resource.assignedTeamId))
+  );
+}
+
+export function authorize<A extends AuthorizationAction>(
+  input: AuthorizationRequest<A>
+): AuthorizationDecision {
+  const { actor, action, resource } = input;
+  const policy = ACTION_POLICIES.get(action);
+  if (!policy) throw new Error(`Unknown authorization action: ${action}`);
+  if (actor.status !== 'ACTIVE') {
+    return { allowed: false, reason: 'ACTOR_INACTIVE', requiredCapability: policy.global };
+  }
+  if (actor.apiKey && policy.apiScope && !actor.apiKey.scopes.includes(policy.apiScope)) {
+    return {
+      allowed: false,
+      reason: 'MISSING_SCOPE',
+      requiredCapability: policy.global,
+      requiredScope: policy.apiScope,
+    };
+  }
+  if (hasCapability(actor.role, policy.global)) return { allowed: true, scope: 'global' };
+  if (!policy.scoped || !hasCapability(actor.role, policy.scoped)) {
+    return { allowed: false, reason: 'MISSING_CAPABILITY', requiredCapability: policy.global };
+  }
+  if (!resource) return { allowed: true, scope: 'resource' };
+  if (isResourceInScope(actor, resource)) return { allowed: true, scope: 'resource' };
+  return { allowed: false, reason: 'RESOURCE_OUT_OF_SCOPE', requiredCapability: policy.scoped };
+}

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -13,6 +13,8 @@ import {
   type AppRole,
   type Capability,
 } from '@/lib/authorization';
+import { resolveUserActor } from '@/lib/authorization-actors';
+import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
 
 function appError(
   code:
@@ -55,10 +57,14 @@ export async function getCurrentUser() {
     throw appError('AUTHENTICATION_REQUIRED', 'User not found');
   }
   if (user.status === 'DISABLED') {
-    throw appError('USER_DISABLED', 'Unauthorized. User is inactive or disabled.', { userId: user.id });
+    throw appError('USER_DISABLED', 'Unauthorized. User is inactive or disabled.', {
+      userId: user.id,
+    });
   }
   if ((user.tokenVersion ?? 0) !== (session.user.tokenVersion ?? 0)) {
-    throw appError('SESSION_REVOKED', 'Unauthorized. Session has been revoked.', { userId: user.id });
+    throw appError('SESSION_REVOKED', 'Unauthorized. Session has been revoked.', {
+      userId: user.id,
+    });
   }
   return user;
 }
@@ -142,7 +148,10 @@ export async function assertCanReadServiceMetrics(opts: {
   const teamIds = Array.isArray(opts.teamId) ? opts.teamId : opts.teamId ? [opts.teamId] : [];
 
   if (serviceIds.length === 0 && teamIds.length === 0) {
-    throw appError('AUTHORIZATION_DENIED', 'Unauthorized. Specify serviceId or teamId to view metrics.');
+    throw appError(
+      'AUTHORIZATION_DENIED',
+      'Unauthorized. Specify serviceId or teamId to view metrics.'
+    );
   }
 
   const memberships = await prisma.teamMember.findMany({
@@ -153,10 +162,14 @@ export async function assertCanReadServiceMetrics(opts: {
 
   for (const teamId of teamIds) {
     if (!userTeamIds.has(teamId)) {
-      throw appError('AUTHORIZATION_DENIED', 'Unauthorized. You are not a member of the requested team.', {
-        teamId,
-        userId: user.id,
-      });
+      throw appError(
+        'AUTHORIZATION_DENIED',
+        'Unauthorized. You are not a member of the requested team.',
+        {
+          teamId,
+          userId: user.id,
+        }
+      );
     }
   }
 
@@ -170,10 +183,14 @@ export async function assertCanReadServiceMetrics(opts: {
     }
     for (const service of services) {
       if (!service.teamId || !userTeamIds.has(service.teamId)) {
-        throw appError('SERVICE_ACCESS_DENIED', 'Unauthorized. Service belongs to a team you are not in.', {
-          serviceId: service.id,
-          userId: user.id,
-        });
+        throw appError(
+          'SERVICE_ACCESS_DENIED',
+          'Unauthorized. Service belongs to a team you are not in.',
+          {
+            serviceId: service.id,
+            userId: user.id,
+          }
+        );
       }
     }
   }
@@ -183,18 +200,27 @@ export async function assertCanReadServiceMetrics(opts: {
 
 export async function assertCanCreateIncidentForService(serviceId: string) {
   const user = await getCurrentUser();
-  if (hasCapability(user.role as AppRole, CAPABILITIES.INCIDENT_CREATE_ALL)) return user;
-  if (!hasCapability(user.role as AppRole, CAPABILITIES.INCIDENT_CREATE_SCOPED)) {
-    throw new AuthorizationError(
-      'Unauthorized. Incident creation access required.',
-      CAPABILITIES.INCIDENT_CREATE_SCOPED
-    );
+  const [actor, service] = await Promise.all([
+    resolveUserActor(user.id),
+    prisma.service.findUnique({ where: { id: serviceId }, select: { id: true, teamId: true } }),
+  ]);
+  if (!service) throw appError('SERVICE_NOT_FOUND', 'Service not found', { serviceId });
+  if (!actor) {
+    throw appError('AUTHORIZATION_DENIED', 'Unauthorized. Incident creation access required.', {
+      userId: user.id,
+    });
   }
-  const service = await prisma.service.findFirst({
-    where: { id: serviceId, team: { members: { some: { userId: user.id } } } },
-    select: { id: true },
+  const decision = authorize({
+    actor,
+    action: AUTHORIZATION_ACTIONS.INCIDENT_CREATE,
+    resource: { type: 'service', teamId: service.teamId },
   });
-  if (!service) {
+  if (!decision.allowed && decision.reason === 'MISSING_CAPABILITY') {
+    throw appError('AUTHORIZATION_DENIED', 'Unauthorized. Incident creation access required.', {
+      userId: user.id,
+    });
+  }
+  if (!decision.allowed) {
     throw appError(
       'INCIDENT_CREATE_SERVICE_ACCESS_DENIED',
       'Unauthorized. You can only create incidents for your team services.',
@@ -206,26 +232,24 @@ export async function assertCanCreateIncidentForService(serviceId: string) {
 
 export async function assertCanAcknowledgeIncident(incidentId: string) {
   const user = await getCurrentUser();
-  if (hasCapability(user.role as AppRole, CAPABILITIES.OPERATIONS_MANAGE)) return user;
-  if (!hasCapability(user.role as AppRole, CAPABILITIES.INCIDENT_ACKNOWLEDGE_SCOPED)) {
-    throw new AuthorizationError(
-      'Unauthorized. Incident acknowledgement access required.',
-      CAPABILITIES.INCIDENT_ACKNOWLEDGE_SCOPED
-    );
-  }
-  return assertCanViewIncident(incidentId);
+  return assertIncidentPolicy(
+    user,
+    incidentId,
+    AUTHORIZATION_ACTIONS.INCIDENT_ACKNOWLEDGE,
+    CAPABILITIES.INCIDENT_ACKNOWLEDGE_SCOPED,
+    'Unauthorized. Incident acknowledgement access required.'
+  );
 }
 
 export async function assertCanAddIncidentNote(incidentId: string) {
   const user = await getCurrentUser();
-  if (hasCapability(user.role as AppRole, CAPABILITIES.OPERATIONS_MANAGE)) return user;
-  if (!hasCapability(user.role as AppRole, CAPABILITIES.INCIDENT_NOTE_SCOPED)) {
-    throw new AuthorizationError(
-      'Unauthorized. Incident note access required.',
-      CAPABILITIES.INCIDENT_NOTE_SCOPED
-    );
-  }
-  return assertCanViewIncident(incidentId);
+  return assertIncidentPolicy(
+    user,
+    incidentId,
+    AUTHORIZATION_ACTIONS.INCIDENT_NOTE,
+    CAPABILITIES.INCIDENT_NOTE_SCOPED,
+    'Unauthorized. Incident note access required.'
+  );
 }
 
 export async function getUserPermissions() {
@@ -288,39 +312,62 @@ export async function assertCanModifyIncident(incidentId: string) {
 
 export async function assertCanViewIncident(incidentId: string) {
   const user = await getCurrentUser();
-  if (hasCapability(user.role as AppRole, CAPABILITIES.INCIDENT_READ_ALL)) return user;
+  return assertIncidentPolicy(
+    user,
+    incidentId,
+    AUTHORIZATION_ACTIONS.INCIDENT_READ,
+    CAPABILITIES.INCIDENT_READ_SCOPED,
+    'Unauthorized. You do not have permission to view this incident.'
+  );
+}
 
+async function assertIncidentPolicy(
+  user: Awaited<ReturnType<typeof getCurrentUser>>,
+  incidentId: string,
+  action:
+    | typeof AUTHORIZATION_ACTIONS.INCIDENT_READ
+    | typeof AUTHORIZATION_ACTIONS.INCIDENT_ACKNOWLEDGE
+    | typeof AUTHORIZATION_ACTIONS.INCIDENT_NOTE,
+  capability: Capability,
+  deniedMessage: string
+) {
+  const actor = await resolveUserActor(user.id);
+  if (!actor) {
+    throw new AuthorizationError(deniedMessage, capability);
+  }
+  const preliminaryDecision = authorize({ actor, action });
+  if (!preliminaryDecision.allowed) {
+    throw new AuthorizationError(deniedMessage, capability);
+  }
   const incident = await prisma.incident.findUnique({
     where: { id: incidentId },
-    include: {
-      assignee: true,
-      watchers: { where: { userId: user.id }, select: { id: true } },
-      service: {
-        include: {
-          team: { include: { members: { where: { userId: user.id } } } },
-        },
-      },
+    select: {
+      assigneeId: true,
+      teamId: true,
+      visibility: true,
+      watchers: { select: { userId: true } },
+      service: { select: { teamId: true } },
     },
   });
 
   if (!incident) {
     throw appError('INCIDENT_NOT_FOUND', 'Incident not found', { incidentId });
   }
-  if (incident.assigneeId === user.id) return user;
-  if (incident.watchers.length > 0) return user;
-  if (
-    incident.visibility === 'PUBLIC' &&
-    incident.service.team &&
-    incident.service.team.members.length > 0
-  ) {
-    return user;
-  }
+  const decision = authorize({
+    actor,
+    action,
+    resource: {
+      type: 'incident',
+      assigneeId: incident.assigneeId,
+      assignedTeamId: incident.teamId,
+      visibility: incident.visibility,
+      watcherIds: incident.watchers.map(watcher => watcher.userId),
+      serviceTeamId: incident.service.teamId,
+    },
+  });
+  if (decision.allowed) return user;
 
-  throw appError(
-    'INCIDENT_ACCESS_DENIED',
-    'Unauthorized. You do not have permission to view this incident.',
-    { incidentId, userId: user.id }
-  );
+  throw appError('INCIDENT_ACCESS_DENIED', deniedMessage, { incidentId, userId: user.id, action });
 }
 
 export async function assertCanModifyService(serviceId: string) {

--- a/src/lib/schedule-api-auth.ts
+++ b/src/lib/schedule-api-auth.ts
@@ -1,26 +1,30 @@
-import prisma from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
-import { CAPABILITIES, hasCapability } from '@/lib/authorization';
+import { AuthorizationError, CAPABILITIES } from '@/lib/authorization';
+import {
+  AUTHORIZATION_ACTIONS,
+  authorize,
+  type AuthorizationActor,
+} from '@/lib/authorization-policy';
 
-export async function getScheduleApiScope(
-  userId: string
-): Promise<Prisma.OnCallScheduleWhereInput> {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { role: true },
-  });
-  if (!user) return { id: '__unauthorized__' };
-  if (hasCapability(user.role, CAPABILITIES.SCHEDULE_READ_ALL)) return {};
+export function getScheduleApiScope(actor: AuthorizationActor): Prisma.OnCallScheduleWhereInput {
+  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.SCHEDULE_READ });
+  if (!decision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Schedule access denied.',
+      CAPABILITIES.SCHEDULE_READ_SCOPED
+    );
+  }
+  if (decision.scope === 'global') return {};
 
   return {
     OR: [
-      { layers: { some: { users: { some: { userId } } } } },
+      { layers: { some: { users: { some: { userId: actor.id } } } } },
       {
         escalationRules: {
           some: {
             policy: {
               services: {
-                some: { team: { members: { some: { userId } } } },
+                some: { team: { members: { some: { userId: actor.id } } } },
               },
             },
           },

--- a/tests/api/routes.test.ts
+++ b/tests/api/routes.test.ts
@@ -61,6 +61,12 @@ describe('API Routes - Incidents', () => {
         scopes: ['read:other'],
       } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
       vi.mocked(apiAuth.hasApiScopes).mockReturnValue(false);
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        id: 'user-1',
+        role: 'USER',
+        status: 'ACTIVE',
+        teamMemberships: [],
+      } as never);
 
       const req = await createMockRequest('GET', '/api/incidents');
       const res = await incidentRoute.GET(req);
@@ -86,6 +92,7 @@ describe('API Routes - Incidents', () => {
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         id: 'user-1',
         role: 'ADMIN',
+        status: 'ACTIVE',
         teamMemberships: [],
       } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -110,6 +117,7 @@ describe('API Routes - Incidents', () => {
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         id: 'auditor-1',
         role: 'AUDITOR',
+        status: 'ACTIVE',
         teamMemberships: [],
       } as never);
       vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
@@ -118,9 +126,7 @@ describe('API Routes - Incidents', () => {
       const res = await incidentRoute.GET(req);
 
       expect(res.status).toBe(200);
-      expect(prisma.incident.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: undefined })
-      );
+      expect(prisma.incident.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: {} }));
     });
   });
 
@@ -142,6 +148,7 @@ describe('API Routes - Incidents', () => {
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         id: 'user-1',
         role: 'ADMIN',
+        status: 'ACTIVE',
         teamMemberships: [],
       } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -191,6 +198,7 @@ describe('API Routes - Incidents', () => {
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         id: 'user-1',
         role: 'ADMIN',
+        status: 'ACTIVE',
         teamMemberships: [],
       } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -212,7 +220,12 @@ describe('API Routes - Incidents', () => {
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         id: 'auditor-1',
         role: 'AUDITOR',
+        status: 'ACTIVE',
         teamMemberships: [],
+      } as never);
+      vi.mocked(prisma.service.findUnique).mockResolvedValue({
+        id: 'svc-1',
+        teamId: 'team-1',
       } as never);
 
       const req = await createMockRequest('POST', '/api/incidents', {
@@ -224,7 +237,7 @@ describe('API Routes - Incidents', () => {
       const { data } = await parseResponse(res);
 
       expect(res.status).toBe(403);
-      expect(data.error).toContain('cannot manage incidents');
+      expect(data.error).toContain('Incident creation access denied');
       expect(prisma.incident.create).not.toHaveBeenCalled();
     });
   });

--- a/tests/lib/authorization-actors.test.ts
+++ b/tests/lib/authorization-actors.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import prisma from '@/lib/prisma';
+import { resolveApiKeyActor, resolveUserActor } from '@/lib/authorization-actors';
+
+vi.mock('@/lib/prisma', () => ({
+  default: { user: { findUnique: vi.fn() } },
+}));
+
+describe('authorization actor adapters', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('normalizes a database user and team memberships', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      role: 'USER',
+      status: 'ACTIVE',
+      teamMemberships: [{ teamId: 'team-1' }],
+    } as never);
+
+    await expect(resolveUserActor('user-1')).resolves.toEqual({
+      id: 'user-1',
+      role: 'USER',
+      status: 'ACTIVE',
+      teamIds: ['team-1'],
+    });
+  });
+
+  it('intersects API scopes with the current database identity', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      role: 'RESPONDER',
+      status: 'ACTIVE',
+      teamMemberships: [],
+    } as never);
+
+    await expect(
+      resolveApiKeyActor({ id: 'key-1', userId: 'user-1', scopes: ['incidents:read'] })
+    ).resolves.toMatchObject({
+      role: 'RESPONDER',
+      apiKey: { id: 'key-1', scopes: ['incidents:read'] },
+    });
+  });
+
+  it('returns null for missing identities', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    await expect(resolveUserActor('missing')).resolves.toBeNull();
+  });
+});

--- a/tests/lib/authorization-filters.test.ts
+++ b/tests/lib/authorization-filters.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { incidentReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
+import { getScheduleApiScope } from '@/lib/schedule-api-auth';
+
+const user: AuthorizationActor = {
+  id: 'user-1',
+  role: 'USER',
+  status: 'ACTIVE',
+  teamIds: ['team-1'],
+};
+
+describe('authorization query filters', () => {
+  it('generates incident scope from the same assignee, watcher, visibility, and team policy', () => {
+    expect(incidentReadWhere(user)).toEqual({
+      OR: [
+        { assigneeId: 'user-1' },
+        { watchers: { some: { userId: 'user-1' } } },
+        {
+          AND: [
+            { visibility: 'PUBLIC' },
+            {
+              OR: [{ teamId: { in: ['team-1'] } }, { service: { teamId: { in: ['team-1'] } } }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('returns global filters for global readers', () => {
+    expect(incidentReadWhere({ ...user, role: 'AUDITOR', teamIds: [] })).toEqual({});
+    expect(serviceReadWhere({ ...user, role: 'RESPONDER', teamIds: [] })).toEqual({});
+  });
+
+  it('fails closed when an API key lacks its required scope', () => {
+    expect(() =>
+      serviceReadWhere({ ...user, apiKey: { id: 'key-1', scopes: ['incidents:read'] } })
+    ).toThrow('Forbidden. Service access denied.');
+  });
+
+  it('generates schedule scope from the normalized actor', () => {
+    const apiUser = {
+      ...user,
+      apiKey: { id: 'key-1', scopes: ['schedules:read'] },
+    };
+    expect(getScheduleApiScope(apiUser)).toEqual({
+      OR: [
+        { layers: { some: { users: { some: { userId: 'user-1' } } } } },
+        {
+          escalationRules: {
+            some: {
+              policy: {
+                services: {
+                  some: { team: { members: { some: { userId: 'user-1' } } } },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/tests/lib/authorization-policy.test.ts
+++ b/tests/lib/authorization-policy.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUTHORIZATION_ACTIONS,
+  authorize,
+  type AuthorizationActor,
+  type AuthorizationRequest,
+  type AuthorizationResource,
+} from '@/lib/authorization-policy';
+
+const actor = (overrides: Partial<AuthorizationActor> = {}): AuthorizationActor => ({
+  id: 'user-1',
+  role: 'USER',
+  status: 'ACTIVE',
+  teamIds: ['team-1'],
+  ...overrides,
+});
+
+const incident = (
+  overrides: Partial<Extract<AuthorizationResource, { type: 'incident' }>> = {}
+): Extract<AuthorizationResource, { type: 'incident' }> => ({
+  type: 'incident',
+  visibility: 'PUBLIC',
+  serviceTeamId: 'team-1',
+  watcherIds: [],
+  ...overrides,
+});
+
+describe('authorization policy matrix', () => {
+  it.each([
+    [
+      'Admin × private incident',
+      actor({ role: 'ADMIN' }),
+      incident({ visibility: 'PRIVATE' }),
+      true,
+    ],
+    [
+      'Responder × private incident',
+      actor({ role: 'RESPONDER' }),
+      incident({ visibility: 'PRIVATE' }),
+      true,
+    ],
+    ['User × own-team public', actor(), incident(), true],
+    ['User × other-team public', actor(), incident({ serviceTeamId: 'team-2' }), false],
+    [
+      'User × watcher × private',
+      actor(),
+      incident({ visibility: 'PRIVATE', serviceTeamId: 'team-2', watcherIds: ['user-1'] }),
+      true,
+    ],
+    [
+      'User × own-team private',
+      actor(),
+      incident({ visibility: 'PRIVATE', serviceTeamId: 'team-1' }),
+      false,
+    ],
+    [
+      'Auditor × private incident',
+      actor({ role: 'AUDITOR', teamIds: [] }),
+      incident({ visibility: 'PRIVATE', serviceTeamId: 'team-2' }),
+      true,
+    ],
+  ])('%s', (_name, testActor, resource, allowed) => {
+    expect(
+      authorize({
+        actor: testActor as AuthorizationActor,
+        action: AUTHORIZATION_ACTIONS.INCIDENT_READ,
+        resource,
+      }).allowed
+    ).toBe(allowed);
+  });
+
+  it('denies Auditor incident modification', () => {
+    expect(
+      authorize({
+        actor: actor({ role: 'AUDITOR' }),
+        action: AUTHORIZATION_ACTIONS.INCIDENT_MANAGE,
+        resource: incident(),
+      }).allowed
+    ).toBe(false);
+  });
+
+  it.each([
+    ['acknowledge', AUTHORIZATION_ACTIONS.INCIDENT_ACKNOWLEDGE],
+    ['add a note to', AUTHORIZATION_ACTIONS.INCIDENT_NOTE],
+  ])(
+    'allows a scoped User to %s a visible incident but keeps Auditor read-only',
+    (_name, action) => {
+      expect(authorize({ actor: actor(), action, resource: incident() }).allowed).toBe(true);
+      expect(
+        authorize({ actor: actor({ role: 'AUDITOR' }), action, resource: incident() })
+      ).toMatchObject({ allowed: false, reason: 'MISSING_CAPABILITY' });
+    }
+  );
+
+  it('requires API scope and user permission together', () => {
+    const apiActor = actor({
+      role: 'USER',
+      apiKey: { id: 'key-1', scopes: ['incidents:read'] },
+    });
+    expect(
+      authorize({
+        actor: apiActor,
+        action: AUTHORIZATION_ACTIONS.INCIDENT_READ,
+        resource: incident(),
+      }).allowed
+    ).toBe(true);
+    expect(
+      authorize({
+        actor: apiActor,
+        action: AUTHORIZATION_ACTIONS.INCIDENT_READ,
+        resource: incident({ serviceTeamId: 'team-2' }),
+      }).allowed
+    ).toBe(false);
+    expect(
+      authorize({
+        actor: { ...apiActor, apiKey: { id: 'key-1', scopes: ['services:read'] } },
+        action: AUTHORIZATION_ACTIONS.INCIDENT_READ,
+        resource: incident(),
+      })
+    ).toMatchObject({ allowed: false, reason: 'MISSING_SCOPE' });
+  });
+
+  it.each(['DISABLED', 'INVITED'] as const)('fails closed for %s users', status => {
+    expect(
+      authorize({
+        actor: actor({ role: 'ADMIN', status }),
+        action: AUTHORIZATION_ACTIONS.INCIDENT_READ,
+        resource: incident(),
+      })
+    ).toMatchObject({ allowed: false, reason: 'ACTOR_INACTIVE' });
+  });
+
+  it('allows scoped creation only for an owned service team', () => {
+    const apiActor = actor({ apiKey: { id: 'key-1', scopes: ['incidents:write'] } });
+    expect(
+      authorize({
+        actor: apiActor,
+        action: AUTHORIZATION_ACTIONS.INCIDENT_CREATE,
+        resource: { type: 'service', teamId: 'team-1' },
+      }).allowed
+    ).toBe(true);
+    expect(
+      authorize({
+        actor: apiActor,
+        action: AUTHORIZATION_ACTIONS.INCIDENT_CREATE,
+        resource: { type: 'service', teamId: 'team-2' },
+      }).allowed
+    ).toBe(false);
+  });
+
+  it.each([
+    [
+      'own service',
+      AUTHORIZATION_ACTIONS.SERVICE_READ,
+      { type: 'service', teamId: 'team-1' },
+      true,
+    ],
+    [
+      'other service',
+      AUTHORIZATION_ACTIONS.SERVICE_READ,
+      { type: 'service', teamId: 'team-2' },
+      false,
+    ],
+    [
+      'participant schedule',
+      AUTHORIZATION_ACTIONS.SCHEDULE_READ,
+      { type: 'schedule', participantIds: ['user-1'] },
+      true,
+    ],
+    [
+      'team schedule',
+      AUTHORIZATION_ACTIONS.SCHEDULE_READ,
+      { type: 'schedule', relatedTeamIds: ['team-1'] },
+      true,
+    ],
+    [
+      'unrelated schedule',
+      AUTHORIZATION_ACTIONS.SCHEDULE_READ,
+      { type: 'schedule', relatedTeamIds: ['team-2'] },
+      false,
+    ],
+  ])('applies resource scope to %s', (_name, action, resource, allowed) => {
+    expect(authorize({ actor: actor(), action, resource } as AuthorizationRequest).allowed).toBe(
+      allowed
+    );
+  });
+
+  it('requires both responder permission and events:write scope for event ingestion', () => {
+    expect(
+      authorize({
+        actor: actor({
+          role: 'RESPONDER',
+          apiKey: { id: 'key-1', scopes: ['events:write'] },
+        }),
+        action: AUTHORIZATION_ACTIONS.EVENT_CREATE,
+        resource: { type: 'service', teamId: 'team-2' },
+      }).allowed
+    ).toBe(true);
+    expect(
+      authorize({
+        actor: actor({ role: 'RESPONDER', apiKey: { id: 'key-1', scopes: [] } }),
+        action: AUTHORIZATION_ACTIONS.EVENT_CREATE,
+      })
+    ).toMatchObject({ allowed: false, reason: 'MISSING_SCOPE' });
+    expect(
+      authorize({
+        actor: actor({
+          role: 'AUDITOR',
+          apiKey: { id: 'key-1', scopes: ['events:write'] },
+        }),
+        action: AUTHORIZATION_ACTIONS.EVENT_CREATE,
+      })
+    ).toMatchObject({ allowed: false, reason: 'MISSING_CAPABILITY' });
+  });
+});

--- a/tests/lib/rbac.test.ts
+++ b/tests/lib/rbac.test.ts
@@ -52,6 +52,8 @@ describe('RBAC Functions', () => {
     email: 'test@example.com',
     role: 'USER',
     name: 'Test User',
+    status: 'ACTIVE',
+    teamMemberships: [{ teamId: 'team-1' }],
   };
 
   const mockAdmin = {
@@ -59,6 +61,8 @@ describe('RBAC Functions', () => {
     email: 'admin@example.com',
     role: 'ADMIN',
     name: 'Admin User',
+    status: 'ACTIVE',
+    teamMemberships: [],
   };
 
   const mockResponder = {
@@ -66,6 +70,8 @@ describe('RBAC Functions', () => {
     email: 'resp@example.com',
     role: 'RESPONDER',
     name: 'Responder User',
+    status: 'ACTIVE',
+    teamMemberships: [],
   };
 
   const mockAuditor = {
@@ -73,6 +79,8 @@ describe('RBAC Functions', () => {
     email: 'auditor@example.com',
     role: 'AUDITOR',
     name: 'Audit User',
+    status: 'ACTIVE',
+    teamMemberships: [],
   };
 
   beforeEach(() => {
@@ -104,7 +112,6 @@ describe('RBAC Functions', () => {
     it('should return user if role is ADMIN', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockAdmin.email } });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAdmin as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-
       const result = await assertAdmin();
       expect(result).toEqual(mockAdmin);
     });
@@ -276,6 +283,10 @@ describe('RBAC Functions', () => {
     it('should allow ADMIN to create incident for any service', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockAdmin.email } });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAdmin as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.service.findUnique).mockResolvedValue({
+        id: serviceId,
+        teamId: null,
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
       expect(await assertCanCreateIncidentForService(serviceId)).toEqual(mockAdmin);
     });
@@ -283,6 +294,10 @@ describe('RBAC Functions', () => {
     it('should allow RESPONDER to create incident for any service', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockResponder.email } });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockResponder as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.service.findUnique).mockResolvedValue({
+        id: serviceId,
+        teamId: null,
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
       expect(await assertCanCreateIncidentForService(serviceId)).toEqual(mockResponder);
     });
@@ -290,7 +305,10 @@ describe('RBAC Functions', () => {
     it('should allow USER to create incident for their team service', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockUser.email } });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-      vi.mocked(prisma.service.findFirst).mockResolvedValue({ id: serviceId } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.service.findUnique).mockResolvedValue({
+        id: serviceId,
+        teamId: 'team-1',
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
       expect(await assertCanCreateIncidentForService(serviceId)).toEqual(mockUser);
     });
@@ -298,7 +316,10 @@ describe('RBAC Functions', () => {
     it('should reject USER from creating incident for non-team service', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockUser.email } });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-      vi.mocked(prisma.service.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.service.findUnique).mockResolvedValue({
+        id: serviceId,
+        teamId: 'team-2',
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
       await expect(assertCanCreateIncidentForService(serviceId)).rejects.toThrow(
         'Unauthorized. You can only create incidents for your team services.'
@@ -308,6 +329,10 @@ describe('RBAC Functions', () => {
     it('should reject AUDITOR from creating incidents', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockAuditor.email } });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAuditor as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.service.findUnique).mockResolvedValue({
+        id: serviceId,
+        teamId: null,
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
       await expect(assertCanCreateIncidentForService(serviceId)).rejects.toThrow(
         'Unauthorized. Incident creation access required.'
@@ -320,9 +345,10 @@ describe('RBAC Functions', () => {
       vi.mocked(prisma.incident.findUnique).mockResolvedValue({
         id: incidentId,
         assigneeId: null,
+        teamId: null,
         visibility: 'PUBLIC',
         watchers: [],
-        service: { team: { members: [{ userId: mockUser.id }] } },
+        service: { teamId: 'team-1' },
       } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
       expect(await assertCanAcknowledgeIncident(incidentId)).toEqual(mockUser);


### PR DESCRIPTION
## Summary
- add a typed actor/action/resource authorization decision contract on top of the existing capability registry
- normalize session and API-key users through shared adapters, with active-account and current-role enforcement
- adopt the policy in incident, event, service, and schedule APIs plus browser RBAC guards
- generate Prisma collection filters from the same incident/service/schedule policy
- add permission-matrix tests for Admin, Responder, Auditor, User, watcher, private/team resources, API scopes, and inactive accounts

## Compatibility and security
- API keys now require both the key scope and the owner current permission
- disabled, invited, deleted, or downgraded key owners fail closed
- regular Users keep team-scoped incident creation and action permissions added in recent main changes
- private incidents remain visible only to global readers, assignees, or watchers

## Validation
- TypeScript: passed
- focused authorization tests: 63 passed
- unit suite: 1,383 passed, 4 skipped
- production build: passed
- changed authorization files: zero lint warnings

## Note
The repository-wide lint command currently exceeds its existing 100-warning ceiling (baseline: 1,174 warnings); this PR introduces no warnings in its authorization files.