### PR TITLE
refactor(incidents): route lifecycle workers through command engine

### DIFF
--- a/src/lib/__tests__/queue.test.ts
+++ b/src/lib/__tests__/queue.test.ts
@@ -3,18 +3,11 @@ import prisma from '@/lib/prisma';
 import * as queue from '../jobs/queue';
 import { sendNotification as mockedSendNotification } from '@/lib/notifications';
 import { processEventSideEffect as mockedProcessEventSideEffect } from '@/lib/event-side-effects';
+import { processAutoUnsnoozeIncidentInternal } from '@/lib/unsnooze';
 
 type TestMock = ReturnType<typeof vi.fn>;
 
 const prismaMock = prisma as unknown as {
-  $transaction: TestMock;
-  incident: {
-    findUnique: TestMock;
-    updateMany: TestMock;
-  };
-  incidentEvent: {
-    create: TestMock;
-  };
   backgroundJob: {
     findUnique: TestMock;
     update: TestMock;
@@ -22,6 +15,7 @@ const prismaMock = prisma as unknown as {
 };
 const sendNotificationMock = mockedSendNotification as unknown as TestMock;
 const processEventSideEffectMock = mockedProcessEventSideEffect as unknown as TestMock;
+const processAutoUnsnoozeIncidentMock = processAutoUnsnoozeIncidentInternal as unknown as TestMock;
 
 vi.mock('@/lib/user-notifications', () => ({
   sendIncidentNotifications: vi.fn(),
@@ -52,84 +46,91 @@ vi.mock('@/lib/event-side-effects', () => ({
   processEventSideEffect: vi.fn(),
 }));
 
-// Prisma mock object
-vi.mock('@/lib/prisma', () => {
-  return {
-    __esModule: true,
-    default: {
-      $transaction: vi.fn(),
-      incident: {
-        findUnique: vi.fn(),
-        update: vi.fn(),
-        updateMany: vi.fn(),
-      },
-      incidentEvent: {
-        create: vi.fn(),
-      },
-      backgroundJob: {
-        findUnique: vi.fn(),
-        update: vi.fn(),
-      },
+vi.mock('@/lib/unsnooze', () => ({
+  processAutoUnsnoozeIncidentInternal: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    notification: { findMany: vi.fn() },
+    backgroundJob: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
     },
-  };
-});
+  },
+}));
 
 describe('queue.processJob AUTO_UNSNOOZE', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prismaMock.$transaction.mockImplementation(
-      async (callback: (client: typeof prismaMock) => Promise<unknown>) => callback(prismaMock)
-    );
+    prismaMock.backgroundJob.update.mockResolvedValue({});
   });
 
-  it('resumes escalation at current step after unsnooze', async () => {
-    const snoozedIncident = {
-      id: 'inc-1',
-      status: 'SNOOZED',
-      snoozedUntil: new Date(Date.now() - 600000), // safely in the past
-      currentEscalationStep: 2,
-    };
-    const updatedIncident = {
-      ...snoozedIncident,
-      status: 'OPEN',
-      createdAt: new Date(),
-      title: 't',
-      description: 'd',
-      urgency: 'HIGH',
-      priority: null,
-      serviceId: 'svc1',
-      service: { id: 'svc1', name: 'svc' },
-      assignee: null,
-      acknowledgedAt: null,
-      resolvedAt: null,
-    };
-    prismaMock.incident.findUnique.mockResolvedValue(updatedIncident);
-    prismaMock.incident.findUnique.mockResolvedValueOnce(snoozedIncident);
-    prismaMock.incident.updateMany.mockResolvedValue({ count: 1 });
-    prismaMock.incidentEvent.create.mockResolvedValue({});
-    prismaMock.backgroundJob.findUnique.mockResolvedValue({
-      id: 'job-1',
-      attempts: 0,
-      maxAttempts: 3,
-      scheduledAt: new Date(),
-    });
-    prismaMock.backgroundJob.update.mockResolvedValue({});
+  it('delegates due jobs to the system lifecycle worker and completes only a real transition', async () => {
+    processAutoUnsnoozeIncidentMock.mockResolvedValue({ outcome: 'changed' });
 
-    const job = {
+    const result = await queue.processJob({
       id: 'job-1',
       type: 'AUTO_UNSNOOZE',
       status: 'PROCESSING',
       payload: { incidentId: 'inc-1' },
-      attempts: 0,
+      attempts: 1,
       maxAttempts: 3,
-    };
+    });
 
-    await queue.processJob(job);
-
-    expect(prisma.incident.updateMany).toHaveBeenCalledWith(
+    expect(result).toBe(true);
+    expect(processAutoUnsnoozeIncidentMock).toHaveBeenCalledWith('inc-1');
+    expect(prismaMock.backgroundJob.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ id: 'inc-1', status: 'SNOOZED' }),
-        data: expect.objectContaining({ status: 'OPEN' }),
+        where: { id: 'job-1' },
+        data: expect.objectContaining({ status: 'COMPLETED' }),
+      })
+    );
+  });
+
+  it('requeues at the authoritative snooze deadline without consuming retries', async () => {
+    const snoozedUntil = new Date('2026-08-28T08:30:00.000Z');
+    processAutoUnsnoozeIncidentMock.mockResolvedValue({ outcome: 'not_due', snoozedUntil });
+
+    const result = await queue.processJob({
+      id: 'job-early',
+      type: 'AUTO_UNSNOOZE',
+      status: 'PROCESSING',
+      payload: { incidentId: 'inc-1' },
+      attempts: 2,
+      maxAttempts: 3,
+    });
+
+    expect(result).toBe(false);
+    expect(prismaMock.backgroundJob.update).toHaveBeenCalledWith({
+      where: { id: 'job-early' },
+      data: {
+        status: 'PENDING',
+        attempts: 0,
+        scheduledAt: snoozedUntil,
+        startedAt: null,
+      },
+    });
+  });
+
+  it('cancels stale jobs when no lifecycle transition is required', async () => {
+    processAutoUnsnoozeIncidentMock.mockResolvedValue({ outcome: 'noop' });
+
+    const result = await queue.processJob({
+      id: 'job-stale',
+      type: 'AUTO_UNSNOOZE',
+      status: 'PROCESSING',
+      payload: { incidentId: 'inc-1' },
+      attempts: 1,
+      maxAttempts: 3,
+    });
+
+    expect(result).toBe(false);
+    expect(prismaMock.backgroundJob.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'job-stale' },
+        data: expect.objectContaining({ status: 'CANCELLED' }),
       })
     );
   });

