### PR TITLE
refactor(errors): normalize provider failures

### DIFF
--- a/src/app/api/jira/test/route.ts
+++ b/src/app/api/jira/test/route.ts
@@ -1,4 +1,6 @@
-import { NextResponse } from 'next/server';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { logger } from '@/lib/logger';
 import { assertAdmin } from '@/lib/rbac';
 import { getDecryptedJiraConfig, testJiraConnection } from '@/lib/jira';
 
@@ -7,23 +9,29 @@ export async function POST() {
     await assertAdmin();
     const config = await getDecryptedJiraConfig();
     if (!config) {
-      return NextResponse.json(
-        { error: 'Jira is not configured or is disabled.' },
-        { status: 400 }
+      return jsonError(
+        new AppError({
+          code: 'INTEGRATION_DISABLED',
+          userMessage: 'Jira is not configured or is disabled.',
+          action: 'Configure and enable Jira before testing the connection.',
+          details: { provider: 'jira' },
+        })
       );
     }
 
     const result = await testJiraConnection(config);
-    return NextResponse.json({
+    return jsonOk({
       ok: true,
       accountId: result.accountId,
       displayName: result.displayName,
       emailAddress: result.emailAddress,
     });
   } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Failed to test Jira connection.' },
-      { status: 500 }
-    );
+    logger.error('api.jira.test_failed', {
+      error,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
+    });
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to test Jira connection.', 500);
   }
 }

--- a/src/app/api/notifications/test-push/route.ts
+++ b/src/app/api/notifications/test-push/route.ts
@@ -1,7 +1,10 @@
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { getAuthOptions } from '@/lib/auth';
+import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
+import { getPushConfig } from '@/lib/notification-providers';
 import prisma from '@/lib/prisma';
+import { notificationProviderUnavailable } from '@/lib/provider-errors';
 import { sendPush } from '@/lib/push';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getServerSession } from 'next-auth';
@@ -10,7 +13,7 @@ export async function POST() {
   try {
     const session = await getServerSession(await getAuthOptions());
     if (!session?.user?.email) {
-      return jsonError('Unauthorized', 401);
+      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED' }));
     }
 
     const user = await prisma.user.findUnique({
@@ -19,14 +22,53 @@ export async function POST() {
     });
 
     if (!user) {
-      return jsonError('User not found', 404);
+      return jsonError(
+        new AppError({
+          code: 'RESOURCE_NOT_FOUND',
+          userMessage: 'The current user could not be found.',
+        })
+      );
     }
 
     const rateLimit = await checkRateLimit(`test-push:${user.id}`, 5, 60_000);
     if (!rateLimit.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((rateLimit.resetAt - Date.now()) / 1000));
       return jsonError(
-        'Rate limit exceeded. Please wait a moment before sending another test.',
-        429
+        new AppError({
+          code: 'RATE_LIMIT_EXCEEDED',
+          userMessage: 'Please wait a moment before sending another test notification.',
+        }),
+        undefined,
+        { retryAfter }
+      );
+    }
+
+    const [pushConfig, deviceCount] = await Promise.all([
+      getPushConfig(),
+      prisma.userDevice.count({ where: { userId: user.id, platform: 'web' } }),
+    ]);
+
+    if (!pushConfig.enabled || pushConfig.provider !== 'web-push') {
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Push notifications are not configured.',
+          action: 'Configure Web Push before sending a test notification.',
+          retryable: false,
+          details: { provider: 'web-push', reason: 'not_configured' },
+        })
+      );
+    }
+
+    if (deviceCount === 0) {
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'No active web push subscription is available for this user.',
+          action: 'Enable push notifications on a device, then try again.',
+          retryable: false,
+          details: { provider: 'web-push', reason: 'no_subscription' },
+        })
       );
     }
 
@@ -42,7 +84,28 @@ export async function POST() {
     });
 
     if (!result.success) {
-      return jsonError(result.error || 'Failed to send test push', 500);
+      const remainingDevices = await prisma.userDevice.count({
+        where: { userId: user.id, platform: 'web' },
+      });
+      if (remainingDevices === 0) {
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: 'The saved push subscription is no longer valid.',
+            action: 'Enable push notifications again on this device and retry.',
+            retryable: false,
+            details: { provider: 'web-push', reason: 'subscription_removed' },
+          })
+        );
+      }
+
+      return jsonError(
+        notificationProviderUnavailable({
+          provider: 'web-push',
+          operation: 'send_test_push',
+          cause: result.error ? new Error(result.error) : undefined,
+        })
+      );
     }
 
     return jsonOk(
@@ -51,8 +114,10 @@ export async function POST() {
     );
   } catch (error) {
     logger.error('api.notifications.test_push_error', {
-      error: error instanceof Error ? error.message : String(error),
+      error,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
     });
+    if (isAppError(error)) return jsonError(error);
     return jsonError('Failed to send test push', 500);
   }
 }

