### PR TITLE
refactor(errors): preserve typed frontend consumers

### DIFF
--- a/src/components/CustomFieldsConfig.tsx
+++ b/src/components/CustomFieldsConfig.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
@@ -12,7 +14,7 @@ import { Alert, AlertDescription } from '@/components/ui/shadcn/alert';
 import { Badge } from '@/components/ui/shadcn/badge';
 import { EmptyState } from '@/components/settings/feedback/EmptyState';
 import ConfirmDialog from '@/components/settings/ConfirmDialog';
-import { FileText, Plus, Trash2, AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
+import { FileText, Plus, Trash2, AlertTriangle, Loader2 } from 'lucide-react';
 
 type CustomField = {
     id: string;
@@ -32,6 +34,11 @@ type CustomField = {
 type CustomFieldsConfigProps = {
     customFields: CustomField[];
 };
+
+function displayError(error: unknown, fallback: string): string {
+    const friendly = toUserFacingError(error, fallback);
+    return friendly.description || friendly.title;
+}
 
 export default function CustomFieldsConfig({ customFields: initialFields }: CustomFieldsConfigProps) {
     const router = useRouter();
@@ -76,8 +83,7 @@ export default function CustomFieldsConfig({ customFields: initialFields }: Cust
                 });
 
                 if (!response.ok) {
-                    const data = await response.json();
-                    throw new Error(data.error || 'Failed to save custom field');
+                    throw await errorFromResponse(response, 'Failed to save custom field');
                 }
 
                 router.refresh();
@@ -91,8 +97,8 @@ export default function CustomFieldsConfig({ customFields: initialFields }: Cust
                     options: '',
                     showInList: false,
                 });
-            } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-                setError(err.message || 'Failed to save custom field');
+            } catch (err: unknown) {
+                setError(displayError(err, 'Failed to save custom field'));
             }
         });
     };
@@ -105,14 +111,13 @@ export default function CustomFieldsConfig({ customFields: initialFields }: Cust
                 });
 
                 if (!response.ok) {
-                    const data = await response.json();
-                    throw new Error(data.error || 'Failed to delete custom field');
+                    throw await errorFromResponse(response, 'Failed to delete custom field');
                 }
 
                 setDeleteId(null);
                 router.refresh();
-            } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-                setError(err.message || 'Failed to delete custom field');
+            } catch (err: unknown) {
+                setError(displayError(err, 'Failed to delete custom field'));
                 setDeleteId(null);
             }
         });

--- a/src/components/GenerateResetLinkButton.tsx
+++ b/src/components/GenerateResetLinkButton.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/ui/shadcn/button';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 import { Loader2, Key, Copy, Check, X, AlertCircle, Link as LinkIcon } from 'lucide-react';
 
 type Props = {
@@ -38,16 +40,26 @@ export default function GenerateResetLinkButton({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId }),
       });
-      const data = await res.json();
 