--- a/src/lib/jobs/queue.ts
+++ b/src/lib/jobs/queue.ts
@@ -452,110 +452,42 @@ export async function processJob(job: any): Promise<boolean> {
         return true;
       }
 
-      case 'AUTO_UNSNOOZE':
-        const incident = await prisma.incident.findUnique({
-          where: { id: job.payload.incidentId },
-        });
+      case 'AUTO_UNSNOOZE': {
+        const { processAutoUnsnoozeIncidentInternal } = await import('../unsnooze');
+        const result = await processAutoUnsnoozeIncidentInternal(job.payload.incidentId);
 
-        if (incident && incident.status === 'SNOOZED' && incident.snoozedUntil) {
-          const now = new Date();
-          if (now >= incident.snoozedUntil) {
-            const unsnoozed = await prisma.$transaction(async tx => {
-              const changed = await tx.incident.updateMany({
-                where: {
-                  id: job.payload.incidentId,
-                  status: 'SNOOZED',
-                  snoozedUntil: { lte: now },
-                },
-                data: {
-                  status: 'OPEN',
-                  snoozedUntil: null,
-                  snoozeReason: null,
-                  escalationStatus: 'ESCALATING',
-                  nextEscalationAt: now,
-                },
-              });
-              if (changed.count === 0) return false;
-              await tx.incidentEvent.create({
-                data: {
-                  incidentId: job.payload.incidentId,
-                  message: 'Incident auto-unsnoozed (snooze duration expired)',
-                },
-              });
-              return true;
-            });
+        if (result.outcome === 'changed') {
+          await markJobCompleted(job.id);
+          return true;
+        }
 
-            if (!unsnoozed) {
-              await prisma.backgroundJob.update({
-                where: { id: job.id },
-                data: { status: 'CANCELLED', completedAt: new Date() },
-              });
-              return false;
-            }
-
-            try {
-              const { sendIncidentNotifications } = await import('../user-notifications');
-              await sendIncidentNotifications(job.payload.incidentId, 'updated');
-              const { notifyStatusPageSubscribers } = await import('../status-page-notifications');
-              await notifyStatusPageSubscribers(job.payload.incidentId, 'investigating');
-              const { triggerWebhooksForService } = await import('../status-page-webhooks');
-              const updatedIncident = await prisma.incident.findUnique({
-                where: { id: job.payload.incidentId },
-                include: {
-                  service: { select: { id: true, name: true } },
-                  assignee: { select: { id: true, name: true, email: true } },
-                },
-              });
-              if (updatedIncident) {
-                await triggerWebhooksForService(updatedIncident.serviceId, 'incident.updated', {
-                  id: updatedIncident.id,
-                  title: updatedIncident.title,
-                  description: updatedIncident.description,
-                  status: updatedIncident.status,
-                  urgency: updatedIncident.urgency,
-                  priority: updatedIncident.priority,
-                  service: updatedIncident.service,
-                  assignee: updatedIncident.assignee,
-                  createdAt: updatedIncident.createdAt.toISOString(),
-                  acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
-                  resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
-                });
-              }
-            } catch (error) {
-              logger.error('Auto-unsnooze notifications failed', {
-                incidentId: job.payload.incidentId,
-                error: error instanceof Error ? error.message : String(error),
-              });
-            }
-            await markJobCompleted(job.id);
-            // Resume escalation at current step (default 0)
-            const nextStep = incident.currentEscalationStep ?? 0;
-            await scheduleEscalation(job.payload.incidentId, nextStep, 0);
-            return true;
-          } else {
-            // Not ready yet, reschedule and reset attempts so premature polls don't exhaust retry budget
-            await prisma.backgroundJob.update({
-              where: { id: job.id },
-              data: {
-                status: 'PENDING',
-                attempts: 0,
-                scheduledAt: incident.snoozedUntil,
-                startedAt: null,
-              },
-            });
-            return false;
-          }
-        } else {
-          // Incident no longer snoozed, cancel job
+        if (result.outcome === 'not_due') {
+          // A snooze may have been extended after this job was originally
+          // scheduled. Requeue at the authoritative deadline without burning
+          // the retry budget.
           await prisma.backgroundJob.update({
             where: { id: job.id },
             data: {
-              status: 'CANCELLED',
-              completedAt: new Date(),
+              status: 'PENDING',
+              attempts: 0,
+              scheduledAt: result.snoozedUntil,
+              startedAt: null,
             },
           });
           return false;
         }
+
+        // The incident no longer requires this stale job (already open,
+        // resolved, deleted, or otherwise no longer snoozed).
+        await prisma.backgroundJob.update({
+          where: { id: job.id },
+          data: {
+            status: 'CANCELLED',
+            completedAt: new Date(),
+          },
+        });
+        return false;
+      }
 
       default:
         await markJobFailed(job.id, `Unknown job type: ${job.type}`);

--- a/src/lib/unsnooze.ts
+++ b/src/lib/unsnooze.ts
@@ -1,5 +1,116 @@
+import 'server-only';
+
 import prisma from '@/lib/prisma';
+import { runSerializableTransaction } from '@/lib/db-utils';
 import { logger } from '@/lib/logger';
+import { applyIncidentLifecycleCommand } from '@/lib/incidents/lifecycle';
+
+export type AutoUnsnoozeResult =
+  | { outcome: 'changed' }
+  | { outcome: 'not_due'; snoozedUntil: Date }
+  | { outcome: 'noop' };
+
+const AUTO_UNSNOOZE_EVENT_MESSAGE = 'Incident auto-unsnoozed (snooze duration expired)';
+
+async function dispatchAutoUnsnoozeSideEffects(incidentId: string): Promise<void> {
+  try {
+    const updatedIncident = await prisma.incident.findUnique({
+      where: { id: incidentId },
+      include: {
+        service: { select: { id: true, name: true } },
+        assignee: {
+          select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
+        },
+      },
+    });
+
+    // A concurrent operator may have changed the incident again after the
+    // lifecycle transaction committed. Do not emit stale OPEN side effects.
+    if (!updatedIncident || updatedIncident.status !== 'OPEN') return;
+
+    const { sendIncidentNotifications } = await import('@/lib/user-notifications');
+    const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
+    const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
+
+    await Promise.all([
+      sendIncidentNotifications(incidentId, 'updated'),
+      notifyStatusPageSubscribers(incidentId, 'investigating'),
+      triggerWebhooksForService(updatedIncident.serviceId, 'incident.updated', {
+        id: updatedIncident.id,
+        title: updatedIncident.title,
+        description: updatedIncident.description,
+        status: updatedIncident.status,
+        urgency: updatedIncident.urgency,
+        priority: updatedIncident.priority,
+        service: updatedIncident.service,
+        assignee: updatedIncident.assignee,
+        createdAt: updatedIncident.createdAt.toISOString(),
+        acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
+        resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
+      }),
+    ]);
+  } catch (error) {
+    logger.error('Failed to notify after auto-unsnooze', {
+      component: 'unsnooze',
+      incidentId,
+      error,
+    });
+  }
+}
+
+/**
+ * Attempts one system-driven unsnooze.
+ *
+ * The expiry check and lifecycle transition intentionally run inside the same
+ * serializable transaction. If an operator extends the snooze concurrently,
+ * PostgreSQL forces the transaction to retry and the fresh deadline is
+ * observed instead of reopening the incident from stale state.
+ */
+export async function attemptAutoUnsnoozeInternal(
+  incidentId: string,
+  now: Date = new Date()
+): Promise<AutoUnsnoozeResult> {
+  return runSerializableTransaction(async tx => {
+    const current = await tx.incident.findUnique({
+      where: { id: incidentId },
+      select: { status: true, snoozedUntil: true },
+    });
+
+    if (!current || current.status !== 'SNOOZED' || !current.snoozedUntil) {
+      return { outcome: 'noop' };
+    }
+
+    if (current.snoozedUntil.getTime() > now.getTime()) {
+      return { outcome: 'not_due', snoozedUntil: current.snoozedUntil };
+    }
+
+    const result = await applyIncidentLifecycleCommand(tx, {
+      incidentId,
+      command: 'UNSNOOZE',
+      source: 'SYSTEM',
+      expectedStatus: 'SNOOZED',
+      eventMessage: AUTO_UNSNOOZE_EVENT_MESSAGE,
+      now,
+    });
+
+    return result.changed ? { outcome: 'changed' } : { outcome: 'noop' };
+  });
+}
+
+/**
+ * Worker-safe one-incident adapter. Side effects are emitted only after a real
+ * lifecycle transition and never for idempotent retries or stale jobs.
+ */
+export async function processAutoUnsnoozeIncidentInternal(
+  incidentId: string,
+  now: Date = new Date()
+): Promise<AutoUnsnoozeResult> {
+  const result = await attemptAutoUnsnoozeInternal(incidentId, now);
+  if (result.outcome === 'changed') {
+    await dispatchAutoUnsnoozeSideEffects(incidentId);
+  }
+  return result;
+}
 
 /**
  * Process expired incident snoozes (background cron safe - no request headers required).
@@ -14,101 +125,13 @@ export async function processAutoUnsnoozeInternal(): Promise<{ processed: number
     select: { id: true },
   });
 
-  let processedCount = 0;
+  let processed = 0;
   for (const incident of incidentsToUnsnooze) {
     try {
-      const policyData = await prisma.incident.findUnique({
-        where: { id: incident.id },
-        select: {
-          status: true,
-          currentEscalationStep: true,
-          service: {
-            select: {
-              policy: {
-                select: {
-                  steps: {
-                    orderBy: { stepOrder: 'asc' },
-                    select: { delayMinutes: true },
-                  },
-                },
-              },
-            },
-          },
-        },
-      });
-
-      if (policyData?.status !== 'SNOOZED') continue;
-
-      const stepIndex = policyData?.currentEscalationStep ?? 0;
-      const delayMinutes = policyData?.service?.policy?.steps?.at(stepIndex)?.delayMinutes ?? 0;
-      const nextEscalationAt = new Date(Date.now() + delayMinutes * 60 * 1000);
-
-      const claim = await prisma.incident.updateMany({
-        where: {
-          id: incident.id,
-          status: 'SNOOZED',
-          snoozedUntil: { lte: now },
-        },
-        data: {
-          status: 'OPEN',
-          snoozedUntil: null,
-          snoozeReason: null,
-          escalationStatus: 'ESCALATING',
-          nextEscalationAt,
-        },
-      });
-
-      if (claim.count === 0) continue;
-
-      await prisma.incidentEvent.create({
-        data: {
-          incidentId: incident.id,
-          type: 'STATUS_CHANGE',
-          message: 'Incident auto-unsnoozed (snooze duration expired)',
-        },
-      });
-      processedCount++;
+      const result = await processAutoUnsnoozeIncidentInternal(incident.id, now);
+      if (result.outcome === 'changed') processed += 1;
     } catch (error) {
       logger.error('Failed to unsnooze incident', {
-        component: 'unsnooze',
-        incidentId: incident.id,
-        error,
-      });
-      continue;
-    }
-
-    try {
-      const updatedIncident = await prisma.incident.findUnique({
-        where: { id: incident.id },
-        include: {
-          service: { select: { id: true, name: true } },
-          assignee: {
-            select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-          },
-        },
-      });
-      if (updatedIncident && updatedIncident.status === 'OPEN') {
-        const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-        await sendIncidentNotifications(incident.id, 'updated');
-        const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
-        await notifyStatusPageSubscribers(incident.id, 'investigating');
-        const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-        await triggerWebhooksForService(updatedIncident.serviceId, 'incident.updated', {
-          id: updatedIncident.id,
-          title: updatedIncident.title,
-          description: updatedIncident.description,
-          status: updatedIncident.status,
-          urgency: updatedIncident.urgency,
-          priority: updatedIncident.priority,
-          service: updatedIncident.service,
-          assignee: updatedIncident.assignee,
-          createdAt: updatedIncident.createdAt.toISOString(),
-          acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
-          resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
-        });
-      }
-    } catch (error) {
-      logger.error('Failed to notify after auto-unsnooze', {
         component: 'unsnooze',
         incidentId: incident.id,
         error,
@@ -116,5 +139,5 @@ export async function processAutoUnsnoozeInternal(): Promise<{ processed: number
     }
   }
 
-  return { processed: processedCount };
+  return { processed };
 }

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -136,16 +136,34 @@ describe('incident flow safeguards', () => {
     expect(updateData).not.toHaveProperty('acknowledgedAt');
   });
 
-  it('auto-unsnooze job resumes escalation', async () => {
+  it('auto-unsnooze job resumes escalation through the lifecycle engine', async () => {
     const snoozedUntil = new Date(Date.now() - 1000);
-    prismaMock.incident.findUnique.mockResolvedValue({
-      id: 'inc-9',
+    const snoozed = lifecycleSnapshot({
       status: 'SNOOZED',
+      currentEscalationStep: 0,
       snoozedUntil,
-      createdAt: new Date(),
+      snoozeReason: 'maintenance',
     });
-    prismaMock.incident.updateMany.mockResolvedValue({ count: 1 });
-    prismaMock.incidentEvent.create.mockResolvedValue({});
+    const updatedIncident = {
+      id: 'inc-9',
+      title: 'Database latency',
+      description: 'p99 elevated',
+      status: 'OPEN',
+      urgency: 'HIGH',
+      priority: null,
+      serviceId: 'svc-1',
+      service: { id: 'svc-1', name: 'Database' },
+      assignee: null,
+      createdAt: new Date(),
+      acknowledgedAt: null,
+      resolvedAt: null,
+    };
+
+    prismaMock.incident.findUnique.mockImplementation((args: any) =>
+      args?.include ? Promise.resolve(updatedIncident) : Promise.resolve(snoozed)
+    );
+    prismaMock.incident.update.mockResolvedValue({});
+    prismaMock.backgroundJob.update.mockResolvedValue({});
 
     const job = {
       id: 'job-1',
@@ -156,15 +174,19 @@ describe('incident flow safeguards', () => {
 
     await processJob(job as any);
 
-    expect(prismaMock.incident.updateMany).toHaveBeenCalledWith(
+    expect(prismaMock.incident.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ id: 'inc-9', status: 'SNOOZED' }),
+        where: { id: 'inc-9' },
         data: expect.objectContaining({
+          status: 'OPEN',
+          snoozedUntil: null,
+          snoozeReason: null,
           escalationStatus: 'ESCALATING',
           nextEscalationAt: expect.any(Date),
         }),
       })
     );
+    expect(prismaMock.incident.updateMany).not.toHaveBeenCalled();
   });
 
   it('re-opened incidents resume escalation when dedup key matches recent resolve', async () => {

--- a/tests/lib/incidents/system-unsnooze.test.ts
+++ b/tests/lib/incidents/system-unsnooze.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runSerializableTransaction: vi.fn(),
+  applyIncidentLifecycleCommand: vi.fn(),
+  sendIncidentNotifications: vi.fn(),
+  notifyStatusPageSubscribers: vi.fn(),
+  triggerWebhooksForService: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  incident: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/db-utils', () => ({
+  runSerializableTransaction: mocks.runSerializableTransaction,
+}));
+
+vi.mock('@/lib/incidents/lifecycle', () => ({
+  applyIncidentLifecycleCommand: mocks.applyIncidentLifecycleCommand,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: prismaMock,
+}));
+
+vi.mock('@/lib/user-notifications', () => ({
+  sendIncidentNotifications: mocks.sendIncidentNotifications,
+}));
+
+vi.mock('@/lib/status-page-notifications', () => ({
+  notifyStatusPageSubscribers: mocks.notifyStatusPageSubscribers,
+}));
+
+vi.mock('@/lib/status-page-webhooks', () => ({
+  triggerWebhooksForService: mocks.triggerWebhooksForService,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: mocks.loggerError },
+}));
+
+import {
+  attemptAutoUnsnoozeInternal,
+  processAutoUnsnoozeIncidentInternal,
+} from '@/lib/unsnooze';
+
+const NOW = new Date('2026-08-28T04:30:00.000Z');
+
+function createTx() {
+  return {
+    incident: {
+      findUnique: vi.fn(),
+    },
+  };
+}
+
+describe('system auto-unsnooze lifecycle adapter', () => {
+  let tx: ReturnType<typeof createTx>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tx = createTx();
+    mocks.runSerializableTransaction.mockImplementation(
+      async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx)
+    );
+    mocks.applyIncidentLifecycleCommand.mockResolvedValue({
+      incidentId: 'inc-1',
+      command: 'UNSNOOZE',
+      source: 'SYSTEM',
+      previousStatus: 'SNOOZED',
+      status: 'OPEN',
+      changed: true,
+    });
+  });
+
+  it('checks expiry and applies UNSNOOZE inside the same serializable transaction', async () => {
+    tx.incident.findUnique.mockResolvedValue({
+      status: 'SNOOZED',
+      snoozedUntil: new Date('2026-08-28T04:00:00.000Z'),
+    });
+
+    const result = await attemptAutoUnsnoozeInternal('inc-1', NOW);
+
+    expect(result).toEqual({ outcome: 'changed' });
+    expect(mocks.runSerializableTransaction).toHaveBeenCalledOnce();
+    expect(mocks.applyIncidentLifecycleCommand).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        incidentId: 'inc-1',
+        command: 'UNSNOOZE',
+        source: 'SYSTEM',
+        expectedStatus: 'SNOOZED',
+        eventMessage: 'Incident auto-unsnoozed (snooze duration expired)',
+        now: NOW,
+      })
+    );
+  });
+
+  it('returns the authoritative deadline when the snooze was extended', async () => {
+    const snoozedUntil = new Date('2026-08-28T05:30:00.000Z');
+    tx.incident.findUnique.mockResolvedValue({ status: 'SNOOZED', snoozedUntil });
+
+    await expect(attemptAutoUnsnoozeInternal('inc-1', NOW)).resolves.toEqual({
+      outcome: 'not_due',
+      snoozedUntil,
+    });
+
+    expect(mocks.applyIncidentLifecycleCommand).not.toHaveBeenCalled();
+  });
+
+  it('treats stale jobs as idempotent no-ops', async () => {
+    tx.incident.findUnique.mockResolvedValue({ status: 'OPEN', snoozedUntil: null });
+
+    await expect(attemptAutoUnsnoozeInternal('inc-1', NOW)).resolves.toEqual({ outcome: 'noop' });
+    expect(mocks.applyIncidentLifecycleCommand).not.toHaveBeenCalled();
+  });
+
+  it('emits post-commit effects only after a real lifecycle change', async () => {
+    tx.incident.findUnique.mockResolvedValue({
+      status: 'SNOOZED',
+      snoozedUntil: new Date('2026-08-28T04:00:00.000Z'),
+    });
+    prismaMock.incident.findUnique.mockResolvedValue({
+      id: 'inc-1',
+      title: 'Database latency',
+      description: 'p99 elevated',
+      status: 'OPEN',
+      urgency: 'HIGH',
+      priority: 'P1',
+      serviceId: 'svc-1',
+      service: { id: 'svc-1', name: 'Database' },
+      assignee: null,
+      createdAt: new Date('2026-08-28T03:00:00.000Z'),
+      acknowledgedAt: null,
+      resolvedAt: null,
+    });
+    mocks.sendIncidentNotifications.mockResolvedValue({ success: true });
+    mocks.notifyStatusPageSubscribers.mockResolvedValue(undefined);
+    mocks.triggerWebhooksForService.mockResolvedValue(undefined);
+
+    await expect(processAutoUnsnoozeIncidentInternal('inc-1', NOW)).resolves.toEqual({
+      outcome: 'changed',
+    });
+
+    expect(mocks.sendIncidentNotifications).toHaveBeenCalledWith('inc-1', 'updated');
+    expect(mocks.notifyStatusPageSubscribers).toHaveBeenCalledWith('inc-1', 'investigating');
+    expect(mocks.triggerWebhooksForService).toHaveBeenCalledWith(
+      'svc-1',
+      'incident.updated',
+      expect.objectContaining({ id: 'inc-1', status: 'OPEN' })
+    );
+  });
+
+  it('does not repeat effects for an already-applied retry', async () => {
+    tx.incident.findUnique.mockResolvedValue({ status: 'OPEN', snoozedUntil: null });
+
+    await expect(processAutoUnsnoozeIncidentInternal('inc-1', NOW)).resolves.toEqual({
+      outcome: 'noop',
+    });
+
+    expect(prismaMock.incident.findUnique).not.toHaveBeenCalled();
+    expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
+    expect(mocks.notifyStatusPageSubscribers).not.toHaveBeenCalled();
+    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
+  });
+
+  it('suppresses stale OPEN effects if the incident changed again after commit', async () => {
+    tx.incident.findUnique.mockResolvedValue({
+      status: 'SNOOZED',
+      snoozedUntil: new Date('2026-08-28T04:00:00.000Z'),
+    });
+    prismaMock.incident.findUnique.mockResolvedValue({ status: 'SNOOZED' });
+
+    await processAutoUnsnoozeIncidentInternal('inc-1', NOW);
+
+    expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
+    expect(mocks.notifyStatusPageSubscribers).not.toHaveBeenCalled();
+    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Routes system/background auto-unsnooze paths through the centralized incident lifecycle command engine instead of maintaining separate direct Prisma lifecycle mutations.

## What changed

- both the queued `AUTO_UNSNOOZE` worker and cron-safe auto-unsnooze path now share one system lifecycle adapter
- expiry validation and `UNSNOOZE` execute in the same serializable transaction
- `UNSNOOZE` runs with `source: SYSTEM`, `expectedStatus: SNOOZED`, and the canonical auto-unsnooze timeline message
- workers no longer directly write `status`, snooze metadata, escalation status, or `nextEscalationAt`
- stale/already-applied jobs are safe no-ops and do not repeat lifecycle side effects
- snoozes extended after a job was scheduled are requeued at the authoritative deadline without consuming retry budget
- removed the queue-specific immediate escalation scheduling shortcut; lifecycle-owned `nextEscalationAt` and the normal pending-escalation processor now remain the source of truth
- post-commit notifications/webhooks run only after a real unsnooze and are suppressed if the incident changed again before effects dispatch

## Concurrency / correctness

The expiry check is deliberately inside the same serializable transaction as the lifecycle command. If an operator extends a snooze concurrently, the transaction retries and observes the fresh deadline rather than reopening from stale worker state.

## Tests

Adds focused coverage for:

- expiry check + lifecycle command sharing one serializable transaction
- `SYSTEM`/`UNSNOOZE` command delegation
- extended snooze returning the authoritative future deadline
- stale/idempotent worker retries
- changed-only side effects
- stale post-commit status suppressing incorrect OPEN effects
- queue completion, requeue, and cancellation semantics
- end-to-end incident-flow safeguard verifying auto-unsnooze now mutates through the lifecycle engine rather than direct `updateMany`

## Scope

No lifecycle transition rules are changed. This PR is worker adoption and race-hardening only.

## Commit history

Exactly one focused commit.