--- a/src/app/api/slack/channels/leave/route.ts
+++ b/src/app/api/slack/channels/leave/route.ts
@@ -1,11 +1,14 @@
 'use server';
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { getCurrentUser } from '@/lib/rbac';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { retryFetch } from '@/lib/retry';
 import { decrypt } from '@/lib/encryption';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { integrationProviderError, jsonProviderError } from '@/lib/provider-errors';
 
 /**
  * POST /api/slack/channels/leave
@@ -15,17 +18,28 @@ export async function POST(request: NextRequest) {
   try {
     const user = await getCurrentUser();
     if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED' }));
     }
 
-    const body = await request.json();
-    const channelId = body?.channelId;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const channelId = typeof payload.channelId === 'string' ? payload.channelId : null;
 
     if (!channelId) {
-      return NextResponse.json({ error: 'Channel ID is required' }, { status: 400 });
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Channel ID is required.',
+          fields: [{ field: 'channelId', code: 'required', message: 'Channel ID is required' }],
+        })
+      );
     }
 
-    // Get bot token
     const globalIntegration = await prisma.slackIntegration.findFirst({
       where: {
         enabled: true,
@@ -34,55 +48,76 @@ export async function POST(request: NextRequest) {
     });
 
     if (!globalIntegration?.botToken) {
-      return NextResponse.json({ error: 'Slack not configured.' }, { status: 503 });
+      return jsonError(
+        new AppError({
+          code: 'NOTIFICATION_PROVIDER_UNAVAILABLE',
+          userMessage: 'Slack is not configured.',
+          action: 'Connect a Slack workspace before managing channels.',
+          retryable: false,
+          details: { provider: 'slack', reason: 'not_configured' },
+        })
+      );
     }
 
     let botToken: string;
     try {
       botToken = await decrypt(globalIntegration.botToken);
-    } catch {
-      return NextResponse.json({ error: 'Failed to decrypt Slack token.' }, { status: 500 });
+    } catch (error) {
+      throw new AppError({
+        code: 'INTERNAL_ERROR',
+        details: { provider: 'slack', operation: 'decrypt_token' },
+        cause: error,
+      });
     }
 
-    // Leave channel
-    const response = await retryFetch(
-      'https://slack.com/api/conversations.leave',
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${botToken}`,
-          'Content-Type': 'application/json',
+    let response: Response;
+    try {
+      response = await retryFetch(
+        'https://slack.com/api/conversations.leave',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${botToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ channel: channelId }),
         },
-        body: JSON.stringify({ channel: channelId }),
-      },
-      { maxAttempts: 2, initialDelayMs: 500 }
-    );
+        { maxAttempts: 2, initialDelayMs: 500 }
+      );
+    } catch (error) {
+      throw integrationProviderError({
+        provider: 'slack',
+        operation: 'conversations.leave',
+        cause: error,
+      });
+    }
 
     const data = await response.json();
 
     if (!data.ok) {
-      logger.warn('[Slack] Failed to leave channel', { error: data.error, channelId });
-
-      const friendlyError =
-        data.error === 'channel_not_found'
-          ? 'Channel not found.'
-          : data.error === 'not_in_channel'
-            ? 'Bot is not in this channel.'
-            : data.error === 'is_archived'
-              ? 'Channel is archived.'
-              : data.error === 'cant_leave_general'
-                ? 'Cannot leave the #general channel.'
-                : `Slack error: ${data.error}`;
-
-      return NextResponse.json({ error: friendlyError }, { status: 400 });
+      const providerCode = typeof data.error === 'string' ? data.error : undefined;
+      logger.warn('[Slack] Failed to leave channel', { error: providerCode, channelId });
+      const providerError = integrationProviderError({
+        provider: 'slack',
+        operation: 'conversations.leave',
+        providerCode,
+        status: response.status,
+      });
+      return jsonProviderError(providerError, {
+        legacyError: providerCode || 'Failed to leave channel',
+        provider: 'slack',
+        providerCode,
+      });
     }
 
     logger.info('[Slack] Bot left channel', { channelId, userId: user.id });
-
-    return NextResponse.json({ ok: true });
-  } catch (error: unknown) {
-    const err = error as { message?: string };
-    logger.error('[Slack] Leave channel error', { error: err.message });
-    return NextResponse.json({ error: 'Failed to leave channel' }, { status: 500 });
+    return jsonOk({ ok: true });
+  } catch (error) {
+    logger.error('[Slack] Leave channel error', {
+      error,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
+    });
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to leave channel', 500);
   }
 }

--- a/src/app/api/slack/channels/route.ts
+++ b/src/app/api/slack/channels/route.ts
@@ -1,8 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { getCurrentUser } from '@/lib/rbac';
 import { logger } from '@/lib/logger';
 import { retryFetch } from '@/lib/retry';
 import { getSlackBotToken } from '@/lib/slack';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { integrationProviderError, jsonProviderError } from '@/lib/provider-errors';
 
 type SlackApiChannel = {
   id: string;
@@ -15,60 +18,74 @@ type SlackApiChannel = {
 
 const SLACK_CHANNEL_TYPES = 'public_channel,private_channel';
 
+function slackNotConfigured() {
+  return new AppError({
+    code: 'NOTIFICATION_PROVIDER_UNAVAILABLE',
+    userMessage: 'Slack is not configured.',
+    action: 'Connect a Slack workspace before managing channels.',
+    retryable: false,
+    details: { provider: 'slack', reason: 'not_configured' },
+  });
+}
+
 export async function GET(request: NextRequest) {
   try {
-    // Require authentication
     const user = await getCurrentUser();
     if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED' }));
     }
 
     const { searchParams } = new URL(request.url);
     const serviceId = searchParams.get('serviceId');
-
     const botToken = await getSlackBotToken(serviceId || undefined);
 
     if (!botToken) {
-      return NextResponse.json(
-        { error: 'Slack bot token not configured. Please connect Slack workspace first.' },
-        { status: 503 }
-      );
+      return jsonError(slackNotConfigured());
     }
 
-    // Fetch channels from Slack API
     const listUrl = new URL('https://slack.com/api/conversations.list');
     listUrl.searchParams.set('exclude_archived', 'true');
     listUrl.searchParams.set('limit', '200');
     listUrl.searchParams.set('types', SLACK_CHANNEL_TYPES);
 
-    const response = await retryFetch(
-      listUrl.toString(),
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${botToken}`,
-          'Content-Type': 'application/json',
+    let response: Response;
+    try {
+      response = await retryFetch(
+        listUrl.toString(),
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${botToken}`,
+            'Content-Type': 'application/json',
+          },
         },
-      },
-      {
-        maxAttempts: 2,
-        initialDelayMs: 500,
-      }
-    );
+        { maxAttempts: 2, initialDelayMs: 500 }
+      );
+    } catch (error) {
+      throw integrationProviderError({
+        provider: 'slack',
+        operation: 'conversations.list',
+        cause: error,
+      });
+    }
 
     const data = await response.json();
 
     if (!data.ok) {
       logger.error('[Slack] Failed to fetch channels', { error: data.error });
-      return NextResponse.json(
-        { error: data.error || 'Failed to fetch channels' },
-        { status: 500 }
-      );
+      const providerError = integrationProviderError({
+        provider: 'slack',
+        operation: 'conversations.list',
+        providerCode: typeof data.error === 'string' ? data.error : undefined,
+        status: response.status,
+      });
+      return jsonProviderError(providerError, {
+        legacyError: typeof data.error === 'string' ? data.error : 'Failed to fetch channels',
+        provider: 'slack',
+        providerCode: typeof data.error === 'string' ? data.error : undefined,
+      });
     }
 
-    // Filter channels:
-    // - Must be a channel (not a DM or group DM)
-    // - Not archived
     const channels = (data.channels || [])
       .filter((channel: SlackApiChannel) => channel.is_channel && !channel.is_archived)
       .map((channel: SlackApiChannel) => ({
@@ -79,13 +96,14 @@ export async function GET(request: NextRequest) {
       }))
       .sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name));
 
-    return NextResponse.json({ channels });
-  } catch (error: any) {
+    return jsonOk({ channels });
+  } catch (error) {
     logger.error('[Slack] Channels API error', {
-      error: error.message,
-      stack: error.stack,
+      error,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
     });
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Internal server error', 500);
   }
 }
 
@@ -93,54 +111,82 @@ export async function POST(request: NextRequest) {
   try {
     const user = await getCurrentUser();
     if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED' }));
     }
 
-    const body = await request.json();
-    const channelId = typeof body?.channelId === 'string' ? body.channelId : null;
-    const serviceId = typeof body?.serviceId === 'string' ? body.serviceId : null;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const channelId = typeof payload.channelId === 'string' ? payload.channelId : null;
+    const serviceId = typeof payload.serviceId === 'string' ? payload.serviceId : null;
 
     if (!channelId) {
-      return NextResponse.json({ error: 'Channel ID is required' }, { status: 400 });
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Channel ID is required.',
+          fields: [{ field: 'channelId', code: 'required', message: 'Channel ID is required' }],
+        })
+      );
     }
 
     const botToken = await getSlackBotToken(serviceId || undefined);
     if (!botToken) {
-      return NextResponse.json(
-        { error: 'Slack bot token not configured. Please connect Slack workspace first.' },
-        { status: 503 }
-      );
+      return jsonError(slackNotConfigured());
     }
 
-    const response = await retryFetch(
-      'https://slack.com/api/conversations.join',
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${botToken}`,
-          'Content-Type': 'application/json',
+    let response: Response;
+    try {
+      response = await retryFetch(
+        'https://slack.com/api/conversations.join',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${botToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ channel: channelId }),
         },
-        body: JSON.stringify({ channel: channelId }),
-      },
-      {
-        maxAttempts: 2,
-        initialDelayMs: 500,
-      }
-    );
+        { maxAttempts: 2, initialDelayMs: 500 }
+      );
+    } catch (error) {
+      throw integrationProviderError({
+        provider: 'slack',
+        operation: 'conversations.join',
+        cause: error,
+      });
+    }
 
     const data = await response.json();
 
     if (!data.ok) {
-      logger.warn('[Slack] Failed to join channel', { error: data.error, channelId });
-      return NextResponse.json({ error: data.error || 'Failed to join channel' }, { status: 400 });
+      const providerCode = typeof data.error === 'string' ? data.error : undefined;
+      logger.warn('[Slack] Failed to join channel', { error: providerCode, channelId });
+      const providerError = integrationProviderError({
+        provider: 'slack',
+        operation: 'conversations.join',
+        providerCode,
+        status: response.status,
+      });
+      return jsonProviderError(providerError, {
+        legacyError: providerCode || 'Failed to join channel',
+        provider: 'slack',
+        providerCode,
+      });
     }
 
-    return NextResponse.json({ ok: true });
-  } catch (error: any) {
+    return jsonOk({ ok: true });
+  } catch (error) {
     logger.error('[Slack] Join channel error', {
-      error: error.message,
-      stack: error.stack,
+      error,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
     });
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Internal server error', 500);
   }
 }

--- a/src/app/api/slack/test/route.ts
+++ b/src/app/api/slack/test/route.ts
@@ -1,8 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { assertAdminOrResponder } from '@/lib/rbac';
 import { logger } from '@/lib/logger';
 import { retryFetch } from '@/lib/retry';
 import { getSlackBotToken } from '@/lib/slack';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { integrationProviderError, jsonProviderError } from '@/lib/provider-errors';
 
 /**
  * POST /api/slack/test
@@ -12,25 +15,39 @@ export async function POST(request: NextRequest) {
   try {
     const user = await assertAdminOrResponder();
 
-    const body = await request.json();
-    const channelId = typeof body?.channelId === 'string' ? body.channelId : null;
-    const channelName = typeof body?.channelName === 'string' ? body.channelName : null;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const channelId = typeof payload.channelId === 'string' ? payload.channelId : null;
+    const channelName = typeof payload.channelName === 'string' ? payload.channelName : null;
 
     if (!channelId) {
-      return NextResponse.json({ error: 'Channel ID is required' }, { status: 400 });
-    }
-
-    // Get bot token (global or env fallback)
-    const botToken = await getSlackBotToken();
-
-    if (!botToken) {
-      return NextResponse.json(
-        { error: 'Slack not configured. Connect Slack workspace first.' },
-        { status: 503 }
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Channel ID is required.',
+          fields: [{ field: 'channelId', code: 'required', message: 'Channel ID is required' }],
+        })
       );
     }
 
-    // Send test message
+    const botToken = await getSlackBotToken();
+    if (!botToken) {
+      return jsonError(
+        new AppError({
+          code: 'NOTIFICATION_PROVIDER_UNAVAILABLE',
+          userMessage: 'Slack is not configured.',
+          action: 'Connect a Slack workspace before sending a test notification.',
+          retryable: false,
+          details: { provider: 'slack', reason: 'not_configured' },
+        })
+      );
+    }
+
     const testMessage = {
       channel: channelId,
       blocks: [
@@ -53,47 +70,58 @@ export async function POST(request: NextRequest) {
       ],
     };
 
-    const response = await retryFetch(
-      'https://slack.com/api/chat.postMessage',
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${botToken}`,
-          'Content-Type': 'application/json',
+    let response: Response;
+    try {
+      response = await retryFetch(
+        'https://slack.com/api/chat.postMessage',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${botToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(testMessage),
         },
-        body: JSON.stringify(testMessage),
-      },
-      { maxAttempts: 2, initialDelayMs: 500 }
-    );
+        { maxAttempts: 2, initialDelayMs: 500 }
+      );
+    } catch (error) {
+      throw integrationProviderError({
+        provider: 'slack',
+        operation: 'chat.postMessage',
+        cause: error,
+      });
+    }
 
     const data = await response.json();
 
     if (!data.ok) {
-      logger.warn('[Slack] Test notification failed', { error: data.error, channelId });
-
-      const friendlyError =
-        data.error === 'channel_not_found'
-          ? 'Channel not found.'
-          : data.error === 'not_in_channel'
-            ? 'Bot is not a member of this channel.'
-            : data.error === 'is_archived'
-              ? 'Channel is archived.'
-              : data.error === 'invalid_auth'
-                ? 'Invalid Slack token. Reconnect workspace.'
-                : `Slack error: ${data.error}`;
-
-      return NextResponse.json({ error: friendlyError }, { status: 400 });
+      const providerCode = typeof data.error === 'string' ? data.error : undefined;
+      logger.warn('[Slack] Test notification failed', { error: providerCode, channelId });
+      const providerError = integrationProviderError({
+        provider: 'slack',
+        operation: 'chat.postMessage',
+        providerCode,
+        status: response.status,
+      });
+      return jsonProviderError(providerError, {
+        legacyError: providerCode || 'Failed to send test notification',
+        provider: 'slack',
+        providerCode,
+      });
     }
 
     logger.info('[Slack] Test notification sent', { channelId, channelName, userId: user.id });
 
-    return NextResponse.json({
+    return jsonOk({
       ok: true,
       message: `Test notification sent to #${channelName || channelId}`,
     });
-  } catch (error: unknown) {
-    const err = error as { message?: string };
-    logger.error('[Slack] Test notification error', { error: err.message });
-    return NextResponse.json({ error: 'Failed to send test notification' }, { status: 500 });
+  } catch (error) {
+    logger.error('[Slack] Test notification error', {
+      error,
+      errorCode: isAppError(error) ? error.code : 'INTERNAL_ERROR',
+    });
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to send test notification', 500);
   }
 }

--- a/src/components/settings/JiraIntegrationPage.tsx
+++ b/src/components/settings/JiraIntegrationPage.tsx
@@ -9,6 +9,8 @@ import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
 import { Alert, AlertDescription } from '@/components/ui/shadcn/alert';
 import { Badge } from '@/components/ui/shadcn/badge';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 import { CheckCircle2, Loader2, PlugZap, XCircle } from 'lucide-react';
 
 type JiraConfigView = {
@@ -31,6 +33,11 @@ function SubmitButton({ disabled }: { disabled: boolean }) {
       Save Jira Configuration
     </Button>
   );
+}
+
+function displayError(error: unknown): string {
+  const friendly = toUserFacingError(error, 'Jira connection failed.');
+  return friendly.description || friendly.title;
 }
 
 export default function JiraIntegrationPage({
@@ -59,8 +66,10 @@ export default function JiraIntegrationPage({
     setTestResult(null);
     try {
       const response = await fetch('/api/jira/test', { method: 'POST' });
+      if (!response.ok) {
+        throw await errorFromResponse(response, 'Jira connection failed.');
+      }
       const data = await response.json();
-      if (!response.ok) throw new Error(data.error || 'Jira connection failed.');
       setTestResult({
         ok: true,
         message: data.displayName ? `Connected as ${data.displayName}` : 'Connected to Jira.',
@@ -68,7 +77,7 @@ export default function JiraIntegrationPage({
     } catch (error) {
       setTestResult({
         ok: false,
-        message: error instanceof Error ? error.message : 'Jira connection failed.',
+        message: displayError(error),
       });
     } finally {
       setTesting(false);

--- a/src/components/status-page/StatusPageWebhooksSettings.tsx
+++ b/src/components/status-page/StatusPageWebhooksSettings.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useTransition, useCallback } from 'react';
 import { Card, Button, FormField, Switch } from '@/components/ui';
+import { errorFromResponse } from '@/lib/client-error';
+import { toUserFacingError } from '@/lib/user-facing-error';
 
 interface Webhook {
     id: string;
@@ -24,6 +26,11 @@ const WEBHOOK_EVENTS = [
     { value: 'maintenance.scheduled', label: 'Maintenance Scheduled' },
 ];
 
+function displayError(error: unknown, fallback: string): string {
+    const friendly = toUserFacingError(error, fallback);
+    return friendly.description || friendly.title;
+}
+
 export default function StatusPageWebhooksSettings({ statusPageId }: StatusPageWebhooksSettingsProps) {
     const [webhooks, setWebhooks] = useState<Webhook[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -38,11 +45,13 @@ export default function StatusPageWebhooksSettings({ statusPageId }: StatusPageW
     const loadWebhooks = useCallback(async () => {
         try {
             const response = await fetch(`/api/status-page/webhooks?statusPageId=${statusPageId}`);
-            if (!response.ok) throw new Error('Failed to load webhooks');
+            if (!response.ok) {
+                throw await errorFromResponse(response, 'Failed to load webhooks');
+            }
             const data = await response.json();
             setWebhooks(data.webhooks || []);
-        } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-            setError(err.message || 'Failed to load webhooks');
+        } catch (err) {
+            setError(displayError(err, 'Failed to load webhooks'));
         } finally {
             setIsLoading(false);
         }
@@ -51,7 +60,6 @@ export default function StatusPageWebhooksSettings({ statusPageId }: StatusPageW
     useEffect(() => {
         loadWebhooks();
     }, [loadWebhooks]);
-
 
     const handleCreate = () => {
         if (!formData.url || formData.events.length === 0) {
@@ -72,15 +80,14 @@ export default function StatusPageWebhooksSettings({ statusPageId }: StatusPageW
                 });
 
                 if (!response.ok) {
-                    const data = await response.json();
-                    throw new Error(data.error || 'Failed to create webhook');
+                    throw await errorFromResponse(response, 'Failed to create webhook');
                 }
 
                 setFormData({ url: '', events: [] });
                 setShowForm(false);
                 await loadWebhooks();
-            } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-                setError(err.message || 'Failed to create webhook');
+            } catch (err) {
+                setError(displayError(err, 'Failed to create webhook'));
             }
         });
     };
@@ -96,12 +103,12 @@ export default function StatusPageWebhooksSettings({ statusPageId }: StatusPageW
                 });
 
                 if (!response.ok) {
-                    throw new Error('Failed to delete webhook');
+                    throw await errorFromResponse(response, 'Failed to delete webhook');
                 }
 
                 await loadWebhooks();
-            } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-                setError(err.message || 'Failed to delete webhook');
+            } catch (err) {
+                setError(displayError(err, 'Failed to delete webhook'));
             }
         });
     };
@@ -246,10 +253,12 @@ export default function StatusPageWebhooksSettings({ statusPageId }: StatusPageW
                                                                         enabled,
                                                                     }),
                                                                 });
-                                                                if (!response.ok) throw new Error('Failed to update webhook');
+                                                                if (!response.ok) {
+                                                                    throw await errorFromResponse(response, 'Failed to update webhook');
+                                                                }
                                                                 await loadWebhooks();
-                                                            } catch (err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-                                                                setError(err.message || 'Failed to update webhook');
+                                                            } catch (err) {
+                                                                setError(displayError(err, 'Failed to update webhook'));
                                                             }
                                                         }}
                                                     />

--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -1,5 +1,7 @@
 import prisma from '@/lib/prisma';
 import { decrypt } from '@/lib/encryption';
+import { AppError } from '@/lib/errors';
+import { integrationProviderError } from '@/lib/provider-errors';
 import { normalizeJiraBaseUrl } from '@/lib/jira-validation';
 
 export type JiraIssueSummary = {
@@ -71,19 +73,35 @@ async function jiraRequest<T>(
   path: string,
   init: RequestInit = {}
 ): Promise<T> {
-  const response = await fetch(`${config.baseUrl}${path}`, {
-    ...init,
-    headers: {
-      Authorization: authHeader(config),
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      ...(init.headers ?? {}),
-    },
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${config.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        Authorization: authHeader(config),
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...(init.headers ?? {}),
+      },
+    });
+  } catch (error) {
+    throw integrationProviderError({
+      provider: 'jira',
+      operation: `${init.method || 'GET'} ${path}`,
+      cause: error,
+    });
+  }
 
   if (!response.ok) {
     const body = await response.text().catch(() => '');
-    throw new Error(`Jira request failed (${response.status}): ${body || response.statusText}`);
+    throw integrationProviderError({
+      provider: 'jira',
+      operation: `${init.method || 'GET'} ${path}`,
+      status: response.status,
+      cause: body
+        ? new Error(`Jira request failed (${response.status}) with a provider response body.`)
+        : new Error(`Jira request failed (${response.status}).`),
+    });
   }
 
   return (await response.json()) as T;
@@ -109,6 +127,15 @@ export async function getDecryptedJiraConfig(): Promise<JiraConfigForRequest | n
   };
 }
 
+function jiraNotConfigured(): AppError {
+  return new AppError({
+    code: 'INTEGRATION_DISABLED',
+    userMessage: 'Jira is not configured or is disabled.',
+    action: 'Configure and enable Jira before using Jira workflows.',
+    details: { provider: 'jira' },
+  });
+}
+
 export async function testJiraConnection(config: JiraConfigForRequest): Promise<{
   accountId?: string;
   displayName?: string;
@@ -120,7 +147,7 @@ export async function testJiraConnection(config: JiraConfigForRequest): Promise<
 export async function createJiraIssue(input: CreateJiraIssueInput): Promise<JiraIssueSummary> {
   const config = await getDecryptedJiraConfig();
   if (!config) {
-    throw new Error('Jira is not configured or is disabled.');
+    throw jiraNotConfigured();
   }
 
   const payload = {
@@ -150,7 +177,7 @@ export async function createJiraIssue(input: CreateJiraIssueInput): Promise<Jira
 export async function getJiraIssue(issueKeyOrId: string): Promise<JiraIssueSummary> {
   const config = await getDecryptedJiraConfig();
   if (!config) {
-    throw new Error('Jira is not configured or is disabled.');
+    throw jiraNotConfigured();
   }
 
   const issue = await jiraRequest<JiraIssueResponse>(
@@ -183,4 +210,3 @@ export async function addJiraComment(
     body: JSON.stringify(payload),
   });
 }
-

--- a/src/lib/provider-errors.ts
+++ b/src/lib/provider-errors.ts
@@ -1,0 +1,158 @@
+import { NextResponse } from 'next/server';
+import { AppError, toPublicAppError } from '@/lib/errors';
+
+export type ProviderName = 'slack' | 'jira' | 'web-push' | string;
+
+export type ProviderFailureInput = {
+  provider: ProviderName;
+  operation: string;
+  providerCode?: string | null;
+  status?: number | null;
+  cause?: unknown;
+};
+
+const AUTHENTICATION_CODES = new Set([
+  'invalid_auth',
+  'not_authed',
+  'token_revoked',
+  'account_inactive',
+]);
+
+const RETRYABLE_CODES = new Set([
+  'ratelimited',
+  'rate_limited',
+  'internal_error',
+  'service_unavailable',
+  'temporarily_unavailable',
+  'timeout',
+]);
+
+function providerLabel(provider: ProviderName): string {
+  if (provider === 'slack') return 'Slack';
+  if (provider === 'jira') return 'Jira';
+  if (provider === 'web-push') return 'Push notification provider';
+  return 'External provider';
+}
+
+function providerAction(providerCode: string | undefined, label: string): string {
+  switch (providerCode) {
+    case 'missing_scope':
+      return 'Update the provider app scopes and reconnect the integration.';
+    case 'not_allowed':
+      return 'Check the provider app permissions and workspace policy, then try again.';
+    case 'restricted_action':
+      return 'Check the provider workspace policy and app permissions.';
+    case 'channel_not_found':
+      return 'Refresh the channel list and choose an existing channel.';
+    case 'not_in_channel':
+      return 'Connect the provider app to the channel before trying again.';
+    case 'is_archived':
+      return 'Choose an active channel and try again.';
+    case 'cant_leave_general':
+      return 'Choose a channel other than the workspace default channel.';
+    default:
+      return `Check the ${label} integration configuration and try again.`;
+  }
+}
+
+/**
+ * Convert structured upstream status/code information into AppError semantics.
+ * This intentionally never inspects English provider error text.
+ */
+export function integrationProviderError(input: ProviderFailureInput): AppError {
+  const providerCode = input.providerCode?.toLowerCase();
+  const label = providerLabel(input.provider);
+  const details = {
+    provider: input.provider,
+    operation: input.operation,
+    providerCode: input.providerCode ?? undefined,
+    providerStatus: input.status ?? undefined,
+  };
+
+  if (
+    input.status === 401 ||
+    input.status === 403 ||
+    (providerCode && AUTHENTICATION_CODES.has(providerCode))
+  ) {
+    return new AppError({
+      code: 'INTEGRATION_AUTHENTICATION_FAILED',
+      userMessage: `${label} authentication failed.`,
+      action: `Reconnect ${label} or update its credentials, then try again.`,
+      retryable: false,
+      details,
+      cause: input.cause,
+    });
+  }
+
+  const networkFailure =
+    input.cause !== undefined &&
+    input.status === undefined &&
+    input.providerCode === undefined;
+
+  if (
+    networkFailure ||
+    input.status === 429 ||
+    (input.status !== undefined && input.status !== null && input.status >= 500) ||
+    (providerCode && RETRYABLE_CODES.has(providerCode))
+  ) {
+    // There is not yet a generic integration dependency code in the registry.
+    // INTERNAL_ERROR is intentionally retryable and keeps provider details private.
+    return new AppError({
+      code: 'INTERNAL_ERROR',
+      details: { ...details, dependencyUnavailable: true },
+      cause: input.cause,
+    });
+  }
+
+  return new AppError({
+    code: 'INTEGRATION_VALIDATION_FAILED',
+    userMessage: `${label} rejected the requested operation.`,
+    action: providerAction(providerCode, label),
+    retryable: false,
+    details,
+    cause: input.cause,
+  });
+}
+
+export function notificationProviderUnavailable(input: ProviderFailureInput): AppError {
+  return new AppError({
+    code: 'NOTIFICATION_PROVIDER_UNAVAILABLE',
+    details: {
+      provider: input.provider,
+      operation: input.operation,
+      providerCode: input.providerCode ?? undefined,
+      providerStatus: input.status ?? undefined,
+    },
+    cause: input.cause,
+  });
+}
+
+/**
+ * Provider APIs historically exposed their native machine error in `error`.
+ * Preserve that field while adding OpsKnight's stable typed contract so old
+ * clients remain compatible and new clients can branch on `code`.
+ */
+export function jsonProviderError(
+  error: AppError,
+  options: {
+    legacyError?: string | null;
+    provider: ProviderName;
+    providerCode?: string | null;
+  }
+) {
+  const publicError = toPublicAppError(error);
+  return NextResponse.json(
+    {
+      error: options.legacyError || publicError.message,
+      code: publicError.code,
+      action: publicError.action,
+      retryable: publicError.retryable,
+      fields: publicError.fields,
+      meta: {
+        provider: options.provider,
+        providerCode: options.providerCode ?? undefined,
+      },
+    },
+    { status: error.status }
+  );
+}

