### PR TITLE
refactor(errors): enforce typed public API semantics

### DIFF
--- a/src/app/api/admin/generate-reset-link/route.ts
+++ b/src/app/api/admin/generate-reset-link/route.ts
@@ -1,8 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { revokeUserSessions } from '@/lib/auth';
 import prisma from '@/lib/prisma';
 import { getAppUrl } from '@/lib/app-url';
 import { randomBytes, createHash } from 'crypto';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { assertAdmin } from '@/lib/rbac';
 import { getClientIp } from '@/lib/client-ip';
@@ -19,23 +21,55 @@ export async function POST(req: NextRequest) {
     try {
       // Use Admin's email to limit *their* activity
       await checkRateLimit(sessionUser.email, ip, 'ADMIN_GENERATED_RESET_LINK');
-    } catch (e) {
-      if (e instanceof Error && e.message.includes('Too many')) {
-        return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    } catch (error) {
+      if (isAppError(error) && error.code === 'RATE_LIMIT_EXCEEDED') {
+        return jsonError(
+          new AppError({
+            code: 'RATE_LIMIT_EXCEEDED',
+            userMessage: 'Too many requests',
+            cause: error,
+          })
+        );
       }
-      throw e;
+      throw error;
     }
 
-    const body = await req.json();
-    const { userId } = body;
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonError(
+        new AppError({
+          code: 'INVALID_JSON',
+          userMessage: 'Please check your input and try again.',
+        })
+      );
+    }
 
-    if (!userId) {
-      return NextResponse.json({ error: 'User ID is required' }, { status: 400 });
+    const userId =
+      body && typeof body === 'object' && 'userId' in body
+        ? (body as { userId?: unknown }).userId
+        : undefined;
+
+    if (typeof userId !== 'string' || userId.trim().length === 0) {
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'User ID is required',
+          fields: [{ field: 'userId', code: 'required', message: 'User ID is required' }],
+        })
+      );
     }
 
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      return jsonError(
+        new AppError({
+          code: 'RESOURCE_NOT_FOUND',
+          userMessage: 'User not found',
+          details: { resource: 'user', userId },
+        })
+      );
     }
 
     // 2. Generate Token
@@ -84,12 +118,13 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    return NextResponse.json({ link: resetLink });
+    return jsonOk({ link: resetLink }, 200);
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('Unauthorized')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
-    }
-    logger.error('API Error /admin/generate-reset-link', { error });
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    if (isAppError(error)) return jsonError(error);
+    logger.error('API Error /admin/generate-reset-link', {
+      error,
+      errorCode: 'INTERNAL_ERROR',
+    });
+    return jsonError('Internal Server Error', 500);
   }
 }

