### PR TITLE
refactor(errors): consume typed errors in frontend

### DIFF
--- a/src/components/OverrideList.tsx
+++ b/src/components/OverrideList.tsx
@@ -3,6 +3,7 @@
 import { useTransition, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-product-notification';
+import type { ScheduleActionState } from '@/lib/schedule-action-errors';
 import ConfirmDialog from './ConfirmDialog';
 import { formatDateTime } from '@/lib/timezone';
 import { Card } from '@/components/ui/shadcn/card';
@@ -28,7 +29,7 @@ type OverrideListProps = {
   deleteOverride: (
     scheduleId: string,
     overrideId: string
-  ) => Promise<{ error?: string } | undefined>;
+  ) => Promise<ScheduleActionState | undefined>;
   timeZone: string;
   title: string;
   emptyMessage: string;
@@ -51,12 +52,16 @@ export default function OverrideList({
   const handleDelete = async (overrideId: string) => {
     setDeleteOverrideId(null);
     startTransition(async () => {
-      const result = await deleteOverride(scheduleId, overrideId);
-      if (result?.error) {
-        showToast(result.error, 'error');
-      } else {
-        showToast('Override deleted successfully', 'success');
-        router.refresh();
+      try {
+        const result = await deleteOverride(scheduleId, overrideId);
+        if (result?.error) {
+          showToast(result, 'error');
+        } else {
+          showToast('Override deleted successfully', 'success');
+          router.refresh();
+        }
+      } catch (error) {
+        showToast(error, 'error');
       }
     });
   };

--- a/src/components/ScheduleEditForm.tsx
+++ b/src/components/ScheduleEditForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-product-notification';
+import type { ScheduleActionState } from '@/lib/schedule-action-errors';
 import TimeZoneSelect from './TimeZoneSelect';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
@@ -17,7 +18,7 @@ type ScheduleEditFormProps = {
   updateSchedule: (
     scheduleId: string,
     formData: FormData
-  ) => Promise<{ error?: string } | undefined>;
+  ) => Promise<ScheduleActionState | undefined>;
   canManageSchedules: boolean;
 };
 
@@ -40,15 +41,14 @@ export default function ScheduleEditForm({
       try {
         const result = await updateSchedule(scheduleId, formData);
         if (result?.error) {
-          showToast(result.error, 'error');
+          showToast(result, 'error');
         } else {
           showToast('Schedule updated successfully', 'success');
           setIsEditing(false);
           router.refresh();
         }
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        showToast(errorMessage || 'Failed to update schedule', 'error');
+        showToast(error, 'error');
       }
     });
   };

--- a/src/components/incident/detail/IncidentWarRoomCard.tsx
+++ b/src/components/incident/detail/IncidentWarRoomCard.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
 import { Button } from '@/components/ui/shadcn/button';
 import { Badge } from '@/components/ui/shadcn/badge';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 import { MessageCircle, Video, ExternalLink, Archive, Hash, Loader2 } from 'lucide-react';
 
 interface IncidentWarRoomCardProps {
@@ -20,6 +22,11 @@ interface IncidentWarRoomCardProps {
     };
   };
   canManage: boolean;
+}
+
+function displayError(error: unknown, fallback: string): string {
+  const friendly = toUserFacingError(error, fallback);
+  return friendly.description ? `${friendly.title} ${friendly.description}` : friendly.title;
 }
 
 export default function IncidentWarRoomCard({ incident, canManage }: IncidentWarRoomCardProps) {
@@ -38,14 +45,13 @@ export default function IncidentWarRoomCard({ incident, canManage }: IncidentWar
         });
 
         if (!response.ok) {
-          const data = await response.json().catch(() => ({}));
-          throw new Error(data.error || 'Failed to create war-room');
+          throw await errorFromResponse(response, 'Failed to create war-room');
         }
 
         // Refresh page to show updated war-room state
         router.refresh();
-      } catch (err: any) {
-        setError(err.message || 'An error occurred');
+      } catch (err: unknown) {
+        setError(displayError(err, 'Failed to create war-room'));
       }
     });
   };