-      if (res.ok && data.link) {
+      if (!res.ok) {
+        const friendly = toUserFacingError(
+          await errorFromResponse(res, 'Failed to generate link')
+        );
+        setError(friendly.description || friendly.title);
+        setConfirming(false);
+        return;
+      }
+
+      const data = await res.json();
+      if (data.link) {
         setResetLink(data.link);
       } else {
-        setError(data.error || 'Failed to generate link');
+        setError('Failed to generate link');
         setConfirming(false);
       }
-    } catch (_err) {
-      setError('An error occurred');
+    } catch (err) {
+      const friendly = toUserFacingError(err, 'Failed to generate link');
+      setError(friendly.description || friendly.title);
       setConfirming(false);
     } finally {
       setIsLoading(false);

--- a/src/components/mobile/PushNotificationToggle.tsx
+++ b/src/components/mobile/PushNotificationToggle.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import MobileCard from '@/components/mobile/MobileCard';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 import { logger } from '@/lib/logger';
 import { cn } from '@/lib/utils';
 
@@ -31,6 +33,11 @@ function normalizeVapidKey(rawKey: string) {
   }
 
   return { key: cleaned };
+}
+
+function displayError(error: unknown, fallback: string): string {
+  const friendly = toUserFacingError(error, fallback);
+  return friendly.description || friendly.title;
 }
 
 export default function PushNotificationToggle() {
@@ -129,7 +136,12 @@ export default function PushNotificationToggle() {
 
       // Fetch VAPID Key from API (supports DB or Env)
       const keyRes = await fetch('/api/system/vapid-public-key');
-      if (!keyRes.ok) throw new Error('VAPID Configuration missing. Please contact admin.');
+      if (!keyRes.ok) {
+        throw await errorFromResponse(
+          keyRes,
+          'VAPID Configuration missing. Please contact admin.'
+        );
+      }
       const { key: vapidKey } = await keyRes.json();
       const normalized = normalizeVapidKey(String(vapidKey || ''));
       if (normalized.error || !normalized.key) {
@@ -158,14 +170,15 @@ export default function PushNotificationToggle() {
         body: JSON.stringify(subscription),
       });
 
-      if (!res.ok) throw new Error('Failed to save subscription');
+      if (!res.ok) {
+        throw await errorFromResponse(res, 'Failed to save subscription');
+      }
 
       setIsSubscribed(true);
       setError('');
     } catch (error: unknown) {
       logger.error('Push subscription failed', { component: 'PushNotificationToggle', error });
-      const message = error instanceof Error ? error.message : 'Failed to subscribe';
-      setError(message);
+      setError(displayError(error, 'Failed to subscribe'));
       if (Notification.permission === 'denied') {
         setError('Notifications blocked. Please enable in browser settings.');
       }
@@ -194,7 +207,7 @@ export default function PushNotificationToggle() {
       });
 
       if (!response.ok) {
-        throw new Error('Failed to remove subscription');
+        throw await errorFromResponse(response, 'Failed to remove subscription');
       }
       setIsSubscribed(false);
     } catch (error: unknown) {
@@ -202,9 +215,7 @@ export default function PushNotificationToggle() {
         component: 'PushNotificationToggle',
         error,
       });
-      setError(
-        error instanceof Error ? error.message : 'Failed to unsubscribe from push notifications'
-      );
+      setError(displayError(error, 'Failed to unsubscribe from push notifications'));
     } finally {
       setLoading(false);
     }
@@ -215,15 +226,14 @@ export default function PushNotificationToggle() {
     setTestMessage('');
     try {
       const response = await fetch('/api/notifications/test-push', { method: 'POST' });
-      const data = (await response.json()) as { message?: string; error?: string };
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to send test push.');
+        throw await errorFromResponse(response, 'Failed to send test push.');
       }
+      const data = (await response.json()) as { message?: string };
       setTestMessage(data.message || 'Test push sent. Check your device.');
     } catch (error: unknown) {
       logger.error('Push test failed', { component: 'PushNotificationToggle', error });
-      const message = error instanceof Error ? error.message : 'Failed to send test push.';
-      setTestMessage(message);
+      setTestMessage(displayError(error, 'Failed to send test push.'));
     } finally {
       setIsTesting(false);
     }

--- a/src/components/settings/AppUrlSettings.tsx
+++ b/src/components/settings/AppUrlSettings.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-product-notification';
+import { errorFromResponse } from '@/lib/client-error';
 import { Input } from '@/components/ui/shadcn/input';
 import { Button } from '@/components/ui/shadcn/button';
 import { Label } from '@/components/ui/shadcn/label';
@@ -47,15 +48,14 @@ export default function AppUrlSettings({ appUrl, fallback }: Props) {
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to update app URL');
+        throw await errorFromResponse(response, 'Failed to update app URL');
       }
 
       showToast('Application URL updated successfully', 'success');
       setLastSaved(new Date().toLocaleString());
       router.refresh();
     } catch (error) {
-      showToast(error instanceof Error ? error.message : 'Failed to update app URL', 'error');
+      showToast(error, 'error');
     } finally {
       setIsLoading(false);
     }
@@ -159,10 +159,7 @@ export default function AppUrlSettings({ appUrl, fallback }: Props) {
             Reset
           </Button>
         )}