--- a/src/app/api/integrations/cloudwatch/route.ts
+++ b/src/app/api/integrations/cloudwatch/route.ts
@@ -5,6 +5,7 @@ import { processEvent } from '@/lib/events';
 import { transformCloudWatchToEvent, CloudWatchAlarmMessage } from '@/lib/integrations/cloudwatch';
 
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { withIntegrationMiddleware } from '@/lib/integrations/handler';
 import {
@@ -16,6 +17,11 @@ import {
   IntegrationBodyTooLargeError,
   readIntegrationBody,
 } from '@/lib/integrations/request-security';
+
+const LEGACY_REQUIRED_MESSAGE = 'Please fill in all required fields.';
+const LEGACY_INVALID_INPUT_MESSAGE = 'Please check your input and try again.';
+const LEGACY_NOT_FOUND_MESSAGE =
+  'The requested item could not be found. It may have been deleted or you may not have access to it.';
 
 /**
  * AWS CloudWatch Webhook Endpoint
@@ -35,7 +41,19 @@ export async function POST(req: NextRequest) {
       const integrationId = searchParams.get('integrationId');
 
       if (!integrationId) {
-        return jsonError('integrationId is required', 400);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_PAYLOAD_INVALID',
+            userMessage: LEGACY_REQUIRED_MESSAGE,
+            fields: [
+              {
+                field: 'integrationId',
+                code: 'required',
+                message: 'integrationId is required',
+              },
+            ],
+          })
+        );
       }
 
       // Verify integration exists and get service
@@ -45,11 +63,23 @@ export async function POST(req: NextRequest) {
       });
 
       if (!integration) {
-        return jsonError('Integration not found', 404);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_NOT_FOUND',
+            userMessage: LEGACY_NOT_FOUND_MESSAGE,
+            details: { integrationId },
+          })
+        );
       }
 
       if (!integration.enabled) {
-        return jsonError('Integration is disabled', 403);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_DISABLED',
+            userMessage: 'Integration is disabled',
+            details: { integrationId },
+          })
+        );
       }
 
       interface SNSMessage {
@@ -64,8 +94,14 @@ export async function POST(req: NextRequest) {
       let body: SNSMessage;
       try {
         body = JSON.parse(await readIntegrationBody(req)) as SNSMessage;
-      } catch (_error) {
-        return jsonError('Invalid JSON in request body.', 400);
+      } catch (error) {
+        if (error instanceof IntegrationBodyTooLargeError) throw error;
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_PAYLOAD_INVALID',
+            userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+          })
+        );
       }
 
       // Handle SNS SubscriptionConfirmation (auto-confirm)
@@ -75,7 +111,6 @@ export async function POST(req: NextRequest) {
           topicArn: body.TopicArn,
         });
 
-        // Automatically confirm the subscription by visiting the SubscribeURL
         // Automatically confirm the subscription by visiting the SubscribeURL
         try {
           // Strict SSRF protection: only allow well-formed AWS SNS HTTPS endpoints
@@ -155,11 +190,22 @@ export async function POST(req: NextRequest) {
               errors: messageValidation.errors,
               integrationId,
             });
-            return jsonError('Invalid CloudWatch message in SNS payload', 400);
+            return jsonError(
+              new AppError({
+                code: 'INTEGRATION_VALIDATION_FAILED',
+                userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+                details: { integrationId, errors: messageValidation.errors },
+              })
+            );
           }
           alarmMessage = messageValidation.data;
         } catch {
-          return jsonError('Invalid CloudWatch message in SNS payload', 400);
+          return jsonError(
+            new AppError({
+              code: 'INTEGRATION_PAYLOAD_INVALID',
+              userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+            })
+          );
         }
       } else if (body.AlarmName) {
         // Direct CloudWatch format - validate
@@ -169,11 +215,22 @@ export async function POST(req: NextRequest) {
             errors: validation.errors,
             integrationId,
           });
-          return jsonError('Invalid CloudWatch payload format', 400);
+          return jsonError(
+            new AppError({
+              code: 'INTEGRATION_VALIDATION_FAILED',
+              userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+              details: { integrationId, errors: validation.errors },
+            })
+          );
         }
         alarmMessage = validation.data;
       } else {
-        return jsonError('Invalid CloudWatch payload format', 400);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_PAYLOAD_INVALID',
+            userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+          })
+        );
       }
 
       // Transform to standard event format
@@ -190,12 +247,22 @@ export async function POST(req: NextRequest) {
 
       return jsonOk({ status: 'success', result }, 202);
     } catch (error: unknown) {
-      if (error instanceof IntegrationBodyTooLargeError) return jsonError(error.message, 413);
+      if (error instanceof IntegrationBodyTooLargeError) {
+        return jsonError(
+          new AppError({ code: 'PAYLOAD_TOO_LARGE', userMessage: error.message, cause: error })
+        );
+      }
       logger.error('api.integration.cloudwatch_error', {
         error: error instanceof Error ? error.message : String(error),
       });
-      if (error instanceof ZodError || (error instanceof Error && error.message.includes('JSON'))) {
-        return jsonError('Validation Error', 400);
+      if (error instanceof ZodError) {
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_VALIDATION_FAILED',
+            userMessage: 'Validation Error',
+            cause: error,
+          })
+        );
       }
       return jsonError('Internal Server Error', 500);
     }

--- a/src/app/api/integrations/prometheus/route.ts
+++ b/src/app/api/integrations/prometheus/route.ts
@@ -5,6 +5,7 @@ import { processEvent } from '@/lib/events';
 import { transformPrometheusToEvent, PrometheusAlert } from '@/lib/integrations/prometheus';
 
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { withIntegrationMiddleware } from '@/lib/integrations/handler';
 import { validatePayload, PrometheusAlertSchema } from '@/lib/integrations/schemas';
@@ -12,6 +13,11 @@ import {
   IntegrationBodyTooLargeError,
   readIntegrationBody,
 } from '@/lib/integrations/request-security';
+
+const LEGACY_REQUIRED_MESSAGE = 'Please fill in all required fields.';
+const LEGACY_INVALID_INPUT_MESSAGE = 'Please check your input and try again.';
+const LEGACY_NOT_FOUND_MESSAGE =
+  'The requested item could not be found. It may have been deleted or you may not have access to it.';
 
 /**
  * Prometheus Alertmanager Webhook Endpoint
@@ -26,7 +32,19 @@ export async function POST(req: NextRequest) {
       const integrationId = searchParams.get('integrationId');
 
       if (!integrationId) {
-        return jsonError('integrationId is required', 400);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_PAYLOAD_INVALID',
+            userMessage: LEGACY_REQUIRED_MESSAGE,
+            fields: [
+              {
+                field: 'integrationId',
+                code: 'required',
+                message: 'integrationId is required',
+              },
+            ],
+          })
+        );
       }
 
       const integration = await prisma.integration.findUnique({
@@ -35,18 +53,36 @@ export async function POST(req: NextRequest) {
       });
 
       if (!integration) {
-        return jsonError('Integration not found', 404);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_NOT_FOUND',
+            userMessage: LEGACY_NOT_FOUND_MESSAGE,
+            details: { integrationId },
+          })
+        );
       }
 
       if (!integration.enabled) {
-        return jsonError('Integration is disabled', 403);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_DISABLED',
+            userMessage: 'Integration is disabled',
+            details: { integrationId },
+          })
+        );
       }
 
-      let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      let body: unknown;
       try {
         body = JSON.parse(await readIntegrationBody(req));
-      } catch (_error) {
-        return jsonError('Invalid JSON in request body.', 400);
+      } catch (error) {
+        if (error instanceof IntegrationBodyTooLargeError) throw error;
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_PAYLOAD_INVALID',
+            userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+          })
+        );
       }
 
       const validation = validatePayload(PrometheusAlertSchema, body);
@@ -55,7 +91,13 @@ export async function POST(req: NextRequest) {
           errors: validation.errors,
           integrationId,
         });
-        return jsonError('Invalid Prometheus Alertmanager payload', 400);
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_VALIDATION_FAILED',
+            userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+            details: { integrationId, errors: validation.errors },
+          })
+        );
       }
 
       const events = transformPrometheusToEvent((validation.data || body) as PrometheusAlert);
@@ -72,12 +114,22 @@ export async function POST(req: NextRequest) {
       });
       return jsonOk({ status: 'success', results }, 202);
     } catch (error: unknown) {
-      if (error instanceof IntegrationBodyTooLargeError) return jsonError(error.message, 413);
+      if (error instanceof IntegrationBodyTooLargeError) {
+        return jsonError(
+          new AppError({ code: 'PAYLOAD_TOO_LARGE', userMessage: error.message, cause: error })
+        );
+      }
       logger.error('api.integration.prometheus_error', {
         error: error instanceof Error ? error.message : String(error),
       });
-      if (error instanceof ZodError || (error instanceof Error && error.message.includes('JSON'))) {
-        return jsonError('Validation Error', 400);
+      if (error instanceof ZodError) {
+        return jsonError(
+          new AppError({
+            code: 'INTEGRATION_VALIDATION_FAILED',
+            userMessage: 'Validation Error',
+            cause: error,
+          })
+        );
       }
       return jsonError('Internal Server Error', 500);
     }

--- a/src/app/api/mobile/incidents/[id]/status/route.ts
+++ b/src/app/api/mobile/incidents/[id]/status/route.ts
@@ -5,6 +5,7 @@ import { createHash } from 'crypto';
 
 import { getAuthOptions } from '@/lib/auth';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { updateIncidentStatus } from '@/app/(app)/incidents/actions';
 import prisma from '@/lib/prisma';
@@ -14,29 +15,66 @@ const StatusSchema = z.object({
   expectedStatus: z.enum(['OPEN', 'ACKNOWLEDGED', 'RESOLVED', 'SNOOZED', 'SUPPRESSED']).optional(),
 });
 
+const LEGACY_UNAUTHORIZED_MESSAGE =
+  'You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
+const LEGACY_INVALID_INPUT_MESSAGE = 'Please check your input and try again.';
+
 export async function PATCH(req: NextRequest, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
   try {
     const session = await getServerSession(await getAuthOptions());
     if (!session?.user?.email) {
-      return jsonError('Unauthorized', 401);
+      return jsonError(
+        new AppError({
+          code: 'AUTHENTICATION_REQUIRED',
+          userMessage: LEGACY_UNAUTHORIZED_MESSAGE,
+        })
+      );
     }
 
     let body: unknown;
     try {
       body = await req.json();
     } catch {
-      return jsonError('Invalid JSON in request body.', 400);
+      return jsonError(
+        new AppError({ code: 'INVALID_JSON', userMessage: LEGACY_INVALID_INPUT_MESSAGE })
+      );
     }
 
     const parsed = StatusSchema.safeParse(body);
     if (!parsed.success) {
-      return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+          fields: parsed.error.issues.map(issue => ({
+            field: issue.path.join('.') || 'request',
+            code: issue.code,
+            message: issue.message,
+          })),
+        }),
+        undefined,
+        { issues: parsed.error.issues }
+      );
     }
 
     const idempotencyKey = req.headers.get('idempotency-key')?.trim();
     if (idempotencyKey) {
-      if (idempotencyKey.length > 200) return jsonError('Idempotency key is too long.', 400);
+      if (idempotencyKey.length > 200) {
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: 'Idempotency key is too long.',
+            fields: [
+              {
+                field: 'idempotency-key',
+                code: 'too_long',
+                message: 'Idempotency key must be 200 characters or fewer.',
+              },
+            ],
+          })
+        );
+      }
       const fingerprint = createHash('sha256')
         .update(`${session.user.email}\0${idempotencyKey}`)
         .digest('hex');
@@ -69,24 +107,14 @@ export async function PATCH(req: NextRequest, props: { params: Promise<{ id: str
     }
     return jsonOk({ success: true }, 200);
   } catch (error) {
-    const message = error instanceof Error ? error.message : '';
     logger.error('api.mobile.incident.update_failed', {
       component: 'mobile-incident-status',
       error,
       incidentId: params.id,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
     });
-    if (message.includes('Incident not found')) {
-      return jsonError('Incident not found.', 404);
-    }
-    if (message.includes('Unauthorized') || message.includes('permission')) {
-      return jsonError('Forbidden.', 403);
-    }
-    if (
-      message.includes('resolved incident cannot be acknowledged') ||
-      message.includes('Incident changed from')
-    ) {
-      return jsonError(message, 409);
-    }
+
+    if (isAppError(error)) return jsonError(error);
     return jsonError('Failed to update incident.', 500);
   }
 }

--- a/src/app/api/settings/notifications/route.ts
+++ b/src/app/api/settings/notifications/route.ts
@@ -2,7 +2,6 @@ import { NextRequest } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { getCurrentUser } from '@/lib/rbac';
 import { jsonError, jsonOk } from '@/lib/api-response';
-import { getUserFriendlyError } from '@/lib/user-friendly-errors';
 import prisma from '@/lib/prisma';
 import {
   SECRET_MASK,
@@ -106,7 +105,7 @@ export async function GET(_req: NextRequest) {
       whatsapp: whatsappConfig,
     });
   } catch (error) {
-    return jsonError(getUserFriendlyError(error), 500);
+    return jsonError(error, 500);
   }
 }
 
@@ -278,6 +277,6 @@ export async function POST(req: NextRequest) {
       message: 'Notification provider settings saved successfully',
     });
   } catch (error) {
-    return jsonError(getUserFriendlyError(error), 500);
+    return jsonError(error, 500);
   }
 }

--- a/src/app/api/slack/war-room/route.ts
+++ b/src/app/api/slack/war-room/route.ts
@@ -3,66 +3,113 @@
  * Handles manual war-room creation and archival from the incident detail page
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { createIncidentWarRoom, archiveWarRoomChannel } from '@/lib/chatops/war-room';
 import { getUserPermissions, assertCanModifyIncident } from '@/lib/rbac';
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-
-    const permissions = await getUserPermissions();
-    if (!permissions) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return jsonError(
+        new AppError({
+          code: 'INVALID_JSON',
+          userMessage: 'Please check your input and try again.',
+        })
+      );
     }
 
-    const { incidentId, action } = body;
+    const permissions = await getUserPermissions();
+    if (!permissions.authenticated) {
+      return jsonError(
+        new AppError({
+          code: 'AUTHENTICATION_REQUIRED',
+          userMessage: 'Authentication required',
+        })
+      );
+    }
 
-    if (!incidentId || !action) {
-      return NextResponse.json({ error: 'Missing incidentId or action' }, { status: 400 });
+    const incidentId =
+      body && typeof body === 'object' && 'incidentId' in body
+        ? (body as { incidentId?: unknown }).incidentId
+        : undefined;
+    const action =
+      body && typeof body === 'object' && 'action' in body
+        ? (body as { action?: unknown }).action
+        : undefined;
+
+    if (typeof incidentId !== 'string' || typeof action !== 'string') {
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Missing incidentId or action',
+          fields: [
+            ...(typeof incidentId === 'string'
+              ? []
+              : [{ field: 'incidentId', code: 'required', message: 'incidentId is required' }]),
+            ...(typeof action === 'string'
+              ? []
+              : [{ field: 'action', code: 'required', message: 'action is required' }]),
+          ],
+        })
+      );
     }
 
     // Authenticated is not sufficient — creating or archiving a war-room is an
     // incident mutation, so require modify rights on this specific incident.
     try {
       await assertCanModifyIncident(incidentId);
-    } catch (authzError) {
-      const message = authzError instanceof Error ? authzError.message : 'Unauthorized';
-      return NextResponse.json(
-        { error: message },
-        { status: message === 'Incident not found' ? 404 : 403 }
-      );
+    } catch (error) {
+      if (isAppError(error)) return jsonError(error);
+      throw error;
     }
 
     if (action === 'create') {
       // Explicit operator action — not subject to the auto-creation thresholds
       const result = await createIncidentWarRoom(incidentId, { force: true });
       if (!result.success) {
-        return NextResponse.json({ error: result.error }, { status: 400 });
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: result.error || 'Unable to create war-room',
+          })
+        );
       }
-      return NextResponse.json(result);
+      return jsonOk(result, 200);
     }
 
     if (action === 'archive') {
       // Explicit operator action — not subject to the archiveOnResolve setting
       const result = await archiveWarRoomChannel(incidentId, { force: true });
       if (!result.success) {
-        return NextResponse.json({ error: result.error }, { status: 400 });
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: result.error || 'Unable to archive war-room',
+          })
+        );
       }
-      return NextResponse.json(result);
+      return jsonOk(result, 200);
     }
 
-    return NextResponse.json(
-      { error: 'Unknown action. Use "create" or "archive".' },
-      { status: 400 }
+    return jsonError(
+      new AppError({
+        code: 'VALIDATION_FAILED',
+        userMessage: 'Unknown action. Use "create" or "archive".',
+        fields: [{ field: 'action', code: 'invalid', message: 'Use "create" or "archive".' }],
+      })
     );
-  } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
+  } catch (error: unknown) {
     logger.error('[ChatOps] War-room API error', {
-      error: error.message,
-      stack: error.stack,
+      error: error instanceof Error ? error.message : String(error),
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
     });
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Internal server error', 500);
   }
 }

--- a/src/app/api/status/create-default/route.ts
+++ b/src/app/api/status/create-default/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { assertAdmin } from '@/lib/rbac';
+
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
 
 /**
  * Create default status page if it doesn't exist
@@ -15,10 +22,8 @@ export async function POST() {
       try {
         await assertAdmin();
       } catch (error) {
-        return jsonError(
-          error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
-          403
-        );
+        if (isAppError(error)) return jsonError(error);
+        return jsonError('Unauthorized. Admin access required.', 403);
       }
     }
 
@@ -55,14 +60,16 @@ export async function POST() {
       },
       200
     );
-  } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
+  } catch (error: unknown) {
     logger.error('api.status.create_default_error', {
       error: error instanceof Error ? error.message : String(error),
+      errorCode: errorCode(error),
     });
 
-    // If table doesn't exist, provide helpful error
-    if (error.message?.includes('does not exist') || error.code === '42P01') {
+    // PostgreSQL undefined-table and Prisma missing-table errors are structured.
+    // Do not infer deployment state from exception wording.
+    const code = errorCode(error);
+    if (code === '42P01' || code === 'P2021') {
       return NextResponse.json(
         {
           error: 'Database tables not found. Please run: npx prisma db push',

--- a/src/app/api/teams/[id]/available-users/route.ts
+++ b/src/app/api/teams/[id]/available-users/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 import { assertResponderOrAbove } from '@/lib/rbac';
 import { logger, withRequestContext } from '@/lib/logger';
 
 const MAX_RESULTS = 50;
+const LEGACY_NOT_FOUND_MESSAGE =
+  'The requested item could not be found. It may have been deleted or you may not have access to it.';
 
 async function getAvailableUsers(
   req: NextRequest,
@@ -18,7 +21,15 @@ async function getAvailableUsers(
     const limit = Math.max(1, Math.min(requestedLimit, MAX_RESULTS));
 
     const team = await prisma.team.findUnique({ where: { id: teamId }, select: { id: true } });
-    if (!team) return jsonError('Team not found', 404);
+    if (!team) {
+      return jsonError(
+        new AppError({
+          code: 'RESOURCE_NOT_FOUND',
+          userMessage: LEGACY_NOT_FOUND_MESSAGE,
+          details: { resource: 'team', teamId },
+        })
+      );
+    }
 
     const users = await prisma.user.findMany({
       where: {
@@ -47,9 +58,11 @@ async function getAvailableUsers(
 
     return jsonOk({ users: users.slice(0, limit), hasMore: users.length > limit });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unable to search users';
-    logger.error('team.available_users.search_failed', { error: message });
-    if (message.startsWith('Unauthorized')) return jsonError(message, 403);
+    logger.error('team.available_users.search_failed', {
+      error,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
+    });
+    if (isAppError(error)) return jsonError(error);
     return jsonError('Unable to search the user directory', 500);
   }
 }

--- a/src/lib/password-reset.ts
+++ b/src/lib/password-reset.ts
@@ -1,6 +1,7 @@
 import { randomBytes, createHash } from 'crypto';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
+import { AppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { validatePasswordStrength } from '@/lib/passwords';
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
@@ -169,7 +170,11 @@ export async function checkRateLimit(
   });
 
   if (emailCount >= MAX_ATTEMPTS_PER_WINDOW) {
-    throw new Error('Too many requests. Please try again later.');
+    throw new AppError({
+      code: 'RATE_LIMIT_EXCEEDED',
+      userMessage: 'Too many requests. Please try again later.',
+      details: { scope: 'email', action },
+    });
   }
 
   // Check by IP using new Indexed Column
@@ -183,7 +188,11 @@ export async function checkRateLimit(
     });
 
     if (ipCount >= MAX_ATTEMPTS_PER_WINDOW * 2) {
-      throw new Error('Too many requests from this IP.');
+      throw new AppError({
+        code: 'RATE_LIMIT_EXCEEDED',
+        userMessage: 'Too many requests from this IP.',
+        details: { scope: 'ip', action },
+      });
     }
   }
 }

--- a/tests/api/team-available-users.test.ts
+++ b/tests/api/team-available-users.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
+import { AuthorizationError, CAPABILITIES } from '@/lib/authorization';
 import { assertResponderOrAbove } from '@/lib/rbac';
 import { GET } from '@/app/api/teams/[id]/available-users/route';
 
@@ -59,13 +60,18 @@ describe('team available-user directory search', () => {
 
   it('does not expose the directory to unauthorized users', async () => {
     vi.mocked(assertResponderOrAbove).mockRejectedValue(
-      new Error('Unauthorized. Responder access or above required.')
+      new AuthorizationError(
+        'Unauthorized. Responder access or above required.',
+        CAPABILITIES.OPERATIONS_MANAGE
+      )
     );
     const request = new NextRequest('http://localhost/api/teams/team-1/available-users');
 
     const response = await GET(request, { params: Promise.resolve({ id: 'team-1' }) });
+    const body = await response.json();
 
     expect(response.status).toBe(403);
+    expect(body.code).toBe('AUTHORIZATION_DENIED');
     expect(prisma.user.findMany).not.toHaveBeenCalled();
   });
 });

--- a/tests/architecture/error-contract.test.ts
+++ b/tests/architecture/error-contract.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const API_ROOT = join(process.cwd(), 'src', 'app', 'api');
+const ERROR_IDENTIFIER = String.raw`(?:error|err|e|[A-Za-z_$][\w$]*(?:Error|Err))`;
+
+function sourceFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const absolute = join(root, entry);
+    const stat = statSync(absolute);
+    if (stat.isDirectory()) files.push(...sourceFiles(absolute));
+    else if (/\.(ts|tsx)$/.test(entry)) files.push(absolute);
+  }
+  return files;
+}
+
+function findViolations(pattern: RegExp): string[] {
+  const violations: string[] = [];
+  for (const file of sourceFiles(API_ROOT)) {
+    const source = readFileSync(file, 'utf8');
+    if (pattern.test(source)) violations.push(relative(process.cwd(), file));
+    pattern.lastIndex = 0;
+  }
+  return violations;
+}
+
+describe('public API error contract architecture', () => {
+  it('does not derive HTTP or domain semantics from error-message text', () => {
+    const methodMatching = new RegExp(
+      String.raw`\b${ERROR_IDENTIFIER}(?:\?\.|\.)message(?:\?\.|\.)(?:includes|startsWith|endsWith|match|search)\s*\(`,
+      'g'
+    );
+    const directComparison = new RegExp(
+      String.raw`\b${ERROR_IDENTIFIER}(?:\?\.|\.)message\s*(?:===|!==|==|!=)\s*['"\x60]`,
+      'g'
+    );
+    const normalizedMethodMatching = new RegExp(
+      String.raw`\bconst\s+message\s*=\s*${ERROR_IDENTIFIER}\s+instanceof\s+Error\s*\?\s*${ERROR_IDENTIFIER}(?:\?\.|\.)message[\s\S]{0,1600}?\bmessage(?:\?\.|\.)(?:includes|startsWith|endsWith|match|search)\s*\(`,
+      'g'
+    );
+    const normalizedComparison = new RegExp(
+      String.raw`\bconst\s+message\s*=\s*${ERROR_IDENTIFIER}\s+instanceof\s+Error\s*\?\s*${ERROR_IDENTIFIER}(?:\?\.|\.)message[\s\S]{0,1600}?\bmessage\s*(?:===|!==|==|!=)\s*['"\x60]`,
+      'g'
+    );
+
+    const violations = new Set([
+      ...findViolations(methodMatching),
+      ...findViolations(directComparison),
+      ...findViolations(normalizedMethodMatching),
+      ...findViolations(normalizedComparison),
+    ]);
+
+    expect(
+      [...violations],
+      'Public API routes must branch on AppError/code/type, never English error text.'
+    ).toEqual([]);
+  });
+
+  it('does not call the legacy friendly-error translator from route handlers', () => {
+    const violations = findViolations(/\bgetUserFriendlyError\s*\(/g);
+    expect(
+      violations,
+      'getUserFriendlyError is a compatibility boundary; API routes should use AppError + jsonError.'
+    ).toEqual([]);
+  });
+});

--- a/tests/integration/admin-reset-link.test.ts
+++ b/tests/integration/admin-reset-link.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import { AppError } from '@/lib/errors';
 
 // Use vi.hoisted to define mocks that will be available when vi.mock is hoisted
 const mockPrisma = vi.hoisted(() => ({
@@ -44,6 +45,7 @@ import { POST } from '@/app/api/admin/generate-reset-link/route';
 describe('API: Admin Generate Reset Link', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrisma.auditLog.count.mockResolvedValue(0);
     mockAssertAdmin.mockResolvedValue({
       id: 'admin-id',
       email: 'admin@example.com',
@@ -82,8 +84,13 @@ describe('API: Admin Generate Reset Link', () => {
     expect(mockPrisma.auditLog.create).toHaveBeenCalled();
   });
 
-  it('rejects non-admin users', async () => {
-    mockAssertAdmin.mockRejectedValue(new Error('Unauthorized. Admin access required.'));
+  it('rejects non-admin users using the typed authorization contract', async () => {
+    mockAssertAdmin.mockRejectedValue(
+      new AppError({
+        code: 'AUTHORIZATION_DENIED',
+        userMessage: 'Unauthorized. Admin access required.',
+      })
+    );
 
     const req = new NextRequest('http://localhost:3000/api/admin/generate-reset-link', {
       method: 'POST',
@@ -91,6 +98,25 @@ describe('API: Admin Generate Reset Link', () => {
     });
 
     const res = await POST(req);
+    const data = await res.json();
     expect(res.status).toBe(403);
+    expect(data.code).toBe('AUTHORIZATION_DENIED');
+  });
+
+  it('maps password-reset rate limiting by code instead of matching error text', async () => {
+    mockPrisma.auditLog.count.mockResolvedValueOnce(5);
+
+    const req = new NextRequest('http://localhost:3000/api/admin/generate-reset-link', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'target-id' }),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(429);
+    expect(data.error).toBe('Too many requests');
+    expect(data.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(data.retryable).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes public-API paths that derive HTTP/domain semantics from English exception text, and adds a zero-baseline architecture guard so that pattern cannot be reintroduced silently.

### What changed

- mobile incident status now passes typed lifecycle/authorization `AppError`s through `jsonError()` instead of matching incident/auth/transition message substrings
- team available-user search handles typed authorization/not-found errors without `message.startsWith(...)`
- password-reset rate limiting throws `RATE_LIMIT_EXCEEDED` with structured details instead of plain `Error('Too many...')`
- admin reset-link API branches on `RATE_LIMIT_EXCEEDED` and typed authorization codes rather than English text
- Prometheus and CloudWatch integration routes use integration/payload AppError codes for expected validation/not-found/disabled/body-size failures and no longer classify exceptions with `error.message.includes('JSON')`
- war-room API passes typed incident authorization/not-found errors through directly instead of selecting 403/404 with message equality
- default status-page creation identifies missing database tables from structured PostgreSQL/Prisma error codes (`42P01` / `P2021`) instead of exception wording
- notification-provider settings no longer call the legacy friendly-message translator directly from API routes; caught exceptions are passed as typed/unknown values through the shared `jsonError()` boundary
- preserves legacy user-visible error strings where the old `jsonError(string)` translator changed them
- adds `tests/architecture/error-contract.test.ts`, which recursively scans `src/app/api` and fails on message substring, prefix/suffix, regex/search, or equality-based error classification, including optional chaining and normalized `const message = error.message` forms
- the architecture guard also forbids direct `getUserFriendlyError()` use inside API routes
- updates admin reset-link coverage to assert typed authorization and rate-limit codes

## Architecture boundary

Public API semantics are expected to follow:

`typed domain/policy error -> AppError code -> jsonError() -> stable status/body`

The legacy `getUserFriendlyError()` mapper remains a compatibility path for older UI/server-action surfaces; API routes may not depend on it.

## Scope / non-goals

This PR deliberately does not replace every plain `Error` in infrastructure code. Low-level provider/crypto/DB/retry exceptions may remain technical errors when they are not used to determine public HTTP/domain semantics.

The repository audit also identified remaining migration work outside this PR: older server actions (especially incident mutations) still flatten some typed errors into strings, several legacy API routes still emit explicit string-only expected errors rather than machine codes, frontend/toast surfaces do not consistently consume `code/action/retryable/fields`, and structured Prisma/provider mappings are not yet universal. Those are separate compatibility migrations rather than message-derived HTTP classification.

## Tests

- zero-baseline architecture guard for public API message matching and legacy-translator use
- admin reset-link typed authorization contract
- admin reset-link typed rate-limit contract
- existing AppError/API-response tests continue to cover safe unknown-error serialization

## Commit history

Intentionally **one commit**.