--- a/tests/api/notifications-test-push.test.ts
+++ b/tests/api/notifications-test-push.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '@/app/api/notifications/test-push/route';
 import prisma from '@/lib/prisma';
+import { getPushConfig } from '@/lib/notification-providers';
 import { getServerSession } from 'next-auth';
 import { sendPush } from '@/lib/push';
 
@@ -18,6 +19,9 @@ vi.mock('@/lib/prisma', () => ({
     user: {
       findUnique: vi.fn(),
     },
+    userDevice: {
+      count: vi.fn(),
+    },
     rateLimit: {
       upsert: vi.fn().mockResolvedValue({ count: 1, resetAt: new Date(Date.now() + 60000) }),
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
@@ -25,21 +29,41 @@ vi.mock('@/lib/prisma', () => ({
   },
 }));
 
+vi.mock('@/lib/notification-providers', () => ({
+  getPushConfig: vi.fn(),
+}));
+
 vi.mock('@/lib/push', () => ({
   sendPush: vi.fn(),
 }));
 
+function mockCurrentUser() {
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    id: 'user-1',
+    name: 'Test User',
+  } as never);
+}
+
 describe('API Route - Notifications Test Push', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getPushConfig).mockResolvedValue({
+      enabled: true,
+      provider: 'web-push',
+      vapidPublicKey: 'public-key',
+      vapidPrivateKey: 'private-key',
+    });
+    vi.mocked(prisma.userDevice.count).mockResolvedValue(1);
   });
 
   it('returns 401 when unauthenticated', async () => {
     vi.mocked(getServerSession).mockResolvedValue(null);
 
     const res = await POST();
+    const body = await res.json();
 
     expect(res.status).toBe(401);
+    expect(body.code).toBe('AUTHENTICATION_REQUIRED');
   });
 
   it('returns 404 when user is missing', async () => {
@@ -47,14 +71,73 @@ describe('API Route - Notifications Test Push', () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
 
     const res = await POST();
+    const body = await res.json();
 
     expect(res.status).toBe(404);
+    expect(body.code).toBe('RESOURCE_NOT_FOUND');
+  });
+
+  it('returns non-retryable validation when push provider is not configured', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
+    mockCurrentUser();
+    vi.mocked(getPushConfig).mockResolvedValue({ enabled: false, provider: null });
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('VALIDATION_FAILED');
+    expect(body.retryable).toBe(false);
+    expect(sendPush).not.toHaveBeenCalled();
+  });
+
+  it('returns non-retryable validation when no web subscription exists', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
+    mockCurrentUser();
+    vi.mocked(prisma.userDevice.count).mockResolvedValue(0);
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('VALIDATION_FAILED');
+    expect(body.retryable).toBe(false);
+    expect(sendPush).not.toHaveBeenCalled();
+  });
+
+  it('returns retryable provider unavailable when delivery fails but subscription remains', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
+    mockCurrentUser();
+    vi.mocked(prisma.userDevice.count).mockResolvedValue(1);
+    vi.mocked(sendPush).mockResolvedValue({ success: false, error: 'provider unavailable' });
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.code).toBe('NOTIFICATION_PROVIDER_UNAVAILABLE');
+    expect(body.retryable).toBe(true);
+  });
+
+  it('returns non-retryable validation when a failed send removes the expired subscription', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
+    mockCurrentUser();
+    vi.mocked(prisma.userDevice.count)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(0);
+    vi.mocked(sendPush).mockResolvedValue({ success: false, error: 'subscription expired' });
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('VALIDATION_FAILED');
+    expect(body.retryable).toBe(false);
   });
 
   it('returns 200 when push succeeds', async () => {
     vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1', name: 'Test User' } as any);
+    mockCurrentUser();
     vi.mocked(sendPush).mockResolvedValue({ success: true });
 
     const res = await POST();

--- a/tests/integration/slack-channels.test.ts
+++ b/tests/integration/slack-channels.test.ts
@@ -78,23 +78,29 @@ describe('Slack Channels API', () => {
 
     const req = new NextRequest('http://localhost:3000/api/slack/channels');
     const response = await GET(req);
+    const body = await response.json();
 
     expect(response.status).toBe(401);
+    expect(body.code).toBe('AUTHENTICATION_REQUIRED');
   });
 
-  it('returns 503 when bot token is missing', async () => {
+  it('returns a non-retryable typed error when bot token is missing', async () => {
     vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue(null);
     delete process.env.SLACK_BOT_TOKEN;
 
     const req = new NextRequest('http://localhost:3000/api/slack/channels');
     const response = await GET(req);
+    const body = await response.json();
 
     expect(response.status).toBe(503);
+    expect(body.code).toBe('NOTIFICATION_PROVIDER_UNAVAILABLE');
+    expect(body.retryable).toBe(false);
   });
 
   it('lists channels and preserves membership status', async () => {
     vi.mocked(retryFetch).mockResolvedValue({
       ok: true,
+      status: 200,
       json: async () => ({
         ok: true,
         channels: [
@@ -118,6 +124,7 @@ describe('Slack Channels API', () => {
   it('joins a public channel when requested', async () => {
     vi.mocked(retryFetch).mockResolvedValue({
       ok: true,
+      status: 200,
       json: async () => ({ ok: true }),
     } as unknown as Response);
 
@@ -134,9 +141,10 @@ describe('Slack Channels API', () => {
     expect(body.ok).toBe(true);
   });
 
-  it('returns an error when Slack join fails', async () => {
+  it('preserves the native Slack code while adding typed semantics', async () => {
     vi.mocked(retryFetch).mockResolvedValue({
       ok: true,
+      status: 200,
       json: async () => ({ ok: false, error: 'missing_scope' }),
     } as unknown as Response);
 
@@ -151,5 +159,25 @@ describe('Slack Channels API', () => {
 
     expect(response.status).toBe(400);
     expect(body.error).toBe('missing_scope');
+    expect(body.code).toBe('INTEGRATION_VALIDATION_FAILED');
+    expect(body.retryable).toBe(false);
+    expect(body.meta).toEqual({ provider: 'slack', providerCode: 'missing_scope' });
+  });
+
+  it('classifies a revoked Slack token as non-retryable authentication failure', async () => {
+    vi.mocked(retryFetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: false, error: 'token_revoked' }),
+    } as unknown as Response);
+
+    const req = new NextRequest('http://localhost:3000/api/slack/channels');
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe('token_revoked');
+    expect(body.code).toBe('INTEGRATION_AUTHENTICATION_FAILED');
+    expect(body.retryable).toBe(false);
   });
 });

--- a/tests/lib/provider-errors.test.ts
+++ b/tests/lib/provider-errors.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  integrationProviderError,
+  notificationProviderUnavailable,
+} from '@/lib/provider-errors';
+
+describe('provider error normalization', () => {
+  it('maps provider authentication codes without inspecting messages', () => {
+    const error = integrationProviderError({
+      provider: 'slack',
+      operation: 'conversations.list',
+      providerCode: 'token_revoked',
+      status: 200,
+    });
+
+    expect(error.code).toBe('INTEGRATION_AUTHENTICATION_FAILED');
+    expect(error.status).toBe(401);
+    expect(error.retryable).toBe(false);
+    expect(error.details).toMatchObject({
+      provider: 'slack',
+      providerCode: 'token_revoked',
+    });
+  });
+
+  it('maps provider input/permission rejections to non-retryable validation errors', () => {
+    const error = integrationProviderError({
+      provider: 'slack',
+      operation: 'conversations.join',
+      providerCode: 'missing_scope',
+      status: 200,
+    });
+
+    expect(error.code).toBe('INTEGRATION_VALIDATION_FAILED');
+    expect(error.status).toBe(400);
+    expect(error.retryable).toBe(false);
+    expect(error.action).toContain('scopes');
+  });
+
+  it('maps provider rate limits and server failures to retryable safe errors', () => {
+    for (const status of [429, 500, 503]) {
+      const error = integrationProviderError({
+        provider: 'jira',
+        operation: 'GET /rest/api/3/myself',
+        status,
+      });
+
+      expect(error.code).toBe('INTERNAL_ERROR');
+      expect(error.status).toBe(500);
+      expect(error.retryable).toBe(true);
+    }
+  });
+
+  it('treats network failures as retryable without parsing the exception text', () => {
+    const error = integrationProviderError({
+      provider: 'jira',
+      operation: 'POST /rest/api/3/issue',
+      cause: new Error('arbitrary transport wording'),
+    });
+
+    expect(error.code).toBe('INTERNAL_ERROR');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('marks actual notification delivery outages as retryable provider failures', () => {
+    const error = notificationProviderUnavailable({
+      provider: 'web-push',
+      operation: 'send_test_push',
+    });
+
+    expect(error.code).toBe('NOTIFICATION_PROVIDER_UNAVAILABLE');
+    expect(error.status).toBe(503);
+    expect(error.retryable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Normalizes provider-facing failures into the typed AppError contract without deriving semantics from English exception text.

### Provider classification

- adds one structured provider error adapter driven by provider machine codes and HTTP status
- classifies Slack/Jira authentication failures as non-retryable integration authentication errors
- classifies provider input/permission rejections as non-retryable integration validation errors
- classifies transport/rate-limit/5xx dependency failures as retryable safe errors
- uses `NOTIFICATION_PROVIDER_UNAVAILABLE` for actual Web Push delivery outages
- keeps provider details internal

### Slack compatibility

- migrates channel list/join, leave, and test-message APIs to typed errors
- preserves Slack's historical native machine code in the legacy `error` field so existing UI branches keep working
- additionally returns stable OpsKnight `code`, `action`, `retryable`, `fields`, and provider metadata
- missing Slack configuration is explicitly non-retryable even though the HTTP status remains 503

### Jira

- Jira request failures are classified from HTTP status / transport failure, never response text
- missing/disabled Jira configuration is typed
- `/api/jira/test` preserves AppError semantics
- Jira connection UI consumes the structured response through the shared client adapter

### Push notifications

- test-push distinguishes missing configuration and missing/expired subscriptions (non-retryable) from an actual provider delivery outage (retryable)
- does not inspect `sendPush()` English error text to decide semantics

### Remaining client adoption

- status-page webhook settings now consume typed API failures through the shared client adapter

## Tests

- provider classifier unit coverage
- Slack native-code compatibility plus typed code/retryability assertions
- push configuration/subscription/provider-outage retryability coverage

## Non-goals

This PR does not change incident lifecycle success semantics when notification delivery fails, does not remove existing provider-specific Slack UI hints, and does not include Prisma/status-settings normalization. Those remain separate concerns.

## Commit history

Intentionally one commit.