### PR TITLE
refactor(incidents): route REST lifecycle through command engine

### DIFF
--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -8,9 +8,8 @@ import { logger } from '@/lib/logger';
 import { scheduleStatusPageNotification } from '@/lib/jobs/queue';
 import { resolveApiKeyActor } from '@/lib/authorization-actors';
 import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
+import { applyRestIncidentPatch } from '@/lib/incidents/rest-patch';
 
-type IncidentStatus = 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED';
-type IncidentUrgency = 'LOW' | 'MEDIUM' | 'HIGH';
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 60;
 
@@ -109,277 +108,137 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return jsonError('Forbidden. API key owner cannot manage incidents.', 403);
   }
 
-  let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  let body: unknown;
   try {
     body = await req.json();
-  } catch (_error) {
+  } catch {
     return jsonError('Invalid JSON in request body.', 400);
   }
+
   const parsed = IncidentPatchSchema.safeParse(body);
   if (!parsed.success) {
     return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
   }
-  const { id } = await params;
-  const currentIncident = await prisma.incident.findUnique({
-    where: { id },
-    select: {
-      id: true,
-      status: true,
-      urgency: true,
-      acknowledgedAt: true,
-      resolvedAt: true,
-      assigneeId: true,
-      service: { select: { teamId: true } },
-    },
-  });
 
