### PR TITLE
refactor(errors): adopt typed backend error contracts

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -10,12 +10,15 @@ import {
   assertCanCreateIncidentForService,
   assertCanAddIncidentNote,
 } from '@/lib/rbac';
-import { getUserFriendlyError } from '@/lib/user-friendly-errors';
+import { AppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import {
   updateIncidentStatus as updateIncidentStatusWithLifecycle,
   resolveIncidentWithNote as resolveIncidentWithLifecycleNote,
 } from '@/lib/incidents/operator-lifecycle';
+
+const LEGACY_NOT_FOUND_MESSAGE =
+  'The requested item could not be found. It may have been deleted or you may not have access to it.';
 
 const allowedUrgencies = new Set<IncidentUrgency>(['LOW', 'MEDIUM', 'HIGH']);
 
@@ -23,7 +26,12 @@ function parseIncidentUrgency(value: string): IncidentUrgency {
   if (allowedUrgencies.has(value as IncidentUrgency)) {
     return value as IncidentUrgency;
   }
-  throw new Error('Invalid incident urgency.');
+  throw new AppError({
+    code: 'INCIDENT_INVALID_ARGUMENT',
+    userMessage: 'Invalid incident urgency.',
+    fields: [{ field: 'urgency', code: 'invalid', message: 'Invalid incident urgency.' }],
+    details: { urgency: value },
+  });
 }
 
 export async function updateIncidentStatus(
@@ -39,12 +47,7 @@ export async function resolveIncidentWithNote(id: string, resolution: string) {
 }
 
 export async function updateIncidentUrgency(id: string, urgency: string) {
-  try {
-    // Check resource-level authorization
-    await assertResponderOrAbove();
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
+  await assertResponderOrAbove();
   const parsedUrgency = parseIncidentUrgency(urgency);
   await prisma.incident.update({
     where: { id },
@@ -79,11 +82,7 @@ export async function updateIncidentUrgency(id: string, urgency: string) {
 }
 
 export async function updateIncidentPriority(id: string, priority: string | null) {
-  try {
-    await assertResponderOrAbove();
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
+  await assertResponderOrAbove();
 
   await prisma.incident.update({
     where: { id },
@@ -122,11 +121,7 @@ export async function createIncident(formData: FormData) {
   const description = formData.get('description') as string;
   const urgency = parseIncidentUrgency(formData.get('urgency') as string);
   const serviceId = formData.get('serviceId') as string;
-  try {
-    await assertCanCreateIncidentForService(serviceId);
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
+  await assertCanCreateIncidentForService(serviceId);
   const priority = formData.get('priority') as string | null;
   const dedupKey = formData.get('dedupKey') as string | null;
   const assigneeId = formData.get('assigneeId') as string | null;
@@ -144,14 +139,42 @@ export async function createIncident(formData: FormData) {
   }
   const customFields = await prisma.customField.findMany({ orderBy: { order: 'asc' } });
   const knownFieldIds = new Set(customFields.map(field => field.id));
-  if (Array.from(customFieldMap.keys()).some(fieldId => !knownFieldIds.has(fieldId))) {
-    throw new Error('One or more custom fields are invalid. Refresh the form and try again.');
+  const invalidCustomFieldIds = Array.from(customFieldMap.keys()).filter(
+    fieldId => !knownFieldIds.has(fieldId)
+  );
+  if (invalidCustomFieldIds.length > 0) {
+    throw new AppError({
+      code: 'INCIDENT_INVALID_ARGUMENT',
+      userMessage: 'One or more custom fields are invalid. Refresh the form and try again.',
+      fields: [
+        {
+          field: 'customFields',
+          code: 'invalid',
+          message: 'One or more custom fields are invalid. Refresh the form and try again.',
+        },
+      ],
+      details: { invalidCustomFieldIds },
+    });
   }
   const { validateCustomFieldValue } = await import('@/lib/custom-fields');
   const customFieldEntries = customFields.flatMap(field => {
     const supplied = customFieldMap.get(field.id) ?? field.defaultValue;
     const validation = validateCustomFieldValue(field, supplied);
-    if (!validation.valid) throw new Error(validation.error || `Invalid ${field.name}`);
+    if (!validation.valid) {
+      const userMessage = validation.error || `Invalid ${field.name}`;
+      throw new AppError({
+        code: 'INCIDENT_INVALID_ARGUMENT',
+        userMessage,
+        fields: [
+          {
+            field: `customField_${field.id}`,
+            code: 'invalid',
+            message: userMessage,
+          },
+        ],
+        details: { fieldId: field.id },
+      });
+    }
     return validation.normalizedValue === null
       ? []
       : [{ fieldId: field.id, value: validation.normalizedValue }];
@@ -162,9 +185,6 @@ export async function createIncident(formData: FormData) {
 
   const incident = await runSerializableTransaction(async tx => {
     const currentUser = await getCurrentUser();
-    if (!currentUser) {
-      throw new Error('User session not found. Please sign in again.');
-    }
 
     let assigneeName: string | null = null;
     if (assigneeId && assigneeId.length) {
@@ -482,12 +502,7 @@ export async function addNote(incidentId: string, content: string) {
 }
 
 export async function reassignIncident(incidentId: string, assigneeId: string, teamId?: string) {
-  try {
-    // Check resource-level authorization
-    await assertResponderOrAbove();
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
+  await assertResponderOrAbove();
 
   // Handle unassigning (empty assigneeId and teamId)
   if ((!assigneeId || assigneeId.trim() === '') && (!teamId || teamId.trim() === '')) {
@@ -529,9 +544,11 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
         select: { name: true },
       });
       if (!teamRecord) {
-        throw new Error(
-          getUserFriendlyError('Team not found. The selected team may have been deleted.')
-        );
+        throw new AppError({
+          code: 'RESOURCE_NOT_FOUND',
+          userMessage: LEGACY_NOT_FOUND_MESSAGE,
+          details: { resource: 'team', teamId },
+        });
       }
 
       await tx.incident.update({
@@ -624,9 +641,11 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
     await prisma.$transaction(async tx => {
       const assigneeRecord = await tx.user.findUnique({ where: { id: assigneeId } });
       if (!assigneeRecord) {
-        throw new Error(
-          getUserFriendlyError('Assignee not found. The selected user may have been deleted.')
-        );
+        throw new AppError({
+          code: 'RESOURCE_NOT_FOUND',
+          userMessage: LEGACY_NOT_FOUND_MESSAGE,
+          details: { resource: 'user', userId: assigneeId },
+        });
       }
 
       await tx.incident.update({
@@ -676,11 +695,7 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
 }
 
 export async function addWatcher(incidentId: string, userId: string, role: string) {
-  try {
-    await assertResponderOrAbove();
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
+  await assertResponderOrAbove();
   if (!userId) return;
 
   await prisma.$transaction(async tx => {
@@ -714,11 +729,7 @@ export async function addWatcher(incidentId: string, userId: string, role: strin
 }
 
 export async function removeWatcher(incidentId: string, watcherId: string) {
-  try {
-    await assertResponderOrAbove();
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
+  await assertResponderOrAbove();
   await prisma.$transaction(async tx => {
     await tx.incidentWatcher.delete({
       where: { id: watcherId },
@@ -737,11 +748,7 @@ export async function removeWatcher(incidentId: string, watcherId: string) {
 }
 
 export async function updateIncidentVisibility(id: string, visibility: 'PUBLIC' | 'PRIVATE') {
-  try {
-    await assertResponderOrAbove();
-  } catch (error) {
-    throw new Error(getUserFriendlyError(error));
-  }
+  await assertResponderOrAbove();
 
   await prisma.incident.update({
     where: { id },

--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { authenticateApiKey } from '@/lib/api-auth';
 import { jsonError, jsonOk } from '@/lib/api-response';
@@ -8,15 +8,38 @@ import { logger } from '@/lib/logger';
 import { scheduleStatusPageNotification } from '@/lib/jobs/queue';
 import { resolveApiKeyActor } from '@/lib/authorization-actors';
 import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
+import { authorizationDecisionError } from '@/lib/api-authorization-error';
+import { AppError } from '@/lib/errors';
 import { applyRestIncidentPatch } from '@/lib/incidents/rest-patch';
+
+const LEGACY_UNAUTHORIZED_MESSAGE =
+  'You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
+const LEGACY_INVALID_INPUT_MESSAGE = 'Please check your input and try again.';
+const LEGACY_NOT_FOUND_MESSAGE =
+  'The requested item could not be found. It may have been deleted or you may not have access to it.';
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 60;
 
+function rateLimitError(retryAfter: number) {
+  return jsonError(
+    new AppError({
+      code: 'RATE_LIMIT_EXCEEDED',
+      userMessage: 'Rate limit exceeded.',
+      details: { retryAfter },
+    }),
+    undefined,
+    undefined,
+    { 'Retry-After': String(retryAfter) }
+  );
+}
+
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const apiKey = await authenticateApiKey(req);
   if (!apiKey) {
-    return jsonError('Unauthorized. Missing or invalid API key.', 401);
+    return jsonError(
+      new AppError({ code: 'API_KEY_INVALID', userMessage: LEGACY_UNAUTHORIZED_MESSAGE })
+    );
   }
 
   const rate = await checkRateLimit(
@@ -25,19 +48,27 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     RATE_LIMIT_WINDOW_MS
   );
   if (!rate.allowed) {
-    const retryAfter = Math.ceil((rate.resetAt - Date.now()) / 1000);
-    return NextResponse.json(
-      { error: 'Rate limit exceeded.' },
-      { status: 429, headers: { 'Retry-After': String(retryAfter) } }
-    );
+    return rateLimitError(Math.ceil((rate.resetAt - Date.now()) / 1000));
   }
 
   const actor = await resolveApiKeyActor(apiKey);
   if (!actor) {
-    return jsonError('Unauthorized. API key user not found.', 401);
+    return jsonError(
+      new AppError({
+        code: 'API_KEY_USER_INVALID',
+        userMessage: LEGACY_UNAUTHORIZED_MESSAGE,
+        details: { apiKeyId: apiKey.id, userId: apiKey.userId },
+      })
+    );
   }
-  if (!authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ }).allowed) {
-    return jsonError('Forbidden. Incident access denied.', 403);
+
+  const readDecision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ });
+  if (!readDecision.allowed) {
+    return jsonError(
+      authorizationDecisionError(readDecision, {
+        forbiddenMessage: 'Forbidden. Incident access denied.',
+      })
+    );
   }
 
   const { id } = await params;
@@ -53,7 +84,13 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   });
 
   if (!incident) {
-    return jsonError('Incident not found.', 404);
+    return jsonError(
+      new AppError({
+        code: 'INCIDENT_NOT_FOUND',
+        userMessage: LEGACY_NOT_FOUND_MESSAGE,
+        details: { incidentId: id },
+      })
+    );
   }
 
   const decision = authorize({
@@ -68,7 +105,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       assignedTeamId: incident.teamId,
     },
   });
-  if (!decision.allowed) return jsonError('Forbidden. Incident access denied.', 403);
+  if (!decision.allowed) {
+    return jsonError(
+      authorizationDecisionError(decision, {
+        forbiddenCode: 'INCIDENT_ACCESS_DENIED',
+        forbiddenMessage: 'Forbidden. Incident access denied.',
+      })
+    );
+  }
 
   const { watchers: _watchers, ...visibleIncident } = incident;
   const responseIncident = visibleIncident.service
@@ -84,7 +128,9 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const apiKey = await authenticateApiKey(req);
   if (!apiKey) {
-    return jsonError('Unauthorized. Missing or invalid API key.', 401);
+    return jsonError(
+      new AppError({ code: 'API_KEY_INVALID', userMessage: LEGACY_UNAUTHORIZED_MESSAGE })
+    );
   }
 
   const rate = await checkRateLimit(
@@ -93,37 +139,58 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     RATE_LIMIT_WINDOW_MS
   );
   if (!rate.allowed) {
-    const retryAfter = Math.ceil((rate.resetAt - Date.now()) / 1000);
-    return NextResponse.json(
-      { error: 'Rate limit exceeded.' },
-      { status: 429, headers: { 'Retry-After': String(retryAfter) } }
-    );
+    return rateLimitError(Math.ceil((rate.resetAt - Date.now()) / 1000));
   }
 
   const actor = await resolveApiKeyActor(apiKey);
   if (!actor) {
-    return jsonError('Unauthorized. API key user not found.', 401);
+    return jsonError(
+      new AppError({
+        code: 'API_KEY_USER_INVALID',
+        userMessage: LEGACY_UNAUTHORIZED_MESSAGE,
+        details: { apiKeyId: apiKey.id, userId: apiKey.userId },
+      })
+    );
   }
-  if (!authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_MANAGE }).allowed) {
-    return jsonError('Forbidden. API key owner cannot manage incidents.', 403);
+
+  const manageDecision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_MANAGE });
+  if (!manageDecision.allowed) {
+    return jsonError(
+      authorizationDecisionError(manageDecision, {
+        forbiddenMessage: 'Forbidden. API key owner cannot manage incidents.',
+      })
+    );
   }
 
   let body: unknown;
   try {
     body = await req.json();
   } catch {
-    return jsonError('Invalid JSON in request body.', 400);
+    return jsonError(
+      new AppError({ code: 'INVALID_JSON', userMessage: LEGACY_INVALID_INPUT_MESSAGE })
+    );
   }
 
   const parsed = IncidentPatchSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
+    return jsonError(
+      new AppError({ code: 'VALIDATION_FAILED', userMessage: LEGACY_INVALID_INPUT_MESSAGE }),
+      undefined,
+      { issues: parsed.error.issues }
+    );
   }
 
   const hasAssigneeUpdate =
-    typeof body === 'object' && body !== null && Object.prototype.hasOwnProperty.call(body, 'assigneeId');
+    typeof body === 'object' &&
+    body !== null &&
+    Object.prototype.hasOwnProperty.call(body, 'assigneeId');
   if (parsed.data.status === undefined && parsed.data.urgency === undefined && !hasAssigneeUpdate) {
-    return jsonError('No valid fields to update.', 400);
+    return jsonError(
+      new AppError({
+        code: 'VALIDATION_FAILED',
+        userMessage: 'No valid fields to update.',
+      })
+    );
   }
 
   const { id } = await params;

--- a/src/app/api/services/[id]/route.ts
+++ b/src/app/api/services/[id]/route.ts
@@ -4,32 +4,62 @@ import { authenticateApiKey } from '@/lib/api-auth';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { resolveApiKeyActor } from '@/lib/authorization-actors';
 import { serviceReadWhere } from '@/lib/authorization-filters';
+import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
+import { authorizationDecisionError } from '@/lib/api-authorization-error';
+import { AppError, isAppError } from '@/lib/errors';
+
+const LEGACY_UNAUTHORIZED_MESSAGE =
+  'You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
+const LEGACY_NOT_FOUND_MESSAGE =
+  'The requested item could not be found. It may have been deleted or you may not have access to it.';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const apiKey = await authenticateApiKey(req);
     if (!apiKey) {
-      return jsonError('Unauthorized. Missing or invalid API key.', 401);
+      return jsonError(
+        new AppError({ code: 'API_KEY_INVALID', userMessage: LEGACY_UNAUTHORIZED_MESSAGE })
+      );
     }
 
     const { checkRateLimit } = await import('@/lib/rate-limit');
     const rate = await checkRateLimit(`api:${apiKey.id}:services:get`, 60, 60_000);
     if (!rate.allowed) {
       const retryAfter = Math.ceil((rate.resetAt - Date.now()) / 1000);
-      return new Response(JSON.stringify({ error: 'Rate limit exceeded.' }), {
-        status: 429,
-        headers: { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) },
-      });
+      return jsonError(
+        new AppError({
+          code: 'RATE_LIMIT_EXCEEDED',
+          userMessage: 'Rate limit exceeded.',
+          details: { retryAfter },
+        }),
+        undefined,
+        undefined,
+        { 'Retry-After': String(retryAfter) }
+      );
     }
+
     const { id } = await params;
     const actor = await resolveApiKeyActor(apiKey);
-    if (!actor) return jsonError('Unauthorized.', 401);
-    let accessFilter;
-    try {
-      accessFilter = serviceReadWhere(actor);
-    } catch {
-      return jsonError('Forbidden. Service access denied.', 403);
+    if (!actor) {
+      return jsonError(
+        new AppError({
+          code: 'API_KEY_USER_INVALID',
+          userMessage: LEGACY_UNAUTHORIZED_MESSAGE,
+          details: { apiKeyId: apiKey.id, userId: apiKey.userId },
+        })
+      );
     }
+
+    const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.SERVICE_READ });
+    if (!decision.allowed) {
+      return jsonError(
+        authorizationDecisionError(decision, {
+          forbiddenMessage: 'Forbidden. Service access denied.',
+        })
+      );
+    }
+
+    const accessFilter = serviceReadWhere(actor);
     const service = await prisma.service.findFirst({
       where: { id, ...accessFilter },
       select: {
@@ -45,11 +75,18 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     });
 
     if (!service) {
-      return jsonError('Service not found.', 404);
+      return jsonError(
+        new AppError({
+          code: 'SERVICE_NOT_FOUND',
+          userMessage: LEGACY_NOT_FOUND_MESSAGE,
+          details: { serviceId: id },
+        })
+      );
     }
 
     return jsonOk({ service });
-  } catch (_error) {
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
     return jsonError('Internal Server Error', 500);
   }
 }

--- a/src/lib/api-authorization-error.ts
+++ b/src/lib/api-authorization-error.ts
@@ -7,7 +7,10 @@ const LEGACY_UNAUTHORIZED_MESSAGE =
 type DeniedDecision = Extract<AuthorizationDecision, { allowed: false }>;
 
 type AuthorizationErrorOptions = {
-  forbiddenCode?: Extract<AppErrorCode, 'AUTHORIZATION_DENIED' | 'SERVICE_ACCESS_DENIED'>;
+  forbiddenCode?: Extract<
+    AppErrorCode,
+    'AUTHORIZATION_DENIED' | 'SERVICE_ACCESS_DENIED' | 'INCIDENT_ACCESS_DENIED'
+  >;
   forbiddenMessage: string;
 };
 

--- a/tests/actions/incident-action-errors.test.ts
+++ b/tests/actions/incident-action-errors.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '@/lib/errors';
+
+const mocks = vi.hoisted(() => ({
+  assertResponderOrAbove: vi.fn(),
+  assertCanCreateIncidentForService: vi.fn(),
+  assertCanAddIncidentNote: vi.fn(),
+  getCurrentUser: vi.fn(),
+  incidentUpdate: vi.fn(),
+  customFieldFindMany: vi.fn(),
+  teamFindUnique: vi.fn(),
+  userFindUnique: vi.fn(),
+  incidentEventCreate: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  assertResponderOrAbove: mocks.assertResponderOrAbove,
+  assertCanCreateIncidentForService: mocks.assertCanCreateIncidentForService,
+  assertCanAddIncidentNote: mocks.assertCanAddIncidentNote,
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    incident: {
+      update: mocks.incidentUpdate,
+    },
+    customField: {
+      findMany: mocks.customFieldFindMany,
+    },
+    team: {
+      findUnique: mocks.teamFindUnique,
+    },
+    user: {
+      findUnique: mocks.userFindUnique,
+    },
+    incidentEvent: {
+      create: mocks.incidentEventCreate,
+    },
+    $transaction: mocks.transaction,
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+import {
+  createIncident,
+  reassignIncident,
+  updateIncidentUrgency,
+} from '@/app/(app)/incidents/actions';
+
+describe('incident server-action typed errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.assertResponderOrAbove.mockResolvedValue({ id: 'responder-1' });
+    mocks.assertCanCreateIncidentForService.mockResolvedValue({ id: 'responder-1' });
+    mocks.getCurrentUser.mockResolvedValue({ id: 'responder-1', name: 'Responder' });
+    mocks.customFieldFindMany.mockResolvedValue([]);
+    mocks.transaction.mockImplementation(async callback => callback({
+      incident: { update: mocks.incidentUpdate },
+      team: { findUnique: mocks.teamFindUnique },
+      user: { findUnique: mocks.userFindUnique },
+      incidentEvent: { create: mocks.incidentEventCreate },
+    }));
+  });
+
+  it('preserves typed authorization failures instead of flattening them to Error', async () => {
+    const denied = new AppError({
+      code: 'AUTHORIZATION_DENIED',
+      userMessage: 'Unauthorized. Responder access or above required.',
+    });
+    mocks.assertResponderOrAbove.mockRejectedValue(denied);
+
+    await expect(updateIncidentUrgency('inc-1', 'HIGH')).rejects.toBe(denied);
+    expect(mocks.incidentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns a typed validation error for an invalid urgency', async () => {
+    await expect(updateIncidentUrgency('inc-1', 'CRITICAL')).rejects.toMatchObject({
+      code: 'INCIDENT_INVALID_ARGUMENT',
+      userMessage: 'Invalid incident urgency.',
+      fields: [
+        expect.objectContaining({ field: 'urgency', code: 'invalid' }),
+      ],
+    });
+    expect(mocks.incidentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('preserves service authorization errors during incident creation', async () => {
+    const denied = new AppError({
+      code: 'INCIDENT_CREATE_SERVICE_ACCESS_DENIED',
+      userMessage: 'Unauthorized. You can only create incidents for your team services.',
+    });
+    mocks.assertCanCreateIncidentForService.mockRejectedValue(denied);
+
+    const formData = new FormData();
+    formData.set('title', 'Database latency');
+    formData.set('serviceId', 'svc-1');
+    formData.set('urgency', 'HIGH');
+
+    await expect(createIncident(formData)).rejects.toBe(denied);
+    expect(mocks.customFieldFindMany).not.toHaveBeenCalled();
+  });
+
+  it('uses a structured not-found error for a missing reassignment team', async () => {
+    mocks.teamFindUnique.mockResolvedValue(null);
+
+    await expect(reassignIncident('inc-1', '', 'team-missing')).rejects.toMatchObject({
+      code: 'RESOURCE_NOT_FOUND',
+      details: { resource: 'team', teamId: 'team-missing' },
+    });
+    expect(mocks.incidentUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/incident-detail-errors.test.ts
+++ b/tests/api/incident-detail-errors.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockRequest, parseResponse } from '../helpers/api-test';
+
+const mocks = vi.hoisted(() => ({
+  authenticateApiKey: vi.fn(),
+  checkRateLimit: vi.fn(),
+  resolveApiKeyActor: vi.fn(),
+  authorize: vi.fn(),
+  incidentFindUnique: vi.fn(),
+}));
+
+vi.mock('@/lib/api-auth', () => ({ authenticateApiKey: mocks.authenticateApiKey }));
+vi.mock('@/lib/rate-limit', () => ({ checkRateLimit: mocks.checkRateLimit }));
+vi.mock('@/lib/authorization-actors', () => ({ resolveApiKeyActor: mocks.resolveApiKeyActor }));
+vi.mock('@/lib/authorization-policy', () => ({
+  AUTHORIZATION_ACTIONS: {
+    INCIDENT_READ: 'incident.read',
+    INCIDENT_MANAGE: 'incident.manage',
+  },
+  authorize: mocks.authorize,
+}));
+vi.mock('@/lib/incidents/rest-patch', () => ({ applyRestIncidentPatch: vi.fn() }));
+vi.mock('@/lib/jobs/queue', () => ({ scheduleStatusPageNotification: vi.fn() }));
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    incident: { findUnique: mocks.incidentFindUnique },
+  },
+}));
+
+import { GET } from '@/app/api/incidents/[id]/route';
+
+const context = { params: Promise.resolve({ id: 'inc-1' }) };
+
+function actor() {
+  return {
+    id: 'user-1',
+    role: 'RESPONDER',
+    status: 'ACTIVE',
+    teamIds: [],
+    apiKey: { id: 'key-1', scopes: ['incidents:read'] },
+  };
+}
+
+function incident() {
+  return {
+    id: 'inc-1',
+    title: 'Database latency',
+    assigneeId: null,
+    teamId: null,
+    visibility: 'PUBLIC',
+    watchers: [],
+    service: { id: 'svc-1', name: 'Database', teamId: null },
+    assignee: null,
+  };
+}
+
+describe('GET /api/incidents/:id typed errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticateApiKey.mockResolvedValue({
+      id: 'key-1',
+      userId: 'user-1',
+      scopes: ['incidents:read'],
+    });
+    mocks.checkRateLimit.mockResolvedValue({
+      allowed: true,
+      remaining: 59,
+      resetAt: Date.now() + 60_000,
+      count: 1,
+    });
+    mocks.resolveApiKeyActor.mockResolvedValue(actor());
+    mocks.authorize.mockReturnValue({ allowed: true, scope: 'global' });
+    mocks.incidentFindUnique.mockResolvedValue(incident());
+  });
+
+  it('returns API_KEY_INVALID for a missing or invalid key', async () => {
+    mocks.authenticateApiKey.mockResolvedValue(null);
+    const req = await createMockRequest('GET', '/api/incidents/inc-1');
+
+    const { status, data } = await parseResponse(await GET(req, context));
+
+    expect(status).toBe(401);
+    expect(data.code).toBe('API_KEY_INVALID');
+  });
+
+  it('returns RATE_LIMIT_EXCEEDED with Retry-After metadata', async () => {
+    mocks.checkRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 30_000,
+      count: 61,
+    });
+    const req = await createMockRequest('GET', '/api/incidents/inc-1');
+
+    const response = await GET(req, context);
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(429);
+    expect(data.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(Number(response.headers.get('Retry-After'))).toBeGreaterThan(0);
+  });
+
+  it('returns INCIDENT_NOT_FOUND when the incident is absent', async () => {
+    mocks.incidentFindUnique.mockResolvedValue(null);
+    const req = await createMockRequest('GET', '/api/incidents/inc-1');
+
+    const { status, data } = await parseResponse(await GET(req, context));
+
+    expect(status).toBe(404);
+    expect(data.code).toBe('INCIDENT_NOT_FOUND');
+  });
+
+  it('returns INCIDENT_ACCESS_DENIED for a resource-level denial', async () => {
+    mocks.authorize
+      .mockReturnValueOnce({ allowed: true, scope: 'scoped' })
+      .mockReturnValueOnce({
+        allowed: false,
+        reason: 'MISSING_CAPABILITY',
+        requiredCapability: 'incident.read.scoped',
+      });
+    const req = await createMockRequest('GET', '/api/incidents/inc-1');
+
+    const { status, data } = await parseResponse(await GET(req, context));
+
+    expect(status).toBe(403);
+    expect(data.code).toBe('INCIDENT_ACCESS_DENIED');
+  });
+});

--- a/tests/api/service-detail-errors.test.ts
+++ b/tests/api/service-detail-errors.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockRequest, parseResponse } from '../helpers/api-test';
+
+const mocks = vi.hoisted(() => ({
+  authenticateApiKey: vi.fn(),
+  checkRateLimit: vi.fn(),
+  resolveApiKeyActor: vi.fn(),
+  authorize: vi.fn(),
+  serviceReadWhere: vi.fn(),
+  serviceFindFirst: vi.fn(),
+}));
+
+vi.mock('@/lib/api-auth', () => ({ authenticateApiKey: mocks.authenticateApiKey }));
+vi.mock('@/lib/rate-limit', () => ({ checkRateLimit: mocks.checkRateLimit }));
+vi.mock('@/lib/authorization-actors', () => ({ resolveApiKeyActor: mocks.resolveApiKeyActor }));
+vi.mock('@/lib/authorization-policy', () => ({
+  AUTHORIZATION_ACTIONS: { SERVICE_READ: 'service.read' },
+  authorize: mocks.authorize,
+}));
+vi.mock('@/lib/authorization-filters', () => ({ serviceReadWhere: mocks.serviceReadWhere }));
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    service: { findFirst: mocks.serviceFindFirst },
+  },
+}));
+
+import { GET } from '@/app/api/services/[id]/route';
+
+const context = { params: Promise.resolve({ id: 'svc-1' }) };
+
+function actor() {
+  return {
+    id: 'user-1',
+    role: 'RESPONDER',
+    status: 'ACTIVE',
+    teamIds: [],
+    apiKey: { id: 'key-1', scopes: ['services:read'] },
+  };
+}
+
+describe('GET /api/services/:id typed errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticateApiKey.mockResolvedValue({
+      id: 'key-1',
+      userId: 'user-1',
+      scopes: ['services:read'],
+    });
+    mocks.checkRateLimit.mockResolvedValue({
+      allowed: true,
+      remaining: 59,
+      resetAt: Date.now() + 60_000,
+      count: 1,
+    });
+    mocks.resolveApiKeyActor.mockResolvedValue(actor());
+    mocks.authorize.mockReturnValue({ allowed: true, scope: 'global' });
+    mocks.serviceReadWhere.mockReturnValue({});
+    mocks.serviceFindFirst.mockResolvedValue({ id: 'svc-1', name: 'Database' });
+  });
+
+  it('returns API_KEY_INVALID for a missing or invalid key', async () => {
+    mocks.authenticateApiKey.mockResolvedValue(null);
+    const req = await createMockRequest('GET', '/api/services/svc-1');
+
+    const { status, data } = await parseResponse(await GET(req, context));
+
+    expect(status).toBe(401);
+    expect(data.code).toBe('API_KEY_INVALID');
+  });
+
+  it('returns API_KEY_USER_INVALID when the key owner cannot be resolved', async () => {
+    mocks.resolveApiKeyActor.mockResolvedValue(null);
+    const req = await createMockRequest('GET', '/api/services/svc-1');
+
+    const { status, data } = await parseResponse(await GET(req, context));
+
+    expect(status).toBe(401);
+    expect(data.code).toBe('API_KEY_USER_INVALID');
+  });
+
+  it('returns SERVICE_NOT_FOUND for an inaccessible or missing service', async () => {
+    mocks.serviceFindFirst.mockResolvedValue(null);
+    const req = await createMockRequest('GET', '/api/services/svc-1');
+
+    const { status, data } = await parseResponse(await GET(req, context));
+
+    expect(status).toBe(404);
+    expect(data.code).toBe('SERVICE_NOT_FOUND');
+  });
+
+  it('returns RATE_LIMIT_EXCEEDED with Retry-After', async () => {
+    mocks.checkRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 30_000,
+      count: 61,
+    });
+    const req = await createMockRequest('GET', '/api/services/svc-1');
+
+    const response = await GET(req, context);
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(429);
+    expect(data.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(Number(response.headers.get('Retry-After'))).toBeGreaterThan(0);
+  });
+});

--- a/tests/architecture/error-contract.test.ts
+++ b/tests/architecture/error-contract.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { basename, join, relative } from 'node:path';
 
 const API_ROOT = join(process.cwd(), 'src', 'app', 'api');
+const APP_ROOT = join(process.cwd(), 'src', 'app');
 const ERROR_IDENTIFIER = String.raw`(?:error|err|e|[A-Za-z_$][\w$]*(?:Error|Err))`;
 
 function sourceFiles(root: string): string[] {
@@ -16,9 +17,16 @@ function sourceFiles(root: string): string[] {
   return files;
 }
 
-function findViolations(pattern: RegExp): string[] {
+function serverActionFiles(): string[] {
+  return sourceFiles(APP_ROOT).filter(file => {
+    const name = basename(file);
+    return name === 'actions.ts' || name.endsWith('-actions.ts');
+  });
+}
+
+function findViolations(pattern: RegExp, files = sourceFiles(API_ROOT)): string[] {
   const violations: string[] = [];
-  for (const file of sourceFiles(API_ROOT)) {
+  for (const file of files) {
     const source = readFileSync(file, 'utf8');
     if (pattern.test(source)) violations.push(relative(process.cwd(), file));
     pattern.lastIndex = 0;
@@ -63,6 +71,14 @@ describe('public API error contract architecture', () => {
     expect(
       violations,
       'getUserFriendlyError is a compatibility boundary; API routes should use AppError + jsonError.'
+    ).toEqual([]);
+  });
+
+  it('does not flatten server-action errors through the legacy friendly-error translator', () => {
+    const violations = findViolations(/\bgetUserFriendlyError\s*\(/g, serverActionFiles());
+    expect(
+      violations,
+      'Server actions should preserve AppError identity instead of translating it back into string-only errors.'
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Continues the typed-error migration behind the public API enforcement added in #420 by preserving `AppError` identity through incident server actions and aligning core incident/service detail routes with their already-typed collection routes.

### Incident server actions

- removes `new Error(getUserFriendlyError(error))` wrappers around RBAC/service authorization so typed authorization/domain errors propagate unchanged
- converts invalid urgency and custom-field validation failures to `INCIDENT_INVALID_ARGUMENT` with structured `fields`
- converts missing reassignment team/user targets to structured `RESOURCE_NOT_FOUND` errors while preserving the existing generic not-found message exposed to users
- removes the unreachable post-`getCurrentUser()` null fallback; `getCurrentUser()` already throws typed authentication errors
- leaves incident dedup/reopen behavior, transactions, escalation, notifications, status-page effects, Jira sync, and ChatOps behavior unchanged

### Core REST detail routes

- `/api/incidents/:id` now returns stable codes for invalid API keys, unresolved key owners, rate limits, authorization denials, invalid JSON/validation, and incident not-found
- `/api/services/:id` now returns the same typed key/rate/auth/not-found contract as `/api/services`
- preserves legacy client-visible error strings where the previous shared translator changed them
- preserves `Retry-After` headers for rate-limited responses

### Architecture enforcement

Extends the existing error-contract architecture test so server-action files (`actions.ts` / `*-actions.ts`) cannot call `getUserFriendlyError()` directly and flatten typed errors back into string-only errors.

This deliberately does **not** ban technical `Error` usage in infrastructure code or force every server action to migrate in this PR.

## Tests

Adds focused coverage for:

- incident server-action authorization identity preservation
- incident urgency validation fields/code
- incident creation service authorization preservation
- structured reassignment not-found errors
- incident detail API key/rate/not-found/resource authorization codes
- service detail API key/actor/rate/not-found codes
- server-action architecture enforcement

## Compatibility / non-goals

No incident lifecycle side-effect ordering or idempotency behavior is changed. This PR also does not migrate status/settings/provider routes or frontend toast behavior; those remain separate follow-up layers.

## Commit history

Intentionally **one commit**.