-        <Button
-          type="submit"
-          disabled={isLoading || !isDirty}
-        >
+        <Button type="submit" disabled={isLoading || !isDirty}>
           {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Save URL
         </Button>

--- a/src/components/settings/RetentionPolicySettings.tsx
+++ b/src/components/settings/RetentionPolicySettings.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
@@ -70,6 +72,11 @@ const DEFAULT_POLICY: RetentionPolicy = {
   realTimeWindowDays: 90,
 };
 
+function displayError(error: unknown, fallback: string): string {
+  const friendly = toUserFacingError(error, fallback);
+  return friendly.description || friendly.title;
+}
+
 export default function RetentionPolicySettings() {
   const [policy, setPolicy] = useState<RetentionPolicy | null>(null);
   const [initialPolicy, setInitialPolicy] = useState<RetentionPolicy | null>(null);
@@ -94,14 +101,16 @@ export default function RetentionPolicySettings() {
     try {
       setLoading(true);
       const res = await fetch('/api/settings/retention');
-      if (!res.ok) throw new Error('Failed to fetch settings');
+      if (!res.ok) {
+        throw await errorFromResponse(res, 'Failed to fetch settings');
+      }
       const data = await res.json();
       setPolicy(data.policy);
       setInitialPolicy(data.policy);
       setStats(data.stats);
       setPresets(data.presets);
     } catch (err) {
-      setGeneralError('Failed to load retention settings');
+      setGeneralError(displayError(err, 'Failed to load retention settings'));
     } finally {
       setLoading(false);
     }
@@ -172,15 +181,14 @@ export default function RetentionPolicySettings() {
       });
 
       if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to save');
+        throw await errorFromResponse(res, 'Failed to save');
       }
 
       setSuccess('Retention policy updated successfully');
       setInitialPolicy(policy);
       setTimeout(() => setSuccess(null), 3000);
     } catch (err) {
-      setGeneralError(err instanceof Error ? err.message : 'Failed to save settings');
+      setGeneralError(displayError(err, 'Failed to save settings'));
     } finally {
       setSaving(false);
     }
@@ -199,8 +207,7 @@ export default function RetentionPolicySettings() {
       });
 
       if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to run cleanup');
+        throw await errorFromResponse(res, 'Failed to run cleanup');
       }
 
       const data = await res.json();
@@ -213,7 +220,7 @@ export default function RetentionPolicySettings() {
         setTimeout(() => setSuccess(null), 3000);
       }
     } catch (err) {
-      setGeneralError(err instanceof Error ? err.message : 'Failed to run cleanup');
+      setGeneralError(displayError(err, 'Failed to run cleanup'));
     } finally {
       setSaving(false);
     }

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -5,6 +5,8 @@ import { Badge } from '@/components/ui/shadcn/badge';
 import UserAvatar from '@/components/UserAvatar';
 import OidcLinkingApprovalButton from './OidcLinkingApprovalButton';
 import { Button } from '@/components/ui/shadcn/button';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -130,15 +132,24 @@ export function UserCard({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId: user.id }),
       });
-      const data = await res.json();
 
-      if (res.ok && data.link) {
+      if (!res.ok) {
+        const friendly = toUserFacingError(
+          await errorFromResponse(res, 'Failed to generate link')
+        );
+        setLinkError(friendly.description || friendly.title);
+        return;
+      }
+
+      const data = await res.json();
+      if (data.link) {
         setInviteLink(data.link);
       } else {
-        setLinkError(data.error || 'Failed to generate link');
+        setLinkError('Failed to generate link');
       }
-    } catch (_err) {
-      setLinkError('An error occurred');
+    } catch (err) {
+      const friendly = toUserFacingError(err, 'Failed to generate link');
+      setLinkError(friendly.description || friendly.title);
     } finally {
       setIsLoadingLink(false);
     }
@@ -217,7 +228,6 @@ export function UserCard({
           size="lg"
           className="ring-2 ring-background shadow-md transition-transform duration-300 group-hover:scale-105"
         />
-
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
             <h3 className="font-semibold text-sm truncate">{user.name}</h3>


### PR DESCRIPTION
## Summary

Follow-up to #425. Applies the new client typed-error adapter to frontend consumers that were still discarding OpsKnight's structured `{ error, code, action, retryable, fields }` response contract.

### Consumers migrated

- application URL settings
- custom-field create/delete flows
- admin invite/reset-link generation surfaces
- retention settings load/save/cleanup flows
- mobile push subscription/test flows

### Behavior

- failed OpsKnight API responses now use `errorFromResponse()` instead of reconstructing `new Error(data.error)`
- local UI state still renders strings where required, but those strings are produced only after `toUserFacingError()` consumes the stable code/action/retryability metadata
- browser-only/service-worker validation remains local and unchanged
- the push VAPID key byte conversion is preserved exactly

### Deliberate non-goal

Raw third-party provider errors (for example Slack `missing_scope`, `not_allowed`, etc.) are not normalized in this PR. Those belong to the provider/AppError normalization layer so the frontend does not incorrectly treat provider codes as OpsKnight AppError codes.

## Commit history

Intentionally one commit, rebased directly onto #425's merge commit.