### PR TITLE
refactor(errors): normalize Prisma and settings errors

### DIFF
--- a/src/app/(app)/incidents/tag-actions.ts
+++ b/src/app/(app)/incidents/tag-actions.ts
@@ -3,94 +3,70 @@
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { assertResponderOrAbove, getCurrentUser } from '@/lib/rbac';
+import { isPrismaErrorCode } from '@/lib/prisma-errors';
 
 export async function addTagToIncident(incidentId: string, tagName: string) {
-    try {
-        await assertResponderOrAbove();
-    } catch (error) {
-        throw new Error(error instanceof Error ? error.message : 'Unauthorized');
-    }
+  await assertResponderOrAbove();
 
-    // Get or create tag
-    const tag = await prisma.tag.upsert({
-        where: { name: tagName },
-        create: { name: tagName },
-        update: {}
-    });
+  const tag = await prisma.tag.upsert({
+    where: { name: tagName },
+    create: { name: tagName },
+    update: {},
+  });
 
-    // Add tag to incident (ignore if already exists)
-    try {
-        await prisma.incidentTag.create({
-            data: {
-                incidentId,
-                tagId: tag.id
-            }
-        });
-
-        const user = await getCurrentUser();
-        await prisma.incidentEvent.create({
-            data: {
-                incidentId,
-                message: `Tag "${tagName}" added${user ? ` by ${user.name}` : ''}`
-            }
-        });
-    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
-        // Ignore unique constraint violations (tag already exists)
-        if (!error.code || error.code !== 'P2002') {
-            throw error;
-        }
-    }
-
-    revalidatePath(`/incidents/${incidentId}`);
-    revalidatePath('/incidents');
-}
-
-export async function removeTagFromIncident(incidentId: string, tagId: string) {
-    try {
-        await assertResponderOrAbove();
-    } catch (error) {
-        throw new Error(error instanceof Error ? error.message : 'Unauthorized');
-    }
-
-    const tag = await prisma.tag.findUnique({ where: { id: tagId } });
-    await prisma.incidentTag.delete({
-        where: {
-            incidentId_tagId: {
-                incidentId,
-                tagId
-            }
-        }
+  try {
+    await prisma.incidentTag.create({
+      data: { incidentId, tagId: tag.id },
     });
 
     const user = await getCurrentUser();
     await prisma.incidentEvent.create({
-        data: {
-            incidentId,
-            message: `Tag "${tag?.name || 'Unknown'}" removed${user ? ` by ${user.name}` : ''}`
-        }
+      data: {
+        incidentId,
+        message: `Tag "${tagName}" added${user ? ` by ${user.name}` : ''}`,
+      },
     });
+  } catch (error) {
+    // Adding an already-associated tag is intentionally idempotent. Interpret
+    // the structured Prisma code centrally; never infer this from DB text.
+    if (!isPrismaErrorCode(error, 'P2002')) {
+      throw error;
+    }
+  }
 
-    revalidatePath(`/incidents/${incidentId}`);
-    revalidatePath('/incidents');
+  revalidatePath(`/incidents/${incidentId}`);
+  revalidatePath('/incidents');
+}
+
+export async function removeTagFromIncident(incidentId: string, tagId: string) {
+  await assertResponderOrAbove();
+
+  const tag = await prisma.tag.findUnique({ where: { id: tagId } });
+  await prisma.incidentTag.delete({
+    where: {
+      incidentId_tagId: { incidentId, tagId },
+    },
+  });
+
+  const user = await getCurrentUser();
+  await prisma.incidentEvent.create({
+    data: {
+      incidentId,
+      message: `Tag "${tag?.name || 'Unknown'}" removed${user ? ` by ${user.name}` : ''}`,
+    },
+  });
+
+  revalidatePath(`/incidents/${incidentId}`);
+  revalidatePath('/incidents');
 }
 
 export async function getAllTags() {
-    const tags = await prisma.tag.findMany({
-        orderBy: { name: 'asc' },
-        include: {
-            _count: {
-                select: { incidents: true }
-            }
-        }
-    });
-    return tags;
+  return prisma.tag.findMany({
+    orderBy: { name: 'asc' },
+    include: {
+      _count: {
+        select: { incidents: true },
+      },
+    },
+  });
 }
-
-
-
-
-
-
-
-
-

--- a/src/app/api/incidents/[id]/context/route.ts
+++ b/src/app/api/incidents/[id]/context/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getIncidentContext } from '@/lib/incident-enrichment';
 import { assertCanViewIncident } from '@/lib/rbac';
 import { logger } from '@/lib/logger';
+import { jsonError } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 
 /**
  * GET: Fetch telemetry context for an incident
@@ -14,9 +16,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
   try {
     await assertCanViewIncident(id);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Unauthorized';
-    return NextResponse.json({ error: msg }, { status: msg === 'Incident not found' ? 404 : 403 });
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+
+    logger.error('api.incident_context.authorization_failed', { error, incidentId: id });
+    return jsonError(
+      new AppError({
+        code: 'INTERNAL_ERROR',
+        details: { incidentId: id },
+        cause: error,
+      })
+    );
   }
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/settings/app-url/route.ts
+++ b/src/app/api/settings/app-url/route.ts
@@ -1,79 +1,86 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { assertAdmin } from '@/lib/rbac';
 import { revalidatePath } from 'next/cache';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 
 // GET /api/settings/app-url
 export async function GET() {
-    try {
-        const settings = await prisma.systemSettings.findUnique({
-            where: { id: 'default' },
-            select: { appUrl: true }
-        });
+  try {
+    const settings = await prisma.systemSettings.findUnique({
+      where: { id: 'default' },
+      select: { appUrl: true },
+    });
 
-        return NextResponse.json({
-            appUrl: settings?.appUrl || null,
-            fallback: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-        });
-    } catch (_error) {
-        return NextResponse.json(
-            { error: 'Failed to fetch app URL' },
-            { status: 500 }
-        );
-    }
+    return jsonOk({
+      appUrl: settings?.appUrl || null,
+      fallback: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
+    });
+  } catch {
+    return jsonError('Failed to fetch app URL', 500);
+  }
 }
 
 // POST /api/settings/app-url
 export async function POST(request: NextRequest) {
+  try {
+    await assertAdmin();
+
+    let body: unknown;
     try {
-        await assertAdmin();
-    } catch (_error) {
-        return NextResponse.json(
-            { error: 'Unauthorized. Admin access required.' },
-            { status: 403 }
-        );
+      body = await request.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
     }
 
-    try {
-        const { appUrl } = await request.json();
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const appUrl = typeof payload.appUrl === 'string' ? payload.appUrl : '';
 
-        // Validate URL format if provided
-        if (appUrl && appUrl.trim() !== '') {
-            try {
-                const url = new URL(appUrl);
-                if (!['http:', 'https:'].includes(url.protocol)) {
-                    return NextResponse.json(
-                        { error: 'URL must use http:// or https:// protocol' },
-                        { status: 400 }
-                    );
-                }
-            } catch (_e) {
-                return NextResponse.json(
-                    { error: 'Invalid URL format' },
-                    { status: 400 }
-                );
-            }
+    if (appUrl.trim() !== '') {
+      try {
+        const url = new URL(appUrl);
+        if (!['http:', 'https:'].includes(url.protocol)) {
+          return jsonError(
+            new AppError({
+              code: 'VALIDATION_FAILED',
+              userMessage: 'URL must use http:// or https:// protocol',
+              fields: [
+                {
+                  field: 'appUrl',
+                  code: 'invalid_protocol',
+                  message: 'URL must use http:// or https:// protocol',
+                },
+              ],
+            })
+          );
         }
-
-        // Upsert the settings
-        await prisma.systemSettings.upsert({
-            where: { id: 'default' },
-            create: {
-                id: 'default',
-                appUrl: appUrl || null
-            },
-            update: {
-                appUrl: appUrl || null
-            }
-        });
-
-        revalidatePath('/settings/system');
-
-        return NextResponse.json({ success: true });
-    } catch (_error) {
-        return NextResponse.json(
-            { error: 'Failed to update app URL' },
-            { status: 500 }
+      } catch {
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: 'Invalid URL format',
+            fields: [{ field: 'appUrl', code: 'invalid_url', message: 'Invalid URL format' }],
+          })
         );
+      }
     }
+
+    await prisma.systemSettings.upsert({
+      where: { id: 'default' },
+      create: {
+        id: 'default',
+        appUrl: appUrl || null,
+      },
+      update: {
+        appUrl: appUrl || null,
+      },
+    });
+
+    revalidatePath('/settings/system');
+    return jsonOk({ success: true });
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to update app URL', 500);
+  }
 }

--- a/src/app/api/settings/custom-fields/[id]/route.ts
+++ b/src/app/api/settings/custom-fields/[id]/route.ts
@@ -4,6 +4,8 @@ import { getAuthOptions } from '@/lib/auth';
 import { assertAdmin } from '@/lib/rbac';
 import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { prismaToAppError } from '@/lib/prisma-errors';
 import { logger } from '@/lib/logger';
 
 /**
@@ -14,34 +16,28 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   try {
     const session = await getServerSession(await getAuthOptions());
     if (!session) {
-      return jsonError('Unauthorized', 401);
+      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED' }));
     }
 
-    try {
-      await assertAdmin();
-    } catch (error) {
-      return jsonError(error instanceof Error ? error.message : 'Unauthorized', 403);
-    }
-
+    await assertAdmin();
     const { id } = await params;
 
-    // Delete all values first (cascade should handle this, but being explicit)
-    await prisma.customFieldValue.deleteMany({
-      where: { customFieldId: id },
-    });
-
-    // Delete the field
-    await prisma.customField.delete({
-      where: { id },
-    });
+    await prisma.customFieldValue.deleteMany({ where: { customFieldId: id } });
+    await prisma.customField.delete({ where: { id } });
 
     logger.info('api.custom_fields.deleted', { customFieldId: id });
     return jsonOk({ success: true }, 200);
-  } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
-    logger.error('api.custom_fields.delete_error', {
-      error: error instanceof Error ? error.message : String(error),
+  } catch (error) {
+    const prismaError = prismaToAppError(error, {
+      notFound: {
+        code: 'RESOURCE_NOT_FOUND',
+        userMessage: 'Custom field not found.',
+      },
     });
+    if (prismaError) return jsonError(prismaError);
+    if (isAppError(error)) return jsonError(error);
+
+    logger.error('api.custom_fields.delete_error', { error });
     return jsonError('Failed to delete custom field', 500);
   }
 }

--- a/src/app/api/settings/custom-fields/route.ts
+++ b/src/app/api/settings/custom-fields/route.ts
@@ -4,9 +4,20 @@ import { getAuthOptions } from '@/lib/auth';
 import { assertAdmin } from '@/lib/rbac';
 import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { prismaToAppError } from '@/lib/prisma-errors';
 import { CustomFieldCreateSchema } from '@/lib/validation';
 import { logger } from '@/lib/logger';
 import type { Prisma } from '@prisma/client';
+
+const CUSTOM_FIELD_KEY_CONFLICT = {
+  code: 'VALIDATION_FAILED' as const,
+  userMessage: 'A custom field with this key already exists',
+  action: 'Choose a different custom-field key.',
+  fields: [
+    { field: 'key', code: 'duplicate', message: 'A custom field with this key already exists' },
+  ],
+};
 
 /**
  * Create Custom Field
@@ -16,40 +27,42 @@ export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(await getAuthOptions());
     if (!session) {
-      return jsonError('Unauthorized', 401);
+      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED' }));
     }
 
-    try {
-      await assertAdmin();
-    } catch (error) {
-      return jsonError(error instanceof Error ? error.message : 'Unauthorized', 403);
-    }
+    await assertAdmin();
 
-    let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let body: unknown;
     try {
       body = await req.json();
-    } catch (_error) {
-      return jsonError('Invalid JSON in request body.', 400);
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
     }
+
     const parsed = CustomFieldCreateSchema.safeParse(body);
     if (!parsed.success) {
-      return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Invalid request body.',
+          fields: parsed.error.issues.map(issue => ({
+            field: issue.path.join('.') || 'request',
+            code: issue.code,
+            message: issue.message,
+          })),
+        }),
+        undefined,
+        { issues: parsed.error.issues }
+      );
     }
     const { name, key, type, required, defaultValue, options, showInList } = parsed.data;
 
-    // Check if key already exists
-    const existing = await prisma.customField.findUnique({
-      where: { key },
-    });
-
+    const existing = await prisma.customField.findUnique({ where: { key } });
     if (existing) {
-      return jsonError('A custom field with this key already exists', 400);
+      return jsonError(new AppError(CUSTOM_FIELD_KEY_CONFLICT));
     }
 
-    // Get max order
-    const maxOrder = await prisma.customField.aggregate({
-      _max: { order: true },
-    });
+    const maxOrder = await prisma.customField.aggregate({ _max: { order: true } });
 
     const fieldData: Prisma.CustomFieldCreateInput = {
       name,
@@ -65,17 +78,16 @@ export async function POST(req: NextRequest) {
       fieldData.options = options as Prisma.InputJsonValue;
     }
 
-    const customField = await prisma.customField.create({
-      data: fieldData,
-    });
+    const customField = await prisma.customField.create({ data: fieldData });
 
     logger.info('api.custom_fields.created', { customFieldId: customField.id });
     return jsonOk({ success: true, field: customField }, 200);
-  } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
-    logger.error('api.custom_fields.create_error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    const prismaError = prismaToAppError(error, { unique: CUSTOM_FIELD_KEY_CONFLICT });
+    if (prismaError) return jsonError(prismaError);
+    if (isAppError(error)) return jsonError(error);
+
+    logger.error('api.custom_fields.create_error', { error });
     return jsonError('Failed to create custom field', 500);
   }
 }
@@ -88,26 +100,22 @@ export async function GET() {
   try {
     const session = await getServerSession(await getAuthOptions());
     if (!session) {
-      return jsonError('Unauthorized', 401);
+      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED' }));
     }
 
     const customFields = await prisma.customField.findMany({
       orderBy: { order: 'asc' },
       include: {
         _count: {
-          select: {
-            values: true,
-          },
+          select: { values: true },
         },
       },
     });
 
     return jsonOk({ fields: customFields }, 200);
-  } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
-    logger.error('api.custom_fields.fetch_error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+    logger.error('api.custom_fields.fetch_error', { error });
     return jsonError('Failed to fetch custom fields', 500);
   }
 }

--- a/src/app/api/settings/email-providers/route.ts
+++ b/src/app/api/settings/email-providers/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest } from 'next/server';
-import { getCurrentUser } from '@/lib/rbac';
+import { assertAdmin } from '@/lib/rbac';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { isAppError } from '@/lib/errors';
 import prisma from '@/lib/prisma';
 import { decryptProviderConfig } from '@/lib/encrypted-provider-config';
 
-/**
- * Type guard for provider config
- */
 function isProviderConfig(config: unknown): config is Record<string, unknown> {
   return typeof config === 'object' && config !== null;
 }
@@ -17,12 +15,8 @@ function isProviderConfig(config: unknown): config is Record<string, unknown> {
  */
 export async function GET(_req: NextRequest) {
   try {
-    const user = await getCurrentUser();
-    if (!user || user.role !== 'ADMIN') {
-      return jsonError('Unauthorized. Admin access required.', 403);
-    }
+    await assertAdmin();
 
-    // Fetch all email providers from database
     const [resendProvider, sendgridProvider, smtpProvider, sesProvider] = await Promise.all([
       prisma.notificationProvider.findUnique({ where: { provider: 'resend' } }),
       prisma.notificationProvider.findUnique({ where: { provider: 'sendgrid' } }),
@@ -30,50 +24,35 @@ export async function GET(_req: NextRequest) {
       prisma.notificationProvider.findUnique({ where: { provider: 'ses' } }),
     ]);
 
-    const providers = [];
+    const providers: Array<{ provider: string; enabled: true }> = [];
 
-    if (resendProvider && resendProvider.enabled && isProviderConfig(resendProvider.config)) {
+    if (resendProvider?.enabled && isProviderConfig(resendProvider.config)) {
       const config = await decryptProviderConfig('resend', resendProvider.config);
-      if (config?.apiKey) {
-        providers.push({
-          provider: 'resend',
-          enabled: true,
-        });
-      }
+      if (config?.apiKey) providers.push({ provider: 'resend', enabled: true });
     }
 
-    if (sendgridProvider && sendgridProvider.enabled && isProviderConfig(sendgridProvider.config)) {
+    if (sendgridProvider?.enabled && isProviderConfig(sendgridProvider.config)) {
       const config = await decryptProviderConfig('sendgrid', sendgridProvider.config);
-      if (config?.apiKey) {
-        providers.push({
-          provider: 'sendgrid',
-          enabled: true,
-        });
-      }
+      if (config?.apiKey) providers.push({ provider: 'sendgrid', enabled: true });
     }
 
-    if (smtpProvider && smtpProvider.enabled && isProviderConfig(smtpProvider.config)) {
+    if (smtpProvider?.enabled && isProviderConfig(smtpProvider.config)) {
       const config = await decryptProviderConfig('smtp', smtpProvider.config);
       if (config?.host && config?.user && config?.password) {
-        providers.push({
-          provider: 'smtp',
-          enabled: true,
-        });
+        providers.push({ provider: 'smtp', enabled: true });
       }
     }
 
-    if (sesProvider && sesProvider.enabled && isProviderConfig(sesProvider.config)) {
+    if (sesProvider?.enabled && isProviderConfig(sesProvider.config)) {
       const config = await decryptProviderConfig('ses', sesProvider.config);
       if (config?.accessKeyId && config?.secretAccessKey) {
-        providers.push({
-          provider: 'ses',
-          enabled: true,
-        });
+        providers.push({ provider: 'ses', enabled: true });
       }
     }
 
     return jsonOk({ providers });
-  } catch (_error) {
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
     return jsonError('Failed to fetch email providers', 500);
   }
 }

--- a/src/app/api/settings/notifications/route.ts
+++ b/src/app/api/settings/notifications/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from 'next/server';
 import { Prisma } from '@prisma/client';
-import { getCurrentUser } from '@/lib/rbac';
+import { assertAdmin } from '@/lib/rbac';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 import prisma from '@/lib/prisma';
 import {
   SECRET_MASK,
@@ -10,12 +11,35 @@ import {
   mergeSensitiveProviderFields,
 } from '@/lib/encrypted-provider-config';
 
-/**
- * Type guard for provider config
- */
 function isProviderConfig(config: unknown): config is Record<string, unknown> {
   return typeof config === 'object' && config !== null;
 }
+
+type NotificationSettingsPayload = {
+  sms?: {
+    enabled?: boolean;
+    provider?: 'twilio' | 'aws-sns';
+    accountSid?: string;
+    authToken?: string;
+    fromNumber?: string;
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+  };
+  push?: {
+    enabled?: boolean;
+    vapidPublicKey?: string;
+    vapidPrivateKey?: string;
+    vapidSubject?: string;
+  };
+  whatsapp?: {
+    number?: string;
+    contentSid?: string;
+    enabled?: boolean;
+    accountSid?: string;
+    authToken?: string;
+  };
+};
 
 /**
  * GET /api/settings/notifications
@@ -23,21 +47,16 @@ function isProviderConfig(config: unknown): config is Record<string, unknown> {
  */
 export async function GET(_req: NextRequest) {
   try {
-    const user = await getCurrentUser();
-    if (!user || user.role !== 'ADMIN') {
-      return jsonError('Unauthorized. Admin access required.', 403);
-    }
+    await assertAdmin();
 
-    // Get settings from database
     const [twilioProvider, awsProvider, webPushProvider] = await Promise.all([
       prisma.notificationProvider.findUnique({ where: { provider: 'twilio' } }),
       prisma.notificationProvider.findUnique({ where: { provider: 'aws-sns' } }),
       prisma.notificationProvider.findUnique({ where: { provider: 'web-push' } }),
     ]);
 
-    // Build SMS config from database
     let smsConfig: Record<string, unknown> = { enabled: false, provider: null };
-    if (twilioProvider && twilioProvider.enabled && isProviderConfig(twilioProvider.config)) {
+    if (twilioProvider?.enabled && isProviderConfig(twilioProvider.config)) {
       const config = await decryptProviderConfig('twilio', twilioProvider.config);
       smsConfig = {
         enabled: true,
@@ -48,7 +67,7 @@ export async function GET(_req: NextRequest) {
         hasAuthToken: Boolean(config.authToken),
         fromNumber: config.fromNumber || '',
       };
-    } else if (awsProvider && awsProvider.enabled && isProviderConfig(awsProvider.config)) {
+    } else if (awsProvider?.enabled && isProviderConfig(awsProvider.config)) {
       const config = await decryptProviderConfig('aws-sns', awsProvider.config);
       smsConfig = {
         enabled: true,
@@ -61,9 +80,8 @@ export async function GET(_req: NextRequest) {
       };
     }
 
-    // Build Push config from database
     let pushConfig: Record<string, unknown> = { enabled: false, provider: null };
-    if (webPushProvider && webPushProvider.enabled && isProviderConfig(webPushProvider.config)) {
+    if (webPushProvider?.enabled && isProviderConfig(webPushProvider.config)) {
       const config = await decryptProviderConfig('web-push', webPushProvider.config);
       pushConfig = {
         enabled: true,
@@ -75,7 +93,6 @@ export async function GET(_req: NextRequest) {
       };
     }
 
-    // Get WhatsApp config from Twilio provider config (independent of SMS enablement)
     let whatsappConfig: Record<string, unknown> = {
       number: '',
       contentSid: '',
@@ -87,7 +104,7 @@ export async function GET(_req: NextRequest) {
       const decryptedConfig = await decryptProviderConfig('twilio', twilioProvider.config);
       const whatsappNumber = decryptedConfig.whatsappNumber || '';
       const whatsappContentSid = decryptedConfig.whatsappContentSid || '';
-      const whatsappEnabled = decryptedConfig.whatsappEnabled ?? !!whatsappNumber;
+      const whatsappEnabled = decryptedConfig.whatsappEnabled ?? Boolean(whatsappNumber);
       whatsappConfig = {
         number: whatsappNumber,
         contentSid: whatsappContentSid,
@@ -95,17 +112,14 @@ export async function GET(_req: NextRequest) {
         hasAccountSid: Boolean(decryptedConfig.whatsappAccountSid),
         authToken: decryptedConfig.whatsappAuthToken ? SECRET_MASK : '',
         hasAuthToken: Boolean(decryptedConfig.whatsappAuthToken),
-        enabled: !!whatsappEnabled && !!whatsappNumber,
+        enabled: Boolean(whatsappEnabled) && Boolean(whatsappNumber),
       };
     }
 
-    return jsonOk({
-      sms: smsConfig,
-      push: pushConfig,
-      whatsapp: whatsappConfig,
-    });
+    return jsonOk({ sms: smsConfig, push: pushConfig, whatsapp: whatsappConfig });
   } catch (error) {
-    return jsonError(error, 500);
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to fetch notification settings', 500);
   }
 }
 
@@ -115,12 +129,21 @@ export async function GET(_req: NextRequest) {
  */
 export async function POST(req: NextRequest) {
   try {
-    const user = await getCurrentUser();
-    if (!user || user.role !== 'ADMIN') {
-      return jsonError('Unauthorized. Admin access required.', 403);
-    }
+    const user = await assertAdmin();
 
-    const body = await req.json();
+    let rawBody: unknown;
+    try {
+      rawBody = await req.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+    if (!rawBody || typeof rawBody !== 'object') {
+      return jsonError(
+        new AppError({ code: 'VALIDATION_FAILED', userMessage: 'Invalid notification settings.' })
+      );
+    }
+    const body = rawBody as NotificationSettingsPayload;
+
     const existingTwilioProvider = await prisma.notificationProvider.findUnique({
       where: { provider: 'twilio' },
     });
@@ -128,9 +151,20 @@ export async function POST(req: NextRequest) {
       ? await decryptProviderConfig('twilio', existingTwilioProvider.config)
       : {};
 
-    // Save SMS provider (Twilio or AWS SNS)
     if (body.sms) {
-      const smsProvider = body.sms.provider === 'twilio' ? 'twilio' : 'aws-sns';
+      if (body.sms.provider !== 'twilio' && body.sms.provider !== 'aws-sns') {
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: 'Invalid SMS provider.',
+            fields: [
+              { field: 'sms.provider', code: 'invalid', message: 'Invalid SMS provider.' },
+            ],
+          })
+        );
+      }
+
+      const smsProvider = body.sms.provider;
       const existingSmsProvider =
         smsProvider === 'twilio'
           ? existingTwilioProvider
@@ -138,33 +172,29 @@ export async function POST(req: NextRequest) {
       const existingSmsConfig = isProviderConfig(existingSmsProvider?.config)
         ? await decryptProviderConfig(smsProvider, existingSmsProvider.config)
         : {};
-      let smsConfig: Record<string, unknown> = {
-        enabled: body.sms.enabled || false,
-      };
+      let smsConfig: Record<string, unknown> = { enabled: body.sms.enabled || false };
 
-      if (body.sms.provider === 'twilio') {
+      if (smsProvider === 'twilio') {
         smsConfig.accountSid = body.sms.accountSid || '';
         smsConfig.authToken = body.sms.authToken || '';
         smsConfig.fromNumber = body.sms.fromNumber || '';
-        // Store WhatsApp config in Twilio provider config
         const whatsappNumber = body.whatsapp?.number ?? existingTwilioConfig.whatsappNumber ?? '';
         smsConfig.whatsappNumber = whatsappNumber;
         smsConfig.whatsappContentSid =
           body.whatsapp?.contentSid ?? existingTwilioConfig.whatsappContentSid ?? '';
         smsConfig.whatsappEnabled =
-          body.whatsapp?.enabled ?? existingTwilioConfig.whatsappEnabled ?? !!whatsappNumber;
+          body.whatsapp?.enabled ?? existingTwilioConfig.whatsappEnabled ?? Boolean(whatsappNumber);
         smsConfig.whatsappAccountSid =
           body.whatsapp?.accountSid ?? existingTwilioConfig.whatsappAccountSid ?? '';
         smsConfig.whatsappAuthToken =
           body.whatsapp?.authToken ?? existingTwilioConfig.whatsappAuthToken ?? '';
-      } else if (body.sms.provider === 'aws-sns') {
+      } else {
         smsConfig.region = body.sms.region || 'us-east-1';
         smsConfig.accessKeyId = body.sms.accessKeyId || '';
         smsConfig.secretAccessKey = body.sms.secretAccessKey || '';
       }
 
       smsConfig = mergeSensitiveProviderFields(smsProvider, smsConfig, existingSmsConfig);
-      // Encrypt sensitive fields before storing
       smsConfig = await encryptProviderConfig(smsProvider, smsConfig);
 
       await prisma.notificationProvider.upsert({
@@ -182,8 +212,7 @@ export async function POST(req: NextRequest) {
         },
       });
 
-      // Disable the other SMS provider if switching
-      const otherProvider = body.sms.provider === 'twilio' ? 'aws-sns' : 'twilio';
+      const otherProvider = smsProvider === 'twilio' ? 'aws-sns' : 'twilio';
       const otherProviderRecord = await prisma.notificationProvider.findUnique({
         where: { provider: otherProvider },
       });
@@ -195,7 +224,6 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Save Push provider (Web Push)
     if (body.push) {
       let pushConfig: Record<string, unknown> = {
         enabled: body.push.enabled || false,
@@ -211,7 +239,6 @@ export async function POST(req: NextRequest) {
         ? await decryptProviderConfig('web-push', existingPushProvider.config)
         : {};
       pushConfig = mergeSensitiveProviderFields('web-push', pushConfig, existingPushConfig);
-      // Encrypt sensitive fields before storing
       pushConfig = await encryptProviderConfig('web-push', pushConfig);
 
       await prisma.notificationProvider.upsert({
@@ -238,7 +265,7 @@ export async function POST(req: NextRequest) {
         whatsappContentSid:
           body.whatsapp.contentSid ?? existingTwilioConfig.whatsappContentSid ?? '',
         whatsappEnabled:
-          body.whatsapp.enabled ?? existingTwilioConfig.whatsappEnabled ?? !!whatsappNumber,
+          body.whatsapp.enabled ?? existingTwilioConfig.whatsappEnabled ?? Boolean(whatsappNumber),
         whatsappAccountSid:
           body.whatsapp.accountSid ?? existingTwilioConfig.whatsappAccountSid ?? '',
         whatsappAuthToken: body.whatsapp.authToken ?? existingTwilioConfig.whatsappAuthToken ?? '',
@@ -249,7 +276,6 @@ export async function POST(req: NextRequest) {
         updatedTwilioConfig,
         existingTwilioConfig
       );
-      // Encrypt sensitive fields before storing
       updatedTwilioConfig = await encryptProviderConfig('twilio', updatedTwilioConfig);
 
       if (existingTwilioProvider) {
@@ -277,6 +303,7 @@ export async function POST(req: NextRequest) {
       message: 'Notification provider settings saved successfully',
     });
   } catch (error) {
-    return jsonError(error, 500);
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to save notification settings', 500);
   }
 }

--- a/src/app/api/settings/retention/route.ts
+++ b/src/app/api/settings/retention/route.ts
@@ -1,6 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { getAuthOptions } from '@/lib/auth';
+import { NextRequest } from 'next/server';
 import {
   getRetentionPolicy,
   updateRetentionPolicy,
@@ -8,6 +6,8 @@ import {
 } from '@/lib/retention-policy';
 import { getStorageStats, performDataCleanup } from '@/lib/data-cleanup';
 import { assertAdmin } from '@/lib/rbac';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { logAudit } from '@/lib/audit';
 import { z } from 'zod';
@@ -22,6 +22,18 @@ const RetentionUpdateSchema = z
   })
   .refine(data => Object.keys(data).length > 0, { message: 'No valid fields provided' });
 
+function retentionValidationError(error: z.ZodError) {
+  return new AppError({
+    code: 'VALIDATION_FAILED',
+    userMessage: 'Invalid retention settings',
+    fields: error.issues.map(issue => ({
+      field: issue.path.join('.') || 'request',
+      code: issue.code,
+      message: issue.message,
+    })),
+  });
+}
+
 /**
  * GET /api/settings/retention
  * Fetch current retention policy and storage statistics
@@ -32,7 +44,7 @@ export async function GET() {
 
     const [policy, stats] = await Promise.all([getRetentionPolicy(), getStorageStats()]);
 
-    return NextResponse.json({
+    return jsonOk({
       policy,
       stats,
       presets: [
@@ -79,12 +91,9 @@ export async function GET() {
       ],
     });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Failed to fetch retention settings';
-    if (msg.includes('Unauthorized') || msg.includes('Admin access required')) {
-      return NextResponse.json({ error: msg }, { status: 403 });
-    }
+    if (isAppError(error)) return jsonError(error);
     logger.error('[API] Failed to fetch retention settings', { error });
-    return NextResponse.json({ error: 'Failed to fetch settings' }, { status: 500 });
+    return jsonError('Failed to fetch settings', 500);
   }
 }
 
@@ -95,14 +104,19 @@ export async function GET() {
 export async function PUT(request: NextRequest) {
   try {
     const admin = await assertAdmin();
-    const body = await request.json();
-    const parsed = RetentionUpdateSchema.safeParse(body);
 
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+
+    const parsed = RetentionUpdateSchema.safeParse(body);
     if (!parsed.success) {
-      return NextResponse.json(
-        { error: 'Invalid retention settings', issues: parsed.error.issues },
-        { status: 400 }
-      );
+      return jsonError(retentionValidationError(parsed.error), undefined, {
+        issues: parsed.error.issues,
+      });
     }
 
     const updates: Partial<RetentionPolicy> = parsed.data;
@@ -116,22 +130,12 @@ export async function PUT(request: NextRequest) {
       details: updates,
     });
 
-    logger.info('[API] Retention policy updated', {
-      userId: admin.id,
-      updates,
-    });
-
-    return NextResponse.json({
-      success: true,
-      policy: updatedPolicy,
-    });
+    logger.info('[API] Retention policy updated', { userId: admin.id, updates });
+    return jsonOk({ success: true, policy: updatedPolicy });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Failed to update settings';
-    if (msg.includes('Unauthorized') || msg.includes('Admin access required')) {
-      return NextResponse.json({ error: msg }, { status: 403 });
-    }
+    if (isAppError(error)) return jsonError(error);
     logger.error('[API] Failed to update retention settings', { error });
-    return NextResponse.json({ error: 'Failed to update settings' }, { status: 500 });
+    return jsonError('Failed to update settings', 500);
   }
 }
 
@@ -142,8 +146,15 @@ export async function PUT(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const admin = await assertAdmin();
-    const body = await request.json();
-    const dryRun = body.dryRun !== false; // Default to dry run for safety
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const dryRun = payload.dryRun !== false;
 
     const result = await performDataCleanup(dryRun);
 
@@ -157,23 +168,11 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    logger.info('[API] Data cleanup executed', {
-      userId: admin.id,
-      dryRun,
-      result,
-    });
-
-    return NextResponse.json({
-      success: true,
-      dryRun,
-      result,
-    });
+    logger.info('[API] Data cleanup executed', { userId: admin.id, dryRun, result });
+    return jsonOk({ success: true, dryRun, result });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Failed to execute cleanup';
-    if (msg.includes('Unauthorized') || msg.includes('Admin access required')) {
-      return NextResponse.json({ error: msg }, { status: 403 });
-    }
+    if (isAppError(error)) return jsonError(error);
     logger.error('[API] Data cleanup failed', { error });
-    return NextResponse.json({ error: 'Failed to execute cleanup' }, { status: 500 });
+    return jsonError('Failed to execute cleanup', 500);
   }
 }

--- a/src/app/api/settings/slack-oauth/route.ts
+++ b/src/app/api/settings/slack-oauth/route.ts
@@ -1,47 +1,41 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { saveSlackOAuthConfig } from '@/app/(app)/settings/slack-oauth/actions';
-import { assertAdmin } from '@/lib/rbac';
+import { assertAdmin, getCurrentUser } from '@/lib/rbac';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 
 export async function POST(request: NextRequest) {
   try {
     await assertAdmin();
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.' },
-      { status: 403 }
-    );
-  }
 
-  try {
     const formData = await request.formData();
     const result = await saveSlackOAuthConfig(formData);
 
     if (result?.error) {
-      return NextResponse.json({ error: result.error }, { status: 400 });
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: result.error,
+        })
+      );
     }
 
-    return NextResponse.json({ success: true });
-  } catch (error: any) {
-    return NextResponse.json({ error: 'Failed to save configuration' }, { status: 500 });
+    return jsonOk({ success: true });
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to save configuration', 500);
   }
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(_request: NextRequest) {
   try {
     await assertAdmin();
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unauthorized' },
-      { status: 403 }
-    );
-  }
 
-  try {
     const prisma = (await import('@/lib/prisma')).default;
     await prisma.slackOAuthConfig.deleteMany({});
 
     const { logAudit } = await import('@/lib/audit');
-    const user = await import('@/lib/rbac').then(m => m.getCurrentUser());
+    const user = await getCurrentUser();
 
     await logAudit({
       action: 'slack.oauth.config.deleted',
@@ -51,8 +45,9 @@ export async function DELETE(request: NextRequest) {
       details: { configType: 'slack-oauth' },
     });
 
-    return NextResponse.json({ success: true });
-  } catch (error: any) {
-    return NextResponse.json({ error: 'Failed to delete configuration' }, { status: 500 });
+    return jsonOk({ success: true });
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Failed to delete configuration', 500);
   }
 }

--- a/src/app/api/settings/status-page/route.ts
+++ b/src/app/api/settings/status-page/route.ts
@@ -3,10 +3,45 @@ import { revalidatePath } from 'next/cache';
 import prisma from '@/lib/prisma';
 import { assertAdmin } from '@/lib/rbac';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { prismaToAppError } from '@/lib/prisma-errors';
 import { StatusPageSettingsSchema } from '@/lib/validation';
 import { logger } from '@/lib/logger';
 import { Prisma } from '@prisma/client';
 import { assertStatusPageNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
+
+function statusPageUniqueError(fields: string[]) {
+  if (fields.includes('subdomain')) {
+    return {
+      code: 'VALIDATION_FAILED' as const,
+      userMessage: 'This subdomain is already in use. Please choose a different one.',
+      fields: [
+        {
+          field: 'subdomain',
+          code: 'duplicate',
+          message: 'This subdomain is already in use. Please choose a different one.',
+        },
+      ],
+    };
+  }
+  if (fields.includes('customDomain')) {
+    return {
+      code: 'VALIDATION_FAILED' as const,
+      userMessage: 'This custom domain is already in use. Please choose a different one.',
+      fields: [
+        {
+          field: 'customDomain',
+          code: 'duplicate',
+          message: 'This custom domain is already in use. Please choose a different one.',
+        },
+      ],
+    };
+  }
+  return {
+    code: 'VALIDATION_FAILED' as const,
+    userMessage: 'A record with this value already exists.',
+  };
+}
 
 /**
  * Update Status Page Settings
@@ -15,21 +50,31 @@ import { assertStatusPageNameAvailable, UniqueNameConflictError } from '@/lib/un
 export async function POST(req: NextRequest) {
   try {
     await assertAdmin();
-  } catch (error) {
-    return jsonError(error instanceof Error ? error.message : 'Unauthorized', 403);
-  }
 
-  try {
-    let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let body: unknown;
     try {
       body = await req.json();
-    } catch (_error) {
-      return jsonError('Invalid JSON in request body.', 400);
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
     }
+
     const parsed = StatusPageSettingsSchema.safeParse(body);
     if (!parsed.success) {
-      return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Invalid request body.',
+          fields: parsed.error.issues.map(issue => ({
+            field: issue.path.join('.') || 'request',
+            code: issue.code,
+            message: issue.message,
+          })),
+        }),
+        undefined,
+        { issues: parsed.error.issues }
+      );
     }
+
     const {
       name,
       organizationName,
@@ -48,7 +93,6 @@ export async function POST(req: NextRequest) {
       branding,
       serviceIds = [],
       serviceConfigs = {},
-      // Privacy settings
       privacyMode,
       showIncidentDetails,
       showIncidentTitles,
@@ -84,11 +128,9 @@ export async function POST(req: NextRequest) {
       statusApiRateLimitWindowSec,
     } = parsed.data;
 
-    // Get or create status page
     let statusPage = await prisma.statusPage.findFirst({});
 
     if (!statusPage) {
-      // Create new status page
       statusPage = await prisma.statusPage.create({
         data: {
           name: name?.trim() || 'Status Page',
@@ -102,7 +144,6 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    // Update status page
     const updateData: Prisma.StatusPageUpdateInput = {
       organizationName:
         organizationName !== undefined
@@ -124,16 +165,34 @@ export async function POST(req: NextRequest) {
       contactUrl: contactUrl && contactUrl.trim() ? contactUrl.trim() : null,
     };
 
-    // Only update name if it's provided and not empty - exclude current status page from duplicate check
     if (name !== undefined && name !== null && name.trim().length > 0) {
       try {
         const uniqueName = await assertStatusPageNameAvailable(name, { excludeId: statusPage.id });
         updateData.name = uniqueName;
       } catch (error) {
         if (error instanceof UniqueNameConflictError) {
-          return jsonError('A status page with this name already exists.', 400);
+          return jsonError(
+            new AppError({
+              code: 'VALIDATION_FAILED',
+              userMessage: 'A status page with this name already exists.',
+              fields: [
+                {
+                  field: 'name',
+                  code: 'duplicate',
+                  message: 'A status page with this name already exists.',
+                },
+              ],
+            })
+          );
         }
-        return jsonError(error instanceof Error ? error.message : 'Invalid status page name.', 400);
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: 'Invalid status page name.',
+            fields: [{ field: 'name', code: 'invalid', message: 'Invalid status page name.' }],
+            cause: error,
+          })
+        );
       }
     }
 
@@ -142,7 +201,6 @@ export async function POST(req: NextRequest) {
         branding === null ? Prisma.JsonNull : (branding as Prisma.InputJsonValue);
     }
 
-    // Privacy settings
     if (privacyMode !== undefined) updateData.privacyMode = privacyMode;
     if (showIncidentDetails !== undefined) updateData.showIncidentDetails = showIncidentDetails;
     if (showIncidentTitles !== undefined) updateData.showIncidentTitles = showIncidentTitles;
@@ -201,14 +259,9 @@ export async function POST(req: NextRequest) {
       data: updateData,
     });
 
-    // Update services
     if (Array.isArray(serviceIds)) {
-      // Delete existing services
-      await prisma.statusPageService.deleteMany({
-        where: { statusPageId: statusPage.id },
-      });
+      await prisma.statusPageService.deleteMany({ where: { statusPageId: statusPage.id } });
 
-      // Create new services with configurations
       if (serviceIds.length > 0) {
         await prisma.statusPageService.createMany({
           data: serviceIds.map((serviceId: string) => {
@@ -225,33 +278,17 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Purge cache for the public status page to ensure updates are reflected immediately
     revalidatePath('/status');
-    // Also revalidate the root path in case of rewrites or home page links
     revalidatePath('/');
 
     logger.info('api.status_page.updated', { statusPageId: statusPage.id });
     return jsonOk({ success: true }, 200);
-  } catch (error: any) {
-    logger.error('api.status_page.update_error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    const prismaError = prismaToAppError(error, { unique: statusPageUniqueError });
+    if (prismaError) return jsonError(prismaError);
+    if (isAppError(error)) return jsonError(error);
 
-    // Handle Prisma unique constraint violations
-    if (error.code === 'P2002') {
-      const field = error.meta?.target?.[0];
-      if (field === 'subdomain') {
-        return jsonError('This subdomain is already in use. Please choose a different one.', 400);
-      }
-      if (field === 'customDomain') {
-        return jsonError(
-          'This custom domain is already in use. Please choose a different one.',
-          400
-        );
-      }
-      return jsonError('A record with this value already exists.', 400);
-    }
-
+    logger.error('api.status_page.update_error', { error });
     return jsonError('Failed to update status page', 500);
   }
 }

--- a/src/app/api/status-page/subscribe/route.ts
+++ b/src/app/api/status-page/subscribe/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { randomBytes } from 'crypto';
 import { sendEmail } from '@/lib/email';
@@ -14,6 +15,10 @@ import {
   getStatusPageVerificationUrl,
 } from '@/lib/status-page-url';
 
+function rateLimitError(retryAfter: number) {
+  return jsonError(new AppError({ code: 'RATE_LIMIT_EXCEEDED' }), undefined, { retryAfter });
+}
+
 /**
  * Subscribe to Status Page Updates
  * POST /api/status-page/subscribe
@@ -23,54 +28,71 @@ export async function POST(req: NextRequest) {
     const ip = getClientIp(req.headers);
     const ipRate = await checkRateLimit(`api:status-page:subscribe:ip:${ip}`, 10, 60_000);
     if (!ipRate.allowed) {
-      const retryAfter = Math.ceil((ipRate.resetAt - Date.now()) / 1000);
-      return jsonError('Rate limit exceeded', 429, { retryAfter });
+      return rateLimitError(Math.max(1, Math.ceil((ipRate.resetAt - Date.now()) / 1000)));
     }
 
-    const body = await req.json();
-    const { statusPageId, email } = body;
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const statusPageId = typeof payload.statusPageId === 'string' ? payload.statusPageId : '';
+    const email = typeof payload.email === 'string' ? payload.email.trim() : '';
 
     if (!statusPageId || !email || !email.includes('@')) {
-      return jsonError('Valid statusPageId and email are required', 400);
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Valid statusPageId and email are required',
+          fields: [
+            ...(!statusPageId
+              ? [{ field: 'statusPageId', code: 'required', message: 'statusPageId is required' }]
+              : []),
+            ...(!email || !email.includes('@')
+              ? [{ field: 'email', code: 'invalid', message: 'A valid email is required' }]
+              : []),
+          ],
+        })
+      );
     }
 
-    const emailKey = `${statusPageId}:${email.trim().toLowerCase()}`;
+    const normalizedEmail = email.toLowerCase();
+    const emailKey = `${statusPageId}:${normalizedEmail}`;
     const emailRate = await checkRateLimit(
       `api:status-page:subscribe:email:${emailKey}`,
       3,
       60_000
     );
     if (!emailRate.allowed) {
-      const retryAfter = Math.ceil((emailRate.resetAt - Date.now()) / 1000);
-      return jsonError('Rate limit exceeded', 429, { retryAfter });
+      return rateLimitError(Math.max(1, Math.ceil((emailRate.resetAt - Date.now()) / 1000)));
     }
 
-    // Verify status page exists and is enabled
     const statusPage = await prisma.statusPage.findFirst({
       where: { id: statusPageId, enabled: true },
     });
 
     if (!statusPage) {
-      return jsonError('Status page not found or disabled', 404);
+      return jsonError(
+        new AppError({
+          code: 'RESOURCE_NOT_FOUND',
+          userMessage: 'Status page not found or disabled',
+        })
+      );
     }
 
-    // Generate tokens
     const token = randomBytes(32).toString('hex');
     const verificationToken = randomBytes(32).toString('hex');
 
-    // Check if subscription already exists
     const existing = await prisma.statusPageSubscription.findUnique({
       where: {
-        statusPageId_email: {
-          statusPageId,
-          email: email.trim().toLowerCase(),
-        },
+        statusPageId_email: { statusPageId, email: normalizedEmail },
       },
     });
 
     if (existing) {
       if (existing.unsubscribedAt) {
-        // Resubscribe
         await prisma.statusPageSubscription.update({
           where: { id: existing.id },
           data: {
@@ -91,19 +113,16 @@ export async function POST(req: NextRequest) {
           200
         );
       } else {
-        // Rotate stale verification credentials and resend so an attacker cannot
-        // permanently reserve somebody else's email address.
         await prisma.statusPageSubscription.update({
           where: { id: existing.id },
           data: { token, verificationToken },
         });
       }
     } else {
-      // Create new subscription
       await prisma.statusPageSubscription.create({
         data: {
           statusPageId,
-          email: email.trim().toLowerCase(),
+          email: normalizedEmail,
           token,
           verificationToken,
           verified: false,
@@ -111,14 +130,12 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    // Send verification email using status page's preferred email provider
     try {
       const { getStatusPageEmailConfig } = await import('@/lib/notification-providers');
       const emailConfig = await getStatusPageEmailConfig(statusPageId);
 
       if (!emailConfig.enabled || !emailConfig.provider) {
         logger.warn('api.status_page.subscription.no_email_provider', { statusPageId });
-        // Continue - subscription created but no email sent
       } else {
         const appBaseUrl = getBaseUrl();
         const statusPageUrl = getStatusPagePublicUrl(statusPage, appBaseUrl);
@@ -150,39 +167,42 @@ export async function POST(req: NextRequest) {
 
         await sendEmail(
           {
-            to: email.trim().toLowerCase(),
+            to: normalizedEmail,
             subject: emailTemplate.subject,
             html: emailTemplate.html,
             text: emailTemplate.text,
           },
           emailConfig
-        ); // Pass the config
+        );
 
         logger.info('api.status_page.subscription.verification_email_sent', {
           statusPageId,
-          email,
+          email: normalizedEmail,
           provider: emailConfig.provider,
         });
       }
-    } catch (emailError: any) {
-      // Log error but don't fail the subscription - email can be resent later
+    } catch (emailError) {
+      // Subscription creation remains successful when delivery fails. The email
+      // can be retried later; do not roll back the subscription contract.
       logger.error('api.status_page.subscription.verification_email_failed', {
         statusPageId,
-        email,
+        email: normalizedEmail,
         error: emailError instanceof Error ? emailError.message : String(emailError),
       });
     }
 
-    logger.info('api.status_page.subscription.created', { statusPageId, email });
+    logger.info('api.status_page.subscription.created', {
+      statusPageId,
+      email: normalizedEmail,
+    });
 
     return jsonOk(
       { success: true, message: 'Subscription created. Please check your email to verify.' },
       200
     );
-  } catch (error: any) {
-    logger.error('api.status_page.subscription.error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+    logger.error('api.status_page.subscription.error', { error });
     return jsonError('Failed to create subscription', 500);
   }
 }

--- a/src/app/api/status-page/subscribers/route.ts
+++ b/src/app/api/status-page/subscribers/route.ts
@@ -1,10 +1,16 @@
 import { NextRequest } from 'next/server';
+import type { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
+import { AppError, isAppError } from '@/lib/errors';
+import { prismaToAppError } from '@/lib/prisma-errors';
 import { logger } from '@/lib/logger';
-import { getServerSession } from 'next-auth';
-import { getAuthOptions } from '@/lib/auth';
 import { assertAdmin } from '@/lib/rbac';
+
+const SUBSCRIPTION_NOT_FOUND = {
+  code: 'RESOURCE_NOT_FOUND' as const,
+  userMessage: 'Subscription not found',
+};
 
 /**
  * Get Status Page Subscribers
@@ -12,64 +18,57 @@ import { assertAdmin } from '@/lib/rbac';
  */
 export async function GET(req: NextRequest) {
   try {
-    const session = await getServerSession(await getAuthOptions());
-    if (!session) {
-      return jsonError('Unauthorized', 401);
-    }
-
-    // Require admin role
-    try {
-      await assertAdmin();
-    } catch {
-      return jsonError('Admin access required', 403);
-    }
+    await assertAdmin();
 
     const searchParams = req.nextUrl.searchParams;
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '10');
+    const page = Number.parseInt(searchParams.get('page') || '1', 10);
+    const limit = Number.parseInt(searchParams.get('limit') || '10', 10);
     const statusPageId = searchParams.get('statusPageId');
-    const verifiedFilter = searchParams.get('verified'); // 'true', 'false', or null (all)
-    const searchEmail = searchParams.get('email'); // Search by email
+    const verifiedFilter = searchParams.get('verified');
+    const searchEmail = searchParams.get('email');
+
+    if (!Number.isFinite(page) || page < 1 || !Number.isFinite(limit) || limit < 1 || limit > 100) {
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Invalid pagination parameters.',
+          fields: [
+            ...(page < 1 || !Number.isFinite(page)
+              ? [{ field: 'page', code: 'invalid', message: 'page must be a positive integer' }]
+              : []),
+            ...(limit < 1 || limit > 100 || !Number.isFinite(limit)
+              ? [
+                  {
+                    field: 'limit',
+                    code: 'invalid',
+                    message: 'limit must be between 1 and 100',
+                  },
+                ]
+              : []),
+          ],
+        })
+      );
+    }
 
     const skip = (page - 1) * limit;
+    const where: Prisma.StatusPageSubscriptionWhereInput = {};
 
-    // Build where clause
-    const where: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-    if (statusPageId) {
-      where.statusPageId = statusPageId;
-    }
-
-    if (verifiedFilter === 'true') {
-      where.verified = true;
-    } else if (verifiedFilter === 'false') {
-      where.verified = false;
-    }
-
+    if (statusPageId) where.statusPageId = statusPageId;
+    if (verifiedFilter === 'true') where.verified = true;
+    else if (verifiedFilter === 'false') where.verified = false;
     if (searchEmail) {
-      where.email = {
-        contains: searchEmail,
-        mode: 'insensitive',
-      };
+      where.email = { contains: searchEmail, mode: 'insensitive' };
     }
 
-    // Get total count
     const total = await prisma.statusPageSubscription.count({ where });
-
-    // Get paginated subscribers
     const subscribers = await prisma.statusPageSubscription.findMany({
       where,
       include: {
         statusPage: {
-          select: {
-            id: true,
-            name: true,
-          },
+          select: { id: true, name: true },
         },
       },
-      orderBy: {
-        subscribedAt: 'desc',
-      },
+      orderBy: { subscribedAt: 'desc' },
       skip,
       take: limit,
     });
@@ -83,21 +82,10 @@ export async function GET(req: NextRequest) {
       verified: verifiedFilter,
     });
 
-    return jsonOk(
-      {
-        subscribers,
-        total,
-        page,
-        limit,
-        totalPages,
-      },
-      200
-    );
-  } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
-    logger.error('api.status_page.subscribers.error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    return jsonOk({ subscribers, total, page, limit, totalPages }, 200);
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+    logger.error('api.status_page.subscribers.error', { error });
     return jsonError('Failed to fetch subscribers', 500);
   }
 }
@@ -108,40 +96,31 @@ export async function GET(req: NextRequest) {
  */
 export async function DELETE(req: NextRequest) {
   try {
-    const session = await getServerSession(await getAuthOptions());
-    if (!session) {
-      return jsonError('Unauthorized', 401);
-    }
+    await assertAdmin();
 
-    // Require admin role
-    try {
-      await assertAdmin();
-    } catch {
-      return jsonError('Admin access required', 403);
-    }
-
-    const searchParams = req.nextUrl.searchParams;
-    const subscriptionId = searchParams.get('id');
-
+    const subscriptionId = req.nextUrl.searchParams.get('id');
     if (!subscriptionId) {
-      return jsonError('Subscription ID is required', 400);
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Subscription ID is required',
+          fields: [
+            { field: 'id', code: 'required', message: 'Subscription ID is required' },
+          ],
+        })
+      );
     }
 
-    // Check if subscription exists
     const subscription = await prisma.statusPageSubscription.findUnique({
       where: { id: subscriptionId },
     });
-
     if (!subscription) {
-      return jsonError('Subscription not found', 404);
+      return jsonError(new AppError(SUBSCRIPTION_NOT_FOUND));
     }
 
-    // Mark as unsubscribed instead of deleting
     await prisma.statusPageSubscription.update({
       where: { id: subscriptionId },
-      data: {
-        unsubscribedAt: new Date(),
-      },
+      data: { unsubscribedAt: new Date() },
     });
 
     logger.info('api.status_page.subscriber.unsubscribed', {
@@ -150,11 +129,12 @@ export async function DELETE(req: NextRequest) {
     });
 
     return jsonOk({ success: true, message: 'Subscriber unsubscribed successfully' }, 200);
-  } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
-    logger.error('api.status_page.subscriber.delete.error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    const prismaError = prismaToAppError(error, { notFound: SUBSCRIPTION_NOT_FOUND });
+    if (prismaError) return jsonError(prismaError);
+    if (isAppError(error)) return jsonError(error);
+
+    logger.error('api.status_page.subscriber.delete.error', { error });
     return jsonError('Failed to unsubscribe', 500);
   }
 }

--- a/src/app/api/status-page/webhooks/route.ts
+++ b/src/app/api/status-page/webhooks/route.ts
@@ -2,34 +2,36 @@ import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { assertAdmin } from '@/lib/rbac';
 import { jsonError, jsonOk } from '@/lib/api-response';
-import { AppError } from '@/lib/errors';
+import { AppError, isAppError } from '@/lib/errors';
+import { prismaToAppError } from '@/lib/prisma-errors';
 import { logger } from '@/lib/logger';
 import { randomBytes } from 'crypto';
 import { assertSafeOutboundUrl } from '@/lib/network-security';
 import { encrypt } from '@/lib/encryption';
 
-const LEGACY_UNAUTHORIZED_MESSAGE =
-  'You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
 const LEGACY_REQUIRED_MESSAGE = 'Please fill in all required fields.';
 const LEGACY_INVALID_INPUT_MESSAGE = 'Please check your input and try again.';
 const LEGACY_NOT_FOUND_MESSAGE =
   'The requested item could not be found. It may have been deleted or you may not have access to it.';
 
-function adminDenied() {
-  return jsonError(
-    new AppError({
-      code: 'AUTHORIZATION_DENIED',
-      userMessage: LEGACY_UNAUTHORIZED_MESSAGE,
-    })
-  );
+const WEBHOOK_NOT_FOUND = {
+  code: 'STATUS_PAGE_WEBHOOK_NOT_FOUND' as const,
+  userMessage: LEGACY_NOT_FOUND_MESSAGE,
+};
+
+async function requireAdmin() {
+  try {
+    await assertAdmin();
+    return null;
+  } catch (error) {
+    if (isAppError(error)) return jsonError(error);
+    return jsonError('Unable to authorize this request', 500);
+  }
 }
 
 export async function GET(req: NextRequest) {
-  try {
-    await assertAdmin();
-  } catch {
-    return adminDenied();
-  }
+  const authError = await requireAdmin();
+  if (authError) return authError;
 
   try {
     const { searchParams } = new URL(req.url);
@@ -52,84 +54,82 @@ export async function GET(req: NextRequest) {
       orderBy: { createdAt: 'desc' },
     });
 
-    return jsonOk(
-      {
-        webhooks: webhooks.map(webhook => ({ ...webhook, secret: '••••••••', hasSecret: true })),
-      },
-      200
-    );
-  } catch (error: any) {
-    logger.error('api.status_page.webhooks.get_error', {
-      error: error instanceof Error ? error.message : String(error),
+    return jsonOk({
+      webhooks: webhooks.map(webhook => ({ ...webhook, secret: '••••••••', hasSecret: true })),
     });
+  } catch (error) {
+    logger.error('api.status_page.webhooks.get_error', { error });
     return jsonError('Failed to fetch webhooks', 500);
   }
 }
 
 export async function POST(req: NextRequest) {
-  try {
-    await assertAdmin();
-  } catch {
-    return adminDenied();
-  }
+  const authError = await requireAdmin();
+  if (authError) return authError;
 
   try {
-    const body = await req.json();
-    const { statusPageId, url, events } = body;
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const statusPageId = typeof payload.statusPageId === 'string' ? payload.statusPageId : null;
+    const url = typeof payload.url === 'string' ? payload.url : null;
+    const events = Array.isArray(payload.events) ? payload.events : null;
 
-    if (!statusPageId || !url || !events || !Array.isArray(events)) {
+    if (!statusPageId || !url || !events) {
       return jsonError(
-        new AppError({
-          code: 'VALIDATION_FAILED',
-          userMessage: LEGACY_REQUIRED_MESSAGE,
-        })
+        new AppError({ code: 'VALIDATION_FAILED', userMessage: LEGACY_REQUIRED_MESSAGE })
       );
     }
 
     try {
       await assertSafeOutboundUrl(url);
-    } catch {
+    } catch (error) {
       return jsonError(
         new AppError({
           code: 'VALIDATION_FAILED',
           userMessage: LEGACY_INVALID_INPUT_MESSAGE,
           fields: [{ field: 'url', code: 'invalid', message: 'Invalid URL format' }],
+          cause: error,
         })
       );
     }
 
     const secret = randomBytes(32).toString('hex');
-
     const webhook = await prisma.statusPageWebhook.create({
       data: {
         statusPageId,
         url,
         secret: await encrypt(secret),
-        events: events,
+        events,
         enabled: true,
       },
     });
 
     logger.info('api.status_page.webhook.created', { webhookId: webhook.id, statusPageId });
     return jsonOk({ webhook: { ...webhook, secret }, hasSecret: true }, 201);
-  } catch (error: any) {
-    logger.error('api.status_page.webhook.create_error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    logger.error('api.status_page.webhook.create_error', { error });
     return jsonError('Failed to create webhook', 500);
   }
 }
 
 export async function PATCH(req: NextRequest) {
-  try {
-    await assertAdmin();
-  } catch {
-    return adminDenied();
-  }
+  const authError = await requireAdmin();
+  if (authError) return authError;
 
   try {
-    const body = await req.json();
-    const { id, url, events, enabled } = body;
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch (error) {
+      return jsonError(new AppError({ code: 'INVALID_JSON', cause: error }));
+    }
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const id = typeof payload.id === 'string' ? payload.id : null;
 
     if (!id) {
       return jsonError(
@@ -141,23 +141,33 @@ export async function PATCH(req: NextRequest) {
       );
     }
 
-    const updateData: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
-    if (url !== undefined) {
+    const updateData: Record<string, unknown> = {};
+    if (payload.url !== undefined) {
+      if (typeof payload.url !== 'string') {
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: LEGACY_INVALID_INPUT_MESSAGE,
+            fields: [{ field: 'url', code: 'invalid_type', message: 'url must be a string' }],
+          })
+        );
+      }
       try {
-        await assertSafeOutboundUrl(url);
-        updateData.url = url;
-      } catch {
+        await assertSafeOutboundUrl(payload.url);
+        updateData.url = payload.url;
+      } catch (error) {
         return jsonError(
           new AppError({
             code: 'VALIDATION_FAILED',
             userMessage: LEGACY_INVALID_INPUT_MESSAGE,
             fields: [{ field: 'url', code: 'invalid', message: 'Invalid URL format' }],
+            cause: error,
           })
         );
       }
     }
-    if (events !== undefined) {
-      if (!Array.isArray(events)) {
+    if (payload.events !== undefined) {
+      if (!Array.isArray(payload.events)) {
         return jsonError(
           new AppError({
             code: 'VALIDATION_FAILED',
@@ -166,54 +176,47 @@ export async function PATCH(req: NextRequest) {
           })
         );
       }
-      updateData.events = events;
+      updateData.events = payload.events;
     }
-    if (enabled !== undefined) {
-      updateData.enabled = enabled;
+    if (payload.enabled !== undefined) {
+      if (typeof payload.enabled !== 'boolean') {
+        return jsonError(
+          new AppError({
+            code: 'VALIDATION_FAILED',
+            userMessage: 'enabled must be a boolean',
+            fields: [{ field: 'enabled', code: 'invalid_type', message: 'enabled must be a boolean' }],
+          })
+        );
+      }
+      updateData.enabled = payload.enabled;
     }
 
     if (Object.keys(updateData).length === 0) {
       return jsonError(
-        new AppError({
-          code: 'VALIDATION_FAILED',
-          userMessage: 'No fields to update',
-        })
+        new AppError({ code: 'VALIDATION_FAILED', userMessage: 'No fields to update' })
       );
     }
 
-    const webhook = await prisma.statusPageWebhook.update({
-      where: { id },
-      data: updateData,
-    });
+    const webhook = await prisma.statusPageWebhook.update({ where: { id }, data: updateData });
 
     logger.info('api.status_page.webhook.updated', { webhookId: id });
     return jsonOk({ webhook }, 200);
-  } catch (error: any) {
-    if (error.code === 'P2025') {
-      return jsonError(
-        new AppError({
-          code: 'STATUS_PAGE_WEBHOOK_NOT_FOUND',
-          userMessage: LEGACY_NOT_FOUND_MESSAGE,
-        })
-      );
-    }
-    logger.error('api.status_page.webhook.update_error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    const prismaError = prismaToAppError(error, { notFound: WEBHOOK_NOT_FOUND });
+    if (prismaError) return jsonError(prismaError);
+    if (isAppError(error)) return jsonError(error);
+
+    logger.error('api.status_page.webhook.update_error', { error });
     return jsonError('Failed to update webhook', 500);
   }
 }
 
 export async function DELETE(req: NextRequest) {
-  try {
-    await assertAdmin();
-  } catch {
-    return adminDenied();
-  }
+  const authError = await requireAdmin();
+  if (authError) return authError;
 
   try {
-    const { searchParams } = new URL(req.url);
-    const id = searchParams.get('id');
+    const id = new URL(req.url).searchParams.get('id');
 
     if (!id) {
       return jsonError(
@@ -225,16 +228,16 @@ export async function DELETE(req: NextRequest) {
       );
     }
 
-    await prisma.statusPageWebhook.delete({
-      where: { id },
-    });
+    await prisma.statusPageWebhook.delete({ where: { id } });
 
     logger.info('api.status_page.webhook.deleted', { webhookId: id });
     return jsonOk({ success: true }, 200);
-  } catch (error: any) {
-    logger.error('api.status_page.webhook.delete_error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  } catch (error) {
+    const prismaError = prismaToAppError(error, { notFound: WEBHOOK_NOT_FOUND });
+    if (prismaError) return jsonError(prismaError);
+    if (isAppError(error)) return jsonError(error);
+
+    logger.error('api.status_page.webhook.delete_error', { error });
     return jsonError('Failed to delete webhook', 500);
   }
 }

--- a/src/lib/prisma-errors.ts
+++ b/src/lib/prisma-errors.ts
@@ -1,0 +1,113 @@
+import { AppError, type AppErrorCode, type ErrorField } from '@/lib/errors';
+
+export type PrismaErrorInfo = {
+  code: string;
+  fields: string[];
+};
+
+type AppErrorFactoryOptions = {
+  code: AppErrorCode;
+  userMessage?: string;
+  action?: string;
+  retryable?: boolean;
+  fields?: ErrorField[];
+  details?: Record<string, unknown>;
+};
+
+export type PrismaAppErrorMapping = {
+  unique?: AppErrorFactoryOptions | ((fields: string[]) => AppErrorFactoryOptions);
+  notFound?: AppErrorFactoryOptions | (() => AppErrorFactoryOptions);
+  writeConflict?: AppErrorFactoryOptions | (() => AppErrorFactoryOptions);
+};
+
+function readStringArray(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+/**
+ * Extract only Prisma's structured machine metadata. This helper intentionally
+ * does not inspect exception messages, so database wording can never control
+ * application semantics.
+ */
+export function getPrismaErrorInfo(error: unknown): PrismaErrorInfo | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+
+  const candidate = error as { code?: unknown; meta?: unknown };
+  if (typeof candidate.code !== 'string' || !/^P\d{4}$/.test(candidate.code)) {
+    return undefined;
+  }
+
+  const meta =
+    candidate.meta && typeof candidate.meta === 'object'
+      ? (candidate.meta as Record<string, unknown>)
+      : undefined;
+  const fields = readStringArray(meta?.target);
+
+  return { code: candidate.code, fields };
+}
+
+export function isPrismaErrorCode(error: unknown, code: string): boolean {
+  return getPrismaErrorInfo(error)?.code === code;
+}
+
+export function getPrismaUniqueFields(error: unknown): string[] {
+  const info = getPrismaErrorInfo(error);
+  return info?.code === 'P2002' ? info.fields : [];
+}
+
+function resolveUniqueMapping(
+  mapping: NonNullable<PrismaAppErrorMapping['unique']>,
+  fields: string[]
+): AppErrorFactoryOptions {
+  return typeof mapping === 'function' ? mapping(fields) : mapping;
+}
+
+function resolveNoArgMapping(
+  mapping: NonNullable<PrismaAppErrorMapping['notFound'] | PrismaAppErrorMapping['writeConflict']>
+): AppErrorFactoryOptions {
+  return typeof mapping === 'function' ? mapping() : mapping;
+}
+
+function toAppError(
+  options: AppErrorFactoryOptions,
+  error: unknown,
+  prisma: PrismaErrorInfo
+): AppError {
+  return new AppError({
+    ...options,
+    details: {
+      prismaCode: prisma.code,
+      prismaFields: prisma.fields,
+      ...options.details,
+    },
+    cause: error,
+  });
+}
+
+/**
+ * Map the Prisma errors that have stable application semantics. Callers supply
+ * domain/public wording; this adapter owns interpretation of Prisma codes.
+ */
+export function prismaToAppError(
+  error: unknown,
+  mapping: PrismaAppErrorMapping
+): AppError | undefined {
+  const prisma = getPrismaErrorInfo(error);
+  if (!prisma) return undefined;
+
+  if (prisma.code === 'P2002' && mapping.unique) {
+    return toAppError(resolveUniqueMapping(mapping.unique, prisma.fields), error, prisma);
+  }
+
+  if (prisma.code === 'P2025' && mapping.notFound) {
+    return toAppError(resolveNoArgMapping(mapping.notFound), error, prisma);
+  }
+
+  if (prisma.code === 'P2034' && mapping.writeConflict) {
+    return toAppError(resolveNoArgMapping(mapping.writeConflict), error, prisma);
+  }
+
+  return undefined;
+}

--- a/tests/architecture/error-contract.test.ts
+++ b/tests/architecture/error-contract.test.ts
@@ -5,6 +5,7 @@ import { basename, join, relative } from 'node:path';
 const API_ROOT = join(process.cwd(), 'src', 'app', 'api');
 const APP_ROOT = join(process.cwd(), 'src', 'app');
 const ERROR_IDENTIFIER = String.raw`(?:error|err|e|[A-Za-z_$][\w$]*(?:Error|Err))`;
+const MESSAGE_ALIAS = String.raw`(?:message|msg)`;
 
 function sourceFiles(root: string): string[] {
   const files: string[] = [];
@@ -45,11 +46,11 @@ describe('public API error contract architecture', () => {
       'g'
     );
     const normalizedMethodMatching = new RegExp(
-      String.raw`\bconst\s+message\s*=\s*${ERROR_IDENTIFIER}\s+instanceof\s+Error\s*\?\s*${ERROR_IDENTIFIER}(?:\?\.|\.)message[\s\S]{0,1600}?\bmessage(?:\?\.|\.)(?:includes|startsWith|endsWith|match|search)\s*\(`,
+      String.raw`\bconst\s+${MESSAGE_ALIAS}\s*=\s*${ERROR_IDENTIFIER}\s+instanceof\s+Error\s*\?\s*${ERROR_IDENTIFIER}(?:\?\.|\.)message[\s\S]{0,1600}?\b${MESSAGE_ALIAS}(?:\?\.|\.)(?:includes|startsWith|endsWith|match|search)\s*\(`,
       'g'
     );
     const normalizedComparison = new RegExp(
-      String.raw`\bconst\s+message\s*=\s*${ERROR_IDENTIFIER}\s+instanceof\s+Error\s*\?\s*${ERROR_IDENTIFIER}(?:\?\.|\.)message[\s\S]{0,1600}?\bmessage\s*(?:===|!==|==|!=)\s*['"\x60]`,
+      String.raw`\bconst\s+${MESSAGE_ALIAS}\s*=\s*${ERROR_IDENTIFIER}\s+instanceof\s+Error\s*\?\s*${ERROR_IDENTIFIER}(?:\?\.|\.)message[\s\S]{0,1600}?\b${MESSAGE_ALIAS}\s*(?:===|!==|==|!=)\s*['"\x60]`,
       'g'
     );
 

--- a/tests/lib/prisma-errors.test.ts
+++ b/tests/lib/prisma-errors.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getPrismaErrorInfo,
+  getPrismaUniqueFields,
+  isPrismaErrorCode,
+  prismaToAppError,
+} from '@/lib/prisma-errors';
+
+describe('Prisma error normalization', () => {
+  it('extracts structured Prisma codes and unique fields without reading messages', () => {
+    const error = {
+      code: 'P2002',
+      meta: { target: ['subdomain', 'tenantId'] },
+      message: 'arbitrary database wording',
+    };
+
+    expect(getPrismaErrorInfo(error)).toEqual({
+      code: 'P2002',
+      fields: ['subdomain', 'tenantId'],
+    });
+    expect(getPrismaUniqueFields(error)).toEqual(['subdomain', 'tenantId']);
+    expect(isPrismaErrorCode(error, 'P2002')).toBe(true);
+  });
+
+  it('ignores non-Prisma error codes', () => {
+    expect(getPrismaErrorInfo({ code: 'SQLITE_CONSTRAINT' })).toBeUndefined();
+    expect(getPrismaErrorInfo(new Error('P2002 in message only'))).toBeUndefined();
+  });
+
+  it('maps P2002 through domain-supplied conflict semantics', () => {
+    const error = { code: 'P2002', meta: { target: ['customDomain'] } };
+    const mapped = prismaToAppError(error, {
+      unique: fields => ({
+        code: 'VALIDATION_FAILED',
+        userMessage: `Duplicate: ${fields.join(',')}`,
+        fields: fields.map(field => ({
+          field,
+          code: 'duplicate',
+          message: 'Already in use',
+        })),
+      }),
+    });
+
+    expect(mapped?.code).toBe('VALIDATION_FAILED');
+    expect(mapped?.status).toBe(400);
+    expect(mapped?.fields).toEqual([
+      { field: 'customDomain', code: 'duplicate', message: 'Already in use' },
+    ]);
+    expect(mapped?.details).toMatchObject({
+      prismaCode: 'P2002',
+      prismaFields: ['customDomain'],
+    });
+  });
+
+  it('maps P2025 to the domain not-found code', () => {
+    const mapped = prismaToAppError({ code: 'P2025' }, {
+      notFound: {
+        code: 'STATUS_PAGE_WEBHOOK_NOT_FOUND',
+        userMessage: 'Webhook not found',
+      },
+    });
+
+    expect(mapped?.code).toBe('STATUS_PAGE_WEBHOOK_NOT_FOUND');
+    expect(mapped?.status).toBe(404);
+  });
+
+  it('does not guess semantics for unmapped Prisma codes', () => {
+    expect(prismaToAppError({ code: 'P2003' }, {})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Completes the backend/settings normalization layer of the typed AppError migration without changing unrelated incident/provider behavior.

### Prisma normalization

- adds a centralized Prisma error adapter driven only by structured Prisma codes/metadata
- maps `P2002`, `P2025`, and `P2034` through domain-supplied AppError semantics
- removes direct Prisma-code interpretation from incident tag actions
- keeps database/provider details internal

### Settings and status-page APIs

- migrates app URL, custom fields, email providers, notification settings, retention, Slack OAuth, status-page settings, subscriptions, subscribers, and status-page webhook expected errors to AppError/jsonError
- preserves safe generic 500 responses for unexpected failures
- removes retention's English substring authorization classification
- keeps existing public wording where compatibility matters

### Authorization and validation

- lets typed RBAC/AppError failures propagate rather than rebuilding local string-only responses
- adds typed invalid JSON / validation / not-found / conflict handling to the migrated settings surfaces
- preserves status-page subscription success semantics when verification-email delivery fails

### Architecture guard

- expands message-inference detection to catch aliases such as `msg` in addition to `message`
- keeps API routes from deriving HTTP/domain semantics from English error text

### Tests

- adds Prisma error-normalization unit coverage
- verifies structured-code extraction and domain-supplied mappings

## Scope

This PR intentionally does not remove the legacy friendly-error translator globally. Final legacy cleanup remains a separate follow-up after this backend normalization lands.

## Commit history

Intentionally one commit, rebased directly on current `main`.