### PR TITLE
refactor(incidents): route ChatOps lifecycle through command engine

### DIFF
--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -1,12 +1,16 @@
 /**
  * Slack Interactive Actions API
- * Handles Slack button clicks for ack/resolve actions
+ * Handles Slack button clicks for incident lifecycle actions
  */
 
 import { after, NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { toSlackResponseUrl, verifySlackSignature } from '@/lib/slack-signature';
+import {
+  chatOpsLifecycleErrorMessage,
+  executeChatOpsLifecycleCommand,
+} from '@/lib/incidents/chatops-lifecycle';
 
 /**
  * Resolve the Slack user who pressed a button to an OpsKnight account and a
@@ -80,7 +84,14 @@ type SlackActionPayload = {
   [key: string]: unknown;
 };
 
-async function handleSlackActionRequest(payload: SlackActionPayload) {
+function lifecycleFailureResponse(error: unknown) {
+  return NextResponse.json({
+    response_type: 'ephemeral',
+    text: `⚠️ ${chatOpsLifecycleErrorMessage(error)}`,
+  });
+}
+
+export async function handleSlackActionRequest(payload: SlackActionPayload) {
   try {
     // Handle URL verification (for Slack app setup)
     if (payload.type === 'url_verification') {
@@ -103,7 +114,7 @@ async function handleSlackActionRequest(payload: SlackActionPayload) {
         return NextResponse.json({ error: 'Invalid action data' }, { status: 400 });
       }
 
-      // Get incident
+      // Get incident context needed for Slack identity resolution and non-lifecycle actions.
       const incident = await prisma.incident.findUnique({
         where: { id: incidentId },
       });
@@ -127,73 +138,78 @@ async function handleSlackActionRequest(payload: SlackActionPayload) {
       }
 
       // Two variants of every message: `responseMessage` goes to Slack and keeps
-      // the <@ID> mention; `timelineMessage` is plain text for the incident
-      // timeline, which has no way to render a Slack mention.
+      // the <@ID> mention; `timelineMessage` is plain text for non-lifecycle
+      // actions. Lifecycle actions write their timeline entry atomically in the
+      // centralized lifecycle engine.
       let responseMessage = '';
       let timelineMessage = '';
-      // Mirrors the event the equivalent web console action notifies with
+      let lifecycleRecordedTimeline = false;
+      // Mirrors the event the equivalent web console action notifies with.
       let notifyEventType: 'acknowledged' | 'resolved' | 'updated' | null = null;
 
       if (actionType === 'ack') {
-        const updateResult = await prisma.incident.updateMany({
-          where: {
-            id: incidentId,
-            status: 'OPEN',
-          },
-          data: {
-            status: 'ACKNOWLEDGED',
-            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-            escalationStatus: 'COMPLETED',
-            nextEscalationAt: null,
-          },
-        });
-
-        if (updateResult.count > 0) {
-          responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
-          timelineMessage = `Acknowledged via Slack button by ${actorName}`;
-          notifyEventType = 'acknowledged';
-        } else {
-          const fresh = await prisma.incident.findUnique({
-            where: { id: incidentId },
-            select: { status: true },
+        let result;
+        try {
+          result = await executeChatOpsLifecycleCommand({
+            incidentId,
+            command: 'ACKNOWLEDGE',
+            actor: { id: actorUser.id, name: actorName },
+            eventMessage: `Acknowledged via Slack button by ${actorName}`,
           });
+        } catch (error) {
+          logger.warn('[Slack Actions] Acknowledge rejected', {
+            incidentId,
+            userId: actorUser.id,
+            error,
+          });
+          return lifecycleFailureResponse(error);
+        }
+
+        if (!result.changed) {
           return NextResponse.json({
-            text: `ℹ️ Incident is already ${fresh?.status?.toLowerCase() || 'processed'}`,
+            text: `ℹ️ Incident is already ${result.status.toLowerCase()}`,
           });
         }
+
+        responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
+        notifyEventType = 'acknowledged';
+        lifecycleRecordedTimeline = true;
       } else if (actionType === 'resolve') {
-        const updateResult = await prisma.incident.updateMany({
-          where: {
-            id: incidentId,
-            status: { not: 'RESOLVED' },
-          },
-          data: {
-            status: 'RESOLVED',
-            resolvedAt: incident.resolvedAt ?? new Date(),
-            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-            escalationStatus: 'COMPLETED',
-            nextEscalationAt: null,
-          },
-        });
-
-        if (updateResult.count > 0) {
-          responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
-          timelineMessage = `Resolved via Slack button by ${actorName}`;
-          notifyEventType = 'resolved';
-
-          // Auto-generate Postmortem draft & archive war-room channel
-          const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-          archiveWarRoomChannel(incidentId).catch(err => {
-            logger.error('[Slack Actions] War-room channel archive failed', {
-              error: err,
-              incidentId,
-            });
+        let result;
+        try {
+          result = await executeChatOpsLifecycleCommand({
+            incidentId,
+            command: 'RESOLVE',
+            actor: { id: actorUser.id, name: actorName },
+            eventMessage: `Resolved via Slack button by ${actorName}`,
           });
-        } else {
+        } catch (error) {
+          logger.warn('[Slack Actions] Resolve rejected', {
+            incidentId,
+            userId: actorUser.id,
+            error,
+          });
+          return lifecycleFailureResponse(error);
+        }
+
+        if (!result.changed) {
           return NextResponse.json({
             text: 'ℹ️ Incident is already resolved',
           });
         }
+
+        responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
+        notifyEventType = 'resolved';
+        lifecycleRecordedTimeline = true;
+
+        // Archive war-room channel only after a real resolve transition.
+        const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
+        archiveWarRoomChannel(incidentId).catch(err => {
+          logger.error('[Slack Actions] War-room channel archive failed', {
+            error: err,
+            incidentId,
+          });
+        });
       } else if (actionType === 'assign_me') {
         if (slackUserId) {
           try {
@@ -207,13 +223,10 @@ async function handleSlackActionRequest(payload: SlackActionPayload) {
               }).catch(() => {});
             }
 
-            // Already resolved once above, by email then real name then
-            // username — the same lookup every action type needs.
             const targetUser = actorUser;
 
             // No "first active user" fallback: assigning the incident to an
-            // arbitrary person is worse than not assigning it. Fail loudly
-            // and tell the clicker how to make resolution work.
+            // arbitrary person is worse than not assigning it. Fail loudly.
             if (!targetUser) {
               logger.warn(
                 '[Slack] assign_me could not resolve Slack user to an OpsKnight account',
@@ -251,19 +264,52 @@ async function handleSlackActionRequest(payload: SlackActionPayload) {
           });
         }
       } else if (actionType === 'snooze' || actionType === 'snooze_incident') {
-        const snoozeMinutes = actionValue.minutes ? parseInt(String(actionValue.minutes), 10) : 60;
+        const snoozeMinutes =
+          actionValue.minutes === undefined ? 60 : Number.parseInt(String(actionValue.minutes), 10);
+        if (!Number.isInteger(snoozeMinutes) || snoozeMinutes <= 0) {
+          return NextResponse.json({
+            response_type: 'ephemeral',
+            text: '⚠️ Snooze duration must be a positive number of minutes.',
+          });
+        }
+
         const snoozedUntil = new Date(Date.now() + snoozeMinutes * 60 * 1000);
-        await prisma.incident.update({
-          where: { id: incidentId },
-          data: {
-            status: 'SNOOZED',
+        let result;
+        try {
+          result = await executeChatOpsLifecycleCommand({
+            incidentId,
+            command: 'SNOOZE',
+            actor: { id: actorUser.id, name: actorName },
             snoozedUntil,
-            escalationStatus: 'PAUSED',
-          },
-        });
+            eventMessage: `Snoozed for ${snoozeMinutes}m via Slack button by ${actorName}`,
+          });
+        } catch (error) {
+          logger.warn('[Slack Actions] Snooze rejected', {
+            incidentId,
+            userId: actorUser.id,
+            error,
+          });
+          return lifecycleFailureResponse(error);
+        }
+
+        if (!result.changed) {
+          return NextResponse.json({ text: 'ℹ️ Incident snooze is already applied' });
+        }
+
         responseMessage = `💤 Incident snoozed for ${snoozeMinutes}m by <@${slackUserId || 'responder'}>`;
-        timelineMessage = `Snoozed for ${snoozeMinutes}m via Slack button by ${actorName}`;
         notifyEventType = 'updated';
+        lifecycleRecordedTimeline = true;
+
+        // Prefer the durable timed job; the cron unsnooze sweep remains the fallback.
+        try {
+          const { scheduleAutoUnsnooze } = await import('@/lib/jobs/queue');
+          await scheduleAutoUnsnooze(incidentId, snoozedUntil);
+        } catch (error) {
+          logger.error('[Slack Actions] Failed to schedule auto-unsnooze', {
+            incidentId,
+            error,
+          });
+        }
       } else if (actionType === 'escalate' || actionType === 'escalate_incident') {
         const { executeEscalation } = await import('@/lib/escalation');
         await executeEscalation(incidentId);
@@ -274,19 +320,19 @@ async function handleSlackActionRequest(payload: SlackActionPayload) {
         return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
       }
 
-      // Create incident event
-      await prisma.incidentEvent
-        .create({
-          data: {
-            incidentId,
-            message: timelineMessage || `${responseMessage} (1-Click Slack Button)`,
-          },
-        })
-        .catch(() => {});
+      // Non-lifecycle actions still own their timeline entry here. Lifecycle
+      // actions already wrote it atomically with the state transition.
+      if (!lifecycleRecordedTimeline && timelineMessage) {
+        await prisma.incidentEvent
+          .create({
+            data: {
+              incidentId,
+              message: timelineMessage,
+            },
+          })
+          .catch(() => {});
+      }
 
-      // Notify the same way the web console does. These handlers write to
-      // Prisma directly, so without this a Slack button silently skips the
-      // notification the equivalent UI action always sends.
       // Fire-and-forget: Slack times the interaction out after 3s.
       if (notifyEventType) {
         import('@/lib/user-notifications')

--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -8,6 +8,10 @@ import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { getSlackBotToken } from '@/lib/slack';
 import { retryFetch } from '@/lib/retry';
+import {
+  chatOpsLifecycleErrorMessage,
+  executeChatOpsLifecycleCommand,
+} from '@/lib/incidents/chatops-lifecycle';
 
 export interface SlashCommandPayload {
   command: string;
@@ -27,10 +31,7 @@ interface SlackResponse {
 }
 
 /**
- * Resolve a Slack user ID to an OpsKnight user with robust multi-level fallback:
- * 1. Match by email (case-insensitive)
- * 2. Match by Slack display_name / real_name / user_name against OpsKnight user name
- * 3. Fallback to incident assignee or first admin user so commands never fail
+ * Resolve a Slack user ID to an active OpsKnight user by verified Slack email.
  */
 async function resolveOpsKnightUser(slackUserId: string, botToken: string) {
   try {
@@ -54,7 +55,6 @@ async function resolveOpsKnightUser(slackUserId: string, botToken: string) {
       }
     }
 
-    // 1. Try match by email
     if (slackEmail) {
       const userByEmail = await prisma.user.findFirst({
         where: {
@@ -163,52 +163,39 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
   switch (subcommand) {
     case 'ack':
     case 'acknowledge': {
-      let updated = false;
-      if (typeof prisma.incident.updateMany === 'function') {
-        const updateResult = await prisma.incident.updateMany({
-          where: { id: incident.id, status: 'OPEN' },
-          data: {
-            status: 'ACKNOWLEDGED',
-            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-            escalationStatus: 'COMPLETED',
-            nextEscalationAt: null,
-          },
+      let lifecycleResult;
+      try {
+        lifecycleResult = await executeChatOpsLifecycleCommand({
+          incidentId: incident.id,
+          command: 'ACKNOWLEDGE',
+          actor: { id: actor!.id, name: actor!.name },
+          eventMessage: `Acknowledged via Slack ChatOps by ${actor!.name}`,
         });
-        updated = updateResult.count > 0;
-      } else {
-        await prisma.incident.update({
-          where: { id: incident.id },
-          data: {
-            status: 'ACKNOWLEDGED',
-            acknowledgedAt: incident.acknowledgedAt ?? new Date(),
-            escalationStatus: 'COMPLETED',
-            nextEscalationAt: null,
-          },
+      } catch (error) {
+        logger.warn('[ChatOps] Slash acknowledge rejected', {
+          incidentId: incident.id,
+          userId: actor!.id,
+          error,
         });
-        updated = true;
-      }
-
-      if (!updated) {
         return {
           response_type: 'ephemeral',
-          text: `ℹ️ Incident is already ${incident.status.toLowerCase()}.`,
+          text: `⚠️ ${chatOpsLifecycleErrorMessage(error)}`,
         };
       }
 
-      await prisma.incidentEvent.create({
-        data: {
-          incidentId: incident.id,
-          type: 'ACKNOWLEDGED',
-          message: `Acknowledged via Slack ChatOps by ${actor!.name}`,
-        },
-      });
+      if (!lifecycleResult.changed) {
+        return {
+          response_type: 'ephemeral',
+          text: `ℹ️ Incident is already ${lifecycleResult.status.toLowerCase()}.`,
+        };
+      }
 
       logger.info('[ChatOps] Incident acknowledged via slash command', {
         incidentId: incident.id,
         slackUser: payload.user_name,
       });
 
-      // Dispatch incident notifications
+      // Dispatch incident notifications only after a real lifecycle change.
       import('@/lib/user-notifications')
         .then(({ sendIncidentNotifications }) =>
           sendIncidentNotifications(incident.id, 'acknowledged')
@@ -238,66 +225,41 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
 
     case 'resolve': {
       const resolution = args || 'Resolved via Slack ChatOps';
+      let lifecycleResult;
 
-      let resolved = false;
-      if (typeof prisma.incident.updateMany === 'function') {
-        const updateResult = await prisma.incident.updateMany({
-          where: { id: incident.id, status: { not: 'RESOLVED' } },
-          data: {
-            status: 'RESOLVED',
-            resolvedAt: incident.resolvedAt ?? new Date(),
-            escalationStatus: 'COMPLETED',
-            nextEscalationAt: null,
-          },
+      try {
+        lifecycleResult = await executeChatOpsLifecycleCommand({
+          incidentId: incident.id,
+          command: 'RESOLVE',
+          actor: { id: actor!.id, name: actor!.name },
+          resolutionNote: resolution,
+          eventMessage: `Resolved via Slack ChatOps by ${actor!.name}: ${resolution}`,
         });
-        resolved = updateResult.count > 0;
-      } else {
-        await prisma.incident.update({
-          where: { id: incident.id },
-          data: {
-            status: 'RESOLVED',
-            resolvedAt: incident.resolvedAt ?? new Date(),
-            escalationStatus: 'COMPLETED',
-            nextEscalationAt: null,
-          },
+      } catch (error) {
+        logger.warn('[ChatOps] Slash resolve rejected', {
+          incidentId: incident.id,
+          userId: actor!.id,
+          error,
         });
-        resolved = true;
+        return {
+          response_type: 'ephemeral',
+          text: `⚠️ ${chatOpsLifecycleErrorMessage(error)}`,
+        };
       }
 
-      if (!resolved) {
+      if (!lifecycleResult.changed) {
         return {
           response_type: 'ephemeral',
           text: 'ℹ️ Incident is already resolved.',
         };
       }
 
-      // Create resolution note
-      const noteUserId = actor!.id;
-
-      if (noteUserId) {
-        await prisma.incidentNote.create({
-          data: {
-            incidentId: incident.id,
-            userId: noteUserId,
-            content: `[Resolution] ${resolution}`,
-          },
-        });
-      }
-
-      await prisma.incidentEvent.create({
-        data: {
-          incidentId: incident.id,
-          type: 'MANUAL_RESOLVED',
-          message: `Resolved via Slack ChatOps by ${actor!.name}: ${resolution}`,
-        },
-      });
-
       logger.info('[ChatOps] Incident resolved via slash command', {
         incidentId: incident.id,
         slackUser: payload.user_name,
       });
 
-      // Dispatch incident notifications
+      // Dispatch incident notifications only after a real lifecycle change.
       import('@/lib/user-notifications')
         .then(({ sendIncidentNotifications }) => sendIncidentNotifications(incident.id, 'resolved'))
         .catch(err =>

--- a/src/lib/incidents/chatops-lifecycle.ts
+++ b/src/lib/incidents/chatops-lifecycle.ts
@@ -1,0 +1,155 @@
+import 'server-only';
+
+import { isAppRole } from '@/lib/authorization';
+import {
+  AUTHORIZATION_ACTIONS,
+  authorize,
+  type AuthorizationActor,
+  type AuthorizationResource,
+} from '@/lib/authorization-policy';
+import { runSerializableTransaction } from '@/lib/db-utils';
+import { AppError, toPublicAppError } from '@/lib/errors';
+import {
+  applyIncidentLifecycleCommand,
+  type IncidentLifecycleCommand,
+  type IncidentLifecycleResult,
+} from '@/lib/incidents/lifecycle';
+
+export type ChatOpsLifecycleCommand = Extract<
+  IncidentLifecycleCommand,
+  'ACKNOWLEDGE' | 'RESOLVE' | 'SNOOZE'
+>;
+
+export type ChatOpsLifecycleActor = {
+  id: string;
+  name: string;
+};
+
+export type ChatOpsLifecycleInput = {
+  incidentId: string;
+  command: ChatOpsLifecycleCommand;
+  actor: ChatOpsLifecycleActor;
+  resolutionNote?: string;
+  snoozedUntil?: Date | null;
+  snoozeReason?: string | null;
+  eventMessage?: string;
+};
+
+function actionForCommand(command: ChatOpsLifecycleCommand) {
+  return command === 'ACKNOWLEDGE'
+    ? AUTHORIZATION_ACTIONS.INCIDENT_ACKNOWLEDGE
+    : AUTHORIZATION_ACTIONS.INCIDENT_MANAGE;
+}
+
+function incidentResource(incident: {
+  assigneeId: string | null;
+  teamId: string | null;
+  visibility: 'PUBLIC' | 'PRIVATE';
+  watchers: Array<{ userId: string }>;
+  service: { teamId: string | null };
+}): Extract<AuthorizationResource, { type: 'incident' }> {
+  return {
+    type: 'incident',
+    assigneeId: incident.assigneeId,
+    assignedTeamId: incident.teamId,
+    visibility: incident.visibility,
+    watcherIds: incident.watchers.map(watcher => watcher.userId),
+    serviceTeamId: incident.service.teamId,
+  };
+}
+
+/**
+ * ChatOps lifecycle adapter.
+ *
+ * Slack identity resolution happens at the transport boundary. This adapter
+ * re-resolves the OpsKnight authorization actor and incident scope inside the
+ * same serializable transaction as the lifecycle mutation, preventing a
+ * permission/resource TOCTOU gap between authorization and state change.
+ */
+export async function executeChatOpsLifecycleCommand(
+  input: ChatOpsLifecycleInput
+): Promise<IncidentLifecycleResult> {
+  return runSerializableTransaction(async tx => {
+    const [user, incident] = await Promise.all([
+      tx.user.findUnique({
+        where: { id: input.actor.id },
+        select: {
+          id: true,
+          role: true,
+          status: true,
+          teamMemberships: { select: { teamId: true } },
+        },
+      }),
+      tx.incident.findUnique({
+        where: { id: input.incidentId },
+        select: {
+          assigneeId: true,
+          teamId: true,
+          visibility: true,
+          watchers: { select: { userId: true } },
+          service: { select: { teamId: true } },
+        },
+      }),
+    ]);
+
+    if (!user || !isAppRole(user.role) || user.status !== 'ACTIVE') {
+      throw new AppError({
+        code: 'AUTHORIZATION_DENIED',
+        userMessage: 'Your OpsKnight account is not allowed to change this incident.',
+        details: { incidentId: input.incidentId, userId: input.actor.id, source: 'CHATOPS' },
+      });
+    }
+
+    if (!incident) {
+      throw new AppError({
+        code: 'INCIDENT_NOT_FOUND',
+        userMessage: 'Incident not found.',
+        details: { incidentId: input.incidentId },
+      });
+    }
+
+    const actor: AuthorizationActor = {
+      id: user.id,
+      role: user.role,
+      status: user.status,
+      teamIds: user.teamMemberships.map(membership => membership.teamId),
+    };
+    const action = actionForCommand(input.command);
+    const decision = authorize({ actor, action, resource: incidentResource(incident) });
+
+    if (!decision.allowed) {
+      throw new AppError({
+        code:
+          input.command === 'ACKNOWLEDGE'
+            ? 'INCIDENT_ACCESS_DENIED'
+            : 'INCIDENT_MODIFY_DENIED',
+        userMessage:
+          input.command === 'ACKNOWLEDGE'
+            ? 'You do not have permission to acknowledge this incident.'
+            : 'You do not have permission to modify this incident.',
+        details: {
+          incidentId: input.incidentId,
+          userId: input.actor.id,
+          command: input.command,
+          reason: decision.reason,
+        },
+      });
+    }
+
+    return applyIncidentLifecycleCommand(tx, {
+      incidentId: input.incidentId,
+      command: input.command,
+      source: 'CHATOPS',
+      actor: input.actor,
+      resolutionNote: input.resolutionNote,
+      snoozedUntil: input.snoozedUntil,
+      snoozeReason: input.snoozeReason,
+      eventMessage: input.eventMessage,
+    });
+  });
+}
+
+/** Safe transport text for Slack responses; internal errors stay generic. */
+export function chatOpsLifecycleErrorMessage(error: unknown): string {
+  return toPublicAppError(error).message;
+}

--- a/tests/api/slack-actions-lifecycle.test.ts
+++ b/tests/api/slack-actions-lifecycle.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleSlackActionRequest } from '@/app/api/slack/actions/route';
+import prisma from '@/lib/prisma';
+import {
+  chatOpsLifecycleErrorMessage,
+  executeChatOpsLifecycleCommand,
+} from '@/lib/incidents/chatops-lifecycle';
+import { scheduleAutoUnsnooze } from '@/lib/jobs/queue';
+import { sendIncidentNotifications } from '@/lib/user-notifications';
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    incident: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    incidentEvent: {
+      create: vi.fn(),
+    },
+    user: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/slack', () => ({
+  getSlackBotToken: vi.fn().mockResolvedValue('xoxb-test-token'),
+}));
+
+vi.mock('@/lib/slack-signature', () => ({
+  verifySlackSignature: vi.fn(),
+  toSlackResponseUrl: vi.fn(),
+}));
+
+vi.mock('@/lib/incidents/chatops-lifecycle', () => ({
+  executeChatOpsLifecycleCommand: vi.fn(),
+  chatOpsLifecycleErrorMessage: vi.fn(error =>
+    error instanceof Error ? error.message : 'Unable to update incident.'
+  ),
+}));
+
+vi.mock('@/lib/jobs/queue', () => ({
+  scheduleAutoUnsnooze: vi.fn().mockResolvedValue('job-1'),
+}));
+
+vi.mock('@/lib/user-notifications', () => ({
+  sendIncidentNotifications: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('@/lib/chatops/war-room', () => ({
+  archiveWarRoomChannel: vi.fn().mockResolvedValue(undefined),
+  updateWarRoomTopic: vi.fn().mockResolvedValue(undefined),
+  slackApiCall: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock('@/lib/escalation', () => ({
+  executeEscalation: vi.fn().mockResolvedValue({ escalated: true }),
+}));
+
+describe('Slack interactive lifecycle actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          ok: true,
+          user: { profile: { email: 'alice@test.com', real_name: 'Alice' } },
+        }),
+      })
+    );
+    vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+      id: 'inc-1',
+      serviceId: 'svc-1',
+      slackChannelId: 'C123',
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(prisma.user.findFirst).mockResolvedValue({
+      id: 'user-1',
+      name: 'Alice',
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(executeChatOpsLifecycleCommand).mockImplementation(async input => ({
+      incidentId: input.incidentId,
+      command: input.command,
+      source: 'CHATOPS',
+      previousStatus: 'OPEN',
+      status:
+        input.command === 'ACKNOWLEDGE'
+          ? 'ACKNOWLEDGED'
+          : input.command === 'RESOLVE'
+            ? 'RESOLVED'
+            : 'SNOOZED',
+      changed: true,
+    }));
+  });
+
+  function payload(action: string, extra: Record<string, unknown> = {}) {
+    return {
+      type: 'block_actions',
+      actions: [{ value: JSON.stringify({ action, incidentId: 'inc-1', ...extra }) }],
+      user: { id: 'U123', name: 'alice' },
+    };
+  }
+
+  it('routes acknowledge through the lifecycle adapter without a duplicate timeline write', async () => {
+    const response = await handleSlackActionRequest(payload('ack'));
+    const body = await response.json();
+
+    expect(body.text).toContain('acknowledged');
+    expect(executeChatOpsLifecycleCommand).toHaveBeenCalledWith({
+      incidentId: 'inc-1',
+      command: 'ACKNOWLEDGE',
+      actor: { id: 'user-1', name: 'Alice' },
+      eventMessage: 'Acknowledged via Slack button by Alice',
+    });
+    expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('does not repeat notifications for an idempotent lifecycle retry', async () => {
+    vi.mocked(executeChatOpsLifecycleCommand).mockResolvedValue({
+      incidentId: 'inc-1',
+      command: 'ACKNOWLEDGE',
+      source: 'CHATOPS',
+      previousStatus: 'ACKNOWLEDGED',
+      status: 'ACKNOWLEDGED',
+      changed: false,
+    });
+
+    const response = await handleSlackActionRequest(payload('ack'));
+    const body = await response.json();
+
+    expect(body.text).toContain('already acknowledged');
+    expect(sendIncidentNotifications).not.toHaveBeenCalled();
+  });
+
+  it('routes resolve through the lifecycle adapter', async () => {
+    const response = await handleSlackActionRequest(payload('resolve'));
+    const body = await response.json();
+
+    expect(body.text).toContain('resolved');
+    expect(executeChatOpsLifecycleCommand).toHaveBeenCalledWith({
+      incidentId: 'inc-1',
+      command: 'RESOLVE',
+      actor: { id: 'user-1', name: 'Alice' },
+      eventMessage: 'Resolved via Slack button by Alice',
+    });
+    expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('routes snooze through the lifecycle adapter and schedules durable auto-unsnooze', async () => {
+    const before = Date.now();
+    const response = await handleSlackActionRequest(payload('snooze', { minutes: 30 }));
+    const body = await response.json();
+
+    expect(body.text).toContain('snoozed for 30m');
+    expect(executeChatOpsLifecycleCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        incidentId: 'inc-1',
+        command: 'SNOOZE',
+        actor: { id: 'user-1', name: 'Alice' },
+        eventMessage: 'Snoozed for 30m via Slack button by Alice',
+        snoozedUntil: expect.any(Date),
+      })
+    );
+    const call = vi.mocked(executeChatOpsLifecycleCommand).mock.calls[0]?.[0];
+    expect(call?.snoozedUntil?.getTime()).toBeGreaterThanOrEqual(before + 30 * 60 * 1000);
+    expect(scheduleAutoUnsnooze).toHaveBeenCalledWith('inc-1', call?.snoozedUntil);
+    expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid snooze duration before lifecycle execution', async () => {
+    const response = await handleSlackActionRequest(payload('snooze', { minutes: 0 }));
+    const body = await response.json();
+
+    expect(body.text).toContain('positive number of minutes');
+    expect(executeChatOpsLifecycleCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns a safe typed lifecycle failure to Slack', async () => {
+    vi.mocked(executeChatOpsLifecycleCommand).mockRejectedValue(new Error('internal detail'));
+    vi.mocked(chatOpsLifecycleErrorMessage).mockReturnValue(
+      'You do not have permission to modify this incident.'
+    );
+
+    const response = await handleSlackActionRequest(payload('resolve'));
+    const body = await response.json();
+
+    expect(body.response_type).toBe('ephemeral');
+    expect(body.text).toBe('⚠️ You do not have permission to modify this incident.');
+  });
+});

--- a/tests/lib/chatops-slash-commands.test.ts
+++ b/tests/lib/chatops-slash-commands.test.ts
@@ -1,25 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleSlashCommand, SlashCommandPayload } from '@/lib/chatops/slash-commands';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleSlashCommand, type SlashCommandPayload } from '@/lib/chatops/slash-commands';
 import prisma from '@/lib/prisma';
 import * as retryModule from '@/lib/retry';
+import {
+  chatOpsLifecycleErrorMessage,
+  executeChatOpsLifecycleCommand,
+} from '@/lib/incidents/chatops-lifecycle';
+import { sendIncidentNotifications } from '@/lib/user-notifications';
 
 vi.mock('@/lib/prisma', () => ({
   default: {
     incident: {
       findFirst: vi.fn(),
-      update: vi.fn(),
     },
     incidentNote: {
       create: vi.fn(),
+      findMany: vi.fn(),
     },
     incidentEvent: {
       create: vi.fn(),
+      findMany: vi.fn(),
     },
     user: {
       findFirst: vi.fn(),
+      findMany: vi.fn(),
     },
     escalationPolicy: {
       findUnique: vi.fn(),
+    },
+    postmortem: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
     },
   },
 }));
@@ -40,17 +51,41 @@ vi.mock('@/lib/retry', () => ({
   retryFetch: vi.fn(),
 }));
 
+vi.mock('@/lib/incidents/chatops-lifecycle', () => ({
+  executeChatOpsLifecycleCommand: vi.fn(),
+  chatOpsLifecycleErrorMessage: vi.fn(error =>
+    error instanceof Error ? error.message : 'Unable to update incident.'
+  ),
+}));
+
+vi.mock('@/lib/user-notifications', () => ({
+  sendIncidentNotifications: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('@/lib/chatops/war-room', () => ({
+  updateWarRoomTopic: vi.fn().mockResolvedValue(undefined),
+  archiveWarRoomChannel: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('ChatOps Slash Command Dispatcher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(retryModule.retryFetch).mockResolvedValue({
       json: async () => ({ ok: true, user: { profile: { email: 'alice@test.com' } } }),
-    } as any);
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
     vi.mocked(prisma.user.findFirst).mockResolvedValue({
       id: 'usr-alice',
       name: 'Alice',
       email: 'alice@test.com',
-    } as any);
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(executeChatOpsLifecycleCommand).mockImplementation(async input => ({
+      incidentId: input.incidentId,
+      command: input.command,
+      source: 'CHATOPS',
+      previousStatus: 'OPEN',
+      status: input.command === 'ACKNOWLEDGE' ? 'ACKNOWLEDGED' : 'RESOLVED',
+      changed: true,
+    }));
   });
 
   const basePayload: SlashCommandPayload = {
@@ -64,13 +99,13 @@ describe('ChatOps Slash Command Dispatcher', () => {
     response_url: 'https://hooks.slack.com/commands/test',
   };
 
-  it('should return help block when /incident help is invoked', async () => {
+  it('returns help block when /incident help is invoked', async () => {
     const result = await handleSlashCommand({ ...basePayload, text: 'help' });
     expect(result.response_type).toBe('ephemeral');
     expect(result.blocks).toBeDefined();
   });
 
-  it('should return error message when channel is not linked to any incident', async () => {
+  it('returns an error when the channel is not linked to an incident', async () => {
     vi.mocked(prisma.incident.findFirst).mockResolvedValue(null);
 
     const result = await handleSlashCommand({ ...basePayload, text: 'ack' });
@@ -78,96 +113,107 @@ describe('ChatOps Slash Command Dispatcher', () => {
     expect(result.text).toContain('No incident is linked to this channel');
   });
 
-  it('should handle /incident ack command', async () => {
+  it('routes /incident ack through the ChatOps lifecycle adapter', async () => {
     vi.mocked(prisma.incident.findFirst).mockResolvedValue({
       id: 'inc-104',
       title: 'Payments API Failure',
       status: 'OPEN',
-      acknowledgedAt: null,
       service: { id: 'srv-1', name: 'Payments' },
-    } as any);
-
-    vi.mocked(prisma.incident.update).mockResolvedValue({} as any);
-    vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const result = await handleSlashCommand({ ...basePayload, text: 'ack' });
+
     expect(result.response_type).toBe('in_channel');
     expect(result.text).toContain('Incident Acknowledged');
-    expect(prisma.incident.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: 'inc-104' },
-        data: expect.objectContaining({ status: 'ACKNOWLEDGED' }),
-      })
-    );
+    expect(executeChatOpsLifecycleCommand).toHaveBeenCalledWith({
+      incidentId: 'inc-104',
+      command: 'ACKNOWLEDGE',
+      actor: { id: 'usr-alice', name: 'Alice' },
+      eventMessage: 'Acknowledged via Slack ChatOps by Alice',
+    });
   });
 
-  it('should handle /incident resolve command with summary', async () => {
+  it('treats duplicate ACK as a no-op without repeating lifecycle notifications', async () => {
     vi.mocked(prisma.incident.findFirst).mockResolvedValue({
       id: 'inc-104',
       title: 'Payments API Failure',
       status: 'ACKNOWLEDGED',
-      resolvedAt: null,
       service: { id: 'srv-1', name: 'Payments' },
-    } as any);
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(executeChatOpsLifecycleCommand).mockResolvedValue({
+      incidentId: 'inc-104',
+      command: 'ACKNOWLEDGE',
+      source: 'CHATOPS',
+      previousStatus: 'ACKNOWLEDGED',
+      status: 'ACKNOWLEDGED',
+      changed: false,
+    });
 
-    vi.mocked(prisma.incident.update).mockResolvedValue({} as any);
-    vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
+    const result = await handleSlashCommand({ ...basePayload, text: 'ack' });
 
-    // Mock Slack user resolution
-    vi.spyOn(retryModule, 'retryFetch').mockResolvedValue({
-      json: async () => ({ ok: true, user: { profile: { email: 'alice@test.com' } } }),
-    } as any);
+    expect(result.response_type).toBe('ephemeral');
+    expect(result.text).toContain('already acknowledged');
+    expect(sendIncidentNotifications).not.toHaveBeenCalled();
+  });
 
-    vi.mocked(prisma.user.findFirst).mockResolvedValue({
-      id: 'usr-alice',
-      name: 'Alice',
-      email: 'alice@test.com',
-    } as any);
-
-    vi.mocked(prisma.incidentNote.create).mockResolvedValue({} as any);
+  it('routes /incident resolve through the lifecycle adapter with the resolution note', async () => {
+    vi.mocked(prisma.incident.findFirst).mockResolvedValue({
+      id: 'inc-104',
+      title: 'Payments API Failure',
+      status: 'ACKNOWLEDGED',
+      service: { id: 'srv-1', name: 'Payments' },
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const result = await handleSlashCommand({
       ...basePayload,
       text: 'resolve Restarted service pods',
     });
+
     expect(result.response_type).toBe('in_channel');
     expect(result.text).toContain('Incident Resolved');
-    expect(result.text).toContain('Restarted service pods');
-    expect(prisma.incident.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: 'inc-104' },
-        data: expect.objectContaining({ status: 'RESOLVED' }),
-      })
-    );
+    expect(executeChatOpsLifecycleCommand).toHaveBeenCalledWith({
+      incidentId: 'inc-104',
+      command: 'RESOLVE',
+      actor: { id: 'usr-alice', name: 'Alice' },
+      resolutionNote: 'Restarted service pods',
+      eventMessage: 'Resolved via Slack ChatOps by Alice: Restarted service pods',
+    });
   });
 
-  it('should handle /incident note command', async () => {
+  it('returns a safe lifecycle error to Slack', async () => {
     vi.mocked(prisma.incident.findFirst).mockResolvedValue({
       id: 'inc-104',
       title: 'Payments API Failure',
       status: 'OPEN',
       service: { id: 'srv-1', name: 'Payments' },
-    } as any);
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(executeChatOpsLifecycleCommand).mockRejectedValue(new Error('denied'));
+    vi.mocked(chatOpsLifecycleErrorMessage).mockReturnValue(
+      'You do not have permission to acknowledge this incident.'
+    );
 
-    vi.spyOn(retryModule, 'retryFetch').mockResolvedValue({
-      json: async () => ({ ok: true, user: { profile: { email: 'alice@test.com' } } }),
-    } as any);
+    const result = await handleSlashCommand({ ...basePayload, text: 'ack' });
 
-    vi.mocked(prisma.user.findFirst).mockResolvedValue({
-      id: 'usr-alice',
-      name: 'Alice',
-      email: 'alice@test.com',
-    } as any);
+    expect(result.response_type).toBe('ephemeral');
+    expect(result.text).toBe('⚠️ You do not have permission to acknowledge this incident.');
+  });
 
-    vi.mocked(prisma.incidentNote.create).mockResolvedValue({} as any);
-    vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
+  it('keeps non-lifecycle /incident note behavior unchanged', async () => {
+    vi.mocked(prisma.incident.findFirst).mockResolvedValue({
+      id: 'inc-104',
+      title: 'Payments API Failure',
+      status: 'OPEN',
+      service: { id: 'srv-1', name: 'Payments' },
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(prisma.incidentNote.create).mockResolvedValue({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const result = await handleSlashCommand({
       ...basePayload,
       text: 'note Checking DB connection pool',
     });
+
     expect(result.response_type).toBe('in_channel');
-    expect(result.text).toContain('Note added');
     expect(prisma.incidentNote.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -177,16 +223,16 @@ describe('ChatOps Slash Command Dispatcher', () => {
         }),
       })
     );
+    expect(executeChatOpsLifecycleCommand).not.toHaveBeenCalled();
   });
 
-  it('should handle /incident who command', async () => {
+  it('handles /incident who command', async () => {
     vi.mocked(prisma.incident.findFirst).mockResolvedValue({
       id: 'inc-104',
       title: 'Payments API Failure',
       status: 'OPEN',
       service: { id: 'srv-1', name: 'Payments', escalationPolicyId: 'pol-1' },
-    } as any);
-
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
     vi.mocked(prisma.escalationPolicy.findUnique).mockResolvedValue({
       id: 'pol-1',
       steps: [
@@ -196,19 +242,19 @@ describe('ChatOps Slash Command Dispatcher', () => {
           targetTeam: null,
         },
       ],
-    } as any);
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const result = await handleSlashCommand({ ...basePayload, text: 'who' });
     expect(result.response_type).toBe('ephemeral');
     expect(result.text).toContain('Bob OnCall');
   });
 
-  it('should return error for unknown subcommand', async () => {
+  it('returns an error for unknown subcommands', async () => {
     vi.mocked(prisma.incident.findFirst).mockResolvedValue({
       id: 'inc-104',
       status: 'OPEN',
       service: { id: 'srv-1', name: 'Payments' },
-    } as any);
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const result = await handleSlashCommand({ ...basePayload, text: 'foobar' });
     expect(result.response_type).toBe('ephemeral');

--- a/tests/lib/incidents/chatops-lifecycle.test.ts
+++ b/tests/lib/incidents/chatops-lifecycle.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '@/lib/errors';
+import {
+  chatOpsLifecycleErrorMessage,
+  executeChatOpsLifecycleCommand,
+} from '@/lib/incidents/chatops-lifecycle';
+import { applyIncidentLifecycleCommand } from '@/lib/incidents/lifecycle';
+import { runSerializableTransaction } from '@/lib/db-utils';
+
+const mocks = vi.hoisted(() => ({
+  tx: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    incident: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/db-utils', () => ({
+  runSerializableTransaction: vi.fn(async callback => callback(mocks.tx)),
+}));
+
+vi.mock('@/lib/incidents/lifecycle', () => ({
+  applyIncidentLifecycleCommand: vi.fn(),
+}));
+
+describe('ChatOps lifecycle adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tx.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      role: 'ADMIN',
+      status: 'ACTIVE',
+      teamMemberships: [],
+    });
+    mocks.tx.incident.findUnique.mockResolvedValue({
+      assigneeId: null,
+      teamId: null,
+      visibility: 'PUBLIC',
+      watchers: [],
+      service: { teamId: 'team-1' },
+    });
+    vi.mocked(applyIncidentLifecycleCommand).mockResolvedValue({
+      incidentId: 'inc-1',
+      command: 'ACKNOWLEDGE',
+      source: 'CHATOPS',
+      previousStatus: 'OPEN',
+      status: 'ACKNOWLEDGED',
+      changed: true,
+    });
+  });
+
+  it('authorizes and applies ACK atomically with CHATOPS as the source', async () => {
+    const result = await executeChatOpsLifecycleCommand({
+      incidentId: 'inc-1',
+      command: 'ACKNOWLEDGE',
+      actor: { id: 'user-1', name: 'Alice' },
+      eventMessage: 'Acknowledged via Slack by Alice',
+    });
+
+    expect(runSerializableTransaction).toHaveBeenCalledTimes(1);
+    expect(applyIncidentLifecycleCommand).toHaveBeenCalledWith(
+      mocks.tx,
+      expect.objectContaining({
+        incidentId: 'inc-1',
+        command: 'ACKNOWLEDGE',
+        source: 'CHATOPS',
+        actor: { id: 'user-1', name: 'Alice' },
+        eventMessage: 'Acknowledged via Slack by Alice',
+      })
+    );
+    expect(result.changed).toBe(true);
+  });
+
+  it('allows scoped USER acknowledgement when the incident is assigned to the actor', async () => {
+    mocks.tx.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      role: 'USER',
+      status: 'ACTIVE',
+      teamMemberships: [],
+    });
+    mocks.tx.incident.findUnique.mockResolvedValue({
+      assigneeId: 'user-1',
+      teamId: null,
+      visibility: 'PRIVATE',
+      watchers: [],
+      service: { teamId: null },
+    });
+
+    await expect(
+      executeChatOpsLifecycleCommand({
+        incidentId: 'inc-1',
+        command: 'ACKNOWLEDGE',
+        actor: { id: 'user-1', name: 'Alice' },
+      })
+    ).resolves.toBeDefined();
+
+    expect(applyIncidentLifecycleCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires manage permission for resolve even when the USER can access the incident', async () => {
+    mocks.tx.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      role: 'USER',
+      status: 'ACTIVE',
+      teamMemberships: [],
+    });
+    mocks.tx.incident.findUnique.mockResolvedValue({
+      assigneeId: 'user-1',
+      teamId: null,
+      visibility: 'PRIVATE',
+      watchers: [],
+      service: { teamId: null },
+    });
+
+    await expect(
+      executeChatOpsLifecycleCommand({
+        incidentId: 'inc-1',
+        command: 'RESOLVE',
+        actor: { id: 'user-1', name: 'Alice' },
+      })
+    ).rejects.toMatchObject({ code: 'INCIDENT_MODIFY_DENIED' });
+
+    expect(applyIncidentLifecycleCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects inactive or stale ChatOps identities before mutation', async () => {
+    mocks.tx.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      role: 'RESPONDER',
+      status: 'DISABLED',
+      teamMemberships: [],
+    });
+
+    await expect(
+      executeChatOpsLifecycleCommand({
+        incidentId: 'inc-1',
+        command: 'ACKNOWLEDGE',
+        actor: { id: 'user-1', name: 'Alice' },
+      })
+    ).rejects.toMatchObject({ code: 'AUTHORIZATION_DENIED' });
+
+    expect(applyIncidentLifecycleCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns typed not-found failures before lifecycle execution', async () => {
+    mocks.tx.incident.findUnique.mockResolvedValue(null);
+
+    await expect(
+      executeChatOpsLifecycleCommand({
+        incidentId: 'missing',
+        command: 'RESOLVE',
+        actor: { id: 'user-1', name: 'Alice' },
+      })
+    ).rejects.toMatchObject({ code: 'INCIDENT_NOT_FOUND' });
+
+    expect(applyIncidentLifecycleCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not leak internal AppError messages into Slack responses', () => {
+    const error = new AppError({
+      code: 'INTERNAL_ERROR',
+      userMessage: 'database credentials leaked here',
+    });
+
+    expect(chatOpsLifecycleErrorMessage(error)).not.toContain('database credentials');
+  });
+});


### PR DESCRIPTION
## Summary

Migrates both Slack lifecycle entry points — `/incident` slash commands and interactive incident buttons — onto the centralized incident lifecycle command engine and deletes their duplicated direct Prisma lifecycle mutations.

## What changed

- adds a shared ChatOps lifecycle adapter for `ACKNOWLEDGE`, `RESOLVE`, and `SNOOZE`
- slash-command ACK/RESOLVE now use the lifecycle engine with `source: CHATOPS`
- interactive ACK/RESOLVE/SNOOZE now use the same adapter
- removes direct Slack writes to `status`, `acknowledgedAt`, `resolvedAt`, `snoozedUntil`, `escalationStatus`, and `nextEscalationAt`
- lifecycle timeline events are now written atomically by the engine instead of duplicated afterward by Slack handlers
- slash resolve passes its summary through the canonical resolution-note path
- interactive snooze schedules the durable `AUTO_UNSNOOZE` job, with the cron sweep remaining the fallback
- lifecycle side effects run only when the lifecycle result reports an actual state change
- duplicate ACK/RESOLVE retries return clean no-op Slack responses without repeating lifecycle notifications

## Authorization / security

Slack identity resolution is no longer treated as authorization for lifecycle mutations.

The shared adapter re-resolves the OpsKnight actor and incident authorization resource inside the **same serializable transaction** as the lifecycle command:

- ACK uses `INCIDENT_ACKNOWLEDGE`, preserving scoped USER acknowledgement permissions
- RESOLVE and SNOOZE require `INCIDENT_MANAGE`
- inactive/deleted/stale mapped users are rejected before mutation
- resource/team/assignee/watcher scope is evaluated from current database state
- typed `AppError` responses are converted through the public error boundary so internal error messages are never exposed to Slack

This closes the previous gap where any Slack account mapped to an active OpsKnight user could reach direct lifecycle writes without consistently passing the centralized authorization policy.

## Lifecycle invariants now inherited by Slack

- ACK preserves the first `acknowledgedAt`
- RESOLVE does not fabricate an acknowledgement timestamp when resolving an OPEN incident
- required custom fields are enforced before ChatOps resolution
- snooze metadata/escalation timing follows the lifecycle engine
- invalid transitions use the typed lifecycle error contract
- lifecycle event + state mutation are atomic
- idempotent retries do not duplicate lifecycle events or effects

## Tests

Adds/updates focused coverage for:

- transaction-bound ChatOps authorization + lifecycle execution
- scoped USER ACK vs manage-only resolve
- inactive actor and missing-incident rejection
- safe public error serialization
- slash ACK/RESOLVE delegation and idempotency
- interactive ACK/RESOLVE/SNOOZE delegation
- no duplicate Slack timeline writes for lifecycle commands
- invalid snooze input
- durable auto-unsnooze scheduling
- changed-only lifecycle notifications

## Scope

Non-lifecycle Slack actions such as assignment, notes, postmortem generation, and explicit escalation keep their existing behavior. This PR does not change lifecycle transition rules; it removes the Slack-specific lifecycle implementations and adopts the existing centralized contract.

## Commit history

Exactly one focused commit.