### PR TITLE
refactor(incidents): enforce centralized lifecycle mutations

### DIFF
--- a/src/app/(app)/incidents/actions.core.test.ts
+++ b/src/app/(app)/incidents/actions.core.test.ts
@@ -20,6 +20,18 @@ vi.mock('@/lib/escalation', () => ({
   executeEscalation: vi.fn().mockResolvedValue({ escalated: false }),
 }));
 
+const applyIncidentLifecycleCommandMock = vi.fn().mockResolvedValue({
+  incidentId: 'inc-resolved',
+  command: 'REOPEN',
+  source: 'WEB',
+  previousStatus: 'RESOLVED',
+  status: 'OPEN',
+  changed: true,
+});
+vi.mock('@/lib/incidents/lifecycle', () => ({
+  applyIncidentLifecycleCommand: applyIncidentLifecycleCommandMock,
+}));
+
 const scheduleEscalationMock = vi.fn().mockResolvedValue('job-1');
 vi.mock('@/lib/jobs/queue', () => ({
   scheduleEscalation: scheduleEscalationMock,
@@ -113,33 +125,24 @@ describe('createIncident Action', () => {
       status: 'RESOLVED',
       resolvedAt,
     };
-    const reopenedAt = new Date();
+    const reopenedAt = new Date(Date.now() + 60_000);
 
-    (prisma.incident.findFirst as any).mockImplementation((args: any) => {
-      if (args?.where?.status?.in) return Promise.resolve(null);
-      if (args?.where?.status === 'RESOLVED') return Promise.resolve(recentResolved);
-      return Promise.resolve(null);
+    vi.mocked(prisma.incident.findFirst).mockImplementation(async args => {
+      if (args?.where?.status && typeof args.where.status === 'object' && 'in' in args.where.status) {
+        return null;
+      }
+      if (args?.where?.status === 'RESOLVED') return recentResolved as never;
+      return null;
     });
 
-    // First lookup is the lifecycle snapshot; second reload is the committed incident.
-    (prisma.incident.findUnique as any)
-      .mockResolvedValueOnce({
-        status: 'RESOLVED',
-        acknowledgedAt: null,
-        resolvedAt,
-        currentEscalationStep: 2,
-        snoozedUntil: null,
-        snoozeReason: null,
-        service: { policy: { steps: [] } },
-      })
-      .mockResolvedValueOnce({
-        id: 'inc-resolved',
-        status: 'OPEN',
-        resolvedAt: null,
-        currentEscalationStep: 0,
-        nextEscalationAt: reopenedAt,
-      });
-    (prisma.incident.update as any).mockResolvedValue({});
+    // The lifecycle engine owns the mutation; this action only reloads the committed incident.
+    vi.mocked(prisma.incident.findUnique).mockResolvedValueOnce({
+      id: 'inc-resolved',
+      status: 'OPEN',
+      resolvedAt: null,
+      currentEscalationStep: 0,
+      nextEscalationAt: reopenedAt,
+    } as never);
     (prisma.$transaction as any).mockImplementation((cb: any) => cb(prisma));
 
     const formData = new FormData();
@@ -151,24 +154,16 @@ describe('createIncident Action', () => {
     const result = await createIncident(formData);
 
     expect(prisma.incident.create).not.toHaveBeenCalled();
-
-    // The lifecycle engine owns status/timestamp/escalation mutation and timeline creation.
-    expect(prisma.incident.update).toHaveBeenCalledWith(
+    expect(prisma.incident.update).not.toHaveBeenCalled();
+    expect(applyIncidentLifecycleCommandMock).toHaveBeenCalledWith(
+      prisma,
       expect.objectContaining({
-        where: { id: 'inc-resolved' },
-        data: expect.objectContaining({
-          status: 'OPEN',
-          resolvedAt: null,
-          currentEscalationStep: 0,
-          escalationStatus: 'ESCALATING',
-          nextEscalationAt: expect.any(Date),
-          events: {
-            create: expect.objectContaining({
-              type: 'REOPENED',
-              message: expect.stringContaining('manual report within 30m window'),
-            }),
-          },
-        }),
+        incidentId: 'inc-resolved',
+        command: 'REOPEN',
+        source: 'WEB',
+        expectedStatus: 'RESOLVED',
+        actor: { id: 'user-1', name: 'Test User' },
+        eventMessage: expect.stringContaining('manual report within 30m window'),
       })
     );
 

--- a/src/app/(app)/incidents/actions.core.test.ts
+++ b/src/app/(app)/incidents/actions.core.test.ts
@@ -20,19 +20,21 @@ vi.mock('@/lib/escalation', () => ({
   executeEscalation: vi.fn().mockResolvedValue({ escalated: false }),
 }));
 
-const applyIncidentLifecycleCommandMock = vi.fn().mockResolvedValue({
-  incidentId: 'inc-resolved',
-  command: 'REOPEN',
-  source: 'WEB',
-  previousStatus: 'RESOLVED',
-  status: 'OPEN',
-  changed: true,
-});
+const { applyIncidentLifecycleCommandMock, scheduleEscalationMock } = vi.hoisted(() => ({
+  applyIncidentLifecycleCommandMock: vi.fn().mockResolvedValue({
+    incidentId: 'inc-resolved',
+    command: 'REOPEN',
+    source: 'WEB',
+    previousStatus: 'RESOLVED',
+    status: 'OPEN',
+    changed: true,
+  }),
+  scheduleEscalationMock: vi.fn().mockResolvedValue('job-1'),
+}));
 vi.mock('@/lib/incidents/lifecycle', () => ({
   applyIncidentLifecycleCommand: applyIncidentLifecycleCommandMock,
 }));
 
-const scheduleEscalationMock = vi.fn().mockResolvedValue('job-1');
 vi.mock('@/lib/jobs/queue', () => ({
   scheduleEscalation: scheduleEscalationMock,
 }));
@@ -172,11 +174,7 @@ describe('createIncident Action', () => {
       })
     );
 
-    expect(scheduleEscalationMock).toHaveBeenCalledWith(
-      'inc-resolved',
-      0,
-      expect.any(Number)
-    );
+    expect(scheduleEscalationMock).toHaveBeenCalledWith('inc-resolved', 0, expect.any(Number));
     expect(result).toHaveProperty('id', 'inc-resolved');
   });
 });

--- a/src/app/(app)/incidents/actions.core.test.ts
+++ b/src/app/(app)/incidents/actions.core.test.ts
@@ -65,10 +65,7 @@ describe('createIncident Action', () => {
 
     const result = await createIncident(formData);
 
-    expect(prisma.incident.findFirst).toHaveBeenCalledTimes(2); // Checks for OPEN and then for RESOLVED
-    // 2nd check for RESOLVED is skipped if key not found (logic dependent, but actually code checks for open first)
-    // Wait, my code currently does: findFirst(OPEN). If null -> findFirst(RESOLVED).
-
+    expect(prisma.incident.findFirst).toHaveBeenCalledTimes(2);
     expect(prisma.incident.create).toHaveBeenCalled();
     expect(result).toHaveProperty('id', 'inc-new');
   });
@@ -109,27 +106,40 @@ describe('createIncident Action', () => {
     expect(result).toHaveProperty('id', 'inc-open');
   });
 
-  it('re-opens a recently RESOLVED incident', async () => {
+  it('re-opens a recently RESOLVED incident through the lifecycle engine', async () => {
+    const resolvedAt = new Date(Date.now() - 1000 * 60 * 10);
     const recentResolved = {
       id: 'inc-resolved',
       status: 'RESOLVED',
-      resolvedAt: new Date(Date.now() - 1000 * 60 * 10), // 10 mins ago
+      resolvedAt,
     };
+    const reopenedAt = new Date();
 
     (prisma.incident.findFirst as any).mockImplementation((args: any) => {
-      // 1. Open check -> null
       if (args?.where?.status?.in) return Promise.resolve(null);
-      // 2. Resolved check -> returns incident
       if (args?.where?.status === 'RESOLVED') return Promise.resolve(recentResolved);
       return Promise.resolve(null);
     });
 
-    (prisma.incident.update as any).mockResolvedValue({
-      id: 'inc-resolved',
-      status: 'OPEN',
-      resolvedAt: null,
-      currentEscalationStep: 0,
-    });
+    // First lookup is the lifecycle snapshot; second reload is the committed incident.
+    (prisma.incident.findUnique as any)
+      .mockResolvedValueOnce({
+        status: 'RESOLVED',
+        acknowledgedAt: null,
+        resolvedAt,
+        currentEscalationStep: 2,
+        snoozedUntil: null,
+        snoozeReason: null,
+        service: { policy: { steps: [] } },
+      })
+      .mockResolvedValueOnce({
+        id: 'inc-resolved',
+        status: 'OPEN',
+        resolvedAt: null,
+        currentEscalationStep: 0,
+        nextEscalationAt: reopenedAt,
+      });
+    (prisma.incident.update as any).mockResolvedValue({});
     (prisma.$transaction as any).mockImplementation((cb: any) => cb(prisma));
 
     const formData = new FormData();
@@ -140,18 +150,28 @@ describe('createIncident Action', () => {
 
     const result = await createIncident(formData);
 
-    // Should NOT create new
     expect(prisma.incident.create).not.toHaveBeenCalled();
 
-    // Should UPDATE (Re-open)
+    // The lifecycle engine owns status/timestamp/escalation mutation and timeline creation.
     expect(prisma.incident.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'inc-resolved' },
-        data: expect.objectContaining({ status: 'OPEN' }),
+        data: expect.objectContaining({
+          status: 'OPEN',
+          resolvedAt: null,
+          currentEscalationStep: 0,
+          escalationStatus: 'ESCALATING',
+          nextEscalationAt: expect.any(Date),
+          events: {
+            create: expect.objectContaining({
+              type: 'REOPENED',
+              message: expect.stringContaining('manual report within 30m window'),
+            }),
+          },
+        }),
       })
     );
 
-    // Should add note
     expect(prisma.incidentNote.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -161,7 +181,11 @@ describe('createIncident Action', () => {
       })
     );
 
-    expect(scheduleEscalationMock).toHaveBeenCalledWith('inc-resolved', 0, 0);
+    expect(scheduleEscalationMock).toHaveBeenCalledWith(
+      'inc-resolved',
+      0,
+      expect.any(Number)
+    );
     expect(result).toHaveProperty('id', 'inc-resolved');
   });
 });

--- a/src/app/(app)/incidents/actions.core.test.ts
+++ b/src/app/(app)/incidents/actions.core.test.ts
@@ -127,13 +127,9 @@ describe('createIncident Action', () => {
     };
     const reopenedAt = new Date(Date.now() + 60_000);
 
-    vi.mocked(prisma.incident.findFirst).mockImplementation(async args => {
-      if (args?.where?.status && typeof args.where.status === 'object' && 'in' in args.where.status) {
-        return null;
-      }
-      if (args?.where?.status === 'RESOLVED') return recentResolved as never;
-      return null;
-    });
+    vi.mocked(prisma.incident.findFirst)
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(recentResolved as never);
 
     // The lifecycle engine owns the mutation; this action only reloads the committed incident.
     vi.mocked(prisma.incident.findUnique).mockResolvedValueOnce({

--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -16,6 +16,7 @@ import {
   updateIncidentStatus as updateIncidentStatusWithLifecycle,
   resolveIncidentWithNote as resolveIncidentWithLifecycleNote,
 } from '@/lib/incidents/operator-lifecycle';
+import { applyIncidentLifecycleCommand } from '@/lib/incidents/lifecycle';
 
 const allowedUrgencies = new Set<IncidentUrgency>(['LOW', 'MEDIUM', 'HIGH']);
 
@@ -222,23 +223,21 @@ export async function createIncident(formData: FormData) {
       });
 
       if (recentResolvedIncident) {
-        // RE-OPEN: Update status to OPEN
-        const reOpenedIncident = await tx.incident.update({
-          where: { id: recentResolvedIncident.id },
-          data: {
-            status: 'OPEN',
-            resolvedAt: null, // Clear resolution time
-            escalationStatus: 'ESCALATING',
-            nextEscalationAt: new Date(),
-            currentEscalationStep: 0,
-            events: {
-              create: {
-                type: 'REOPENED',
-                message: `Incident re-opened due to manual report within 30m window.\nSummary: ${title}`,
-              },
-            },
-          },
+        await applyIncidentLifecycleCommand(tx, {
+          incidentId: recentResolvedIncident.id,
+          command: 'REOPEN',
+          source: 'WEB',
+          actor: { id: currentUser.id, name: currentUser.name ?? undefined },
+          expectedStatus: 'RESOLVED',
+          eventMessage: `Incident re-opened due to manual report within 30m window.\nSummary: ${title}`,
         });
+
+        const reOpenedIncident = await tx.incident.findUnique({
+          where: { id: recentResolvedIncident.id },
+        });
+        if (!reOpenedIncident) {
+          throw new Error('Incident disappeared while reopening. Please try again.');
+        }
 
         await tx.incidentNote.create({
           data: {
@@ -287,7 +286,9 @@ export async function createIncident(formData: FormData) {
     return createdIncident;
   });
 
-  // If we reopened a recently resolved incident, immediately schedule the first escalation step
+  // If we reopened a recently resolved incident, schedule the first escalation
+  // at the lifecycle engine's canonical nextEscalationAt rather than overriding
+  // its delay semantics with a zero-delay job.
   if (
     incident.status === 'OPEN' &&
     incident.resolvedAt === null &&
@@ -295,10 +296,14 @@ export async function createIncident(formData: FormData) {
   ) {
     try {
       const { scheduleEscalation } = await import('@/lib/jobs/queue');
+      const delayMs = Math.max(
+        0,
+        (incident.nextEscalationAt?.getTime() ?? Date.now()) - Date.now()
+      );
       // Retry up to 3 times with short backoff to ensure the first escalation job is queued
       for (let attempt = 0; attempt < 3; attempt++) {
         try {
-          await scheduleEscalation(incident.id, 0, 0);
+          await scheduleEscalation(incident.id, 0, delayMs);
           break;
         } catch (err) {
           if (attempt === 2) throw err;

--- a/src/app/(app)/incidents/snooze-actions.ts
+++ b/src/app/(app)/incidents/snooze-actions.ts
@@ -1,11 +1,11 @@
 'use server';
 
-import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { assertResponderOrAbove, getCurrentUser } from '@/lib/rbac';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { logger } from '@/lib/logger';
 import { processAutoUnsnoozeInternal } from '@/lib/unsnooze';
+import { executeIncidentLifecycleCommand } from '@/lib/incidents/lifecycle';
 
 export async function snoozeIncidentWithDuration(
   incidentId: string,
@@ -18,52 +18,39 @@ export async function snoozeIncidentWithDuration(
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
 
-  const incident = await prisma.incident.findUnique({
-    where: { id: incidentId },
-    select: { status: true },
-  });
-
-  if (!incident) {
-    throw new Error('Incident not found');
-  }
-
-  if (incident.status === 'RESOLVED') {
-    throw new Error('Cannot snooze an already resolved incident');
+  if (!Number.isInteger(durationMinutes) || durationMinutes <= 0) {
+    throw new Error('Snooze duration must be a positive number of minutes.');
   }
 
   const snoozedUntil = new Date(Date.now() + durationMinutes * 60 * 1000);
   const user = await getCurrentUser();
   const userTimeZone = getUserTimeZone(user ?? undefined);
+  const normalizedReason = reason?.trim() || null;
 
   try {
-    await prisma.incident.update({
-      where: { id: incidentId },
-      data: {
-        status: 'SNOOZED',
-        snoozedUntil,
-        snoozeReason: reason || null,
-        escalationStatus: 'PAUSED',
-        nextEscalationAt: null,
-        events: {
-          create: {
-            type: 'STATUS_CHANGE',
-            message: `Incident snoozed until ${formatDateTime(snoozedUntil, userTimeZone, { format: 'datetime' })}${reason ? ` (Reason: ${reason})` : ''}${user ? ` by ${user.name}` : ''}`,
-          },
-        },
-      },
+    const result = await executeIncidentLifecycleCommand({
+      incidentId,
+      command: 'SNOOZE',
+      source: 'WEB',
+      actor: { id: user.id, name: user.name ?? undefined },
+      snoozedUntil,
+      snoozeReason: normalizedReason,
+      eventMessage: `Incident snoozed until ${formatDateTime(snoozedUntil, userTimeZone, { format: 'datetime' })}${normalizedReason ? ` (Reason: ${normalizedReason})` : ''}${user ? ` by ${user.name}` : ''}`,
     });
 
-    // Schedule auto-unsnooze job using PostgreSQL job queue
-    try {
-      const { scheduleAutoUnsnooze } = await import('@/lib/jobs/queue');
-      await scheduleAutoUnsnooze(incidentId, snoozedUntil);
-    } catch (error) {
-      logger.error('Failed to schedule auto-unsnooze job', {
-        component: 'snooze-actions',
-        error,
-        incidentId,
-      });
-      // Continue anyway - internal worker will pick it up via snoozedUntil field
+    // Schedule only after a committed lifecycle change. PostgreSQL job delivery
+    // remains best-effort because the cron sweep also observes snoozedUntil.
+    if (result.changed) {
+      try {
+        const { scheduleAutoUnsnooze } = await import('@/lib/jobs/queue');
+        await scheduleAutoUnsnooze(incidentId, snoozedUntil);
+      } catch (error) {
+        logger.error('Failed to schedule auto-unsnooze job', {
+          component: 'snooze-actions',
+          error,
+          incidentId,
+        });
+      }
     }
 
     revalidatePath(`/incidents/${incidentId}`);
@@ -76,7 +63,7 @@ export async function snoozeIncidentWithDuration(
       incidentId,
       userId: user?.id,
     });
-    throw new Error('Failed to snooze incident. Please try again.');
+    throw error;
   }
 }
 

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -198,17 +198,27 @@ describe('incident flow safeguards', () => {
         resolvedAt: new Date(),
       });
     prismaMock.incident.update.mockResolvedValue({ id: 'inc-old' });
-    prismaMock.incident.findUnique.mockResolvedValue({
-      id: 'inc-old',
-      title: 'Disk full',
-      description: 'Disk usage exceeded',
-      status: 'OPEN',
-      urgency: 'HIGH',
-      priority: 'P1',
-      service: { id: 'svc-1', name: 'Service 1' },
-      assignee: null,
-      createdAt: new Date(),
-    });
+    prismaMock.incident.findUnique
+      .mockResolvedValueOnce(
+        lifecycleSnapshot({
+          status: 'RESOLVED',
+          resolvedAt: new Date(),
+        })
+      )
+      .mockResolvedValueOnce({
+        id: 'inc-old',
+        title: 'Disk full',
+        description: 'Disk usage exceeded',
+        status: 'OPEN',
+        urgency: 'HIGH',
+        priority: 'P1',
+        resolvedAt: null,
+        currentEscalationStep: 0,
+        nextEscalationAt: new Date(),
+        service: { id: 'svc-1', name: 'Service 1' },
+        assignee: null,
+        createdAt: new Date(),
+      });
 
     const formData = new FormData();
     formData.append('title', 'Disk full');

--- a/tests/lib/incidents/lifecycle-mutation-boundary.test.ts
+++ b/tests/lib/incidents/lifecycle-mutation-boundary.test.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
@@ -27,18 +26,13 @@ const ALLOWED_FIELDS_BY_FILE = new Map<string, ReadonlySet<string>>([
 ]);
 
 const MUTATION_METHODS = new Set(['update', 'updateMany', 'upsert']);
+const INCIDENT_UPDATE_SQL = /UPDATE\s+["`]?Incident["`]?\s+SET\s+/i;
+const SQL_CLAUSE_END = /\s+(?:WHERE|RETURNING)\b/i;
 
 function sourceFiles(root: string): string[] {
-  const files: string[] = [];
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    const absolute = path.join(root, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...sourceFiles(absolute));
-    } else if (/\.(?:ts|tsx)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) {
-      files.push(absolute);
-    }
-  }
-  return files;
+  return ts.sys
+    .readDirectory(root, ['.ts', '.tsx'], undefined, undefined)
+    .filter(file => !file.endsWith('.d.ts'));
 }
 
 function propertyName(node: ts.ObjectLiteralElementLike): string | null {
@@ -114,12 +108,27 @@ function lineOf(source: ts.SourceFile, node: ts.Node): number {
   return source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
 }
 
-function rawSqlViolations(relativePath: string, text: string): string[] {
-  // Direct SQL updates are outside Prisma's AST shape, so guard them explicitly.
-  // This intentionally ignores SELECT predicates containing lifecycle fields.
-  if (!/UPDATE\s+["`]?Incident["`]?/i.test(text)) return [];
+function staticStringText(node: ts.Node): string | null {
+  if (ts.isStringLiteralLike(node)) return node.text;
+  if (!ts.isTemplateExpression(node)) return null;
+
+  return [node.head.text, ...node.templateSpans.map(span => span.literal.text)].join(' ');
+}
+
+function rawSqlViolations(relativePath: string, node: ts.Node): string[] {
+  const sql = staticStringText(node);
+  if (!sql) return [];
+
+  const updateMatch = INCIDENT_UPDATE_SQL.exec(sql);
+  if (!updateMatch) return [];
+
+  const setStart = updateMatch.index + updateMatch[0].length;
+  const tail = sql.slice(setStart);
+  const clauseEnd = SQL_CLAUSE_END.exec(tail);
+  const setClause = (clauseEnd ? tail.slice(0, clauseEnd.index) : tail).toLowerCase();
+
   return [...PROTECTED_FIELDS]
-    .filter(field => new RegExp(`\\b${field}\\b`).test(text))
+    .filter(field => setClause.includes(field.toLowerCase()))
     .map(field => `${relativePath}: raw SQL mutates protected field "${field}"`);
 }
 
@@ -131,7 +140,12 @@ describe('incident lifecycle mutation architecture', () => {
 
     for (const absolutePath of sourceFiles(srcRoot)) {
       const relativePath = path.relative(repositoryRoot, absolutePath).split(path.sep).join('/');
-      const text = fs.readFileSync(absolutePath, 'utf8');
+      const text = ts.sys.readFile(absolutePath);
+      if (text === undefined) {
+        violations.push(`${relativePath}: source file could not be read`);
+        continue;
+      }
+
       const source = ts.createSourceFile(
         absolutePath,
         text,
@@ -163,13 +177,13 @@ describe('incident lifecycle mutation architecture', () => {
             }
           }
         }
+
+        if (!ALLOWED_FIELDS_BY_FILE.has(relativePath)) {
+          violations.push(...rawSqlViolations(relativePath, node));
+        }
         ts.forEachChild(node, visit);
       };
       visit(source);
-
-      if (!ALLOWED_FIELDS_BY_FILE.has(relativePath)) {
-        violations.push(...rawSqlViolations(relativePath, text));
-      }
     }
 
     expect(

--- a/tests/lib/incidents/lifecycle-mutation-boundary.test.ts
+++ b/tests/lib/incidents/lifecycle-mutation-boundary.test.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const PROTECTED_FIELDS = new Set([
+  'status',
+  'acknowledgedAt',
+  'resolvedAt',
+  'snoozedUntil',
+  'snoozeReason',
+  'escalationStatus',
+  'currentEscalationStep',
+  'nextEscalationAt',
+]);
+
+// The lifecycle engine owns all lifecycle-sensitive mutations. The escalation
+// runner is the only narrower exception: it advances escalation cursor/timing
+// while an incident remains OPEN, but it may not change lifecycle status,
+// acknowledgement/resolution timestamps, or snooze state.
+const ALLOWED_FIELDS_BY_FILE = new Map<string, ReadonlySet<string>>([
+  ['src/lib/incidents/lifecycle.ts', PROTECTED_FIELDS],
+  [
+    'src/lib/escalation.ts',
+    new Set(['escalationStatus', 'currentEscalationStep', 'nextEscalationAt']),
+  ],
+]);
+
+const MUTATION_METHODS = new Set(['update', 'updateMany', 'upsert']);
+
+function sourceFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const absolute = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...sourceFiles(absolute));
+    } else if (/\.(?:ts|tsx)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) {
+      files.push(absolute);
+    }
+  }
+  return files;
+}
+
+function propertyName(node: ts.ObjectLiteralElementLike): string | null {
+  if (!('name' in node) || !node.name) return null;
+  if (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) return node.name.text;
+  return null;
+}
+
+function objectProperty(
+  object: ts.ObjectLiteralExpression,
+  name: string
+): ts.ObjectLiteralElementLike | undefined {
+  return object.properties.find(property => propertyName(property) === name);
+}
+
+function initializerOf(property: ts.ObjectLiteralElementLike | undefined): ts.Expression | null {
+  if (!property) return null;
+  if (ts.isPropertyAssignment(property)) return property.initializer;
+  if (ts.isShorthandPropertyAssignment(property)) return property.name;
+  return null;
+}
+
+function resolveObjectLiteral(
+  expression: ts.Expression | null,
+  source: ts.SourceFile
+): ts.ObjectLiteralExpression | null {
+  if (!expression) return null;
+  if (ts.isObjectLiteralExpression(expression)) return expression;
+  if (!ts.isIdentifier(expression)) return null;
+
+  let resolved: ts.ObjectLiteralExpression | null = null;
+  const visit = (node: ts.Node) => {
+    if (
+      !resolved &&
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === expression.text &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      resolved = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return resolved;
+}
+
+function incidentMutation(call: ts.CallExpression): { method: string; data: ts.Expression | null } | null {
+  if (!ts.isPropertyAccessExpression(call.expression)) return null;
+  const method = call.expression.name.text;
+  if (!MUTATION_METHODS.has(method)) return null;
+
+  const modelAccess = call.expression.expression;
+  if (!ts.isPropertyAccessExpression(modelAccess) || modelAccess.name.text !== 'incident') return null;
+
+  const firstArg = call.arguments[0];
+  if (!firstArg || !ts.isObjectLiteralExpression(firstArg)) return { method, data: null };
+
+  const dataProperty = objectProperty(firstArg, method === 'upsert' ? 'update' : 'data');
+  return { method, data: initializerOf(dataProperty) };
+}
+
+function topLevelFields(object: ts.ObjectLiteralExpression): string[] {
+  return object.properties.flatMap(property => {
+    const name = propertyName(property);
+    return name ? [name] : [];
+  });
+}
+
+function lineOf(source: ts.SourceFile, node: ts.Node): number {
+  return source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+}
+
+function rawSqlViolations(relativePath: string, text: string): string[] {
+  // Direct SQL updates are outside Prisma's AST shape, so guard them explicitly.
+  // This intentionally ignores SELECT predicates containing lifecycle fields.
+  if (!/UPDATE\s+["`]?Incident["`]?/i.test(text)) return [];
+  return [...PROTECTED_FIELDS]
+    .filter(field => new RegExp(`\\b${field}\\b`).test(text))
+    .map(field => `${relativePath}: raw SQL mutates protected field "${field}"`);
+}
+
+describe('incident lifecycle mutation architecture', () => {
+  it('keeps existing-incident lifecycle writes behind the centralized engine', () => {
+    const repositoryRoot = process.cwd();
+    const srcRoot = path.join(repositoryRoot, 'src');
+    const violations: string[] = [];
+
+    for (const absolutePath of sourceFiles(srcRoot)) {
+      const relativePath = path.relative(repositoryRoot, absolutePath).split(path.sep).join('/');
+      const text = fs.readFileSync(absolutePath, 'utf8');
+      const source = ts.createSourceFile(
+        absolutePath,
+        text,
+        ts.ScriptTarget.Latest,
+        true,
+        absolutePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+      );
+      const allowed = ALLOWED_FIELDS_BY_FILE.get(relativePath) ?? new Set<string>();
+
+      const visit = (node: ts.Node) => {
+        if (ts.isCallExpression(node)) {
+          const mutation = incidentMutation(node);
+          if (mutation) {
+            const data = resolveObjectLiteral(mutation.data, source);
+            // If a production caller hides update data behind a shape this guard
+            // cannot inspect, fail closed unless that file is an approved owner.
+            if (!data && allowed.size === 0) {
+              violations.push(
+                `${relativePath}:${lineOf(source, node)} uses opaque incident.${mutation.method} data; lifecycle ownership cannot be verified`
+              );
+            } else if (data) {
+              for (const field of topLevelFields(data)) {
+                if (PROTECTED_FIELDS.has(field) && !allowed.has(field)) {
+                  violations.push(
+                    `${relativePath}:${lineOf(source, node)} directly mutates protected field "${field}" via incident.${mutation.method}`
+                  );
+                }
+              }
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+
+      if (!ALLOWED_FIELDS_BY_FILE.has(relativePath)) {
+        violations.push(...rawSqlViolations(relativePath, text));
+      }
+    }
+
+    expect(
+      violations,
+      `Lifecycle-sensitive incident mutations must go through src/lib/incidents/lifecycle.ts.\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the lifecycle centralization pass by removing the final direct operator lifecycle writes discovered in the production audit and adding a repository-level architecture guard that prevents them from returning.

## What changed

- manual duration snooze now uses the centralized lifecycle command engine (`SNOOZE`, source `WEB`)
- recently-resolved manual-create dedup now reopens through `REOPEN` inside the existing serializable creation transaction
- reopen escalation scheduling now respects the lifecycle engine's canonical `nextEscalationAt` instead of forcing a zero-delay job
- stale create-action tests now assert lifecycle-engine-owned reopen semantics
- adds an AST-based repository safeguard for direct existing-incident lifecycle mutations

## Removed decentralized writes

The migrated paths no longer directly own writes to:

- `status`
- `resolvedAt`
- `snoozedUntil`
- `snoozeReason`
- `escalationStatus`
- `currentEscalationStep`
- `nextEscalationAt`

## Architecture enforcement

`tests/lib/incidents/lifecycle-mutation-boundary.test.ts` parses production TypeScript/TSX with the TypeScript AST and inspects Prisma `incident.update`, `updateMany`, and `upsert` mutation data. This avoids false positives from status reads and `where` predicates.

Protected fields are:

- `status`
- `acknowledgedAt`
- `resolvedAt`
- `snoozedUntil`
- `snoozeReason`
- `escalationStatus`
- `currentEscalationStep`
- `nextEscalationAt`

The allowlist is field-scoped rather than file-scoped:

- `src/lib/incidents/lifecycle.ts` owns all protected lifecycle fields
- `src/lib/escalation.ts` may mutate only escalation cursor/timing fields (`escalationStatus`, `currentEscalationStep`, `nextEscalationAt`)

`escalation.ts` is therefore still prevented from directly changing incident status, acknowledgement/resolution timestamps, or snooze state.

The guard also checks direct SQL `UPDATE Incident` statements for protected fields, scoped to the SQL `SET` clause rather than unrelated predicates or nearby source text.

## Behavioral safeguards

- manual snooze validates a positive integer duration before transition
- auto-unsnooze scheduling happens only after an actual committed snooze change
- snooze lifecycle/timeline semantics now come from the engine
- manual dedup reopen keeps mutation + timeline atomic in the existing transaction
- first escalation job uses the engine-computed delay
- direct creation of an incident's initial state remains legal; the guard targets mutations of existing incidents

## Scope

This does not move escalation progression into the lifecycle engine. Escalation progression is a separate state machine and retains narrowly-scoped ownership of its cursor/timing fields.

## Commit history

Two focused commits: the lifecycle centralization change and one follow-up test/security hardening commit addressing review and CI findings.