### PR TITLE
refactor(incidents): make lifecycle side effects durable

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -250,6 +250,10 @@ export async function createIncident(formData: FormData) {
           actor: { id: currentUser.id, name: currentUser.name ?? undefined },
           expectedStatus: 'RESOLVED',
           eventMessage: `Incident re-opened due to manual report within 30m window.\nSummary: ${title}`,
+          // Incident creation still owns its broader triggered/escalation/Jira/war-room
+          // bundle. Keep that one legacy path caller-owned until creation itself is
+          // moved onto a transactional outbox, avoiding duplicate lifecycle effects.
+          sideEffectPolicy: 'CALLER_OWNED',
         });
 
         const reOpenedIncident = await tx.incident.findUnique({

--- a/src/app/(app)/incidents/bulk-actions.ts
+++ b/src/app/(app)/incidents/bulk-actions.ts
@@ -61,20 +61,6 @@ async function runBulkLifecycleTarget(
   return changedIncidentIds(results);
 }
 
-async function loadIncidentsForLifecycleEffects(incidentIds: string[]) {
-  if (incidentIds.length === 0) return [];
-
-  return prisma.incident.findMany({
-    where: { id: { in: incidentIds } },
-    include: {
-      service: { select: { id: true, name: true } },
-      assignee: {
-        select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-      },
-    },
-  });
-}
-
 export async function bulkAcknowledge(incidentIds: string[]) {
   if (!incidentIds || incidentIds.length === 0) {
     return { success: false, error: 'No incidents selected' };
@@ -95,42 +81,8 @@ export async function bulkAcknowledge(incidentIds: string[]) {
       `Bulk acknowledged${user ? ` by ${user.name}` : ''}`
     );
 
-    const incidents = await loadIncidentsForLifecycleEffects(changedIds);
-
-    const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-    const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
-    const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-
-    await Promise.allSettled(
-      incidents.map(async incident => {
-        try {
-          await Promise.all([
-            sendIncidentNotifications(incident.id, 'acknowledged'),
-            notifyStatusPageSubscribers(incident.id, 'acknowledged'),
-            triggerWebhooksForService(incident.serviceId, 'incident.acknowledged', {
-              id: incident.id,
-              title: incident.title,
-              description: incident.description,
-              status: incident.status,
-              urgency: incident.urgency,
-              priority: incident.priority,
-              service: incident.service,
-              assignee: incident.assignee,
-              createdAt: incident.createdAt.toISOString(),
-              acknowledgedAt: incident.acknowledgedAt?.toISOString() || new Date().toISOString(),
-            }),
-          ]);
-        } catch (error) {
-          logger.error('Failed to send notifications for incident', {
-            component: 'bulk-actions',
-            action: 'acknowledge',
-            error,
-            incidentId: incident.id,
-          });
-        }
-      })
-    );
-
+    // Notifications, status-page delivery and webhooks are durable lifecycle
+    // outbox jobs committed with the batch transaction.
     revalidatePath('/incidents');
     revalidatePath('/');
     return { success: true, count: changedIds.length };
@@ -158,49 +110,6 @@ export async function bulkResolve(incidentIds: string[]) {
       'RESOLVE',
       { id: user.id, name: user.name ?? undefined },
       `Bulk resolved${user ? ` by ${user.name}` : ''}`
-    );
-
-    const incidents = await loadIncidentsForLifecycleEffects(changedIds);
-
-    const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-    const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
-    const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-    const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-
-    await Promise.allSettled(
-      incidents.map(async incident => {
-        try {
-          await Promise.all([
-            sendIncidentNotifications(incident.id, 'resolved'),
-            notifyStatusPageSubscribers(incident.id, 'resolved'),
-            archiveWarRoomChannel(incident.id).catch(error =>
-              logger.warn('[ChatOps] Failed to archive war-room channel on bulk resolve', {
-                incidentId: incident.id,
-                error,
-              })
-            ),
-            triggerWebhooksForService(incident.serviceId, 'incident.resolved', {
-              id: incident.id,
-              title: incident.title,
-              description: incident.description,
-              status: incident.status,
-              urgency: incident.urgency,
-              priority: incident.priority,
-              service: incident.service,
-              assignee: incident.assignee,
-              createdAt: incident.createdAt.toISOString(),
-              resolvedAt: incident.resolvedAt?.toISOString() || new Date().toISOString(),
-            }),
-          ]);
-        } catch (error) {
-          logger.error('Failed to send notifications for incident', {
-            component: 'bulk-actions',
-            action: 'resolve',
-            error,
-            incidentId: incident.id,
-          });
-        }
-      })
     );
 
     revalidatePath('/incidents');
@@ -522,72 +431,6 @@ export async function bulkUpdateStatus(incidentIds: string[], status: BulkLifecy
       status,
       { id: user.id, name: user.name ?? undefined },
       `Bulk status updated to ${status}${user ? ` by ${user.name}` : ''}`
-    );
-
-    const incidents = await loadIncidentsForLifecycleEffects(changedIds);
-    const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-    const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
-    const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-
-    let eventType = 'incident.updated';
-    if (status === 'RESOLVED') eventType = 'incident.resolved';
-    else if (status === 'ACKNOWLEDGED') eventType = 'incident.acknowledged';
-    else if (status === 'SNOOZED') eventType = 'incident.snoozed';
-    else if (status === 'SUPPRESSED') eventType = 'incident.suppressed';
-
-    await Promise.allSettled(
-      incidents.map(async incident => {
-        try {
-          const notificationPromises: Promise<unknown>[] = [];
-
-          if (status === 'ACKNOWLEDGED') {
-            notificationPromises.push(
-              sendIncidentNotifications(incident.id, 'acknowledged'),
-              notifyStatusPageSubscribers(incident.id, 'acknowledged')
-            );
-          } else if (status === 'RESOLVED') {
-            const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-            notificationPromises.push(
-              sendIncidentNotifications(incident.id, 'resolved'),
-              notifyStatusPageSubscribers(incident.id, 'resolved'),
-              archiveWarRoomChannel(incident.id).catch(error =>
-                logger.warn('[ChatOps] Failed to archive war-room channel on bulk status update', {
-                  incidentId: incident.id,
-                  error,
-                })
-              )
-            );
-          } else if (status === 'OPEN') {
-            notificationPromises.push(sendIncidentNotifications(incident.id, 'updated'));
-          }
-
-          notificationPromises.push(
-            triggerWebhooksForService(incident.serviceId, eventType, {
-              id: incident.id,
-              title: incident.title,
-              description: incident.description,
-              status: incident.status,
-              urgency: incident.urgency,
-              priority: incident.priority,
-              service: incident.service,
-              assignee: incident.assignee,
-              createdAt: incident.createdAt.toISOString(),
-              acknowledgedAt: incident.acknowledgedAt?.toISOString() || null,
-              resolvedAt: incident.resolvedAt?.toISOString() || null,
-            })
-          );
-
-          await Promise.all(notificationPromises);
-        } catch (error) {
-          logger.error('Failed to send notifications for incident', {
-            component: 'bulk-actions',
-            action: 'status-update',
-            error,
-            incidentId: incident.id,
-            status,
-          });
-        }
-      })
     );
 
     revalidatePath('/incidents');

--- a/src/app/(app)/incidents/snooze-actions.ts
+++ b/src/app/(app)/incidents/snooze-actions.ts
@@ -28,7 +28,9 @@ export async function snoozeIncidentWithDuration(
   const normalizedReason = reason?.trim() || null;
 
   try {
-    const result = await executeIncidentLifecycleCommand({
+    // The lifecycle transaction persists both the transition side effects and
+    // the finite AUTO_UNSNOOZE timer. There is no post-commit scheduling gap.
+    await executeIncidentLifecycleCommand({
       incidentId,
       command: 'SNOOZE',
       source: 'WEB',
@@ -37,21 +39,6 @@ export async function snoozeIncidentWithDuration(
       snoozeReason: normalizedReason,
       eventMessage: `Incident snoozed until ${formatDateTime(snoozedUntil, userTimeZone, { format: 'datetime' })}${normalizedReason ? ` (Reason: ${normalizedReason})` : ''}${user ? ` by ${user.name}` : ''}`,
     });
-
-    // Schedule only after a committed lifecycle change. PostgreSQL job delivery
-    // remains best-effort because the cron sweep also observes snoozedUntil.
-    if (result.changed) {
-      try {
-        const { scheduleAutoUnsnooze } = await import('@/lib/jobs/queue');
-        await scheduleAutoUnsnooze(incidentId, snoozedUntil);
-      } catch (error) {
-        logger.error('Failed to schedule auto-unsnooze job', {
-          component: 'snooze-actions',
-          error,
-          incidentId,
-        });
-      }
-    }
 
     revalidatePath(`/incidents/${incidentId}`);
     revalidatePath('/incidents');

--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -5,7 +5,6 @@ import { jsonError, jsonOk } from '@/lib/api-response';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { IncidentPatchSchema } from '@/lib/validation';
 import { logger } from '@/lib/logger';
-import { scheduleStatusPageNotification } from '@/lib/jobs/queue';
 import { resolveApiKeyActor } from '@/lib/authorization-actors';
 import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
 import { authorizationDecisionError } from '@/lib/api-authorization-error';
@@ -213,14 +212,17 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return jsonError(error);
   }
 
-  const { incident, lifecycle } = result;
+  const { incident, lifecycle, urgencyChanged, assigneeChanged } = result;
   logger.info('api.incident.updated', {
     incidentId: incident.id,
     apiKeyId: apiKey.id,
     changed: result.changed,
   });
 
-  if (result.changed) {
+  // Lifecycle effects are already persisted in the same transaction as the
+  // status change. Keep the existing immediate path only for a pure
+  // urgency/assignee update; a mixed PATCH emits the lifecycle event once.
+  if (!lifecycle?.changed && (urgencyChanged || assigneeChanged)) {
     try {
       const updatedIncident = await prisma.incident.findUnique({
         where: { id },
@@ -234,15 +236,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 
       if (updatedIncident) {
         const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-        let eventType = 'incident.updated';
-        if (lifecycle?.changed) {
-          if (lifecycle.status === 'RESOLVED') eventType = 'incident.resolved';
-          else if (lifecycle.status === 'ACKNOWLEDGED') eventType = 'incident.acknowledged';
-          else if (lifecycle.status === 'SNOOZED') eventType = 'incident.snoozed';
-          else if (lifecycle.status === 'SUPPRESSED') eventType = 'incident.suppressed';
-        }
-
-        await triggerWebhooksForService(updatedIncident.serviceId, eventType, {
+        await triggerWebhooksForService(updatedIncident.serviceId, 'incident.updated', {
           id: updatedIncident.id,
           title: updatedIncident.title,
           description: updatedIncident.description,
@@ -267,12 +261,8 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     }
 
     try {
-      let eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated' = 'updated';
-      if (lifecycle?.changed && lifecycle.status === 'ACKNOWLEDGED') eventType = 'acknowledged';
-      else if (lifecycle?.changed && lifecycle.status === 'RESOLVED') eventType = 'resolved';
-
       const { sendServiceNotifications } = await import('@/lib/service-notifications');
-      sendServiceNotifications(incident.id, eventType).catch(error => {
+      sendServiceNotifications(incident.id, 'updated').catch(error => {
         logger.error('api.incident.service_notification_failed', {
           error: error instanceof Error ? error.message : String(error),
           incidentId: incident.id,
@@ -280,28 +270,6 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       });
     } catch (error) {
       logger.error('api.incident.service_notification_import_failed', {
-        error: error instanceof Error ? error.message : String(error),
-        incidentId: incident.id,
-      });
-    }
-  }
-
-  if (lifecycle?.changed) {
-    try {
-      const notifyEvent =
-        lifecycle.status === 'ACKNOWLEDGED'
-          ? 'acknowledged'
-          : lifecycle.status === 'RESOLVED'
-            ? 'resolved'
-            : lifecycle.status === 'OPEN'
-              ? 'investigating'
-              : null;
-
-      if (notifyEvent) {
-        await scheduleStatusPageNotification(incident.id, notifyEvent);
-      }
-    } catch (error) {
-      logger.error('api.incident.status_page_notification_failed', {
         error: error instanceof Error ? error.message : String(error),
         incidentId: incident.id,
       });

--- a/src/app/api/slack/actions/route.ts
+++ b/src/app/api/slack/actions/route.ts
@@ -139,13 +139,12 @@ export async function handleSlackActionRequest(payload: SlackActionPayload) {
 
       // Two variants of every message: `responseMessage` goes to Slack and keeps
       // the <@ID> mention; `timelineMessage` is plain text for non-lifecycle
-      // actions. Lifecycle actions write their timeline entry atomically in the
-      // centralized lifecycle engine.
+      // actions. Lifecycle actions write their timeline entry and durable
+      // external side effects atomically in the centralized lifecycle engine.
       let responseMessage = '';
       let timelineMessage = '';
       let lifecycleRecordedTimeline = false;
-      // Mirrors the event the equivalent web console action notifies with.
-      let notifyEventType: 'acknowledged' | 'resolved' | 'updated' | null = null;
+      let notifyNonLifecycleUpdate = false;
 
       if (actionType === 'ack') {
         let result;
@@ -172,7 +171,6 @@ export async function handleSlackActionRequest(payload: SlackActionPayload) {
         }
 
         responseMessage = `👀 Incident acknowledged by <@${slackUserId || 'responder'}>`;
-        notifyEventType = 'acknowledged';
         lifecycleRecordedTimeline = true;
       } else if (actionType === 'resolve') {
         let result;
@@ -199,17 +197,7 @@ export async function handleSlackActionRequest(payload: SlackActionPayload) {
         }
 
         responseMessage = `✅ Incident resolved by <@${slackUserId || 'responder'}>`;
-        notifyEventType = 'resolved';
         lifecycleRecordedTimeline = true;
-
-        // Archive war-room channel only after a real resolve transition.
-        const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-        archiveWarRoomChannel(incidentId).catch(err => {
-          logger.error('[Slack Actions] War-room channel archive failed', {
-            error: err,
-            incidentId,
-          });
-        });
       } else if (actionType === 'assign_me') {
         if (slackUserId) {
           try {
@@ -249,7 +237,7 @@ export async function handleSlackActionRequest(payload: SlackActionPayload) {
             updateWarRoomTopic(incidentId).catch(() => {});
             responseMessage = `🙋 Incident assigned to *${targetUser.name}* (<@${slackUserId}>)`;
             timelineMessage = `Assigned to ${targetUser.name} via Slack button`;
-            notifyEventType = 'updated';
+            notifyNonLifecycleUpdate = true;
           } catch (err) {
             logger.warn('[Slack] Assign to Me failed', { error: err, incidentId });
             return NextResponse.json({
@@ -297,25 +285,13 @@ export async function handleSlackActionRequest(payload: SlackActionPayload) {
         }
 
         responseMessage = `💤 Incident snoozed for ${snoozeMinutes}m by <@${slackUserId || 'responder'}>`;
-        notifyEventType = 'updated';
         lifecycleRecordedTimeline = true;
-
-        // Prefer the durable timed job; the cron unsnooze sweep remains the fallback.
-        try {
-          const { scheduleAutoUnsnooze } = await import('@/lib/jobs/queue');
-          await scheduleAutoUnsnooze(incidentId, snoozedUntil);
-        } catch (error) {
-          logger.error('[Slack Actions] Failed to schedule auto-unsnooze', {
-            incidentId,
-            error,
-          });
-        }
       } else if (actionType === 'escalate' || actionType === 'escalate_incident') {
         const { executeEscalation } = await import('@/lib/escalation');
         await executeEscalation(incidentId);
         responseMessage = `⚡ Incident escalated by <@${slackUserId || 'responder'}>`;
         timelineMessage = `Escalated via Slack button by ${actorName}`;
-        notifyEventType = 'updated';
+        notifyNonLifecycleUpdate = true;
       } else {
         return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
       }
@@ -333,12 +309,11 @@ export async function handleSlackActionRequest(payload: SlackActionPayload) {
           .catch(() => {});
       }
 
-      // Fire-and-forget: Slack times the interaction out after 3s.
-      if (notifyEventType) {
+      // Assignment/escalation are not lifecycle transitions and retain their
+      // existing immediate notification path. Lifecycle delivery is outboxed.
+      if (notifyNonLifecycleUpdate) {
         import('@/lib/user-notifications')
-          .then(({ sendIncidentNotifications }) =>
-            sendIncidentNotifications(incidentId, notifyEventType)
-          )
+          .then(({ sendIncidentNotifications }) => sendIncidentNotifications(incidentId, 'updated'))
           .catch(err =>
             logger.error('[Slack] Failed to send notifications for button action', {
               error: err instanceof Error ? err.message : String(err),

--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -195,28 +195,7 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
         slackUser: payload.user_name,
       });
 
-      // Dispatch incident notifications only after a real lifecycle change.
-      import('@/lib/user-notifications')
-        .then(({ sendIncidentNotifications }) =>
-          sendIncidentNotifications(incident.id, 'acknowledged')
-        )
-        .catch(err =>
-          logger.error('[ChatOps] Failed to send ack notifications', {
-            error: err,
-            incidentId: incident.id,
-          })
-        );
-
-      // Update channel topic to ACKNOWLEDGED
-      try {
-        const { updateWarRoomTopic } = await import('@/lib/chatops/war-room');
-        updateWarRoomTopic(incident.id, 'ACKNOWLEDGED').catch(err =>
-          logger.warn('[ChatOps] Failed to update topic on ack', { error: err })
-        );
-      } catch (e) {
-        logger.warn('[ChatOps] Failed to load war-room module', { error: e });
-      }
-
+      // Notifications/topic updates are persisted by the lifecycle outbox.
       return {
         response_type: 'in_channel',
         text: `👀 *Incident Acknowledged* by <@${user_id}>\n_${incident.title}_`,
@@ -259,26 +238,7 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
         slackUser: payload.user_name,
       });
 
-      // Dispatch incident notifications only after a real lifecycle change.
-      import('@/lib/user-notifications')
-        .then(({ sendIncidentNotifications }) => sendIncidentNotifications(incident.id, 'resolved'))
-        .catch(err =>
-          logger.error('[ChatOps] Failed to send resolve notifications', {
-            error: err,
-            incidentId: incident.id,
-          })
-        );
-
-      // Archive war-room channel on resolve
-      try {
-        const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-        archiveWarRoomChannel(incident.id).catch(err =>
-          logger.warn('[ChatOps] Failed to archive war-room after slash resolve', { error: err })
-        );
-      } catch (e) {
-        logger.warn('[ChatOps] Failed to load war-room module', { error: e });
-      }
-
+      // Notifications/archive are persisted by the lifecycle outbox.
       return {
         response_type: 'in_channel',
         text: `✅ *Incident Resolved* by <@${user_id}>\n_${resolution}_`,

--- a/src/lib/event-outbox.ts
+++ b/src/lib/event-outbox.ts
@@ -1,4 +1,8 @@
-import { Prisma } from '@prisma/client';
+import { IncidentStatus, Prisma } from '@prisma/client';
+import type {
+  IncidentLifecycleCommand,
+  IncidentLifecycleSource,
+} from './incidents/lifecycle';
 
 export type EventOutboxAction = 'triggered' | 'resolved' | 'acknowledged';
 
@@ -9,9 +13,31 @@ export type EventSideEffect =
   | 'RESOLVE_WEBHOOK'
   | 'RESOLVE_SLACK'
   | 'RESOLVE_WAR_ROOM_ARCHIVE'
-  | 'ACK_SLACK';
+  | 'ACK_SLACK'
+  | 'LIFECYCLE_USER_NOTIFICATION'
+  | 'LIFECYCLE_SERVICE_NOTIFICATION'
+  | 'LIFECYCLE_STATUS_PAGE'
+  | 'LIFECYCLE_WEBHOOK'
+  | 'LIFECYCLE_WAR_ROOM_SYNC'
+  | 'LIFECYCLE_WAR_ROOM_TOPIC'
+  | 'LIFECYCLE_WAR_ROOM_ARCHIVE';
 
-export type EventSideEffectLane = 'WEBHOOK' | 'ESCALATION' | 'WAR_ROOM' | 'SLACK';
+export type EventSideEffectLane =
+  | 'WEBHOOK'
+  | 'ESCALATION'
+  | 'WAR_ROOM'
+  | 'SLACK'
+  | 'NOTIFICATION'
+  | 'STATUS_PAGE';
+
+export interface LifecycleSideEffectContext {
+  command: IncidentLifecycleCommand;
+  source: IncidentLifecycleSource;
+  previousStatus: IncidentStatus;
+  status: IncidentStatus;
+  transitionAt: string;
+  snoozedUntil: string | null;
+}
 
 export interface EventSideEffectPayload {
   task: 'EVENT_SIDE_EFFECT';
@@ -19,6 +45,17 @@ export interface EventSideEffectPayload {
   lane: EventSideEffectLane;
   incidentId: string;
   eventOrderAt: string;
+  lifecycle?: LifecycleSideEffectContext;
+}
+
+export interface LifecycleOutboxInput {
+  incidentId: string;
+  command: IncidentLifecycleCommand;
+  source: IncidentLifecycleSource;
+  previousStatus: IncidentStatus;
+  status: IncidentStatus;
+  transitionAt: Date;
+  snoozedUntil?: Date | null;
 }
 
 export function getEventSideEffects(action: EventOutboxAction): readonly EventSideEffect[] {
@@ -32,45 +69,134 @@ export function getEventSideEffects(action: EventOutboxAction): readonly EventSi
   }
 }
 
+/**
+ * Preserve the side-effect semantics each adapter had before lifecycle
+ * centralization while making delivery durable. The domain engine owns when a
+ * transition happened; this mapping owns which external systems should hear
+ * about that committed transition.
+ */
+export function getLifecycleSideEffects(
+  input: Pick<LifecycleOutboxInput, 'command' | 'source' | 'status'>
+): readonly EventSideEffect[] {
+  const effects = new Set<EventSideEffect>();
+
+  // Event ingestion already persists its ACK/RESOLVE effects through the same
+  // EVENT_SIDE_EFFECT envelope in events.ts. Keep that existing owner until the
+  // creation/trigger outbox is generalized so event jobs are not duplicated.
+  if (input.source === 'EVENT') return [];
+
+  if (input.source === 'WEB' || input.source === 'MOBILE') {
+    effects.add('LIFECYCLE_STATUS_PAGE');
+    effects.add('LIFECYCLE_WEBHOOK');
+
+    if (
+      input.status === 'ACKNOWLEDGED' ||
+      input.status === 'RESOLVED' ||
+      input.status === 'OPEN'
+    ) {
+      effects.add('LIFECYCLE_USER_NOTIFICATION');
+    }
+
+    if (input.status === 'RESOLVED') {
+      effects.add('LIFECYCLE_WAR_ROOM_ARCHIVE');
+    } else {
+      effects.add('LIFECYCLE_WAR_ROOM_SYNC');
+    }
+    return Array.from(effects);
+  }
+
+  if (input.source === 'BULK') {
+    effects.add('LIFECYCLE_WEBHOOK');
+    if (
+      input.status === 'ACKNOWLEDGED' ||
+      input.status === 'RESOLVED' ||
+      input.status === 'OPEN'
+    ) {
+      effects.add('LIFECYCLE_USER_NOTIFICATION');
+    }
+    if (input.status === 'ACKNOWLEDGED' || input.status === 'RESOLVED') {
+      effects.add('LIFECYCLE_STATUS_PAGE');
+    }
+    if (input.status === 'RESOLVED') effects.add('LIFECYCLE_WAR_ROOM_ARCHIVE');
+    return Array.from(effects);
+  }
+
+  if (input.source === 'REST_API') {
+    effects.add('LIFECYCLE_SERVICE_NOTIFICATION');
+    effects.add('LIFECYCLE_WEBHOOK');
+    if (
+      input.status === 'ACKNOWLEDGED' ||
+      input.status === 'RESOLVED' ||
+      input.status === 'OPEN'
+    ) {
+      effects.add('LIFECYCLE_STATUS_PAGE');
+    }
+    return Array.from(effects);
+  }
+
+  if (input.source === 'CHATOPS') {
+    if (
+      input.status === 'ACKNOWLEDGED' ||
+      input.status === 'RESOLVED' ||
+      input.status === 'SNOOZED'
+    ) {
+      effects.add('LIFECYCLE_USER_NOTIFICATION');
+    }
+    if (input.status === 'ACKNOWLEDGED') effects.add('LIFECYCLE_WAR_ROOM_TOPIC');
+    if (input.status === 'RESOLVED') effects.add('LIFECYCLE_WAR_ROOM_ARCHIVE');
+    return Array.from(effects);
+  }
+
+  if (input.source === 'SYSTEM' && input.status === 'OPEN') {
+    effects.add('LIFECYCLE_USER_NOTIFICATION');
+    effects.add('LIFECYCLE_STATUS_PAGE');
+    effects.add('LIFECYCLE_WEBHOOK');
+  }
+
+  return Array.from(effects);
+}
+
 function getEventSideEffectLane(effect: EventSideEffect): EventSideEffectLane {
   switch (effect) {
     case 'TRIGGER_WEBHOOK':
     case 'RESOLVE_WEBHOOK':
+    case 'LIFECYCLE_WEBHOOK':
       return 'WEBHOOK';
     case 'TRIGGER_ESCALATION_NOTIFICATIONS':
       return 'ESCALATION';
     case 'TRIGGER_WAR_ROOM':
     case 'RESOLVE_WAR_ROOM_ARCHIVE':
+    case 'LIFECYCLE_WAR_ROOM_SYNC':
+    case 'LIFECYCLE_WAR_ROOM_TOPIC':
+    case 'LIFECYCLE_WAR_ROOM_ARCHIVE':
       return 'WAR_ROOM';
     case 'RESOLVE_SLACK':
     case 'ACK_SLACK':
       return 'SLACK';
+    case 'LIFECYCLE_USER_NOTIFICATION':
+    case 'LIFECYCLE_SERVICE_NOTIFICATION':
+      return 'NOTIFICATION';
+    case 'LIFECYCLE_STATUS_PAGE':
+      return 'STATUS_PAGE';
   }
 }
 
-/**
- * Persist event side-effects in the same database transaction as the incident
- * state change. The existing SCHEDULED_TASK job type is intentionally used as
- * the durable internal outbox envelope so self-hosted installs do not require
- * Redis, Kafka, or another queueing service.
- *
- * A PostgreSQL clock timestamp is captured after the event's advisory lock is
- * acquired. Workers use this value to preserve lifecycle order within a single
- * incident/lane (for example created webhook before resolved webhook), while
- * independent lanes remain free to execute concurrently.
- */
-export async function enqueueEventSideEffects(
-  tx: Prisma.TransactionClient,
-  action: EventOutboxAction,
-  incidentId: string
-): Promise<void> {
-  const effects = getEventSideEffects(action);
-  if (effects.length === 0) return;
-
-  const [databaseClock] = await tx.$queryRaw<Array<{ now: Date }>>`
+async function databaseClock(tx: Prisma.TransactionClient): Promise<Date> {
+  const [clock] = await tx.$queryRaw<Array<{ now: Date }>>`
     SELECT clock_timestamp() AS "now"
   `;
-  const eventOrderAt = databaseClock?.now ?? new Date();
+  return clock?.now ?? new Date();
+}
+
+async function enqueueSideEffects(
+  tx: Prisma.TransactionClient,
+  incidentId: string,
+  effects: readonly EventSideEffect[],
+  lifecycle?: LifecycleSideEffectContext
+): Promise<void> {
+  if (effects.length === 0) return;
+
+  const eventOrderAt = await databaseClock(tx);
   const eventOrderAtIso = eventOrderAt.toISOString();
 
   await tx.backgroundJob.createMany({
@@ -85,7 +211,59 @@ export async function enqueueEventSideEffects(
         lane: getEventSideEffectLane(effect),
         incidentId,
         eventOrderAt: eventOrderAtIso,
+        ...(lifecycle ? { lifecycle } : {}),
       } satisfies EventSideEffectPayload,
     })),
   });
+}
+
+/**
+ * Persist event-ingestion side-effects in the same database transaction as the
+ * incident state change/creation. The existing SCHEDULED_TASK job type is the
+ * durable internal outbox envelope, so self-hosted installs need no extra
+ * queueing infrastructure.
+ */
+export async function enqueueEventSideEffects(
+  tx: Prisma.TransactionClient,
+  action: EventOutboxAction,
+  incidentId: string
+): Promise<void> {
+  await enqueueSideEffects(tx, incidentId, getEventSideEffects(action));
+}
+
+/**
+ * Persist lifecycle side-effects atomically with a real lifecycle transition.
+ * Idempotent lifecycle no-ops never call this function, so retries do not
+ * create duplicate outbox work.
+ *
+ * Finite snoozes also persist their AUTO_UNSNOOZE timer in the same transaction
+ * rather than relying on a post-commit scheduling call. The cron sweep remains
+ * a safety net for old/missing jobs.
+ */
+export async function enqueueLifecycleSideEffects(
+  tx: Prisma.TransactionClient,
+  input: LifecycleOutboxInput
+): Promise<void> {
+  const lifecycle: LifecycleSideEffectContext = {
+    command: input.command,
+    source: input.source,
+    previousStatus: input.previousStatus,
+    status: input.status,
+    transitionAt: input.transitionAt.toISOString(),
+    snoozedUntil: input.snoozedUntil?.toISOString() ?? null,
+  };
+
+  await enqueueSideEffects(tx, input.incidentId, getLifecycleSideEffects(input), lifecycle);
+
+  if (input.command === 'SNOOZE' && input.snoozedUntil) {
+    await tx.backgroundJob.create({
+      data: {
+        type: 'AUTO_UNSNOOZE',
+        status: 'PENDING',
+        scheduledAt: input.snoozedUntil,
+        maxAttempts: 3,
+        payload: { incidentId: input.incidentId },
+      },
+    });
+  }
 }

--- a/src/lib/event-outbox.ts
+++ b/src/lib/event-outbox.ts
@@ -1,8 +1,5 @@
 import { IncidentStatus, Prisma } from '@prisma/client';
-import type {
-  IncidentLifecycleCommand,
-  IncidentLifecycleSource,
-} from './incidents/lifecycle';
+import type { IncidentLifecycleCommand, IncidentLifecycleSource } from './incidents/lifecycle';
 
 export type EventOutboxAction = 'triggered' | 'resolved' | 'acknowledged';
 
@@ -89,11 +86,7 @@ export function getLifecycleSideEffects(
     effects.add('LIFECYCLE_STATUS_PAGE');
     effects.add('LIFECYCLE_WEBHOOK');
 
-    if (
-      input.status === 'ACKNOWLEDGED' ||
-      input.status === 'RESOLVED' ||
-      input.status === 'OPEN'
-    ) {
+    if (input.status === 'ACKNOWLEDGED' || input.status === 'RESOLVED' || input.status === 'OPEN') {
       effects.add('LIFECYCLE_USER_NOTIFICATION');
     }
 
@@ -107,11 +100,7 @@ export function getLifecycleSideEffects(
 
   if (input.source === 'BULK') {
     effects.add('LIFECYCLE_WEBHOOK');
-    if (
-      input.status === 'ACKNOWLEDGED' ||
-      input.status === 'RESOLVED' ||
-      input.status === 'OPEN'
-    ) {
+    if (input.status === 'ACKNOWLEDGED' || input.status === 'RESOLVED' || input.status === 'OPEN') {
       effects.add('LIFECYCLE_USER_NOTIFICATION');
     }
     if (input.status === 'ACKNOWLEDGED' || input.status === 'RESOLVED') {
@@ -124,11 +113,7 @@ export function getLifecycleSideEffects(
   if (input.source === 'REST_API') {
     effects.add('LIFECYCLE_SERVICE_NOTIFICATION');
     effects.add('LIFECYCLE_WEBHOOK');
-    if (
-      input.status === 'ACKNOWLEDGED' ||
-      input.status === 'RESOLVED' ||
-      input.status === 'OPEN'
-    ) {
+    if (input.status === 'ACKNOWLEDGED' || input.status === 'RESOLVED' || input.status === 'OPEN') {
       effects.add('LIFECYCLE_STATUS_PAGE');
     }
     return Array.from(effects);
@@ -211,8 +196,19 @@ async function enqueueSideEffects(
         lane: getEventSideEffectLane(effect),
         incidentId,
         eventOrderAt: eventOrderAtIso,
-        ...(lifecycle ? { lifecycle } : {}),
-      } satisfies EventSideEffectPayload,
+        ...(lifecycle
+          ? {
+              lifecycle: {
+                command: lifecycle.command,
+                source: lifecycle.source,
+                previousStatus: lifecycle.previousStatus,
+                status: lifecycle.status,
+                transitionAt: lifecycle.transitionAt,
+                snoozedUntil: lifecycle.snoozedUntil,
+              },
+            }
+          : {}),
+      } satisfies EventSideEffectPayload & Prisma.InputJsonObject,
     })),
   });
 }

--- a/src/lib/event-side-effects.ts
+++ b/src/lib/event-side-effects.ts
@@ -2,7 +2,7 @@ import prisma from './prisma';
 import { executeEscalation } from './notifications';
 import { notifySlackForIncident } from './slack';
 import { logger } from './logger';
-import type { EventSideEffectPayload } from './event-outbox';
+import type { EventSideEffectPayload, LifecycleSideEffectContext } from './event-outbox';
 
 export function escalationNotificationRoute(result: {
   escalated?: boolean;
@@ -31,7 +31,6 @@ async function sendEventWebhook(
     },
   });
 
-  // Incident deletion makes the side-effect obsolete rather than retryable.
   if (!incident) {
     logger.info('event.outbox.incident_missing', { incidentId: payload.incidentId, eventType });
     return;
@@ -42,9 +41,6 @@ async function sendEventWebhook(
     id: incident.id,
     title: incident.title,
     description: incident.description,
-    // The job can run after a later incident transition has committed. Preserve
-    // the lifecycle state represented by this durable event rather than leaking
-    // a newer current status into an older webhook.
     status: eventType === 'incident.created' ? 'OPEN' : 'RESOLVED',
     urgency: incident.urgency,
     priority: incident.priority,
@@ -72,9 +68,6 @@ async function runTriggerEscalationAndNotifications(incidentId: string): Promise
   try {
     escalationResult = await executeEscalation(incidentId);
   } catch (error) {
-    // Preserve the previous fallback only for an escalation execution failure.
-    // Notification-provider failures below must escape to the durable queue so
-    // they are retried instead of immediately entering a second send path.
     logger.error('event.outbox.escalation_failed', {
       incidentId,
       error: error instanceof Error ? error.message : String(error),
@@ -99,6 +92,124 @@ async function runTriggerEscalationAndNotifications(incidentId: string): Promise
     route,
     latencyMs: performance.now() - startedAt,
   });
+}
+
+function lifecycleContext(payload: EventSideEffectPayload): LifecycleSideEffectContext {
+  if (!payload.lifecycle) {
+    throw new Error(`Lifecycle context missing for ${payload.effect}`);
+  }
+  return payload.lifecycle;
+}
+
+function lifecycleNotificationEvent(
+  lifecycle: LifecycleSideEffectContext
+): 'acknowledged' | 'resolved' | 'updated' {
+  if (lifecycle.status === 'ACKNOWLEDGED') return 'acknowledged';
+  if (lifecycle.status === 'RESOLVED') return 'resolved';
+  return 'updated';
+}
+
+function lifecycleStatusPageEvent(
+  lifecycle: LifecycleSideEffectContext
+): 'acknowledged' | 'resolved' | 'investigating' | 'snoozed' | 'suppressed' {
+  switch (lifecycle.status) {
+    case 'ACKNOWLEDGED':
+      return 'acknowledged';
+    case 'RESOLVED':
+      return 'resolved';
+    case 'OPEN':
+      return 'investigating';
+    case 'SNOOZED':
+      return 'snoozed';
+    case 'SUPPRESSED':
+      return 'suppressed';
+  }
+}
+
+function lifecycleWebhookEvent(lifecycle: LifecycleSideEffectContext): string {
+  switch (lifecycle.status) {
+    case 'ACKNOWLEDGED':
+      return 'incident.acknowledged';
+    case 'RESOLVED':
+      return 'incident.resolved';
+    case 'SNOOZED':
+      return 'incident.snoozed';
+    case 'SUPPRESSED':
+      return 'incident.suppressed';
+    case 'OPEN':
+      return 'incident.updated';
+  }
+}
+
+async function sendLifecycleWebhook(payload: EventSideEffectPayload): Promise<void> {
+  const lifecycle = lifecycleContext(payload);
+  const incident = await prisma.incident.findUnique({
+    where: { id: payload.incidentId },
+    include: {
+      service: { select: { id: true, name: true } },
+      assignee: {
+        select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
+      },
+    },
+  });
+
+  if (!incident) {
+    logger.info('lifecycle.outbox.incident_missing', {
+      incidentId: payload.incidentId,
+      effect: payload.effect,
+    });
+    return;
+  }
+
+  if (
+    (lifecycle.source === 'WEB' || lifecycle.source === 'MOBILE') &&
+    incident.visibility !== 'PUBLIC'
+  ) {
+    return;
+  }
+
+  const { triggerWebhooksForService } = await import('./status-page-webhooks');
+  const resolvedAt =
+    lifecycle.status === 'RESOLVED'
+      ? incident.resolvedAt?.toISOString() || lifecycle.transitionAt
+      : incident.resolvedAt?.toISOString() || null;
+
+  await triggerWebhooksForService(incident.serviceId, lifecycleWebhookEvent(lifecycle), {
+    id: incident.id,
+    title: incident.title,
+    description: incident.description,
+    status: lifecycle.status,
+    urgency: incident.urgency,
+    priority: incident.priority,
+    service: incident.service,
+    assignee: incident.assignee,
+    createdAt: incident.createdAt.toISOString(),
+    acknowledgedAt: incident.acknowledgedAt?.toISOString() || null,
+    resolvedAt,
+  });
+}
+
+async function syncLifecycleWarRoom(payload: EventSideEffectPayload): Promise<void> {
+  const lifecycle = lifecycleContext(payload);
+  if (lifecycle.status === 'RESOLVED') {
+    throw new Error('Resolved lifecycle transitions must use the archive effect');
+  }
+
+  const { postWarRoomUpdate, updateWarRoomTopic } = await import('./chatops/war-room');
+  const statusEmoji = {
+    ACKNOWLEDGED: '👀',
+    OPEN: '🔄',
+    SNOOZED: '😴',
+    SUPPRESSED: '🔇',
+  } as const;
+
+  await Promise.all([
+    postWarRoomUpdate(
+      payload.incidentId,
+      `${statusEmoji[lifecycle.status]} *Status updated to ${lifecycle.status}*`
+    ),
+    updateWarRoomTopic(payload.incidentId, lifecycle.status),
+  ]);
 }
 
 export async function processEventSideEffect(payload: EventSideEffectPayload): Promise<void> {
@@ -150,6 +261,55 @@ export async function processEventSideEffect(payload: EventSideEffectPayload): P
     case 'ACK_SLACK':
       await notifySlackForIncident(payload.incidentId, 'acknowledged');
       return;
+
+    case 'LIFECYCLE_USER_NOTIFICATION': {
+      const { sendIncidentNotifications } = await import('./user-notifications');
+      await sendIncidentNotifications(
+        payload.incidentId,
+        lifecycleNotificationEvent(lifecycleContext(payload))
+      );
+      return;
+    }
+
+    case 'LIFECYCLE_SERVICE_NOTIFICATION': {
+      const { sendServiceNotifications } = await import('./service-notifications');
+      await sendServiceNotifications(
+        payload.incidentId,
+        lifecycleNotificationEvent(lifecycleContext(payload))
+      );
+      return;
+    }
+
+    case 'LIFECYCLE_STATUS_PAGE': {
+      const { notifyStatusPageSubscribers } = await import('./status-page-notifications');
+      const notify = notifyStatusPageSubscribers as (
+        incidentId: string,
+        eventType: string
+      ) => Promise<void>;
+      await notify(payload.incidentId, lifecycleStatusPageEvent(lifecycleContext(payload)));
+      return;
+    }
+
+    case 'LIFECYCLE_WEBHOOK':
+      await sendLifecycleWebhook(payload);
+      return;
+
+    case 'LIFECYCLE_WAR_ROOM_SYNC':
+      await syncLifecycleWarRoom(payload);
+      return;
+
+    case 'LIFECYCLE_WAR_ROOM_TOPIC': {
+      const lifecycle = lifecycleContext(payload);
+      const { updateWarRoomTopic } = await import('./chatops/war-room');
+      await updateWarRoomTopic(payload.incidentId, lifecycle.status);
+      return;
+    }
+
+    case 'LIFECYCLE_WAR_ROOM_ARCHIVE': {
+      const { archiveWarRoomChannel } = await import('./chatops/war-room');
+      await archiveWarRoomChannel(payload.incidentId);
+      return;
+    }
   }
 
   throw new Error(

--- a/src/lib/incidents/lifecycle.ts
+++ b/src/lib/incidents/lifecycle.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import type { IncidentEventType, IncidentStatus, Prisma } from '@prisma/client';
 import { runSerializableTransaction } from '@/lib/db-utils';
 import { AppError } from '@/lib/errors';
+import { enqueueLifecycleSideEffects } from '@/lib/event-outbox';
 
 export const INCIDENT_LIFECYCLE_COMMANDS = [
   'ACKNOWLEDGE',
@@ -41,6 +42,11 @@ export interface IncidentLifecycleInput {
   snoozedUntil?: Date | null;
   snoozeReason?: string | null;
   eventMessage?: string;
+  /**
+   * Temporary compatibility seam for workflows that still own a larger
+   * creation-side-effect bundle. New lifecycle callers must use the outbox.
+   */
+  sideEffectPolicy?: 'OUTBOX' | 'CALLER_OWNED';
   /** Test seam. Production callers should use the server/DB clock. */
   now?: Date;
 }
@@ -542,6 +548,18 @@ export async function applyIncidentLifecycleCommand(
         type: 'COMMENT',
         message: `Resolution note added by ${input.actor.name?.trim() || 'responder'}`,
       },
+    });
+  }
+
+  if (input.sideEffectPolicy !== 'CALLER_OWNED') {
+    await enqueueLifecycleSideEffects(tx, {
+      incidentId: input.incidentId,
+      command: input.command,
+      source: input.source,
+      previousStatus: incident.status,
+      status: targetStatus,
+      transitionAt: now,
+      snoozedUntil: input.command === 'SNOOZE' ? input.snoozedUntil : null,
     });
   }
 

--- a/src/lib/incidents/operator-lifecycle.ts
+++ b/src/lib/incidents/operator-lifecycle.ts
@@ -9,114 +9,15 @@ import {
   getCurrentUser,
 } from '@/lib/rbac';
 import { AppError } from '@/lib/errors';
-import { logger } from '@/lib/logger';
 import {
   executeIncidentLifecycleCommand,
   transitionIncidentToStatus,
-  type IncidentLifecycleResult,
   type IncidentLifecycleSource,
 } from '@/lib/incidents/lifecycle';
 
 type OperatorLifecycleSource = Extract<IncidentLifecycleSource, 'WEB' | 'MOBILE'>;
 
-async function dispatchLifecycleSideEffects(result: IncidentLifecycleResult): Promise<void> {
-  if (!result.changed) return;
-
-  const { incidentId, status, previousStatus } = result;
-
-  try {
-    const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-    if (status === 'ACKNOWLEDGED') {
-      await sendIncidentNotifications(incidentId, 'acknowledged');
-    } else if (status === 'RESOLVED') {
-      await sendIncidentNotifications(incidentId, 'resolved');
-    } else if (status === 'OPEN' && previousStatus !== 'OPEN') {
-      await sendIncidentNotifications(incidentId, 'updated');
-    }
-  } catch (error) {
-    logger.error('Service notification failed', {
-      component: 'incident-lifecycle',
-      error,
-      incidentId,
-    });
-  }
-
-  try {
-    const { scheduleStatusPageNotification } = await import('@/lib/jobs/queue');
-    const event =
-      status === 'ACKNOWLEDGED'
-        ? 'acknowledged'
-        : status === 'RESOLVED'
-          ? 'resolved'
-          : status === 'OPEN'
-            ? 'investigating'
-            : status === 'SNOOZED'
-              ? 'snoozed'
-              : status === 'SUPPRESSED'
-                ? 'suppressed'
-                : null;
-
-    if (event) await scheduleStatusPageNotification(incidentId, event);
-  } catch (error) {
-    logger.error('Status page subscriber notification failed', {
-      component: 'incident-lifecycle',
-      error,
-      incidentId,
-    });
-  }
-
-  if (status === 'RESOLVED') {
-    try {
-      const { archiveWarRoomChannel } = await import('@/lib/chatops/war-room');
-      await archiveWarRoomChannel(incidentId);
-    } catch (error) {
-      logger.error('ChatOps war-room archive failed', {
-        component: 'incident-lifecycle',
-        error,
-        incidentId,
-      });
-    }
-  } else {
-    try {
-      const { postWarRoomUpdate, updateWarRoomTopic } = await import('@/lib/chatops/war-room');
-      const statusEmoji: Record<Exclude<IncidentStatus, 'RESOLVED'>, string> = {
-        ACKNOWLEDGED: '👀',
-        OPEN: '🔄',
-        SNOOZED: '😴',
-        SUPPRESSED: '🔇',
-      };
-
-      const [postResult, topicResult] = await Promise.allSettled([
-        postWarRoomUpdate(
-          incidentId,
-          `${statusEmoji[status as Exclude<IncidentStatus, 'RESOLVED'>]} *Status updated to ${status}*`
-        ),
-        updateWarRoomTopic(incidentId, status),
-      ]);
-
-      if (postResult.status === 'rejected') {
-        logger.error('ChatOps status sync failed', {
-          component: 'incident-lifecycle',
-          error: postResult.reason,
-          incidentId,
-        });
-      }
-      if (topicResult.status === 'rejected') {
-        logger.error('ChatOps topic sync failed', {
-          component: 'incident-lifecycle',
-          error: topicResult.reason,
-          incidentId,
-        });
-      }
-    } catch (error) {
-      logger.error('Failed to load ChatOps lifecycle handlers', {
-        component: 'incident-lifecycle',
-        error,
-        incidentId,
-      });
-    }
-  }
-
+function revalidateIncident(incidentId: string): void {
   revalidatePath(`/incidents/${incidentId}`);
   revalidatePath('/incidents');
   revalidatePath('/');
@@ -126,6 +27,7 @@ async function dispatchLifecycleSideEffects(result: IncidentLifecycleResult): Pr
  * Internal application service for human/operator lifecycle changes.
  * Authorization is deliberately performed before the domain command.
  * Typed authorization failures are allowed to cross this boundary unchanged.
+ * External effects are persisted transactionally by the lifecycle engine.
  */
 export async function updateIncidentStatus(
   id: string,
@@ -143,7 +45,7 @@ export async function updateIncidentStatus(
     source,
   });
 
-  await dispatchLifecycleSideEffects(result);
+  if (result.changed) revalidateIncident(id);
 }
 
 export async function resolveIncidentWithNote(
@@ -159,11 +61,13 @@ export async function resolveIncidentWithNote(
       code: 'INCIDENT_INVALID_ARGUMENT',
       userMessage:
         'Resolution note must be at least 10 characters. Please provide more details about how the incident was resolved.',
-      fields: [{
-        field: 'resolution',
-        code: 'too_short',
-        message: 'Resolution note must be at least 10 characters.',
-      }],
+      fields: [
+        {
+          field: 'resolution',
+          code: 'too_short',
+          message: 'Resolution note must be at least 10 characters.',
+        },
+      ],
       details: { minLength: 10 },
     });
   }
@@ -171,11 +75,13 @@ export async function resolveIncidentWithNote(
     throw new AppError({
       code: 'INCIDENT_INVALID_ARGUMENT',
       userMessage: 'Resolution note must be 1000 characters or fewer. Please shorten your description.',
-      fields: [{
-        field: 'resolution',
-        code: 'too_long',
-        message: 'Resolution note must be 1000 characters or fewer.',
-      }],
+      fields: [
+        {
+          field: 'resolution',
+          code: 'too_long',
+          message: 'Resolution note must be 1000 characters or fewer.',
+        },
+      ],
       details: { maxLength: 1000 },
     });
   }
@@ -189,5 +95,5 @@ export async function resolveIncidentWithNote(
     resolutionNote: trimmedResolution,
   });
 
-  await dispatchLifecycleSideEffects(result);
+  if (result.changed) revalidateIncident(id);
 }

--- a/src/lib/unsnooze.ts
+++ b/src/lib/unsnooze.ts
@@ -12,60 +12,6 @@ export type AutoUnsnoozeResult =
 
 const AUTO_UNSNOOZE_EVENT_MESSAGE = 'Incident auto-unsnoozed (snooze duration expired)';
 
-async function dispatchAutoUnsnoozeSideEffects(incidentId: string): Promise<void> {
-  try {
-    const updatedIncident = await prisma.incident.findUnique({
-      where: { id: incidentId },
-      include: {
-        service: { select: { id: true, name: true } },
-        assignee: {
-          select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
-        },
-      },
-    });
-
-    // A concurrent operator may have changed the incident again after the
-    // lifecycle transaction committed. Do not emit stale OPEN side effects.
-    if (!updatedIncident || updatedIncident.status !== 'OPEN') return;
-
-    const { sendIncidentNotifications } = await import('@/lib/user-notifications');
-    const { notifyStatusPageSubscribers } = await import('@/lib/status-page-notifications');
-    const { triggerWebhooksForService } = await import('@/lib/status-page-webhooks');
-
-    await Promise.all([
-      sendIncidentNotifications(incidentId, 'updated'),
-      notifyStatusPageSubscribers(incidentId, 'investigating'),
-      triggerWebhooksForService(updatedIncident.serviceId, 'incident.updated', {
-        id: updatedIncident.id,
-        title: updatedIncident.title,
-        description: updatedIncident.description,
-        status: updatedIncident.status,
-        urgency: updatedIncident.urgency,
-        priority: updatedIncident.priority,
-        service: updatedIncident.service,
-        assignee: updatedIncident.assignee,
-        createdAt: updatedIncident.createdAt.toISOString(),
-        acknowledgedAt: updatedIncident.acknowledgedAt?.toISOString() || null,
-        resolvedAt: updatedIncident.resolvedAt?.toISOString() || null,
-      }),
-    ]);
-  } catch (error) {
-    logger.error('Failed to notify after auto-unsnooze', {
-      component: 'unsnooze',
-      incidentId,
-      error,
-    });
-  }
-}
-
-/**
- * Attempts one system-driven unsnooze.
- *
- * The expiry check and lifecycle transition intentionally run inside the same
- * serializable transaction. If an operator extends the snooze concurrently,
- * PostgreSQL forces the transaction to retry and the fresh deadline is
- * observed instead of reopening the incident from stale state.
- */
 export async function attemptAutoUnsnoozeInternal(
   incidentId: string,
   now: Date = new Date()
@@ -98,23 +44,16 @@ export async function attemptAutoUnsnoozeInternal(
 }
 
 /**
- * Worker-safe one-incident adapter. Side effects are emitted only after a real
- * lifecycle transition and never for idempotent retries or stale jobs.
+ * Worker-safe one-incident adapter. The lifecycle transaction already persists
+ * the timeline entry and durable side-effect work before it commits.
  */
 export async function processAutoUnsnoozeIncidentInternal(
   incidentId: string,
   now: Date = new Date()
 ): Promise<AutoUnsnoozeResult> {
-  const result = await attemptAutoUnsnoozeInternal(incidentId, now);
-  if (result.outcome === 'changed') {
-    await dispatchAutoUnsnoozeSideEffects(incidentId);
-  }
-  return result;
+  return attemptAutoUnsnoozeInternal(incidentId, now);
 }
 
-/**
- * Process expired incident snoozes (background cron safe - no request headers required).
- */
 export async function processAutoUnsnoozeInternal(): Promise<{ processed: number }> {
   const now = new Date();
   const incidentsToUnsnooze = await prisma.incident.findMany({

--- a/tests/actions/incident-status-idempotency.test.ts
+++ b/tests/actions/incident-status-idempotency.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   assertCanModifyIncident: vi.fn(),
   assertCanAcknowledgeIncident: vi.fn(),
   getCurrentUser: vi.fn(),
+  enqueueLifecycleSideEffects: vi.fn(),
   sendIncidentNotifications: vi.fn(),
   scheduleStatusPageNotification: vi.fn(),
   archiveWarRoomChannel: vi.fn(),
@@ -20,6 +21,10 @@ vi.mock('@/lib/prisma', () => ({
 
 vi.mock('@/lib/db-utils', () => ({
   runSerializableTransaction: mocks.runSerializableTransaction,
+}));
+
+vi.mock('@/lib/event-outbox', () => ({
+  enqueueLifecycleSideEffects: mocks.enqueueLifecycleSideEffects,
 }));
 
 vi.mock('@/lib/rbac', () => ({
@@ -45,14 +50,14 @@ vi.mock('next/cache', () => ({
   revalidatePath: mocks.revalidatePath,
 }));
 
+// These mocks intentionally remain as regression tripwires: lifecycle action
+// adapters must no longer dispatch external work directly after commit.
 vi.mock('@/lib/user-notifications', () => ({
   sendIncidentNotifications: mocks.sendIncidentNotifications,
 }));
-
 vi.mock('@/lib/jobs/queue', () => ({
   scheduleStatusPageNotification: mocks.scheduleStatusPageNotification,
 }));
-
 vi.mock('@/lib/chatops/war-room', () => ({
   archiveWarRoomChannel: mocks.archiveWarRoomChannel,
   postWarRoomUpdate: mocks.postWarRoomUpdate,
@@ -84,17 +89,13 @@ describe('incident lifecycle action idempotency', () => {
     vi.clearAllMocks();
     mocks.assertCanModifyIncident.mockResolvedValue(undefined);
     mocks.getCurrentUser.mockResolvedValue({ id: 'user-1', name: 'Responder' });
-    mocks.sendIncidentNotifications.mockResolvedValue({ success: true });
-    mocks.scheduleStatusPageNotification.mockResolvedValue(undefined);
-    mocks.archiveWarRoomChannel.mockResolvedValue(undefined);
-    mocks.postWarRoomUpdate.mockResolvedValue(undefined);
-    mocks.updateWarRoomTopic.mockResolvedValue(undefined);
+    mocks.enqueueLifecycleSideEffects.mockResolvedValue(undefined);
     mocks.runSerializableTransaction.mockImplementation(async (callback: TransactionCallback) =>
       callback(tx)
     );
   });
 
-  it('does not repeat side effects when ACK is retried after it already committed', async () => {
+  it('does not enqueue or dispatch side effects when ACK is retried after it already committed', async () => {
     tx.incident.findUnique.mockResolvedValue({
       status: 'ACKNOWLEDGED',
       acknowledgedAt: new Date(),
@@ -105,6 +106,7 @@ describe('incident lifecycle action idempotency', () => {
     await updateIncidentStatus('inc-1', 'ACKNOWLEDGED', 'OPEN');
 
     expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(mocks.enqueueLifecycleSideEffects).not.toHaveBeenCalled();
     expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
     expect(mocks.scheduleStatusPageNotification).not.toHaveBeenCalled();
     expect(mocks.postWarRoomUpdate).not.toHaveBeenCalled();
@@ -124,13 +126,14 @@ describe('incident lifecycle action idempotency', () => {
     expect(tx.incident.update).not.toHaveBeenCalled();
     expect(tx.incidentNote.create).not.toHaveBeenCalled();
     expect(tx.incidentEvent.create).not.toHaveBeenCalled();
+    expect(mocks.enqueueLifecycleSideEffects).not.toHaveBeenCalled();
     expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
     expect(mocks.scheduleStatusPageNotification).not.toHaveBeenCalled();
     expect(mocks.archiveWarRoomChannel).not.toHaveBeenCalled();
     expect(mocks.revalidatePath).not.toHaveBeenCalled();
   });
 
-  it('still runs lifecycle effects for a real status transition', async () => {
+  it('persists durable side-effect work for a real status transition without inline network dispatch', async () => {
     tx.incident.findUnique.mockResolvedValue({
       status: 'OPEN',
       acknowledgedAt: null,
@@ -142,9 +145,11 @@ describe('incident lifecycle action idempotency', () => {
     await updateIncidentStatus('inc-1', 'ACKNOWLEDGED', 'OPEN');
 
     expect(tx.incident.update).toHaveBeenCalledOnce();
-    expect(mocks.sendIncidentNotifications).toHaveBeenCalledWith('inc-1', 'acknowledged');
-    expect(mocks.scheduleStatusPageNotification).toHaveBeenCalledWith('inc-1', 'acknowledged');
-    expect(mocks.postWarRoomUpdate).toHaveBeenCalledOnce();
-    expect(mocks.updateWarRoomTopic).toHaveBeenCalledWith('inc-1', 'ACKNOWLEDGED');
+    expect(mocks.enqueueLifecycleSideEffects).toHaveBeenCalledOnce();
+    expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
+    expect(mocks.scheduleStatusPageNotification).not.toHaveBeenCalled();
+    expect(mocks.postWarRoomUpdate).not.toHaveBeenCalled();
+    expect(mocks.updateWarRoomTopic).not.toHaveBeenCalled();
+    expect(mocks.revalidatePath).toHaveBeenCalled();
   });
 });

--- a/tests/api/incident-patch-lifecycle.test.ts
+++ b/tests/api/incident-patch-lifecycle.test.ts
@@ -8,7 +8,6 @@ const mocks = vi.hoisted(() => ({
   resolveApiKeyActor: vi.fn(),
   authorize: vi.fn(),
   applyRestIncidentPatch: vi.fn(),
-  scheduleStatusPageNotification: vi.fn(),
   sendServiceNotifications: vi.fn(),
   triggerWebhooksForService: vi.fn(),
   incidentFindUnique: vi.fn(),
@@ -26,9 +25,6 @@ vi.mock('@/lib/authorization-policy', () => ({
 }));
 vi.mock('@/lib/incidents/rest-patch', () => ({
   applyRestIncidentPatch: mocks.applyRestIncidentPatch,
-}));
-vi.mock('@/lib/jobs/queue', () => ({
-  scheduleStatusPageNotification: mocks.scheduleStatusPageNotification,
 }));
 vi.mock('@/lib/service-notifications', () => ({
   sendServiceNotifications: mocks.sendServiceNotifications,
@@ -88,11 +84,10 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
     });
     mocks.authorize.mockReturnValue({ allowed: true, scope: 'global' });
     mocks.sendServiceNotifications.mockResolvedValue({ success: true });
-    mocks.scheduleStatusPageNotification.mockResolvedValue(undefined);
     mocks.triggerWebhooksForService.mockResolvedValue(undefined);
   });
 
-  it('routes status changes through the REST lifecycle transaction and dispatches changed-only effects', async () => {
+  it('routes status changes through the REST lifecycle transaction without post-commit lifecycle dispatch', async () => {
     const patchedIncident = incident('ACKNOWLEDGED');
     mocks.applyRestIncidentPatch.mockResolvedValue({
       incident: patchedIncident,
@@ -107,11 +102,6 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
       urgencyChanged: false,
       assigneeChanged: false,
       changed: true,
-    });
-    mocks.incidentFindUnique.mockResolvedValue({
-      ...patchedIncident,
-      service: { id: 'svc-1', name: 'Database' },
-      assignee: null,
     });
 
     const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {
@@ -130,13 +120,38 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
       hasAssigneeUpdate: false,
       actor: { id: 'user-1' },
     });
+    expect(mocks.incidentFindUnique).not.toHaveBeenCalled();
+    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
+    expect(mocks.sendServiceNotifications).not.toHaveBeenCalled();
+  });
+
+  it('keeps immediate updated effects for a pure non-lifecycle urgency patch', async () => {
+    const patchedIncident = { ...incident('OPEN'), urgency: 'HIGH' };
+    mocks.applyRestIncidentPatch.mockResolvedValue({
+      incident: patchedIncident,
+      lifecycle: null,
+      urgencyChanged: true,
+      assigneeChanged: false,
+      changed: true,
+    });
+    mocks.incidentFindUnique.mockResolvedValue({
+      ...patchedIncident,
+      service: { id: 'svc-1', name: 'Database' },
+      assignee: null,
+    });
+
+    const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {
+      urgency: 'HIGH',
+    });
+    const res = await PATCH(req, context);
+
+    expect(res.status).toBe(200);
     expect(mocks.triggerWebhooksForService).toHaveBeenCalledWith(
       'svc-1',
-      'incident.acknowledged',
-      expect.objectContaining({ id: 'inc-1', status: 'ACKNOWLEDGED' })
+      'incident.updated',
+      expect.objectContaining({ id: 'inc-1', status: 'OPEN' })
     );
-    expect(mocks.sendServiceNotifications).toHaveBeenCalledWith('inc-1', 'acknowledged');
-    expect(mocks.scheduleStatusPageNotification).toHaveBeenCalledWith('inc-1', 'acknowledged');
+    expect(mocks.sendServiceNotifications).toHaveBeenCalledWith('inc-1', 'updated');
   });
 
   it('does not repeat lifecycle side effects for an idempotent status retry', async () => {
@@ -164,7 +179,6 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
     expect(mocks.incidentFindUnique).not.toHaveBeenCalled();
     expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
     expect(mocks.sendServiceNotifications).not.toHaveBeenCalled();
-    expect(mocks.scheduleStatusPageNotification).not.toHaveBeenCalled();
   });
 
   it('returns the typed lifecycle validation contract at the API boundary', async () => {

--- a/tests/api/slack-actions-lifecycle.test.ts
+++ b/tests/api/slack-actions-lifecycle.test.ts
@@ -5,8 +5,6 @@ import {
   chatOpsLifecycleErrorMessage,
   executeChatOpsLifecycleCommand,
 } from '@/lib/incidents/chatops-lifecycle';
-import { scheduleAutoUnsnooze } from '@/lib/jobs/queue';
-import { sendIncidentNotifications } from '@/lib/user-notifications';
 
 vi.mock('@/lib/prisma', () => ({
   default: {
@@ -47,16 +45,7 @@ vi.mock('@/lib/incidents/chatops-lifecycle', () => ({
   ),
 }));
 
-vi.mock('@/lib/jobs/queue', () => ({
-  scheduleAutoUnsnooze: vi.fn().mockResolvedValue('job-1'),
-}));
-
-vi.mock('@/lib/user-notifications', () => ({
-  sendIncidentNotifications: vi.fn().mockResolvedValue({ success: true }),
-}));
-
 vi.mock('@/lib/chatops/war-room', () => ({
-  archiveWarRoomChannel: vi.fn().mockResolvedValue(undefined),
   updateWarRoomTopic: vi.fn().mockResolvedValue(undefined),
   slackApiCall: vi.fn().mockResolvedValue({ ok: true }),
 }));
@@ -123,7 +112,7 @@ describe('Slack interactive lifecycle actions', () => {
     expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
   });
 
-  it('does not repeat notifications for an idempotent lifecycle retry', async () => {
+  it('keeps an idempotent lifecycle retry side-effect free at the adapter', async () => {
     vi.mocked(executeChatOpsLifecycleCommand).mockResolvedValue({
       incidentId: 'inc-1',
       command: 'ACKNOWLEDGE',
@@ -137,10 +126,10 @@ describe('Slack interactive lifecycle actions', () => {
     const body = await response.json();
 
     expect(body.text).toContain('already acknowledged');
-    expect(sendIncidentNotifications).not.toHaveBeenCalled();
+    expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
   });
 
-  it('routes resolve through the lifecycle adapter', async () => {
+  it('routes resolve through the lifecycle adapter without post-commit lifecycle work', async () => {
     const response = await handleSlackActionRequest(payload('resolve'));
     const body = await response.json();
 
@@ -154,7 +143,7 @@ describe('Slack interactive lifecycle actions', () => {
     expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
   });
 
-  it('routes snooze through the lifecycle adapter and schedules durable auto-unsnooze', async () => {
+  it('routes snooze through the lifecycle adapter with the durable timer owned by the lifecycle transaction', async () => {
     const before = Date.now();
     const response = await handleSlackActionRequest(payload('snooze', { minutes: 30 }));
     const body = await response.json();
@@ -171,7 +160,6 @@ describe('Slack interactive lifecycle actions', () => {
     );
     const call = vi.mocked(executeChatOpsLifecycleCommand).mock.calls[0]?.[0];
     expect(call?.snoozedUntil?.getTime()).toBeGreaterThanOrEqual(before + 30 * 60 * 1000);
-    expect(scheduleAutoUnsnooze).toHaveBeenCalledWith('inc-1', call?.snoozedUntil);
     expect(prisma.incidentEvent.create).not.toHaveBeenCalled();
   });
 

--- a/tests/lib/bulk-actions.test.ts
+++ b/tests/lib/bulk-actions.test.ts
@@ -103,9 +103,7 @@ describe('Bulk Actions', () => {
         }),
       ]);
       expect(prisma.incident.updateMany).not.toHaveBeenCalled();
-      expect(prisma.incident.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: { in: ['incident-1'] } } })
-      );
+      expect(prisma.incident.findMany).not.toHaveBeenCalled();
     });
 
     it('returns an error if no incidents are selected', async () => {

--- a/tests/lib/event-side-effects.test.ts
+++ b/tests/lib/event-side-effects.test.ts
@@ -34,6 +34,10 @@ vi.mock('@/lib/status-page-webhooks', () => ({
   triggerWebhooksForService: vi.fn(),
 }));
 
+vi.mock('@/lib/status-page-notifications', () => ({
+  notifyStatusPageSubscribers: vi.fn(),
+}));
+
 vi.mock('@/lib/slack', () => ({
   notifySlackForIncident: vi.fn(),
 }));
@@ -50,6 +54,8 @@ vi.mock('@/lib/prisma', () => ({
 vi.mock('@/lib/chatops/war-room', () => ({
   createIncidentWarRoom: vi.fn(),
   archiveWarRoomChannel: vi.fn(),
+  postWarRoomUpdate: vi.fn(),
+  updateWarRoomTopic: vi.fn(),
 }));
 
 const executeEscalationMock = mockedExecuteEscalation as unknown as TestMock;
@@ -60,14 +66,16 @@ const prismaMock = prisma as unknown as { incident: { findUnique: TestMock } };
 
 function payload(
   effect: EventSideEffectPayload['effect'],
-  lane: EventSideEffectPayload['lane'] = 'ESCALATION'
+  lane: EventSideEffectPayload['lane'] = 'ESCALATION',
+  lifecycle?: EventSideEffectPayload['lifecycle']
 ): EventSideEffectPayload {
   return {
     task: 'EVENT_SIDE_EFFECT',
     effect,
     lane,
     incidentId: 'inc-1',
-    eventOrderAt: new Date().toISOString(),
+    eventOrderAt: '2026-08-28T07:00:00.000Z',
+    ...(lifecycle ? { lifecycle } : {}),
   };
 }
 
@@ -127,6 +135,59 @@ describe('event durable side effects', () => {
       'incident.created',
       expect.objectContaining({ status: 'OPEN' })
     );
+  });
+
+  it('replays the queued lifecycle state instead of leaking a newer current state into webhooks', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue({
+      id: 'inc-1',
+      title: 'Incident',
+      description: null,
+      status: 'RESOLVED',
+      urgency: 'HIGH',
+      priority: 'P1',
+      visibility: 'PUBLIC',
+      serviceId: 'svc-1',
+      service: { id: 'svc-1', name: 'Service' },
+      assignee: null,
+      createdAt: new Date('2026-08-28T06:00:00.000Z'),
+      acknowledgedAt: new Date('2026-08-28T06:01:00.000Z'),
+      resolvedAt: new Date('2026-08-28T06:02:00.000Z'),
+    });
+    triggerWebhooksForServiceMock.mockResolvedValue(undefined);
+
+    await processEventSideEffect(
+      payload('LIFECYCLE_WEBHOOK', 'WEBHOOK', {
+        command: 'ACKNOWLEDGE',
+        source: 'REST_API',
+        previousStatus: 'OPEN',
+        status: 'ACKNOWLEDGED',
+        transitionAt: '2026-08-28T06:01:00.000Z',
+        snoozedUntil: null,
+      })
+    );
+
+    expect(triggerWebhooksForServiceMock).toHaveBeenCalledWith(
+      'svc-1',
+      'incident.acknowledged',
+      expect.objectContaining({ id: 'inc-1', status: 'ACKNOWLEDGED' })
+    );
+  });
+
+  it('lets lifecycle notification failures escape to the durable job retry path', async () => {
+    sendIncidentNotificationsMock.mockRejectedValue(new Error('notification unavailable'));
+
+    await expect(
+      processEventSideEffect(
+        payload('LIFECYCLE_USER_NOTIFICATION', 'NOTIFICATION', {
+          command: 'RESOLVE',
+          source: 'WEB',
+          previousStatus: 'ACKNOWLEDGED',
+          status: 'RESOLVED',
+          transitionAt: '2026-08-28T06:02:00.000Z',
+          snoozedUntil: null,
+        })
+      )
+    ).rejects.toThrow('notification unavailable');
   });
 
   it('rejects an unknown effect instead of silently completing it', async () => {

--- a/tests/lib/incident-flow.test.ts
+++ b/tests/lib/incident-flow.test.ts
@@ -63,6 +63,8 @@ describe('incident flow safeguards', () => {
     prismaMock.incident.findMany.mockReset().mockResolvedValue([]);
     prismaMock.incidentEvent.create = vi.fn().mockResolvedValue({});
     prismaMock.incidentEvent.createMany = vi.fn().mockResolvedValue({ count: 0 });
+    prismaMock.$queryRaw = vi.fn().mockResolvedValue([{ now: new Date() }]);
+    prismaMock.backgroundJob.createMany = vi.fn().mockResolvedValue({ count: 0 });
   });
 
   it('bulk acknowledge stops escalation through the lifecycle engine', async () => {

--- a/tests/lib/incidents/lifecycle-outbox.test.ts
+++ b/tests/lib/incidents/lifecycle-outbox.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  enqueueLifecycleSideEffects,
+  getLifecycleSideEffects,
+} from '@/lib/event-outbox';
+
+const DB_NOW = new Date('2026-08-28T07:00:00.000Z');
+
+function createTx() {
+  return {
+    $queryRaw: vi.fn().mockResolvedValue([{ now: DB_NOW }]),
+    backgroundJob: {
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      create: vi.fn().mockResolvedValue({ id: 'job-unsnooze' }),
+    },
+  };
+}
+
+function asTransactionClient(tx: ReturnType<typeof createTx>) {
+  return tx as unknown as Parameters<typeof enqueueLifecycleSideEffects>[0];
+}
+
+describe('durable lifecycle outbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps operator acknowledgement to durable notification, status, webhook, and war-room lanes', () => {
+    expect(
+      getLifecycleSideEffects({
+        command: 'ACKNOWLEDGE',
+        source: 'WEB',
+        status: 'ACKNOWLEDGED',
+      })
+    ).toEqual([
+      'LIFECYCLE_STATUS_PAGE',
+      'LIFECYCLE_WEBHOOK',
+      'LIFECYCLE_USER_NOTIFICATION',
+      'LIFECYCLE_WAR_ROOM_SYNC',
+    ]);
+  });
+
+  it('keeps event ingestion on its existing outbox owner to avoid duplicate ACK/RESOLVE jobs', () => {
+    expect(
+      getLifecycleSideEffects({
+        command: 'RESOLVE',
+        source: 'EVENT',
+        status: 'RESOLVED',
+      })
+    ).toEqual([]);
+  });
+
+  it('persists lifecycle jobs with one database ordering timestamp and immutable transition context', async () => {
+    const tx = createTx();
+    await enqueueLifecycleSideEffects(asTransactionClient(tx), {
+      incidentId: 'inc-1',
+      command: 'RESOLVE',
+      source: 'REST_API',
+      previousStatus: 'ACKNOWLEDGED',
+      status: 'RESOLVED',
+      transitionAt: new Date('2026-08-28T06:59:59.000Z'),
+    });
+
+    expect(tx.$queryRaw).toHaveBeenCalledOnce();
+    expect(tx.backgroundJob.createMany).toHaveBeenCalledOnce();
+    const call = tx.backgroundJob.createMany.mock.calls[0]?.[0];
+    expect(call?.data).toHaveLength(3);
+    expect(call?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'SCHEDULED_TASK',
+          status: 'PENDING',
+          scheduledAt: DB_NOW,
+          payload: expect.objectContaining({
+            task: 'EVENT_SIDE_EFFECT',
+            incidentId: 'inc-1',
+            eventOrderAt: DB_NOW.toISOString(),
+            lifecycle: {
+              command: 'RESOLVE',
+              source: 'REST_API',
+              previousStatus: 'ACKNOWLEDGED',
+              status: 'RESOLVED',
+              transitionAt: '2026-08-28T06:59:59.000Z',
+              snoozedUntil: null,
+            },
+          }),
+        }),
+      ])
+    );
+    expect(
+      call?.data.every(
+        (job: { payload: { eventOrderAt: string } }) =>
+          job.payload.eventOrderAt === DB_NOW.toISOString()
+      )
+    ).toBe(true);
+  });
+
+  it('persists finite auto-unsnooze timing in the same transaction as snooze effects', async () => {
+    const tx = createTx();
+    const snoozedUntil = new Date('2026-08-28T08:00:00.000Z');
+
+    await enqueueLifecycleSideEffects(asTransactionClient(tx), {
+      incidentId: 'inc-snooze',
+      command: 'SNOOZE',
+      source: 'CHATOPS',
+      previousStatus: 'OPEN',
+      status: 'SNOOZED',
+      transitionAt: DB_NOW,
+      snoozedUntil,
+    });
+
+    expect(tx.backgroundJob.createMany).toHaveBeenCalledOnce();
+    expect(tx.backgroundJob.create).toHaveBeenCalledWith({
+      data: {
+        type: 'AUTO_UNSNOOZE',
+        status: 'PENDING',
+        scheduledAt: snoozedUntil,
+        maxAttempts: 3,
+        payload: { incidentId: 'inc-snooze' },
+      },
+    });
+  });
+
+  it('does not create generic lifecycle work for event resolve because events.ts already enqueues it', async () => {
+    const tx = createTx();
+
+    await enqueueLifecycleSideEffects(asTransactionClient(tx), {
+      incidentId: 'inc-event',
+      command: 'RESOLVE',
+      source: 'EVENT',
+      previousStatus: 'OPEN',
+      status: 'RESOLVED',
+      transitionAt: DB_NOW,
+    });
+
+    expect(tx.$queryRaw).not.toHaveBeenCalled();
+    expect(tx.backgroundJob.createMany).not.toHaveBeenCalled();
+    expect(tx.backgroundJob.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/incidents/lifecycle.test.ts
+++ b/tests/lib/incidents/lifecycle.test.ts
@@ -2,10 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   runSerializableTransaction: vi.fn(),
+  enqueueLifecycleSideEffects: vi.fn(),
 }));
 
 vi.mock('@/lib/db-utils', () => ({
   runSerializableTransaction: mocks.runSerializableTransaction,
+}));
+
+vi.mock('@/lib/event-outbox', () => ({
+  enqueueLifecycleSideEffects: mocks.enqueueLifecycleSideEffects,
 }));
 
 import {
@@ -86,6 +91,7 @@ describe('incident lifecycle command engine', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     tx = createTx();
+    mocks.enqueueLifecycleSideEffects.mockResolvedValue(undefined);
     mocks.runSerializableTransaction.mockImplementation(
       async (callback: (client: ReturnType<typeof asTransactionClient>) => Promise<unknown>) =>
         callback(asTransactionClient(tx))
@@ -107,9 +113,10 @@ describe('incident lifecycle command engine', () => {
 
     expect(result).toMatchObject({ incidentId: 'inc-ack', changed: false, status: 'ACKNOWLEDGED' });
     expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(mocks.enqueueLifecycleSideEffects).not.toHaveBeenCalled();
   });
 
-  it('treats duplicate RESOLVE as a no-op without repeating validation or notes', async () => {
+  it('treats duplicate RESOLVE as a no-op without repeating validation, notes, or outbox work', async () => {
     tx.incident.findUnique.mockResolvedValue(
       snapshot({ status: 'RESOLVED', resolvedAt: new Date(NOW.getTime() - 60_000) })
     );
@@ -129,6 +136,7 @@ describe('incident lifecycle command engine', () => {
     expect(tx.incident.update).not.toHaveBeenCalled();
     expect(tx.incidentNote.create).not.toHaveBeenCalled();
     expect(tx.incidentEvent.create).not.toHaveBeenCalled();
+    expect(mocks.enqueueLifecycleSideEffects).not.toHaveBeenCalled();
   });
 
   it('rejects a stale expectedStatus for a real transition', async () => {
@@ -145,6 +153,7 @@ describe('incident lifecycle command engine', () => {
     ).rejects.toMatchObject({ code: 'INCIDENT_TRANSITION_CONFLICT', status: 409 });
 
     expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(mocks.enqueueLifecycleSideEffects).not.toHaveBeenCalled();
   });
 
   it('rejects RESOLVED to ACKNOWLEDGED without an explicit reopen', async () => {
@@ -182,6 +191,17 @@ describe('incident lifecycle command engine', () => {
           escalationStatus: 'ESCALATING',
           nextEscalationAt: new Date('2026-08-27T12:05:00.000Z'),
         }),
+      })
+    );
+    expect(mocks.enqueueLifecycleSideEffects).toHaveBeenCalledWith(
+      asTransactionClient(tx),
+      expect.objectContaining({
+        incidentId: 'inc-reopen',
+        command: 'REOPEN',
+        source: 'WEB',
+        previousStatus: 'RESOLVED',
+        status: 'OPEN',
+        transitionAt: NOW,
       })
     );
   });
@@ -240,7 +260,9 @@ describe('incident lifecycle command engine', () => {
   });
 
   it('unsuppresses immediately and clears pause metadata', async () => {
-    tx.incident.findUnique.mockResolvedValue(snapshot({ status: 'SUPPRESSED', currentEscalationStep: 2 }));
+    tx.incident.findUnique.mockResolvedValue(
+      snapshot({ status: 'SUPPRESSED', currentEscalationStep: 2 })
+    );
 
     await applyIncidentLifecycleCommand(asTransactionClient(tx), {
       incidentId: 'inc-unsuppress',
@@ -274,9 +296,10 @@ describe('incident lifecycle command engine', () => {
     ).rejects.toMatchObject({ code: 'INCIDENT_REQUIRED_FIELDS_MISSING', status: 422 });
 
     expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(mocks.enqueueLifecycleSideEffects).not.toHaveBeenCalled();
   });
 
-  it('persists resolution state, resolution note and timeline event in one transaction callback', async () => {
+  it('persists resolution state, resolution note, timeline, and outbox work in one transaction callback', async () => {
     tx.incident.findUnique.mockResolvedValue(snapshot({ status: 'OPEN' }));
 
     const result = await executeIncidentLifecycleCommand({
@@ -305,6 +328,33 @@ describe('incident lifecycle command engine', () => {
         message: 'Resolution note added by Responder',
       },
     });
+    expect(mocks.enqueueLifecycleSideEffects).toHaveBeenCalledWith(
+      asTransactionClient(tx),
+      expect.objectContaining({
+        incidentId: 'inc-note',
+        command: 'RESOLVE',
+        source: 'WEB',
+        previousStatus: 'OPEN',
+        status: 'RESOLVED',
+        transitionAt: NOW,
+      })
+    );
+  });
+
+  it('allows the temporary creation workflow to retain caller-owned effects', async () => {
+    tx.incident.findUnique.mockResolvedValue(snapshot({ status: 'RESOLVED', resolvedAt: NOW }));
+
+    const result = await applyIncidentLifecycleCommand(asTransactionClient(tx), {
+      incidentId: 'inc-create-reopen',
+      command: 'REOPEN',
+      source: 'WEB',
+      sideEffectPolicy: 'CALLER_OWNED',
+      now: NOW,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(tx.incident.update).toHaveBeenCalledOnce();
+    expect(mocks.enqueueLifecycleSideEffects).not.toHaveBeenCalled();
   });
 
   it('does not treat changed snooze metadata as idempotent', async () => {
@@ -332,6 +382,14 @@ describe('incident lifecycle command engine', () => {
           snoozedUntil: new Date('2026-08-27T14:00:00.000Z'),
           snoozeReason: 'extended maintenance',
         }),
+      })
+    );
+    expect(mocks.enqueueLifecycleSideEffects).toHaveBeenCalledWith(
+      asTransactionClient(tx),
+      expect.objectContaining({
+        incidentId: 'inc-snooze',
+        command: 'SNOOZE',
+        snoozedUntil: new Date('2026-08-27T14:00:00.000Z'),
       })
     );
   });

--- a/tests/lib/incidents/system-unsnooze.test.ts
+++ b/tests/lib/incidents/system-unsnooze.test.ts
@@ -3,10 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   runSerializableTransaction: vi.fn(),
   applyIncidentLifecycleCommand: vi.fn(),
-  sendIncidentNotifications: vi.fn(),
-  notifyStatusPageSubscribers: vi.fn(),
-  triggerWebhooksForService: vi.fn(),
-  loggerError: vi.fn(),
 }));
 
 const prismaMock = vi.hoisted(() => ({
@@ -27,22 +23,6 @@ vi.mock('@/lib/incidents/lifecycle', () => ({
 vi.mock('@/lib/prisma', () => ({
   __esModule: true,
   default: prismaMock,
-}));
-
-vi.mock('@/lib/user-notifications', () => ({
-  sendIncidentNotifications: mocks.sendIncidentNotifications,
-}));
-
-vi.mock('@/lib/status-page-notifications', () => ({
-  notifyStatusPageSubscribers: mocks.notifyStatusPageSubscribers,
-}));
-
-vi.mock('@/lib/status-page-webhooks', () => ({
-  triggerWebhooksForService: mocks.triggerWebhooksForService,
-}));
-
-vi.mock('@/lib/logger', () => ({
-  logger: { error: mocks.loggerError },
 }));
 
 import {
@@ -121,66 +101,28 @@ describe('system auto-unsnooze lifecycle adapter', () => {
     expect(mocks.applyIncidentLifecycleCommand).not.toHaveBeenCalled();
   });
 
-  it('emits post-commit effects only after a real lifecycle change', async () => {
+  it('returns after the lifecycle transaction because external effects are already durable', async () => {
     tx.incident.findUnique.mockResolvedValue({
       status: 'SNOOZED',
       snoozedUntil: new Date('2026-08-28T04:00:00.000Z'),
     });
-    prismaMock.incident.findUnique.mockResolvedValue({
-      id: 'inc-1',
-      title: 'Database latency',
-      description: 'p99 elevated',
-      status: 'OPEN',
-      urgency: 'HIGH',
-      priority: 'P1',
-      serviceId: 'svc-1',
-      service: { id: 'svc-1', name: 'Database' },
-      assignee: null,
-      createdAt: new Date('2026-08-28T03:00:00.000Z'),
-      acknowledgedAt: null,
-      resolvedAt: null,
-    });
-    mocks.sendIncidentNotifications.mockResolvedValue({ success: true });
-    mocks.notifyStatusPageSubscribers.mockResolvedValue(undefined);
-    mocks.triggerWebhooksForService.mockResolvedValue(undefined);
 
     await expect(processAutoUnsnoozeIncidentInternal('inc-1', NOW)).resolves.toEqual({
       outcome: 'changed',
     });
 
-    expect(mocks.sendIncidentNotifications).toHaveBeenCalledWith('inc-1', 'updated');
-    expect(mocks.notifyStatusPageSubscribers).toHaveBeenCalledWith('inc-1', 'investigating');
-    expect(mocks.triggerWebhooksForService).toHaveBeenCalledWith(
-      'svc-1',
-      'incident.updated',
-      expect.objectContaining({ id: 'inc-1', status: 'OPEN' })
-    );
+    expect(mocks.applyIncidentLifecycleCommand).toHaveBeenCalledTimes(1);
+    expect(prismaMock.incident.findUnique).not.toHaveBeenCalled();
   });
 
-  it('does not repeat effects for an already-applied retry', async () => {
+  it('does not perform any post-commit work for an already-applied retry', async () => {
     tx.incident.findUnique.mockResolvedValue({ status: 'OPEN', snoozedUntil: null });
 
     await expect(processAutoUnsnoozeIncidentInternal('inc-1', NOW)).resolves.toEqual({
       outcome: 'noop',
     });
 
+    expect(mocks.applyIncidentLifecycleCommand).not.toHaveBeenCalled();
     expect(prismaMock.incident.findUnique).not.toHaveBeenCalled();
-    expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
-    expect(mocks.notifyStatusPageSubscribers).not.toHaveBeenCalled();
-    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
-  });
-
-  it('suppresses stale OPEN effects if the incident changed again after commit', async () => {
-    tx.incident.findUnique.mockResolvedValue({
-      status: 'SNOOZED',
-      snoozedUntil: new Date('2026-08-28T04:00:00.000Z'),
-    });
-    prismaMock.incident.findUnique.mockResolvedValue({ status: 'SNOOZED' });
-
-    await processAutoUnsnoozeIncidentInternal('inc-1', NOW);
-
-    expect(mocks.sendIncidentNotifications).not.toHaveBeenCalled();
-    expect(mocks.notifyStatusPageSubscribers).not.toHaveBeenCalled();
-    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Moves incident lifecycle follow-up work onto the existing PostgreSQL durable outbox so lifecycle state, timeline entries, and external side-effect jobs are committed atomically.

- enqueue durable lifecycle notification/status-page/webhook/war-room work from the lifecycle transaction
- reuse the existing `EVENT_SIDE_EFFECT` lane ordering so older lifecycle effects cannot overtake newer ones
- remove duplicated post-commit lifecycle dispatch from web/mobile, REST, bulk, ChatOps, and system unsnooze callers
- keep event-trigger creation on the existing event outbox and avoid double-enqueueing EVENT ACK/RESOLVE effects
- persist finite auto-unsnooze jobs in the same lifecycle transaction
- preserve historical transition status/timestamps when delayed webhooks run after a newer incident transition
- retain idempotent no-op semantics: duplicate ACK/RESOLVE produce no new outbox work or caller side effects

## Tests

Adds/updates coverage for transactional lifecycle outbox insertion, duplicate-command idempotency, lifecycle webhook replay semantics, REST/Slack/bulk/system adapters, and snooze timer durability.

Exactly one focused commit.