-  if (!currentIncident) {
-    return jsonError('Incident not found.', 404);
-  }
-
-  const status: IncidentStatus | null = parsed.data.status ?? null;
-  const urgency: IncidentUrgency | null = parsed.data.urgency ?? null;
-  const hasAssigneeUpdate = Object.prototype.hasOwnProperty.call(body, 'assigneeId');
-  const assigneeId = hasAssigneeUpdate ? (parsed.data.assigneeId ?? null) : undefined;
-
-  const updates: Record<string, unknown> = {};
-  if (status) {
-    const valid = ['OPEN', 'ACKNOWLEDGED', 'RESOLVED', 'SNOOZED', 'SUPPRESSED'].includes(status);
-    if (!valid) {
-      return jsonError('Invalid status.', 400);
-    }
-    updates.status = status;
-    if (status === 'ACKNOWLEDGED' && !currentIncident.acknowledgedAt) {
-      updates.acknowledgedAt = new Date();
-    }
-    if (status === 'RESOLVED' && !currentIncident.resolvedAt) {
-      updates.resolvedAt = new Date();
-    }
-    if (currentIncident.status === 'RESOLVED' && status !== 'RESOLVED') {
-      updates.resolvedAt = null;
-    }
-    if (status === 'ACKNOWLEDGED' || status === 'RESOLVED') {
-      updates.escalationStatus = 'COMPLETED';
-      updates.nextEscalationAt = null;
-    } else if (status === 'SNOOZED' || status === 'SUPPRESSED') {
-      updates.escalationStatus = 'PAUSED';
-      updates.nextEscalationAt = null;
-    } else if (
-      status === 'OPEN' &&
-      ['SNOOZED', 'SUPPRESSED', 'ACKNOWLEDGED', 'RESOLVED'].includes(currentIncident.status)
-    ) {
-      updates.escalationStatus = 'ESCALATING';
-      if (currentIncident.status === 'ACKNOWLEDGED') {
-        const policyData = await prisma.incident.findUnique({
-          where: { id },
-          select: {
-            currentEscalationStep: true,
-            service: {
-              select: {
-                policy: {
-                  select: {
-                    steps: {
-                      orderBy: { stepOrder: 'asc' },
-                      select: { delayMinutes: true },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        });
-        const stepIndex = policyData?.currentEscalationStep ?? 0;
-        const delayMinutes = policyData?.service?.policy?.steps?.[stepIndex]?.delayMinutes ?? 0;
-        updates.nextEscalationAt = new Date(Date.now() + delayMinutes * 60 * 1000);
-      } else {
-        updates.nextEscalationAt = new Date();
-      }
-      if (currentIncident.status === 'ACKNOWLEDGED' || currentIncident.status === 'RESOLVED') {
-        updates.acknowledgedAt = null;
-      }
-      if (currentIncident.status === 'RESOLVED') {
-        updates.resolvedAt = null;
-        updates.currentEscalationStep = 0;
-      }
-    }
-  }
-  if (urgency) {
-    const valid = ['LOW', 'MEDIUM', 'HIGH'].includes(urgency);
-    if (!valid) {
-      return jsonError('Invalid urgency.', 400);
-    }
-    updates.urgency = urgency;
-  }
-  if (hasAssigneeUpdate) {
-    updates.assigneeId = assigneeId;
-  }
-
-  if (Object.keys(updates).length === 0) {
+  const hasAssigneeUpdate =
+    typeof body === 'object' && body !== null && Object.prototype.hasOwnProperty.call(body, 'assigneeId');
+  if (parsed.data.status === undefined && parsed.data.urgency === undefined && !hasAssigneeUpdate) {
     return jsonError('No valid fields to update.', 400);
   }
 
-  const incident = await prisma.incident.update({
-    where: { id },
-    data: updates,
+  const { id } = await params;
+  let result: Awaited<ReturnType<typeof applyRestIncidentPatch>>;
+  try {
+    result = await applyRestIncidentPatch({
+      incidentId: id,
+      status: parsed.data.status,
+      urgency: parsed.data.urgency,
+      assigneeId: hasAssigneeUpdate ? (parsed.data.assigneeId ?? null) : undefined,
+      hasAssigneeUpdate,
+      actor: { id: actor.id },
+    });
+  } catch (error) {
+    logger.warn('api.incident.patch_rejected', {
+      incidentId: id,
+      apiKeyId: apiKey.id,
+      error,
+    });
+    return jsonError(error);
+  }
+
+  const { incident, lifecycle } = result;
+  logger.info('api.incident.updated', {
+    incidentId: incident.id,
+    apiKeyId: apiKey.id,
+    changed: result.changed,
   });
 
-  logger.info('api.incident.updated', { incidentId: incident.id, apiKeyId: apiKey.id });
-
-  if (status) {
-    const eventMessage =
-      status === 'SNOOZED'
-        ? 'Incident snoozed (escalation paused)'
-        : status === 'SUPPRESSED'
-          ? 'Incident suppressed (escalation paused)'
-          : status === 'OPEN' && currentIncident.status === 'ACKNOWLEDGED'
-            ? 'Incident unacknowledged (escalation resumed)'
-            : status === 'OPEN' &&
-                (currentIncident.status === 'SNOOZED' || currentIncident.status === 'SUPPRESSED')
-              ? 'Incident unsnoozed/unsuppressed (escalation resumed)'
-              : `Status updated to ${status}${status === 'ACKNOWLEDGED' || status === 'RESOLVED' ? ' (escalation stopped)' : ''}`;
-
-    await prisma.incidentEvent.create({
-      data: {
-        incidentId: incident.id,
-        message: eventMessage,
-      },
-    });
-  }
-
-  if (urgency && urgency !== currentIncident.urgency) {
-    await prisma.incidentEvent.create({
-      data: {
-        incidentId: incident.id,
-        message: `Urgency updated to ${urgency}`,
-      },
-    });
-  }
-
-  if (hasAssigneeUpdate && assigneeId !== currentIncident.assigneeId) {
-    if (!assigneeId) {
-      await prisma.incidentEvent.create({
-        data: {
-          incidentId: incident.id,
-          message: 'Incident unassigned',
-        },
-      });
-    } else {
-      const assignee = await prisma.user.findUnique({
-        where: { id: assigneeId },
-        select: { name: true },
-      });
-      await prisma.incidentEvent.create({
-        data: {
-          incidentId: incident.id,
-          message: `Incident manually reassigned to ${assignee?.name || 'user'}`,
-        },
-      });
-    }
-  }
-
-  // If incident was reopened, ensure escalation is triggered if due
-  if (
-    status === 'OPEN' &&
-    ['SNOOZED', 'SUPPRESSED', 'ACKNOWLEDGED', 'RESOLVED'].includes(currentIncident.status)
-  ) {
+  if (result.changed) {
     try {
-      const { executeEscalation } = await import('@/lib/escalation');
-      await executeEscalation(incident.id, 0);
-    } catch (err) {
-      logger.warn('[Incidents API] Failed to trigger escalation on reopen', {
-        error: err,
-        incidentId: incident.id,
-      });
-    }
-  }
-
-  // Trigger status page webhooks for incident updates
-  try {
-    const updatedIncident = await prisma.incident.findUnique({
-      where: { id },
-      include: {
-        service: { select: { id: true, name: true } },
-        assignee: {
-          select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
+      const updatedIncident = await prisma.incident.findUnique({
+        where: { id },
+        include: {
+          service: { select: { id: true, name: true } },
+          assignee: {
+            select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
+          },
         },
-      },
-    });
+      });
 
-    if (updatedIncident) {
-      const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-      let eventType = 'incident.updated';
+      if (updatedIncident) {
+        const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
+        let eventType = 'incident.updated';
+        if (lifecycle?.changed) {
+          if (lifecycle.status === 'RESOLVED') eventType = 'incident.resolved';
+          else if (lifecycle.status === 'ACKNOWLEDGED') eventType = 'incident.acknowledged';
+          else if (lifecycle.status === 'SNOOZED') eventType = 'incident.snoozed';
+          else if (lifecycle.status === 'SUPPRESSED') eventType = 'incident.suppressed';
+        }
 
-      if (updatedIncident.status === 'RESOLVED') {
-        eventType = 'incident.resolved';
-      } else if (updatedIncident.status === 'ACKNOWLEDGED') {
-        eventType = 'incident.acknowledged';
-      } else if (updatedIncident.status === 'SNOOZED') {
-        eventType = 'incident.snoozed';
-      } else if (updatedIncident.status === 'SUPPRESSED') {
-        eventType = 'incident.suppressed';
+        await triggerWebhooksForService(updatedIncident.serviceId, eventType, {
+          id: updatedIncident.id,
+          title: updatedIncident.title,
+          description: updatedIncident.description,
+          status: updatedIncident.status,
+          urgency: updatedIncident.urgency,
+          priority: updatedIncident.priority,
+          service: {
+            id: updatedIncident.service.id,
+            name: updatedIncident.service.name,
+          },
+          assignee: updatedIncident.assignee,
+          createdAt: updatedIncident.createdAt.toISOString(),
+          acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
+          resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
+        });
       }
-
-      await triggerWebhooksForService(updatedIncident.serviceId, eventType, {
-        id: updatedIncident.id,
-        title: updatedIncident.title,
-        description: updatedIncident.description,
-        status: updatedIncident.status,
-        urgency: updatedIncident.urgency,
-        priority: updatedIncident.priority,
-        service: {
-          id: updatedIncident.service.id,
-          name: updatedIncident.service.name,
-        },
-        assignee: updatedIncident.assignee,
-        createdAt: updatedIncident.createdAt.toISOString(),
-        acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
-        resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
+    } catch (error) {
+      logger.error('api.incident.webhook_trigger_failed', {
+        error: error instanceof Error ? error.message : String(error),
+        incidentId: id,
       });
     }
-  } catch (e) {
-    // Log but don't fail the request
-    logger.error('api.incident.webhook_trigger_failed', {
-      error: e instanceof Error ? e.message : String(e),
-    });
-  }
 
-  // Trigger service-level notifications (Slack, Webhooks)
-  try {
-    // Determine event type based on status change
-    let eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated' = 'updated';
-    if (status === 'ACKNOWLEDGED') eventType = 'acknowledged';
-    else if (status === 'RESOLVED') eventType = 'resolved';
-    // If status didn't change but we had an update, it's 'updated'
+    try {
+      let eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated' = 'updated';
+      if (lifecycle?.changed && lifecycle.status === 'ACKNOWLEDGED') eventType = 'acknowledged';
+      else if (lifecycle?.changed && lifecycle.status === 'RESOLVED') eventType = 'resolved';
 
-    const { sendServiceNotifications } = await import('@/lib/service-notifications');
-    // Run in background
-    sendServiceNotifications(incident.id, eventType).catch(err => {
-      logger.error('api.incident.service_notification_failed', {
-        error: err.message,
+      const { sendServiceNotifications } = await import('@/lib/service-notifications');
+      sendServiceNotifications(incident.id, eventType).catch(error => {
+        logger.error('api.incident.service_notification_failed', {
+          error: error instanceof Error ? error.message : String(error),
+          incidentId: incident.id,
+        });
+      });
+    } catch (error) {
+      logger.error('api.incident.service_notification_import_failed', {
+        error: error instanceof Error ? error.message : String(error),
         incidentId: incident.id,
       });
-    });
-  } catch (e) {
-    logger.error('api.incident.service_notification_import_failed', {
-      error: e instanceof Error ? e.message : String(e),
-    });
+    }
   }
 
-  // Notify status page subscribers (Email)
-  try {
-    let notifyEvent: 'acknowledged' | 'resolved' | 'investigating' | null = null;
-    if (status === 'ACKNOWLEDGED') notifyEvent = 'acknowledged';
-    else if (status === 'RESOLVED') notifyEvent = 'resolved';
-    else if (status === 'OPEN') notifyEvent = 'investigating';
+  if (lifecycle?.changed) {
+    try {
+      const notifyEvent =
+        lifecycle.status === 'ACKNOWLEDGED'
+          ? 'acknowledged'
+          : lifecycle.status === 'RESOLVED'
+            ? 'resolved'
+            : lifecycle.status === 'OPEN'
+              ? 'investigating'
+              : null;
 
-    if (notifyEvent) {
-      await scheduleStatusPageNotification(incident.id, notifyEvent);
+      if (notifyEvent) {
+        await scheduleStatusPageNotification(incident.id, notifyEvent);
+      }
+    } catch (error) {
+      logger.error('api.incident.status_page_notification_failed', {
+        error: error instanceof Error ? error.message : String(error),
+        incidentId: incident.id,
+      });
     }
-  } catch (e) {
-    logger.error('api.incident.status_page_notification_failed', {
-      error: e instanceof Error ? e.message : String(e),
-      incidentId: incident.id,
-    });
   }
 
   return jsonOk({ incident }, 200);

--- a/src/lib/incidents/rest-patch.ts
+++ b/src/lib/incidents/rest-patch.ts
@@ -1,0 +1,119 @@
+import 'server-only';
+
+import { AppError } from '@/lib/errors';
+import { runSerializableTransaction } from '@/lib/db-utils';
+import {
+  applyIncidentLifecycleTargetStatus,
+  type IncidentLifecycleResult,
+} from '@/lib/incidents/lifecycle';
+
+export type RestIncidentStatus = 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED';
+export type RestIncidentUrgency = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export type RestIncidentPatchInput = {
+  incidentId: string;
+  status?: RestIncidentStatus;
+  urgency?: RestIncidentUrgency;
+  assigneeId?: string | null;
+  hasAssigneeUpdate: boolean;
+  actor: { id: string; name?: string };
+};
+
+export async function applyRestIncidentPatch(input: RestIncidentPatchInput) {
+  return runSerializableTransaction(async tx => {
+    const current = await tx.incident.findUnique({
+      where: { id: input.incidentId },
+      select: {
+        id: true,
+        status: true,
+        urgency: true,
+        assigneeId: true,
+      },
+    });
+
+    if (!current) {
+      throw new AppError({
+        code: 'INCIDENT_NOT_FOUND',
+        userMessage: 'Incident not found.',
+        details: { incidentId: input.incidentId },
+      });
+    }
+
+    let lifecycle: IncidentLifecycleResult | null = null;
+    if (input.status) {
+      lifecycle = await applyIncidentLifecycleTargetStatus(tx, {
+        incidentId: input.incidentId,
+        status: input.status,
+        source: 'REST_API',
+        actor: input.actor,
+      });
+    }
+
+    const urgencyChanged = input.urgency !== undefined && input.urgency !== current.urgency;
+    const assigneeChanged =
+      input.hasAssigneeUpdate && (input.assigneeId ?? null) !== (current.assigneeId ?? null);
+
+    let assigneeName: string | null = null;
+    if (assigneeChanged && input.assigneeId) {
+      const assignee = await tx.user.findUnique({
+        where: { id: input.assigneeId },
+        select: { name: true },
+      });
+      if (!assignee) {
+        throw new AppError({
+          code: 'RESOURCE_NOT_FOUND',
+          userMessage: 'Assignee not found.',
+          details: { assigneeId: input.assigneeId },
+        });
+      }
+      assigneeName = assignee.name;
+    }
+
+    if (urgencyChanged || assigneeChanged) {
+      await tx.incident.update({
+        where: { id: input.incidentId },
+        data: {
+          ...(urgencyChanged ? { urgency: input.urgency } : {}),
+          ...(assigneeChanged ? { assigneeId: input.assigneeId ?? null } : {}),
+        },
+      });
+    }
+
+    if (urgencyChanged) {
+      await tx.incidentEvent.create({
+        data: {
+          incidentId: input.incidentId,
+          message: `Urgency updated to ${input.urgency}`,
+        },
+      });
+    }
+
+    if (assigneeChanged) {
+      await tx.incidentEvent.create({
+        data: {
+          incidentId: input.incidentId,
+          message: input.assigneeId
+            ? `Incident manually reassigned to ${assigneeName || 'user'}`
+            : 'Incident unassigned',
+        },
+      });
+    }
+
+    const incident = await tx.incident.findUnique({ where: { id: input.incidentId } });
+    if (!incident) {
+      throw new AppError({
+        code: 'INCIDENT_NOT_FOUND',
+        userMessage: 'Incident not found.',
+        details: { incidentId: input.incidentId },
+      });
+    }
+
+    return {
+      incident,
+      lifecycle,
+      urgencyChanged,
+      assigneeChanged,
+      changed: Boolean(lifecycle?.changed || urgencyChanged || assigneeChanged),
+    };
+  });
+}

--- a/tests/api/incident-patch-lifecycle.test.ts
+++ b/tests/api/incident-patch-lifecycle.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockRequest, parseResponse } from '../helpers/api-test';
+import { AppError } from '@/lib/errors';
+
+const mocks = vi.hoisted(() => ({
+  authenticateApiKey: vi.fn(),
+  checkRateLimit: vi.fn(),
+  resolveApiKeyActor: vi.fn(),
+  authorize: vi.fn(),
+  applyRestIncidentPatch: vi.fn(),
+  scheduleStatusPageNotification: vi.fn(),
+  sendServiceNotifications: vi.fn(),
+  triggerWebhooksForService: vi.fn(),
+  incidentFindUnique: vi.fn(),
+}));
+
+vi.mock('@/lib/api-auth', () => ({ authenticateApiKey: mocks.authenticateApiKey }));
+vi.mock('@/lib/rate-limit', () => ({ checkRateLimit: mocks.checkRateLimit }));
+vi.mock('@/lib/authorization-actors', () => ({ resolveApiKeyActor: mocks.resolveApiKeyActor }));
+vi.mock('@/lib/authorization-policy', () => ({
+  AUTHORIZATION_ACTIONS: {
+    INCIDENT_READ: 'incident.read',
+    INCIDENT_MANAGE: 'incident.manage',
+  },
+  authorize: mocks.authorize,
+}));
+vi.mock('@/lib/incidents/rest-patch', () => ({
+  applyRestIncidentPatch: mocks.applyRestIncidentPatch,
+}));
+vi.mock('@/lib/jobs/queue', () => ({
+  scheduleStatusPageNotification: mocks.scheduleStatusPageNotification,
+}));
+vi.mock('@/lib/service-notifications', () => ({
+  sendServiceNotifications: mocks.sendServiceNotifications,
+}));
+vi.mock('@/lib/status-page-webhooks', () => ({
+  triggerWebhooksForService: mocks.triggerWebhooksForService,
+}));
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    incident: { findUnique: mocks.incidentFindUnique },
+  },
+}));
+
+import { PATCH } from '@/app/api/incidents/[id]/route';
+
+const context = { params: Promise.resolve({ id: 'inc-1' }) };
+
+function incident(status = 'ACKNOWLEDGED') {
+  return {
+    id: 'inc-1',
+    title: 'Database latency',
+    description: 'High latency detected',
+    status,
+    urgency: 'HIGH',
+    priority: 'P1',
+    serviceId: 'svc-1',
+    assigneeId: null,
+    teamId: null,
+    visibility: 'PUBLIC',
+    createdAt: new Date('2026-08-28T00:00:00.000Z'),
+    acknowledgedAt: status === 'ACKNOWLEDGED' ? new Date('2026-08-28T00:01:00.000Z') : null,
+    resolvedAt: status === 'RESOLVED' ? new Date('2026-08-28T00:10:00.000Z') : null,
+  };
+}
+
+describe('PATCH /api/incidents/:id lifecycle adoption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticateApiKey.mockResolvedValue({
+      id: 'key-1',
+      userId: 'user-1',
+      scopes: ['incidents:write'],
+    });
+    mocks.checkRateLimit.mockResolvedValue({
+      allowed: true,
+      remaining: 59,
+      resetAt: Date.now() + 60_000,
+      count: 1,
+    });
+    mocks.resolveApiKeyActor.mockResolvedValue({
+      id: 'user-1',
+      role: 'RESPONDER',
+      status: 'ACTIVE',
+      teamIds: [],
+      apiKey: { id: 'key-1', scopes: ['incidents:write'] },
+    });
+    mocks.authorize.mockReturnValue({ allowed: true, scope: 'global' });
+    mocks.sendServiceNotifications.mockResolvedValue({ success: true });
+    mocks.scheduleStatusPageNotification.mockResolvedValue(undefined);
+    mocks.triggerWebhooksForService.mockResolvedValue(undefined);
+  });
+
+  it('routes status changes through the REST lifecycle transaction and dispatches changed-only effects', async () => {
+    const patchedIncident = incident('ACKNOWLEDGED');
+    mocks.applyRestIncidentPatch.mockResolvedValue({
+      incident: patchedIncident,
+      lifecycle: {
+        incidentId: 'inc-1',
+        command: 'ACKNOWLEDGE',
+        source: 'REST_API',
+        previousStatus: 'OPEN',
+        status: 'ACKNOWLEDGED',
+        changed: true,
+      },
+      urgencyChanged: false,
+      assigneeChanged: false,
+      changed: true,
+    });
+    mocks.incidentFindUnique.mockResolvedValue({
+      ...patchedIncident,
+      service: { id: 'svc-1', name: 'Database' },
+      assignee: null,
+    });
+
+    const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {
+      status: 'ACKNOWLEDGED',
+    });
+    const res = await PATCH(req, context);
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(data.incident.status).toBe('ACKNOWLEDGED');
+    expect(mocks.applyRestIncidentPatch).toHaveBeenCalledWith({
+      incidentId: 'inc-1',
+      status: 'ACKNOWLEDGED',
+      urgency: undefined,
+      assigneeId: undefined,
+      hasAssigneeUpdate: false,
+      actor: { id: 'user-1' },
+    });
+    expect(mocks.triggerWebhooksForService).toHaveBeenCalledWith(
+      'svc-1',
+      'incident.acknowledged',
+      expect.objectContaining({ id: 'inc-1', status: 'ACKNOWLEDGED' })
+    );
+    expect(mocks.sendServiceNotifications).toHaveBeenCalledWith('inc-1', 'acknowledged');
+    expect(mocks.scheduleStatusPageNotification).toHaveBeenCalledWith('inc-1', 'acknowledged');
+  });
+
+  it('does not repeat lifecycle side effects for an idempotent status retry', async () => {
+    mocks.applyRestIncidentPatch.mockResolvedValue({
+      incident: incident('ACKNOWLEDGED'),
+      lifecycle: {
+        incidentId: 'inc-1',
+        command: null,
+        source: 'REST_API',
+        previousStatus: 'ACKNOWLEDGED',
+        status: 'ACKNOWLEDGED',
+        changed: false,
+      },
+      urgencyChanged: false,
+      assigneeChanged: false,
+      changed: false,
+    });
+
+    const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {
+      status: 'ACKNOWLEDGED',
+    });
+    const res = await PATCH(req, context);
+
+    expect(res.status).toBe(200);
+    expect(mocks.incidentFindUnique).not.toHaveBeenCalled();
+    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
+    expect(mocks.sendServiceNotifications).not.toHaveBeenCalled();
+    expect(mocks.scheduleStatusPageNotification).not.toHaveBeenCalled();
+  });
+
+  it('returns the typed lifecycle validation contract at the API boundary', async () => {
+    mocks.applyRestIncidentPatch.mockRejectedValue(
+      new AppError({
+        code: 'INCIDENT_REQUIRED_FIELDS_MISSING',
+        userMessage: 'Complete required custom fields before resolving: Impact',
+        details: { fields: ['Impact'] },
+      })
+    );
+
+    const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {
+      status: 'RESOLVED',
+    });
+    const res = await PATCH(req, context);
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(422);
+    expect(data.code).toBe('INCIDENT_REQUIRED_FIELDS_MISSING');
+    expect(data.error).toContain('Complete required custom fields');
+    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
+    expect(mocks.sendServiceNotifications).not.toHaveBeenCalled();
+  });
+
+  it('authorizes the API-key actor before entering the lifecycle transaction', async () => {
+    mocks.authorize.mockReturnValue({ allowed: false, reason: 'role_denied' });
+
+    const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {
+      status: 'ACKNOWLEDGED',
+    });
+    const res = await PATCH(req, context);
+
+    expect(res.status).toBe(403);
+    expect(mocks.applyRestIncidentPatch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/incidents/rest-patch.test.ts
+++ b/tests/lib/incidents/rest-patch.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runSerializableTransaction: vi.fn(),
+  applyIncidentLifecycleTargetStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/db-utils', () => ({
+  runSerializableTransaction: mocks.runSerializableTransaction,
+}));
+
+vi.mock('@/lib/incidents/lifecycle', () => ({
+  applyIncidentLifecycleTargetStatus: mocks.applyIncidentLifecycleTargetStatus,
+}));
+
+import { applyRestIncidentPatch } from '@/lib/incidents/rest-patch';
+
+type Tx = {
+  incident: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  incidentEvent: {
+    create: ReturnType<typeof vi.fn>;
+  };
+  user: {
+    findUnique: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createTx(): Tx {
+  return {
+    incident: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    incidentEvent: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+  };
+}
+
+describe('REST incident patch transaction', () => {
+  let tx: Tx;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tx = createTx();
+    mocks.runSerializableTransaction.mockImplementation(
+      async (callback: (client: Tx) => Promise<unknown>) => callback(tx)
+    );
+  });
+
+  it('keeps lifecycle and non-lifecycle fields in one serializable transaction', async () => {
+    tx.incident.findUnique
+      .mockResolvedValueOnce({
+        id: 'inc-1',
+        status: 'OPEN',
+        urgency: 'LOW',
+        assigneeId: null,
+      })
+      .mockResolvedValueOnce({
+        id: 'inc-1',
+        status: 'ACKNOWLEDGED',
+        urgency: 'HIGH',
+        assigneeId: 'user-2',
+      });
+    tx.user.findUnique.mockResolvedValue({ name: 'Responder Two' });
+    mocks.applyIncidentLifecycleTargetStatus.mockResolvedValue({
+      incidentId: 'inc-1',
+      command: 'ACKNOWLEDGE',
+      source: 'REST_API',
+      previousStatus: 'OPEN',
+      status: 'ACKNOWLEDGED',
+      changed: true,
+    });
+
+    const result = await applyRestIncidentPatch({
+      incidentId: 'inc-1',
+      status: 'ACKNOWLEDGED',
+      urgency: 'HIGH',
+      assigneeId: 'user-2',
+      hasAssigneeUpdate: true,
+      actor: { id: 'api-user' },
+    });
+
+    expect(mocks.runSerializableTransaction).toHaveBeenCalledOnce();
+    expect(mocks.applyIncidentLifecycleTargetStatus).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        incidentId: 'inc-1',
+        status: 'ACKNOWLEDGED',
+        source: 'REST_API',
+        actor: { id: 'api-user' },
+      })
+    );
+    expect(tx.incident.update).toHaveBeenCalledWith({
+      where: { id: 'inc-1' },
+      data: { urgency: 'HIGH', assigneeId: 'user-2' },
+    });
+    expect(tx.incidentEvent.create).toHaveBeenCalledWith({
+      data: { incidentId: 'inc-1', message: 'Urgency updated to HIGH' },
+    });
+    expect(tx.incidentEvent.create).toHaveBeenCalledWith({
+      data: { incidentId: 'inc-1', message: 'Incident manually reassigned to Responder Two' },
+    });
+    expect(result).toMatchObject({
+      changed: true,
+      urgencyChanged: true,
+      assigneeChanged: true,
+      lifecycle: { changed: true, status: 'ACKNOWLEDGED' },
+    });
+  });
+
+  it('preserves lifecycle no-op semantics without writing duplicate metadata or events', async () => {
+    const current = {
+      id: 'inc-2',
+      status: 'ACKNOWLEDGED',
+      urgency: 'HIGH',
+      assigneeId: 'user-2',
+    };
+    tx.incident.findUnique.mockResolvedValue(current);
+    mocks.applyIncidentLifecycleTargetStatus.mockResolvedValue({
+      incidentId: 'inc-2',
+      command: null,
+      source: 'REST_API',
+      previousStatus: 'ACKNOWLEDGED',
+      status: 'ACKNOWLEDGED',
+      changed: false,
+    });
+
+    const result = await applyRestIncidentPatch({
+      incidentId: 'inc-2',
+      status: 'ACKNOWLEDGED',
+      urgency: 'HIGH',
+      assigneeId: 'user-2',
+      hasAssigneeUpdate: true,
+      actor: { id: 'api-user' },
+    });
+
+    expect(result.changed).toBe(false);
+    expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(tx.incidentEvent.create).not.toHaveBeenCalled();
+    expect(tx.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('fails the atomic patch when a requested assignee does not exist', async () => {
+    tx.incident.findUnique.mockResolvedValueOnce({
+      id: 'inc-3',
+      status: 'OPEN',
+      urgency: 'LOW',
+      assigneeId: null,
+    });
+    tx.user.findUnique.mockResolvedValue(null);
+    mocks.applyIncidentLifecycleTargetStatus.mockResolvedValue({
+      incidentId: 'inc-3',
+      command: 'ACKNOWLEDGE',
+      source: 'REST_API',
+      previousStatus: 'OPEN',
+      status: 'ACKNOWLEDGED',
+      changed: true,
+    });
+
+    await expect(
+      applyRestIncidentPatch({
+        incidentId: 'inc-3',
+        status: 'ACKNOWLEDGED',
+        assigneeId: 'missing-user',
+        hasAssigneeUpdate: true,
+        actor: { id: 'api-user' },
+      })
+    ).rejects.toMatchObject({ code: 'RESOURCE_NOT_FOUND', status: 404 });
+
+    expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(tx.incidentEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('propagates typed lifecycle validation failures unchanged', async () => {
+    tx.incident.findUnique.mockResolvedValueOnce({
+      id: 'inc-4',
+      status: 'OPEN',
+      urgency: 'LOW',
+      assigneeId: null,
+    });
+    mocks.applyIncidentLifecycleTargetStatus.mockRejectedValue(
+      Object.assign(new Error('Complete required custom fields'), {
+        code: 'INCIDENT_REQUIRED_FIELDS_MISSING',
+        status: 422,
+      })
+    );
+
+    await expect(
+      applyRestIncidentPatch({
+        incidentId: 'inc-4',
+        status: 'RESOLVED',
+        hasAssigneeUpdate: false,
+        actor: { id: 'api-user' },
+      })
+    ).rejects.toMatchObject({ code: 'INCIDENT_REQUIRED_FIELDS_MISSING', status: 422 });
+  });
+});


### PR DESCRIPTION
## Summary

Routes REST incident lifecycle mutations through the centralized lifecycle command engine instead of maintaining a separate status/timestamp/escalation implementation in `PATCH /api/incidents/:id`.

## What changed

- REST status changes now use `applyIncidentLifecycleTargetStatus` with source `REST_API`
- mixed PATCH requests (`status + urgency + assigneeId`) execute inside one serializable transaction
- lifecycle fields are no longer written directly by the REST route
- urgency and assignee updates remain non-lifecycle concerns but commit atomically with the lifecycle transition
- lifecycle `AppError` values propagate through `jsonError()` with registry-owned status/code
- status-specific notifications, status-page updates, and webhooks run only when the lifecycle transition actually changed state
- idempotent status retries no longer repeat lifecycle side effects
- the old immediate `executeEscalation(..., 0)` reopen path is removed; reopen timing is owned by the lifecycle engine
- assignee existence is validated transactionally and fails with a typed 404 instead of relying on a later FK/runtime failure

## Invariants

- REST ACK cannot overwrite the first `acknowledgedAt`
- REST `OPEN` uses semantic source-state commands (`REOPEN`, `UNACKNOWLEDGE`, `UNSNOOZE`, `UNSUPPRESS`)
- REST reopen preserves acknowledgement history and uses lifecycle-engine escalation reset/timing
- REST resolve inherits required-custom-field validation
- duplicate lifecycle requests are successful no-ops without duplicate side effects
- mixed REST patches are all-or-nothing under serializable isolation

## Tests

Adds focused coverage for:

- lifecycle + urgency + reassignment in the same transaction
- no-op lifecycle retries avoiding duplicate metadata/events
- missing assignee rollback/error contract
- lifecycle validation propagation
- REST API lifecycle delegation
- changed-only webhooks/service notifications/status-page effects
- typed 422 lifecycle validation responses
- authorization before lifecycle execution

## Scope

This is lifecycle adoption only. It does not change lifecycle transition rules or authorization policy.

## Commit history

Exactly one focused commit.