### PR TITLE
refactor(incidents): route event lifecycle through command engine

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -4,6 +4,7 @@ import { EVENT_TRANSACTION_MAX_ATTEMPTS } from './config';
 import { createHash } from 'crypto';
 import { runReadCommittedTransaction } from './db-utils';
 import { enqueueEventSideEffects } from './event-outbox';
+import { applyIncidentLifecycleCommand } from './incidents/lifecycle';
 
 export type EventSeverity = 'critical' | 'error' | 'warning' | 'info';
 
@@ -131,6 +132,14 @@ async function lockEventDedupKeys(
   for (const lockKey of lockKeys) {
     await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`;
   }
+}
+
+async function reloadIncident(tx: Prisma.TransactionClient, incidentId: string) {
+  const incident = await tx.incident.findUnique({ where: { id: incidentId } });
+  if (!incident) {
+    throw new Error(`Incident disappeared during event lifecycle transition: ${incidentId}`);
+  }
+  return incident;
 }
 
 export async function processEvent(
@@ -295,7 +304,8 @@ export async function processEvent(
       // Sanitize title to prevent XSS and truncate to reasonable length
       const sanitizedTitle = truncateString(sanitizeText(eventData.summary.trim()), 500);
 
-      // If a resolve event already arrived, create the incident in RESOLVED state immediately
+      // Creation is not a lifecycle transition. A buffered upstream resolve may
+      // legitimately create the incident directly in its terminal state.
       if (recentResolveAlert) {
         const rawDescription = eventData.custom_details
           ? JSON.stringify(eventData.custom_details, null, 2)
@@ -348,6 +358,8 @@ export async function processEvent(
         ? truncateString(rawDescription, MAX_DESCRIPTION_LENGTH)
         : null;
 
+      // Initial OPEN/SUPPRESSED state is creation policy, not a transition of an
+      // existing incident, so it intentionally remains in the ingestion path.
       const newIncident = await tx.incident.create({
         data: {
           title: sanitizedTitle,
@@ -399,74 +411,60 @@ export async function processEvent(
     }
 
     if (event_action === 'resolve') {
-      // existingIncident is guaranteed to exist here (checked above before alert creation)
+      // Alert linkage, lifecycle mutation, timeline event, and outbox enqueue stay
+      // in this same ReadCommitted transaction under the dedup advisory lock.
       await tx.alert.update({
         where: { id: alert.id },
         data: { incidentId: existingIncident!.id },
       });
 
-      const resolvedIncident = await tx.incident.update({
-        where: { id: existingIncident!.id },
-        data: {
-          status: 'RESOLVED',
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
-          resolvedAt: existingIncident!.resolvedAt ?? new Date(),
-          // Clear stale snooze metadata so if incident is reopened it starts fresh
-          snoozedUntil: null,
-          snoozeReason: null,
-        },
+      const transition = await applyIncidentLifecycleCommand(tx, {
+        incidentId: existingIncident!.id,
+        command: 'RESOLVE',
+        source: 'EVENT',
+        eventMessage: `Auto-resolved by event from ${eventData.source}.`,
       });
+      const resolvedIncident = await reloadIncident(tx, existingIncident!.id);
 
-      await tx.incidentEvent.create({
-        data: {
-          incidentId: existingIncident!.id,
-          type: 'AUTO_RESOLVED',
-          message: `Auto-resolved by event from ${eventData.source}.`,
-        },
-      });
-
-      await enqueueEventSideEffects(tx, 'resolved', resolvedIncident.id);
+      if (transition.changed) {
+        await enqueueEventSideEffects(tx, 'resolved', resolvedIncident.id);
+      }
 
       logger.info('event.incident_resolved', {
         incidentId: resolvedIncident.id,
         dedupKey: dedup_key,
         source: eventData.source,
+        changed: transition.changed,
       });
 
       return { action: 'resolved', incident: resolvedIncident };
     }
 
     if (event_action === 'acknowledge') {
-      // existingIncident is guaranteed to exist here (checked above before alert creation)
+      // Repeated acknowledge signals still attach their raw alert, but the
+      // lifecycle engine makes the state transition/event/effects idempotent.
       await tx.alert.update({
         where: { id: alert.id },
         data: { incidentId: existingIncident!.id },
       });
 
-      const ackIncident = await tx.incident.update({
-        where: { id: existingIncident!.id },
-        data: {
-          status: 'ACKNOWLEDGED',
-          escalationStatus: 'COMPLETED',
-          nextEscalationAt: null,
-          acknowledgedAt: existingIncident!.acknowledgedAt ?? new Date(),
-        },
+      const transition = await applyIncidentLifecycleCommand(tx, {
+        incidentId: existingIncident!.id,
+        command: 'ACKNOWLEDGE',
+        source: 'EVENT',
+        eventMessage: 'Acknowledged via API event.',
       });
+      const ackIncident = await reloadIncident(tx, existingIncident!.id);
 
-      await tx.incidentEvent.create({
-        data: {
-          incidentId: existingIncident!.id,
-          message: `Acknowledged via API event.`,
-        },
-      });
-
-      await enqueueEventSideEffects(tx, 'acknowledged', ackIncident.id);
+      if (transition.changed) {
+        await enqueueEventSideEffects(tx, 'acknowledged', ackIncident.id);
+      }
 
       logger.info('event.incident_acknowledged', {
         incidentId: ackIncident.id,
         dedupKey: dedup_key,
         source: eventData.source,
+        changed: transition.changed,
       });
 
       return { action: 'acknowledged', incident: ackIncident };

--- a/src/lib/incidents/lifecycle.ts
+++ b/src/lib/incidents/lifecycle.ts
@@ -23,6 +23,7 @@ export type IncidentLifecycleSource =
   | 'REST_API'
   | 'BULK'
   | 'CHATOPS'
+  | 'EVENT'
   | 'SYSTEM';
 
 export interface IncidentLifecycleActor {
@@ -282,6 +283,10 @@ function atDelay(now: Date, delayMinutes: number): Date {
   return new Date(now.getTime() + delayMinutes * 60_000);
 }
 
+function resolutionEventType(input: IncidentLifecycleInput): IncidentEventType {
+  return input.source === 'EVENT' ? 'AUTO_RESOLVED' : 'MANUAL_RESOLVED';
+}
+
 function eventForCommand(
   input: IncidentLifecycleInput,
   resolutionNote?: string
@@ -292,7 +297,7 @@ function eventForCommand(
       case 'ACKNOWLEDGE':
         return { type: 'ACKNOWLEDGED', message: suppliedMessage };
       case 'RESOLVE':
-        return { type: 'MANUAL_RESOLVED', message: suppliedMessage };
+        return { type: resolutionEventType(input), message: suppliedMessage };
       case 'REOPEN':
         return { type: 'REOPENED', message: suppliedMessage };
       case 'UNACKNOWLEDGE':
@@ -310,7 +315,7 @@ function eventForCommand(
       return { type: 'ACKNOWLEDGED', message: `Incident acknowledged${suffix}` };
     case 'RESOLVE':
       return {
-        type: 'MANUAL_RESOLVED',
+        type: resolutionEventType(input),
         message: resolutionNote ? `Resolved: ${resolutionNote}` : `Incident resolved${suffix}`,
       };
     case 'REOPEN':
@@ -504,7 +509,10 @@ export async function applyIncidentLifecycleCommand(
     });
   }
 
-  if (input.command === 'RESOLVE') {
+  // Required custom fields gate human/operator resolution. Event ingestion is
+  // authoritative automation: upstream resolve signals must not be blocked by
+  // fields that can only be completed interactively.
+  if (input.command === 'RESOLVE' && input.source !== 'EVENT') {
     await assertRequiredCustomFieldsPresent(tx, input.incidentId);
   }
 

--- a/tests/integration/event-lifecycle-adoption.test.ts
+++ b/tests/integration/event-lifecycle-adoption.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { processEvent, type EventPayload } from '@/lib/events';
+import { createTestService, resetDatabase, testPrisma } from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+type SideEffectPayload = {
+  effect?: string;
+  incidentId?: string;
+};
+
+describeIfRealDB('Event lifecycle engine adoption', { timeout: 30000 }, () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  it('keeps repeated acknowledge alerts but emits lifecycle work only once', async () => {
+    const service = await createTestService('Event Lifecycle Idempotency Service');
+    const dedupKey = `event-lifecycle-ack-${Date.now()}`;
+    const basePayload = {
+      dedup_key: dedupKey,
+      payload: {
+        summary: 'Event lifecycle acknowledgement',
+        source: 'event-lifecycle-test',
+        severity: 'warning' as const,
+      },
+    };
+
+    const triggered = await processEvent(
+      { ...basePayload, event_action: 'trigger' },
+      service.id,
+      'event-lifecycle'
+    );
+    expect(triggered.action).toBe('triggered');
+
+    const acknowledgePayload: EventPayload = {
+      ...basePayload,
+      event_action: 'acknowledge',
+    };
+
+    const first = await processEvent(acknowledgePayload, service.id, 'event-lifecycle');
+    const second = await processEvent(acknowledgePayload, service.id, 'event-lifecycle');
+
+    expect(first.action).toBe('acknowledged');
+    expect(second.action).toBe('acknowledged');
+
+    const incident = await testPrisma.incident.findFirst({
+      where: { serviceId: service.id, dedupKey: `event-lifecycle:${dedupKey}` },
+    });
+    expect(incident?.status).toBe('ACKNOWLEDGED');
+    expect(incident?.acknowledgedAt).not.toBeNull();
+
+    // Raw ingestion remains lossless: trigger + both acknowledge signals are retained.
+    const alerts = await testPrisma.alert.findMany({
+      where: { incidentId: incident!.id },
+    });
+    expect(alerts).toHaveLength(3);
+
+    // Lifecycle state/audit is idempotent even when the upstream provider retries.
+    const acknowledgeEvents = await testPrisma.incidentEvent.findMany({
+      where: { incidentId: incident!.id, type: 'ACKNOWLEDGED' },
+    });
+    expect(acknowledgeEvents).toHaveLength(1);
+    expect(acknowledgeEvents[0]?.message).toBe('Acknowledged via API event.');
+
+    const jobs = await testPrisma.backgroundJob.findMany({
+      where: { type: 'SCHEDULED_TASK' },
+    });
+    const acknowledgeJobs = jobs.filter(
+      job =>
+        (job.payload as SideEffectPayload).effect === 'ACK_SLACK' &&
+        (job.payload as SideEffectPayload).incidentId === incident!.id
+    );
+    expect(acknowledgeJobs).toHaveLength(1);
+  });
+});

--- a/tests/lib/incidents/event-lifecycle.test.ts
+++ b/tests/lib/incidents/event-lifecycle.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyIncidentLifecycleCommand } from '@/lib/incidents/lifecycle';
+
+const NOW = new Date('2026-08-28T05:30:00.000Z');
+
+function createTx() {
+  return {
+    incident: {
+      findUnique: vi.fn().mockResolvedValue({
+        status: 'OPEN',
+        acknowledgedAt: null,
+        resolvedAt: null,
+        currentEscalationStep: 0,
+        snoozedUntil: null,
+        snoozeReason: null,
+        service: { policy: { steps: [{ delayMinutes: 5 }] } },
+      }),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    customField: {
+      findMany: vi.fn().mockResolvedValue([{ name: 'Impact' }]),
+    },
+    incidentNote: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    incidentEvent: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+function asTransactionClient(tx: ReturnType<typeof createTx>) {
+  return tx as unknown as Parameters<typeof applyIncidentLifecycleCommand>[0];
+}
+
+describe('event-driven incident lifecycle semantics', () => {
+  it('treats upstream resolve as automatic and does not require human custom fields', async () => {
+    const tx = createTx();
+
+    const result = await applyIncidentLifecycleCommand(asTransactionClient(tx), {
+      incidentId: 'inc-event-resolve',
+      command: 'RESOLVE',
+      source: 'EVENT',
+      eventMessage: 'Auto-resolved by event from prometheus.',
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      incidentId: 'inc-event-resolve',
+      source: 'EVENT',
+      status: 'RESOLVED',
+      changed: true,
+    });
+    expect(tx.customField.findMany).not.toHaveBeenCalled();
+    expect(tx.incident.update).toHaveBeenCalledWith({
+      where: { id: 'inc-event-resolve' },
+      data: expect.objectContaining({
+        status: 'RESOLVED',
+        resolvedAt: NOW,
+        escalationStatus: 'COMPLETED',
+        nextEscalationAt: null,
+        events: {
+          create: {
+            type: 'AUTO_RESOLVED',
+            message: 'Auto-resolved by event from prometheus.',
+          },
+        },
+      }),
+    });
+  });
+
+  it('classifies an event resolve as AUTO_RESOLVED even without a custom message', async () => {
+    const tx = createTx();
+
+    await applyIncidentLifecycleCommand(asTransactionClient(tx), {
+      incidentId: 'inc-event-default-message',
+      command: 'RESOLVE',
+      source: 'EVENT',
+      now: NOW,
+    });
+
+    expect(tx.incident.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          events: {
+            create: {
+              type: 'AUTO_RESOLVED',
+              message: 'Incident resolved',
+            },
+          },
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Routes existing-incident event ACK/RESOLVE transitions through the centralized incident lifecycle command engine while preserving event-ingestion concurrency, deduplication, alert storage, out-of-order buffering, and the durable event outbox.

## What changed

- event-driven ACK/RESOLVE now call the transaction-bound lifecycle engine inside the existing ReadCommitted ingestion transaction
- adds `EVENT` as an explicit lifecycle source
- event-driven resolve timeline entries are centrally classified as `AUTO_RESOLVED`
- automatic upstream resolves remain exempt from human required-custom-field gating
- duplicate acknowledge signals still retain their raw alerts but no longer duplicate lifecycle events or ACK side-effect jobs
- lifecycle outbox work is enqueued only when the engine reports an actual state transition
- snooze metadata cleanup, first-ack preservation, escalation completion, and timestamps now come from the lifecycle engine

## Preserved ingestion behavior

This PR intentionally does **not** route incident creation through lifecycle commands:

- advisory dedup locks remain unchanged
- ReadCommitted transaction boundaries remain unchanged
- trigger deduplication remains unchanged
- out-of-order resolve-before-trigger still creates a resolved incident directly
- flapping detection may still create an initially suppressed incident directly
- alert linkage and durable outbox writes remain in the same ingestion transaction

Creation establishes initial state; this PR centralizes transitions of existing incidents only.

## Validation semantics

Required custom fields continue to gate human/operator resolution. `source: EVENT` is explicitly treated as authoritative automation so an upstream monitoring resolve cannot be blocked by fields that require interactive completion. This is encoded by lifecycle source rather than a generic validation-bypass flag.

## Tests

Adds focused coverage for:

- `EVENT` resolve producing `AUTO_RESOLVED`
- event resolve bypassing only human required-field validation
- duplicate event ACK retaining all raw alerts
- duplicate event ACK creating exactly one lifecycle timeline event
- duplicate event ACK enqueueing exactly one ACK side-effect job

Existing event resilience/outbox suites continue to cover trigger → acknowledge → resolve, concurrent deduplication, resolve idempotency, outbox ordering, and transaction rollback.

## Commit history

Exactly one focused commit.