@@ -61,14 +67,13 @@ export default function IncidentWarRoomCard({ incident, canManage }: IncidentWar
         });
 
         if (!response.ok) {
-          const data = await response.json().catch(() => ({}));
-          throw new Error(data.error || 'Failed to archive war-room');
+          throw await errorFromResponse(response, 'Failed to archive war-room');
         }
 
         // Refresh page to show updated war-room state
         router.refresh();
-      } catch (err: any) {
-        setError(err.message || 'An error occurred');
+      } catch (err: unknown) {
+        setError(displayError(err, 'Failed to archive war-room'));
       }
     });
   };

--- a/src/hooks/use-product-notification.ts
+++ b/src/hooks/use-product-notification.ts
@@ -5,20 +5,31 @@ import { notify } from '@/lib/toast';
 
 type ToastType = 'success' | 'error' | 'warning' | 'info';
 
+function toastText(message: unknown): string {
+  if (typeof message === 'string') return message;
+  if (message instanceof Error) return message.message;
+  return String(message ?? '');
+}
+
 export function useToast() {
-  const showToast = useCallback((message: string, type: ToastType = 'info') => {
+  const showToast = useCallback((message: unknown, type: ToastType = 'info') => {
+    if (type === 'error') {
+      // Keep structured error payloads intact so notify.error() can consume
+      // stable code/action/retryable/fields metadata instead of only a string.
+      notify.error(message);
+      return;
+    }
+
+    const text = toastText(message);
     switch (type) {
       case 'success':
-        notify.success(message);
-        break;
-      case 'error':
-        notify.error(message);
+        notify.success(text);
         break;
       case 'warning':
-        notify.warning(message);
+        notify.warning(text);
         break;
       case 'info':
-        notify.info(message);
+        notify.info(text);
         break;
     }
   }, []);

--- a/src/lib/client-error.ts
+++ b/src/lib/client-error.ts
@@ -1,0 +1,119 @@
+import {
+  isAppErrorCode,
+  type AppErrorCode,
+  type ErrorField,
+} from '@/lib/errors';
+
+export type StructuredErrorPayload = {
+  error?: string;
+  code?: AppErrorCode;
+  action?: string;
+  retryable?: boolean;
+  fields?: ErrorField[];
+};
+
+function asTrimmedString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asErrorFields(value: unknown): ErrorField[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const fields = value.filter((field): field is ErrorField => {
+    if (!field || typeof field !== 'object') return false;
+    const candidate = field as Record<string, unknown>;
+    return typeof candidate.field === 'string' && typeof candidate.message === 'string';
+  });
+
+  return fields.length > 0 ? fields : undefined;
+}
+
+/**
+ * Reads the public AppError wire/state contract without requiring callers to
+ * know whether the error came from a REST response, a server action state, or
+ * an Error-like object. Unknown codes are deliberately ignored so legacy
+ * string errors continue through the compatibility path.
+ */
+export function extractStructuredError(value: unknown): StructuredErrorPayload | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+
+  const candidate = value as Record<string, unknown>;
+  const code = isAppErrorCode(candidate.code) ? candidate.code : undefined;
+  const error =
+    asTrimmedString(candidate.error) ??
+    asTrimmedString(candidate.message) ??
+    (value instanceof Error ? asTrimmedString(value.message) : undefined);
+  const action = asTrimmedString(candidate.action);
+  const retryable = typeof candidate.retryable === 'boolean' ? candidate.retryable : undefined;
+  const fields = asErrorFields(candidate.fields);
+
+  if (!code && !error && !action && retryable === undefined && !fields) return undefined;
+
+  return { error, code, action, retryable, fields };
+}
+
+export class ClientAppError extends Error {
+  readonly code?: AppErrorCode;
+  readonly action?: string;
+  readonly retryable?: boolean;
+  readonly fields?: ErrorField[];
+
+  constructor(payload: StructuredErrorPayload & { error: string }) {
+    super(payload.error);
+    this.name = 'ClientAppError';
+    this.code = payload.code;
+    this.action = payload.action;
+    this.retryable = payload.retryable;
+    this.fields = payload.fields;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function toClientAppError(
+  value: unknown,
+  fallback = 'The request could not be completed.'
+): ClientAppError {
+  if (value instanceof ClientAppError) return value;
+
+  const structured = extractStructuredError(value);
+  if (structured) {
+    return new ClientAppError({
+      ...structured,
+      error: structured.error ?? fallback,
+    });
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    return new ClientAppError({ error: value.trim() });
+  }
+
+  if (value instanceof Error && value.message.trim()) {
+    return new ClientAppError({ error: value.message.trim() });
+  }
+
+  return new ClientAppError({ error: fallback });
+}
+
+/**
+ * Preserve typed error metadata from a failed fetch instead of flattening the
+ * response body into `new Error(data.error)`.
+ */
+export async function errorFromResponse(
+  response: Response,
+  fallback = `Request failed (${response.status}).`
+): Promise<ClientAppError> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+
+  return toClientAppError(body, fallback);
+}
+
+export async function throwIfResponseError(response: Response, fallback?: string): Promise<void> {
+  if (!response.ok) {
+    throw await errorFromResponse(response, fallback);
+  }
+}

--- a/src/lib/user-facing-error.ts
+++ b/src/lib/user-facing-error.ts
@@ -1,6 +1,18 @@
+import {
+  ERROR_REGISTRY,
+  type AppErrorCode,
+  type ErrorDefinition,
+  type ErrorField,
+} from '@/lib/errors';
+import { extractStructuredError } from '@/lib/client-error';
+
 export type UserFacingError = {
   title: string;
   description?: string;
+  code?: AppErrorCode;
+  action?: string;
+  retryable?: boolean;
+  fields?: ErrorField[];
 };
 
 const TECHNICAL_ERROR_PATTERNS = [
@@ -13,6 +25,16 @@ const TECHNICAL_ERROR_PATTERNS = [
   /\bat .+\(.+:\d+:\d+\)/,
 ];
 
+const GENERIC_AUTHORIZATION_CODES = new Set<AppErrorCode>([
+  'AUTHORIZATION_DENIED',
+  'INCIDENT_ACCESS_DENIED',
+  'INCIDENT_MODIFY_DENIED',
+  'INCIDENT_CREATE_SERVICE_ACCESS_DENIED',
+  'SERVICE_ACCESS_DENIED',
+  'SCHEDULE_ACCESS_DENIED',
+  'SCHEDULE_OVERRIDE_ACCESS_DENIED',
+]);
+
 function errorText(error: unknown): string {
   if (typeof error === 'string') return error.trim();
   if (error instanceof Error) return error.message.trim();
@@ -22,10 +44,91 @@ function errorText(error: unknown): string {
   return '';
 }
 
+function typedUserFacingError(
+  error: unknown,
+  fallback: string
+): UserFacingError | undefined {
+  const structured = extractStructuredError(error);
+  if (!structured?.code) return undefined;
+
+  const definition: ErrorDefinition = ERROR_REGISTRY[structured.code];
+  const message = structured.error || definition.userMessage;
+  const action = structured.action || definition.action;
+  const retryable = structured.retryable ?? definition.retryable ?? false;
+  const metadata = {
+    code: structured.code,
+    action,
+    retryable,
+    fields: structured.fields,
+  };
+
+  if (structured.code === 'AUTHENTICATION_REQUIRED' || structured.code === 'SESSION_REVOKED') {
+    return {
+      title: 'Your session has expired',
+      description: action || 'Sign in again, then retry the action.',
+      ...metadata,
+    };
+  }
+
+  if (structured.code === 'USER_DISABLED') {
+    return {
+      title: message,
+      description: action,
+      ...metadata,
+    };
+  }
+
+  if (definition.category === 'authorization' && GENERIC_AUTHORIZATION_CODES.has(structured.code)) {
+    return {
+      title: 'You do not have permission to do that',
+      description:
+        action ||
+        message ||
+        'Ask an administrator for access, or sign in with an account that has permission.',
+      ...metadata,
+    };
+  }
+
+  if (definition.category === 'rate_limit') {
+    return {
+      title: 'Too many requests',
+      description: action || message,
+      ...metadata,
+    };
+  }
+
+  if (definition.category === 'dependency' || definition.category === 'network') {
+    return {
+      title: 'Service temporarily unavailable',
+      description: action || message,
+      ...metadata,
+    };
+  }
+
+  if (definition.category === 'internal') {
+    return {
+      title: "We couldn't complete that action",
+      description: action || fallback,
+      ...metadata,
+    };
+  }
+
+  return {
+    title: message,
+    description: action,
+    ...metadata,
+  };
+}
+
 export function toUserFacingError(
   error: unknown,
   fallback = 'Please try again. If the problem continues, contact an administrator.'
 ): UserFacingError {
+  // Stable machine-readable semantics always win. Regex/string inference below
+  // is retained only as a compatibility bridge for legacy/untyped failures.
+  const typed = typedUserFacingError(error, fallback);
+  if (typed) return typed;
+
   const message = errorText(error);
 
   if (!message) {

--- a/tests/unit/client-error.test.ts
+++ b/tests/unit/client-error.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ClientAppError,
+  errorFromResponse,
+  extractStructuredError,
+  toClientAppError,
+} from '@/lib/client-error';
+
+describe('client error adapter', () => {
+  it('extracts the public typed error contract', () => {
+    expect(
+      extractStructuredError({
+        error: 'Required incident fields are missing.',
+        code: 'INCIDENT_REQUIRED_FIELDS_MISSING',
+        action: 'Complete the required fields and try again.',
+        retryable: false,
+        fields: [{ field: 'summary', message: 'Summary is required.' }],
+      })
+    ).toEqual({
+      error: 'Required incident fields are missing.',
+      code: 'INCIDENT_REQUIRED_FIELDS_MISSING',
+      action: 'Complete the required fields and try again.',
+      retryable: false,
+      fields: [{ field: 'summary', message: 'Summary is required.' }],
+    });
+  });
+
+  it('ignores unknown machine codes while preserving the legacy message', () => {
+    expect(
+      extractStructuredError({
+        error: 'Legacy failure',
+        code: 'NOT_A_REAL_CODE',
+      })
+    ).toEqual({
+      error: 'Legacy failure',
+      code: undefined,
+      action: undefined,
+      retryable: undefined,
+      fields: undefined,
+    });
+  });
+
+  it('preserves typed metadata from a failed fetch response', async () => {
+    const response = new Response(
+      JSON.stringify({
+        error: 'The incident status changed before this action completed.',
+        code: 'INCIDENT_TRANSITION_CONFLICT',
+        action: 'Refresh the incident and try again.',
+        retryable: true,
+        fields: [{ field: 'status', message: 'Status is stale.' }],
+      }),
+      {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const error = await errorFromResponse(response);
+
+    expect(error).toBeInstanceOf(ClientAppError);
+    expect(error.message).toBe('The incident status changed before this action completed.');
+    expect(error.code).toBe('INCIDENT_TRANSITION_CONFLICT');
+    expect(error.action).toBe('Refresh the incident and try again.');
+    expect(error.retryable).toBe(true);
+    expect(error.fields).toEqual([{ field: 'status', message: 'Status is stale.' }]);
+  });
+
+  it('keeps legacy errors usable when no structured payload exists', () => {
+    const error = toClientAppError(new Error('Failed to fetch'));
+    expect(error.message).toBe('Failed to fetch');
+    expect(error.code).toBeUndefined();
+  });
+});

--- a/tests/unit/user-facing-error.test.ts
+++ b/tests/unit/user-facing-error.test.ts
@@ -24,10 +24,63 @@ describe('toUserFacingError', () => {
     });
   });
 
-  it('explains authorization failures without exposing server text', () => {
+  it('explains legacy authorization failures without exposing server text', () => {
     expect(toUserFacingError('Unauthorized. Admin access required.')).toEqual({
       title: 'You do not have permission to do that',
       description: 'Ask an administrator for access, or sign in with an account that has permission.',
+    });
+  });
+
+  it('uses the stable code instead of inferring semantics from a misleading message', () => {
+    expect(
+      toUserFacingError({
+        error: 'Everything is fine',
+        code: 'AUTHORIZATION_DENIED',
+        action: 'Ask your team administrator for access.',
+        retryable: false,
+      })
+    ).toEqual({
+      title: 'You do not have permission to do that',
+      description: 'Ask your team administrator for access.',
+      code: 'AUTHORIZATION_DENIED',
+      action: 'Ask your team administrator for access.',
+      retryable: false,
+      fields: undefined,
+    });
+  });
+
+  it('preserves field metadata and conflict recovery guidance', () => {
+    expect(
+      toUserFacingError({
+        error: 'Schedule name is already in use.',
+        code: 'SCHEDULE_NAME_CONFLICT',
+        retryable: false,
+        fields: [{ field: 'name', code: 'duplicate', message: 'Choose another name.' }],
+      })
+    ).toEqual({
+      title: 'Schedule name is already in use.',
+      description: 'Choose a different schedule name.',
+      code: 'SCHEDULE_NAME_CONFLICT',
+      action: 'Choose a different schedule name.',
+      retryable: false,
+      fields: [{ field: 'name', code: 'duplicate', message: 'Choose another name.' }],
+    });
+  });
+
+  it('uses retry metadata for rate-limit errors', () => {
+    expect(
+      toUserFacingError({
+        error: 'Do not trust this text for classification.',
+        code: 'RATE_LIMIT_EXCEEDED',
+        retryable: true,
+      })
+    ).toEqual({
+      title: 'Too many requests',
+      description: 'Wait briefly before trying again.',
+      code: 'RATE_LIMIT_EXCEEDED',
+      action: 'Wait briefly before trying again.',
+      retryable: true,
+      fields: undefined,
     });
   });
 });


### PR DESCRIPTION
## Summary

Makes the frontend consume the typed error contract introduced by the backend error migration instead of immediately falling back to English-message inference.

### Client error adapter

- adds a client-safe structured error adapter for REST responses, server-action states, and Error-like objects
- preserves `code`, `action`, `retryable`, and `fields`
- ignores unknown machine codes so legacy string failures still use the compatibility path
- adds `errorFromResponse()` so failed fetches no longer need to flatten `{ error, code, ... }` into `new Error(data.error)`

### Code-first user-facing UX

- `toUserFacingError()` now checks the stable AppError code first and uses the central error registry as its source of truth
- authentication/session, authorization, rate-limit, dependency, conflict, validation and internal errors get category-aware UX
- stable codes win even when the accompanying English message is misleading
- legacy regex/string inference remains only as a fallback for untyped errors
- structured `fields`, `retryable`, `action`, and `code` remain available to form/toast consumers

### Real consumers

- the shared toast hook now accepts structured errors without flattening them to strings
- schedule edit and override deletion preserve their structured server-action state into the toast layer
- the incident Slack war-room REST client uses the typed response adapter and code-aware formatter instead of `new Error(data.error)`

## Tests

Adds focused tests for:

- typed payload extraction
- failed fetch response metadata preservation
- unknown-code legacy compatibility
- code-over-message precedence
- structured conflict fields/action handling
- retryable rate-limit UX
- existing legacy database/network/authorization fallbacks

## Compatibility / non-goals

The legacy regex formatter remains intentionally available for untyped code paths. This PR does not attempt to migrate every existing client fetch call, centralize Prisma mapping, or wire all notification providers to retryable AppErrors; those remain separate follow-up work.

## Commit history

Intentionally **one commit**.