### PR TITLE
feat(core): persist incident request idempotency

### DIFF
--- a/src/app/api/incidents/[id]/route.ts
+++ b/src/app/api/incidents/[id]/route.ts
@@ -195,6 +195,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const { id } = await params;
   let result: Awaited<ReturnType<typeof applyRestIncidentPatch>>;
   try {
+    const idempotencyKey = req.headers.get('idempotency-key')?.trim();
     result = await applyRestIncidentPatch({
       incidentId: id,
       status: parsed.data.status,
@@ -202,6 +203,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       assigneeId: hasAssigneeUpdate ? (parsed.data.assigneeId ?? null) : undefined,
       hasAssigneeUpdate,
       actor: { id: actor.id },
+      idempotency: idempotencyKey ? { key: idempotencyKey, principalId: apiKey.id } : undefined,
     });
   } catch (error) {
     logger.warn('api.incident.patch_rejected', {
@@ -212,17 +214,18 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return jsonError(error);
   }
 
-  const { incident, lifecycle, urgencyChanged, assigneeChanged } = result;
+  const { incident, lifecycle, urgencyChanged, assigneeChanged, idempotencyReplayed } = result;
   logger.info('api.incident.updated', {
     incidentId: incident.id,
     apiKeyId: apiKey.id,
     changed: result.changed,
+    idempotencyReplayed,
   });
 
   // Lifecycle effects are already persisted in the same transaction as the
-  // status change. Keep the existing immediate path only for a pure
-  // urgency/assignee update; a mixed PATCH emits the lifecycle event once.
-  if (!lifecycle?.changed && (urgencyChanged || assigneeChanged)) {
+  // status change. Keep the existing immediate path only for a new, pure
+  // urgency/assignee update; idempotent replays must not resend these effects.
+  if (!idempotencyReplayed && !lifecycle?.changed && (urgencyChanged || assigneeChanged)) {
     try {
       const updatedIncident = await prisma.incident.findUnique({
         where: { id },
@@ -276,5 +279,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     }
   }
 
-  return jsonOk({ incident }, 200);
+  return jsonOk(
+    { incident },
+    200,
+    idempotencyReplayed ? { 'Idempotency-Replayed': 'true' } : undefined
+  );
 }

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -10,7 +10,7 @@ import { incidentReadWhere } from '@/lib/authorization-filters';
 import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
 import { authorizationDecisionError } from '@/lib/api-authorization-error';
 import { AppError } from '@/lib/errors';
-import { executeIncidentCreation } from '@/lib/incidents/creation';
+import { executeIdempotentIncidentCreation } from '@/lib/incidents/idempotent-commands';
 
 const LEGACY_UNAUTHORIZED_MESSAGE =
   'You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
@@ -179,15 +179,20 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const creation = await executeIncidentCreation({
-      title,
-      description: description ?? null,
-      serviceId,
-      urgency,
-      priority: priority ?? null,
-      source: 'REST_API',
-      actor: { id: actor.id },
-    });
+    const idempotencyKey = req.headers.get('idempotency-key')?.trim();
+    const execution = await executeIdempotentIncidentCreation(
+      {
+        title,
+        description: description ?? null,
+        serviceId,
+        urgency,
+        priority: priority ?? null,
+        source: 'REST_API',
+        actor: { id: actor.id },
+      },
+      idempotencyKey ? { key: idempotencyKey, principalId: apiKey.id } : undefined
+    );
+    const creation = execution.value;
 
     const incident = await prisma.incident.findUnique({
       where: { id: creation.id },
@@ -210,9 +215,14 @@ export async function POST(req: NextRequest) {
       serviceId: incident.serviceId,
       apiKeyId: apiKey.id,
       outcome: creation.outcome,
+      idempotencyReplayed: execution.replayed,
     });
 
-    return jsonOk({ incident, outcome: creation.outcome }, 201);
+    return jsonOk(
+      { incident, outcome: creation.outcome },
+      201,
+      execution.replayed ? { 'Idempotency-Replayed': 'true' } : undefined
+    );
   } catch (error) {
     logger.error('api.incident.create_failed', {
       error: error instanceof Error ? error.message : String(error),

--- a/src/app/api/mobile/incidents/[id]/status/route.ts
+++ b/src/app/api/mobile/incidents/[id]/status/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { z } from 'zod';
-import { createHash } from 'crypto';
 
 import { getAuthOptions } from '@/lib/auth';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
-import { updateIncidentStatus } from '@/app/(app)/incidents/actions';
-import prisma from '@/lib/prisma';
+import { updateIncidentStatus } from '@/lib/incidents/operator-lifecycle';
 
 const StatusSchema = z.object({
   status: z.enum(['OPEN', 'ACKNOWLEDGED', 'RESOLVED', 'SNOOZED', 'SUPPRESSED']),
@@ -59,53 +57,21 @@ export async function PATCH(req: NextRequest, props: { params: Promise<{ id: str
     }
 
     const idempotencyKey = req.headers.get('idempotency-key')?.trim();
-    if (idempotencyKey) {
-      if (idempotencyKey.length > 200) {
-        return jsonError(
-          new AppError({
-            code: 'VALIDATION_FAILED',
-            userMessage: 'Idempotency key is too long.',
-            fields: [
-              {
-                field: 'idempotency-key',
-                code: 'too_long',
-                message: 'Idempotency key must be 200 characters or fewer.',
-              },
-            ],
-          })
-        );
-      }
-      const fingerprint = createHash('sha256')
-        .update(`${session.user.email}\0${idempotencyKey}`)
-        .digest('hex');
-      const existing = await prisma.rateLimit.findUnique({
-        where: { key: `mobile-idempotency:${fingerprint}` },
-        select: { expiresAt: true },
-      });
-      if (existing && existing.expiresAt > new Date()) {
-        return jsonOk({ success: true, duplicate: true }, 200);
-      }
-    }
+    const result = await updateIncidentStatus(
+      params.id,
+      parsed.data.status,
+      parsed.data.expectedStatus,
+      'MOBILE',
+      idempotencyKey
+        ? { key: idempotencyKey, principalId: session.user.email.toLowerCase() }
+        : undefined
+    );
 
-    await updateIncidentStatus(params.id, parsed.data.status, parsed.data.expectedStatus);
-    if (idempotencyKey) {
-      const fingerprint = createHash('sha256')
-        .update(`${session.user.email}\0${idempotencyKey}`)
-        .digest('hex');
-      await prisma.rateLimit.upsert({
-        where: { key: `mobile-idempotency:${fingerprint}` },
-        create: {
-          key: `mobile-idempotency:${fingerprint}`,
-          count: 1,
-          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
-        },
-        update: {
-          count: 1,
-          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
-        },
-      });
-    }
-    return jsonOk({ success: true }, 200);
+    return jsonOk(
+      { success: true, ...(result.replayed ? { duplicate: true } : {}) },
+      200,
+      result.replayed ? { 'Idempotency-Replayed': 'true' } : undefined
+    );
   } catch (error) {
     logger.error('api.mobile.incident.update_failed', {
       component: 'mobile-incident-status',
@@ -115,7 +81,7 @@ export async function PATCH(req: NextRequest, props: { params: Promise<{ id: str
     });
 
     if (isAppError(error)) return jsonError(error);
-    return jsonError('Failed to update incident.', 500);
+    return jsonError(new AppError({ code: 'INTERNAL_ERROR' }));
   }
 }
 

--- a/src/lib/errors/registry.ts
+++ b/src/lib/errors/registry.ts
@@ -194,6 +194,22 @@ export const ERROR_REGISTRY = {
     retryable: true,
     exposure: 'public',
   },
+  IDEMPOTENCY_KEY_INVALID: {
+    status: 400,
+    category: 'validation',
+    userMessage: 'The idempotency key is invalid.',
+    action: 'Provide a non-empty Idempotency-Key of 200 characters or fewer.',
+    retryable: false,
+    exposure: 'public',
+  },
+  IDEMPOTENCY_KEY_CONFLICT: {
+    status: 409,
+    category: 'conflict',
+    userMessage: 'This idempotency key was already used for a different request.',
+    action: 'Use a new Idempotency-Key for a different request payload.',
+    retryable: false,
+    exposure: 'public',
+  },
   INCIDENT_NOT_FOUND: {
     status: 404,
     category: 'not_found',

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -74,10 +74,10 @@ function canonicalize(value: unknown): string {
         return `[${value.map(item => canonicalize(item)).join(',')}]`;
       }
       const objectValue = value as Record<string, unknown>;
-      const entries = Object.keys(objectValue)
-        .sort()
-        .filter(key => objectValue[key] !== undefined)
-        .map(key => `${JSON.stringify(key)}:${canonicalize(objectValue[key])}`);
+      const entries = Object.entries(objectValue)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`);
       return `{${entries.join(',')}}`;
     }
     default:
@@ -108,11 +108,10 @@ function encodeJson(value: unknown): Prisma.InputJsonValue {
     return value.map(item => encodeJson(item)) as Prisma.InputJsonArray;
   }
   if (typeof value === 'object') {
-    const encoded: Prisma.InputJsonObject = {};
-    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
-      if (nested !== undefined) encoded[key] = encodeJson(nested);
-    }
-    return encoded;
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .map(([key, nested]) => [key, encodeJson(nested)]);
+    return Object.fromEntries(entries) as Prisma.InputJsonObject;
   }
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     return value;
@@ -128,14 +127,21 @@ function decodeJson(value: Prisma.JsonValue): unknown {
   if (Array.isArray(value)) return value.map(item => decodeJson(item));
 
   const objectValue = value as Record<string, Prisma.JsonValue>;
-  if (typeof objectValue[DATE_TAG] === 'string' && Object.keys(objectValue).length === 1) {
-    return new Date(objectValue[DATE_TAG] as string);
-  }
-  if (typeof objectValue[BIGINT_TAG] === 'string' && Object.keys(objectValue).length === 1) {
-    return BigInt(objectValue[BIGINT_TAG] as string);
+  const entries = Object.entries(objectValue);
+  if (entries.length === 1) {
+    const [firstEntry] = entries;
+    if (firstEntry) {
+      const [key, val] = firstEntry;
+      if (key === DATE_TAG && typeof val === 'string') {
+        return new Date(val);
+      }
+      if (key === BIGINT_TAG && typeof val === 'string') {
+        return BigInt(val);
+      }
+    }
   }
 
-  return Object.fromEntries(Object.entries(objectValue).map(([key, nested]) => [key, decodeJson(nested)]));
+  return Object.fromEntries(entries.map(([key, nested]) => [key, decodeJson(nested)]));
 }
 
 function parseRecord(payload: Prisma.JsonValue): PersistedIdempotencyPayload | null {

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,0 +1,235 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import type { Prisma } from '@prisma/client';
+
+import { AppError } from '@/lib/errors';
+
+const MAX_IDEMPOTENCY_KEY_LENGTH = 200;
+const MAX_PRINCIPAL_ID_LENGTH = 200;
+const IDEMPOTENCY_TASK = 'IDEMPOTENCY_RECORD';
+const DATE_TAG = '__opsknight_date';
+const BIGINT_TAG = '__opsknight_bigint';
+
+export type IdempotencyContext = {
+  key: string;
+  principalId: string;
+};
+
+export type IdempotentExecution<T> = {
+  value: T;
+  replayed: boolean;
+};
+
+type PersistedIdempotencyPayload = {
+  task: typeof IDEMPOTENCY_TASK;
+  scope: string;
+  principalId: string;
+  requestId: string;
+  fingerprint: string;
+  result: Prisma.JsonValue;
+};
+
+function invalidIdempotencyKey(message: string): AppError {
+  return new AppError({
+    code: 'IDEMPOTENCY_KEY_INVALID',
+    userMessage: message,
+    fields: [{ field: 'Idempotency-Key', code: 'invalid', message }],
+  });
+}
+
+function normalizeContext(context: IdempotencyContext): IdempotencyContext {
+  const key = context.key.trim();
+  const principalId = context.principalId.trim();
+
+  if (!key || key.length > MAX_IDEMPOTENCY_KEY_LENGTH) {
+    throw invalidIdempotencyKey(
+      `Idempotency-Key must be between 1 and ${MAX_IDEMPOTENCY_KEY_LENGTH} characters.`
+    );
+  }
+  if (!principalId || principalId.length > MAX_PRINCIPAL_ID_LENGTH) {
+    throw invalidIdempotencyKey('Idempotency principal is invalid.');
+  }
+
+  return { key, principalId };
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (value instanceof Date) return `date:${value.toISOString()}`;
+
+  switch (typeof value) {
+    case 'string':
+      return JSON.stringify(value);
+    case 'number':
+      if (!Number.isFinite(value)) return `number:${String(value)}`;
+      return String(value);
+    case 'boolean':
+      return value ? 'true' : 'false';
+    case 'bigint':
+      return `bigint:${value.toString()}`;
+    case 'object': {
+      if (Array.isArray(value)) {
+        return `[${value.map(item => canonicalize(item)).join(',')}]`;
+      }
+      const objectValue = value as Record<string, unknown>;
+      const entries = Object.keys(objectValue)
+        .sort()
+        .filter(key => objectValue[key] !== undefined)
+        .map(key => `${JSON.stringify(key)}:${canonicalize(objectValue[key])}`);
+      return `{${entries.join(',')}}`;
+    }
+    default:
+      return `${typeof value}:${String(value)}`;
+  }
+}
+
+export function fingerprintIdempotencyPayload(payload: unknown): string {
+  return createHash('sha256').update(canonicalize(payload)).digest('hex');
+}
+
+function recordId(scope: string, context: IdempotencyContext): string {
+  const digest = createHash('sha256')
+    .update(`${scope}\0${context.principalId}\0${context.key}`)
+    .digest('hex');
+  return `idem_${digest}`;
+}
+
+function encodeJson(value: unknown): Prisma.InputJsonValue {
+  if (value === null) return null as unknown as Prisma.InputJsonValue;
+  if (value instanceof Date) {
+    return { [DATE_TAG]: value.toISOString() };
+  }
+  if (typeof value === 'bigint') {
+    return { [BIGINT_TAG]: value.toString() };
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => encodeJson(item)) as Prisma.InputJsonArray;
+  }
+  if (typeof value === 'object') {
+    const encoded: Prisma.InputJsonObject = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (nested !== undefined) encoded[key] = encodeJson(nested);
+    }
+    return encoded;
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  throw new AppError({
+    code: 'INTERNAL_ERROR',
+    details: { reason: 'Unsupported idempotency result type', valueType: typeof value },
+  });
+}
+
+function decodeJson(value: Prisma.JsonValue): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(item => decodeJson(item));
+
+  const objectValue = value as Record<string, Prisma.JsonValue>;
+  if (typeof objectValue[DATE_TAG] === 'string' && Object.keys(objectValue).length === 1) {
+    return new Date(objectValue[DATE_TAG] as string);
+  }
+  if (typeof objectValue[BIGINT_TAG] === 'string' && Object.keys(objectValue).length === 1) {
+    return BigInt(objectValue[BIGINT_TAG] as string);
+  }
+
+  return Object.fromEntries(Object.entries(objectValue).map(([key, nested]) => [key, decodeJson(nested)]));
+}
+
+function parseRecord(payload: Prisma.JsonValue): PersistedIdempotencyPayload | null {
+  if (!payload || Array.isArray(payload) || typeof payload !== 'object') return null;
+  const candidate = payload as Record<string, Prisma.JsonValue>;
+  if (
+    candidate.task !== IDEMPOTENCY_TASK ||
+    typeof candidate.scope !== 'string' ||
+    typeof candidate.principalId !== 'string' ||
+    typeof candidate.requestId !== 'string' ||
+    typeof candidate.fingerprint !== 'string' ||
+    !Object.prototype.hasOwnProperty.call(candidate, 'result')
+  ) {
+    return null;
+  }
+
+  return candidate as unknown as PersistedIdempotencyPayload;
+}
+
+/**
+ * Executes an operation with a persistent idempotency key inside the caller's
+ * transaction. The operation result and the incident mutation commit or roll
+ * back together. A deterministic BackgroundJob primary key provides the
+ * concurrency fence; runSerializableTransaction retries the losing P2002 race.
+ *
+ * Completed BackgroundJob cleanup currently gives these records the same
+ * seven-day retention window as other completed durable jobs.
+ */
+export async function executeIdempotentOperation<T>(
+  tx: Prisma.TransactionClient,
+  input: {
+    scope: string;
+    context?: IdempotencyContext;
+    payload: unknown;
+    execute: () => Promise<T>;
+  }
+): Promise<IdempotentExecution<T>> {
+  if (!input.context) {
+    return { value: await input.execute(), replayed: false };
+  }
+
+  const context = normalizeContext(input.context);
+  const fingerprint = fingerprintIdempotencyPayload(input.payload);
+  const id = recordId(input.scope, context);
+  const existing = await tx.backgroundJob.findUnique({
+    where: { id },
+    select: { payload: true },
+  });
+
+  if (existing) {
+    const record = parseRecord(existing.payload);
+    if (
+      !record ||
+      record.scope !== input.scope ||
+      record.principalId !== context.principalId ||
+      record.requestId !== context.key
+    ) {
+      throw new AppError({
+        code: 'INTERNAL_ERROR',
+        details: { reason: 'Idempotency record collision or corruption', id, scope: input.scope },
+      });
+    }
+
+    if (record.fingerprint !== fingerprint) {
+      throw new AppError({
+        code: 'IDEMPOTENCY_KEY_CONFLICT',
+        userMessage: 'This Idempotency-Key was already used for a different request.',
+        details: { scope: input.scope, requestId: context.key },
+      });
+    }
+
+    return { value: decodeJson(record.result) as T, replayed: true };
+  }
+
+  const value = await input.execute();
+  const now = new Date();
+  await tx.backgroundJob.create({
+    data: {
+      id,
+      type: 'SCHEDULED_TASK',
+      status: 'COMPLETED',
+      scheduledAt: now,
+      completedAt: now,
+      maxAttempts: 1,
+      payload: {
+        task: IDEMPOTENCY_TASK,
+        scope: input.scope,
+        principalId: context.principalId,
+        requestId: context.key,
+        fingerprint,
+        result: encodeJson(value),
+      },
+    },
+  });
+
+  return { value, replayed: false };
+}

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -90,10 +90,7 @@ export function fingerprintIdempotencyPayload(payload: unknown): string {
 }
 
 function recordId(scope: string, context: IdempotencyContext): string {
-  const digest = createHash('sha256')
-    .update(`${scope}\0${context.principalId}\0${context.key}`)
-    .digest('hex');
-  return `idem_${digest}`;
+  return `idem:${scope}:${context.principalId}:${context.key}`;
 }
 
 function encodeJson(value: unknown): Prisma.InputJsonValue {

--- a/src/lib/incidents/idempotent-commands.ts
+++ b/src/lib/incidents/idempotent-commands.ts
@@ -1,0 +1,112 @@
+import 'server-only';
+
+import type { IncidentStatus } from '@prisma/client';
+
+import { runSerializableTransaction } from '@/lib/db-utils';
+import {
+  executeIdempotentOperation,
+  type IdempotencyContext,
+  type IdempotentExecution,
+} from '@/lib/idempotency';
+import {
+  applyIncidentCreation,
+  type IncidentCreationInput,
+  type IncidentCreationResult,
+} from '@/lib/incidents/creation';
+import {
+  applyIncidentLifecycleCommand,
+  applyIncidentLifecycleTargetStatus,
+  type IncidentLifecycleInput,
+  type IncidentLifecycleResult,
+} from '@/lib/incidents/lifecycle';
+
+function lifecyclePayload(input: IncidentLifecycleInput): Record<string, unknown> {
+  return {
+    incidentId: input.incidentId,
+    command: input.command,
+    source: input.source,
+    actorId: input.actor?.id ?? null,
+    expectedStatus: input.expectedStatus ?? null,
+    resolutionNote: input.resolutionNote ?? null,
+    snoozedUntil: input.snoozedUntil ?? null,
+    snoozeReason: input.snoozeReason ?? null,
+    eventMessage: input.eventMessage ?? null,
+  };
+}
+
+function targetPayload(
+  input: Omit<IncidentLifecycleInput, 'command'> & { status: IncidentStatus }
+): Record<string, unknown> {
+  return {
+    incidentId: input.incidentId,
+    status: input.status,
+    source: input.source,
+    actorId: input.actor?.id ?? null,
+    expectedStatus: input.expectedStatus ?? null,
+    resolutionNote: input.resolutionNote ?? null,
+    snoozedUntil: input.snoozedUntil ?? null,
+    snoozeReason: input.snoozeReason ?? null,
+    eventMessage: input.eventMessage ?? null,
+  };
+}
+
+function creationPayload(input: IncidentCreationInput): Record<string, unknown> {
+  return {
+    title: input.title,
+    description: input.description ?? null,
+    serviceId: input.serviceId,
+    urgency: input.urgency,
+    priority: input.priority ?? null,
+    dedupKey: input.dedupKey ?? null,
+    assigneeId: input.assigneeId ?? null,
+    teamId: input.teamId ?? null,
+    visibility: input.visibility ?? 'PUBLIC',
+    customFields: [...(input.customFields ?? [])]
+      .map(field => ({ fieldId: field.fieldId, value: field.value }))
+      .sort((left, right) => left.fieldId.localeCompare(right.fieldId)),
+    source: input.source,
+    actorId: input.actor?.id ?? null,
+  };
+}
+
+export async function executeIdempotentIncidentLifecycleCommand(
+  input: IncidentLifecycleInput,
+  context?: IdempotencyContext
+): Promise<IdempotentExecution<IncidentLifecycleResult>> {
+  return runSerializableTransaction(tx =>
+    executeIdempotentOperation(tx, {
+      scope: 'INCIDENT_LIFECYCLE',
+      context,
+      payload: lifecyclePayload(input),
+      execute: () => applyIncidentLifecycleCommand(tx, input),
+    })
+  );
+}
+
+export async function transitionIncidentToStatusIdempotent(
+  input: Omit<IncidentLifecycleInput, 'command'> & { status: IncidentStatus },
+  context?: IdempotencyContext
+): Promise<IdempotentExecution<IncidentLifecycleResult>> {
+  return runSerializableTransaction(tx =>
+    executeIdempotentOperation(tx, {
+      scope: 'INCIDENT_LIFECYCLE_TARGET',
+      context,
+      payload: targetPayload(input),
+      execute: () => applyIncidentLifecycleTargetStatus(tx, input),
+    })
+  );
+}
+
+export async function executeIdempotentIncidentCreation(
+  input: IncidentCreationInput,
+  context?: IdempotencyContext
+): Promise<IdempotentExecution<IncidentCreationResult>> {
+  return runSerializableTransaction(tx =>
+    executeIdempotentOperation(tx, {
+      scope: 'INCIDENT_CREATION',
+      context,
+      payload: creationPayload(input),
+      execute: () => applyIncidentCreation(tx, input),
+    })
+  );
+}

--- a/src/lib/incidents/operator-lifecycle.ts
+++ b/src/lib/incidents/operator-lifecycle.ts
@@ -9,11 +9,12 @@ import {
   getCurrentUser,
 } from '@/lib/rbac';
 import { AppError } from '@/lib/errors';
+import type { IdempotencyContext } from '@/lib/idempotency';
+import type { IncidentLifecycleSource } from '@/lib/incidents/lifecycle';
 import {
-  executeIncidentLifecycleCommand,
-  transitionIncidentToStatus,
-  type IncidentLifecycleSource,
-} from '@/lib/incidents/lifecycle';
+  executeIdempotentIncidentLifecycleCommand,
+  transitionIncidentToStatusIdempotent,
+} from '@/lib/incidents/idempotent-commands';
 
 type OperatorLifecycleSource = Extract<IncidentLifecycleSource, 'WEB' | 'MOBILE'>;
 
@@ -33,26 +34,32 @@ export async function updateIncidentStatus(
   id: string,
   status: IncidentStatus,
   expectedStatus: IncidentStatus | undefined,
-  source: OperatorLifecycleSource
-): Promise<void> {
+  source: OperatorLifecycleSource,
+  idempotency?: IdempotencyContext
+): Promise<{ replayed: boolean }> {
   if (status === 'ACKNOWLEDGED') await assertCanAcknowledgeIncident(id);
   else await assertResponderOrAbove();
 
-  const result = await transitionIncidentToStatus({
-    incidentId: id,
-    status,
-    expectedStatus,
-    source,
-  });
+  const result = await transitionIncidentToStatusIdempotent(
+    {
+      incidentId: id,
+      status,
+      expectedStatus,
+      source,
+    },
+    idempotency
+  );
 
-  if (result.changed) revalidateIncident(id);
+  if (result.value.changed && !result.replayed) revalidateIncident(id);
+  return { replayed: result.replayed };
 }
 
 export async function resolveIncidentWithNote(
   id: string,
   resolution: string,
-  source: OperatorLifecycleSource = 'WEB'
-): Promise<void> {
+  source: OperatorLifecycleSource = 'WEB',
+  idempotency?: IdempotencyContext
+): Promise<{ replayed: boolean }> {
   await assertResponderOrAbove();
 
   const trimmedResolution = resolution?.trim();
@@ -87,13 +94,17 @@ export async function resolveIncidentWithNote(
   }
 
   const user = await getCurrentUser();
-  const result = await executeIncidentLifecycleCommand({
-    incidentId: id,
-    command: 'RESOLVE',
-    source,
-    actor: { id: user.id, name: user.name ?? undefined },
-    resolutionNote: trimmedResolution,
-  });
+  const result = await executeIdempotentIncidentLifecycleCommand(
+    {
+      incidentId: id,
+      command: 'RESOLVE',
+      source,
+      actor: { id: user.id, name: user.name ?? undefined },
+      resolutionNote: trimmedResolution,
+    },
+    idempotency
+  );
 
-  if (result.changed) revalidateIncident(id);
+  if (result.value.changed && !result.replayed) revalidateIncident(id);
+  return { replayed: result.replayed };
 }

--- a/src/lib/incidents/rest-patch.ts
+++ b/src/lib/incidents/rest-patch.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { AppError } from '@/lib/errors';
 import { runSerializableTransaction } from '@/lib/db-utils';
+import { executeIdempotentOperation, type IdempotencyContext } from '@/lib/idempotency';
 import {
   applyIncidentLifecycleTargetStatus,
   type IncidentLifecycleResult,
@@ -17,103 +18,120 @@ export type RestIncidentPatchInput = {
   assigneeId?: string | null;
   hasAssigneeUpdate: boolean;
   actor: { id: string; name?: string };
+  idempotency?: IdempotencyContext;
 };
 
 export async function applyRestIncidentPatch(input: RestIncidentPatchInput) {
   return runSerializableTransaction(async tx => {
-    const current = await tx.incident.findUnique({
-      where: { id: input.incidentId },
-      select: {
-        id: true,
-        status: true,
-        urgency: true,
-        assigneeId: true,
+    const execution = await executeIdempotentOperation(tx, {
+      scope: 'INCIDENT_REST_PATCH',
+      context: input.idempotency,
+      payload: {
+        incidentId: input.incidentId,
+        status: input.status ?? null,
+        urgency: input.urgency ?? null,
+        assigneeId: input.hasAssigneeUpdate ? (input.assigneeId ?? null) : undefined,
+        hasAssigneeUpdate: input.hasAssigneeUpdate,
+        actorId: input.actor.id,
+      },
+      execute: async () => {
+        const current = await tx.incident.findUnique({
+          where: { id: input.incidentId },
+          select: {
+            id: true,
+            status: true,
+            urgency: true,
+            assigneeId: true,
+          },
+        });
+
+        if (!current) {
+          throw new AppError({
+            code: 'INCIDENT_NOT_FOUND',
+            userMessage: 'Incident not found.',
+            details: { incidentId: input.incidentId },
+          });
+        }
+
+        let lifecycle: IncidentLifecycleResult | null = null;
+        if (input.status) {
+          lifecycle = await applyIncidentLifecycleTargetStatus(tx, {
+            incidentId: input.incidentId,
+            status: input.status,
+            source: 'REST_API',
+            actor: input.actor,
+          });
+        }
+
+        const urgencyChanged = input.urgency !== undefined && input.urgency !== current.urgency;
+        const assigneeChanged =
+          input.hasAssigneeUpdate && (input.assigneeId ?? null) !== (current.assigneeId ?? null);
+
+        let assigneeName: string | null = null;
+        if (assigneeChanged && input.assigneeId) {
+          const assignee = await tx.user.findUnique({
+            where: { id: input.assigneeId },
+            select: { name: true },
+          });
+          if (!assignee) {
+            throw new AppError({
+              code: 'RESOURCE_NOT_FOUND',
+              userMessage: 'Assignee not found.',
+              details: { assigneeId: input.assigneeId },
+            });
+          }
+          assigneeName = assignee.name;
+        }
+
+        if (urgencyChanged || assigneeChanged) {
+          await tx.incident.update({
+            where: { id: input.incidentId },
+            data: {
+              ...(urgencyChanged ? { urgency: input.urgency } : {}),
+              ...(assigneeChanged ? { assigneeId: input.assigneeId ?? null } : {}),
+            },
+          });
+        }
+
+        if (urgencyChanged) {
+          await tx.incidentEvent.create({
+            data: {
+              incidentId: input.incidentId,
+              message: `Urgency updated to ${input.urgency}`,
+            },
+          });
+        }
+
+        if (assigneeChanged) {
+          await tx.incidentEvent.create({
+            data: {
+              incidentId: input.incidentId,
+              message: input.assigneeId
+                ? `Incident manually reassigned to ${assigneeName || 'user'}`
+                : 'Incident unassigned',
+            },
+          });
+        }
+
+        const incident = await tx.incident.findUnique({ where: { id: input.incidentId } });
+        if (!incident) {
+          throw new AppError({
+            code: 'INCIDENT_NOT_FOUND',
+            userMessage: 'Incident not found.',
+            details: { incidentId: input.incidentId },
+          });
+        }
+
+        return {
+          incident,
+          lifecycle,
+          urgencyChanged,
+          assigneeChanged,
+          changed: Boolean(lifecycle?.changed || urgencyChanged || assigneeChanged),
+        };
       },
     });
 
-    if (!current) {
-      throw new AppError({
-        code: 'INCIDENT_NOT_FOUND',
-        userMessage: 'Incident not found.',
-        details: { incidentId: input.incidentId },
-      });
-    }
-
-    let lifecycle: IncidentLifecycleResult | null = null;
-    if (input.status) {
-      lifecycle = await applyIncidentLifecycleTargetStatus(tx, {
-        incidentId: input.incidentId,
-        status: input.status,
-        source: 'REST_API',
-        actor: input.actor,
-      });
-    }
-
-    const urgencyChanged = input.urgency !== undefined && input.urgency !== current.urgency;
-    const assigneeChanged =
-      input.hasAssigneeUpdate && (input.assigneeId ?? null) !== (current.assigneeId ?? null);
-
-    let assigneeName: string | null = null;
-    if (assigneeChanged && input.assigneeId) {
-      const assignee = await tx.user.findUnique({
-        where: { id: input.assigneeId },
-        select: { name: true },
-      });
-      if (!assignee) {
-        throw new AppError({
-          code: 'RESOURCE_NOT_FOUND',
-          userMessage: 'Assignee not found.',
-          details: { assigneeId: input.assigneeId },
-        });
-      }
-      assigneeName = assignee.name;
-    }
-
-    if (urgencyChanged || assigneeChanged) {
-      await tx.incident.update({
-        where: { id: input.incidentId },
-        data: {
-          ...(urgencyChanged ? { urgency: input.urgency } : {}),
-          ...(assigneeChanged ? { assigneeId: input.assigneeId ?? null } : {}),
-        },
-      });
-    }
-
-    if (urgencyChanged) {
-      await tx.incidentEvent.create({
-        data: {
-          incidentId: input.incidentId,
-          message: `Urgency updated to ${input.urgency}`,
-        },
-      });
-    }
-
-    if (assigneeChanged) {
-      await tx.incidentEvent.create({
-        data: {
-          incidentId: input.incidentId,
-          message: input.assigneeId
-            ? `Incident manually reassigned to ${assigneeName || 'user'}`
-            : 'Incident unassigned',
-        },
-      });
-    }
-
-    const incident = await tx.incident.findUnique({ where: { id: input.incidentId } });
-    if (!incident) {
-      throw new AppError({
-        code: 'INCIDENT_NOT_FOUND',
-        userMessage: 'Incident not found.',
-        details: { incidentId: input.incidentId },
-      });
-    }
-
-    return {
-      incident,
-      lifecycle,
-      urgencyChanged,
-      assigneeChanged,
-      changed: Boolean(lifecycle?.changed || urgencyChanged || assigneeChanged),
-    };
+    return { ...execution.value, idempotencyReplayed: execution.replayed };
   });
 }

--- a/tests/api/incident-patch-lifecycle.test.ts
+++ b/tests/api/incident-patch-lifecycle.test.ts
@@ -102,6 +102,7 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
       urgencyChanged: false,
       assigneeChanged: false,
       changed: true,
+      idempotencyReplayed: false,
     });
 
     const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {
@@ -119,6 +120,7 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
       assigneeId: undefined,
       hasAssigneeUpdate: false,
       actor: { id: 'user-1' },
+      idempotency: undefined,
     });
     expect(mocks.incidentFindUnique).not.toHaveBeenCalled();
     expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
@@ -133,6 +135,7 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
       urgencyChanged: true,
       assigneeChanged: false,
       changed: true,
+      idempotencyReplayed: false,
     });
     mocks.incidentFindUnique.mockResolvedValue({
       ...patchedIncident,
@@ -154,6 +157,37 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
     expect(mocks.sendServiceNotifications).toHaveBeenCalledWith('inc-1', 'updated');
   });
 
+  it('does not repeat immediate non-lifecycle effects when an Idempotency-Key is replayed', async () => {
+    const patchedIncident = { ...incident('OPEN'), urgency: 'HIGH' };
+    mocks.applyRestIncidentPatch.mockResolvedValue({
+      incident: patchedIncident,
+      lifecycle: null,
+      urgencyChanged: true,
+      assigneeChanged: false,
+      changed: true,
+      idempotencyReplayed: true,
+    });
+
+    const req = await createMockRequest(
+      'PATCH',
+      '/api/incidents/inc-1',
+      { urgency: 'HIGH' },
+      { 'Idempotency-Key': 'patch-42' }
+    );
+    const res = await PATCH(req, context);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Idempotency-Replayed')).toBe('true');
+    expect(mocks.applyRestIncidentPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotency: { key: 'patch-42', principalId: 'key-1' },
+      })
+    );
+    expect(mocks.incidentFindUnique).not.toHaveBeenCalled();
+    expect(mocks.triggerWebhooksForService).not.toHaveBeenCalled();
+    expect(mocks.sendServiceNotifications).not.toHaveBeenCalled();
+  });
+
   it('does not repeat lifecycle side effects for an idempotent status retry', async () => {
     mocks.applyRestIncidentPatch.mockResolvedValue({
       incident: incident('ACKNOWLEDGED'),
@@ -168,6 +202,7 @@ describe('PATCH /api/incidents/:id lifecycle adoption', () => {
       urgencyChanged: false,
       assigneeChanged: false,
       changed: false,
+      idempotencyReplayed: false,
     });
 
     const req = await createMockRequest('PATCH', '/api/incidents/inc-1', {

--- a/tests/api/mobile-incident-status.test.ts
+++ b/tests/api/mobile-incident-status.test.ts
@@ -3,12 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getServerSession = vi.hoisted(() => vi.fn());
 const updateIncidentStatus = vi.hoisted(() => vi.fn());
-const rateLimit = vi.hoisted(() => ({ findUnique: vi.fn(), upsert: vi.fn() }));
 
 vi.mock('next-auth', () => ({ getServerSession }));
 vi.mock('@/lib/auth', () => ({ getAuthOptions: vi.fn().mockResolvedValue({}) }));
-vi.mock('@/app/(app)/incidents/actions', () => ({ updateIncidentStatus }));
-vi.mock('@/lib/prisma', () => ({ default: { rateLimit } }));
+vi.mock('@/lib/incidents/operator-lifecycle', () => ({ updateIncidentStatus }));
 
 import { PATCH } from '@/app/api/mobile/incidents/[id]/status/route';
 
@@ -25,31 +23,51 @@ const props = { params: Promise.resolve({ id: 'inc-1' }) };
 describe('mobile incident status idempotency', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getServerSession.mockResolvedValue({ user: { email: 'responder@example.com' } });
-    rateLimit.findUnique.mockResolvedValue(null);
-    rateLimit.upsert.mockResolvedValue({});
-    updateIncidentStatus.mockResolvedValue(undefined);
+    getServerSession.mockResolvedValue({ user: { email: 'Responder@Example.com' } });
+    updateIncidentStatus.mockResolvedValue({ replayed: false });
   });
 
-  it('records the idempotency outcome only after a successful mutation', async () => {
-    updateIncidentStatus.mockRejectedValueOnce(new Error('temporary database failure'));
+  it('passes the request key into the transaction-bound lifecycle command', async () => {
+    const response = await PATCH(request(), props);
 
-    const failed = await PATCH(request(), props);
-    expect(failed.status).toBe(500);
-    expect(rateLimit.upsert).not.toHaveBeenCalled();
-
-    const retried = await PATCH(request(), props);
-    expect(retried.status).toBe(200);
-    expect(updateIncidentStatus).toHaveBeenCalledTimes(2);
-    expect(rateLimit.upsert).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(updateIncidentStatus).toHaveBeenCalledWith(
+      'inc-1',
+      'ACKNOWLEDGED',
+      'OPEN',
+      'MOBILE',
+      { key: 'offline-action-1', principalId: 'responder@example.com' }
+    );
   });
 
-  it('returns the completed outcome without replaying the mutation', async () => {
-    rateLimit.findUnique.mockResolvedValue({ expiresAt: new Date(Date.now() + 60_000) });
+  it('returns the persisted result as a duplicate without inventing a second mutation path', async () => {
+    updateIncidentStatus.mockResolvedValue({ replayed: true });
 
     const response = await PATCH(request(), props);
+
     expect(response.status).toBe(200);
+    expect(response.headers.get('Idempotency-Replayed')).toBe('true');
     expect(await response.json()).toEqual({ success: true, duplicate: true });
-    expect(updateIncidentStatus).not.toHaveBeenCalled();
+    expect(updateIncidentStatus).toHaveBeenCalledOnce();
+  });
+
+  it('does not require an idempotency key for online calls', async () => {
+    const req = new NextRequest('https://ops.example.com/api/mobile/incidents/inc-1/status', {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'ACKNOWLEDGED' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const response = await PATCH(req, props);
+
+    expect(response.status).toBe(200);
+    expect(updateIncidentStatus).toHaveBeenCalledWith(
+      'inc-1',
+      'ACKNOWLEDGED',
+      undefined,
+      'MOBILE',
+      undefined
+    );
   });
 });

--- a/tests/api/routes.test.ts
+++ b/tests/api/routes.test.ts
@@ -6,13 +6,13 @@ import * as apiAuth from '@/lib/api-auth';
 import * as rateLimit from '@/lib/rate-limit';
 
 const mocks = vi.hoisted(() => ({
-  executeIncidentCreation: vi.fn(),
+  executeIdempotentIncidentCreation: vi.fn(),
 }));
 
 vi.mock('@/lib/api-auth');
 vi.mock('@/lib/rate-limit');
-vi.mock('@/lib/incidents/creation', () => ({
-  executeIncidentCreation: mocks.executeIncidentCreation,
+vi.mock('@/lib/incidents/idempotent-commands', () => ({
+  executeIdempotentIncidentCreation: mocks.executeIdempotentIncidentCreation,
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -40,7 +40,10 @@ describe('API Routes - Incidents', () => {
       resetAt: Date.now() + 60000,
       count: 1,
     });
-    mocks.executeIncidentCreation.mockResolvedValue({ id: 'inc-new', outcome: 'CREATED' });
+    mocks.executeIdempotentIncidentCreation.mockResolvedValue({
+      value: { id: 'inc-new', outcome: 'CREATED' },
+      replayed: false,
+    });
   });
 
   describe('GET /api/incidents', () => {
@@ -127,13 +130,7 @@ describe('API Routes - Incidents', () => {
   });
 
   describe('POST /api/incidents', () => {
-    it('delegates valid REST creation to the centralized creation engine', async () => {
-      const incidentData = {
-        title: 'New Incident',
-        serviceId: 'svc-1',
-        urgency: 'HIGH',
-      };
-
+    function allowCreate() {
       vi.mocked(apiAuth.authenticateApiKey).mockResolvedValue({
         id: 'key-1',
         userId: 'user-1',
@@ -151,7 +148,9 @@ describe('API Routes - Incidents', () => {
       } as never);
       vi.mocked(prisma.incident.findUnique).mockResolvedValue({
         id: 'inc-new',
-        ...incidentData,
+        title: 'New Incident',
+        serviceId: 'svc-1',
+        urgency: 'HIGH',
         description: null,
         priority: null,
         status: 'OPEN',
@@ -159,6 +158,15 @@ describe('API Routes - Incidents', () => {
         assignee: null,
         createdAt: new Date('2026-08-28T09:00:00.000Z'),
       } as never);
+    }
+
+    it('delegates valid REST creation to the centralized creation engine', async () => {
+      allowCreate();
+      const incidentData = {
+        title: 'New Incident',
+        serviceId: 'svc-1',
+        urgency: 'HIGH',
+      };
 
       const req = await createMockRequest('POST', '/api/incidents', incidentData);
       const res = await incidentRoute.POST(req);
@@ -167,15 +175,41 @@ describe('API Routes - Incidents', () => {
       expect(status).toBe(201);
       expect(data.incident.title).toBe('New Incident');
       expect(data.outcome).toBe('CREATED');
-      expect(mocks.executeIncidentCreation).toHaveBeenCalledWith({
-        title: 'New Incident',
-        description: null,
-        serviceId: 'svc-1',
-        urgency: 'HIGH',
-        priority: null,
-        source: 'REST_API',
-        actor: { id: 'user-1' },
+      expect(mocks.executeIdempotentIncidentCreation).toHaveBeenCalledWith(
+        {
+          title: 'New Incident',
+          description: null,
+          serviceId: 'svc-1',
+          urgency: 'HIGH',
+          priority: null,
+          source: 'REST_API',
+          actor: { id: 'user-1' },
+        },
+        undefined
+      );
+    });
+
+    it('passes Idempotency-Key through the API-key namespace and marks replays', async () => {
+      allowCreate();
+      mocks.executeIdempotentIncidentCreation.mockResolvedValue({
+        value: { id: 'inc-new', outcome: 'CREATED' },
+        replayed: true,
       });
+
+      const req = await createMockRequest(
+        'POST',
+        '/api/incidents',
+        { title: 'New Incident', serviceId: 'svc-1', urgency: 'HIGH' },
+        { 'Idempotency-Key': 'deploy-42' }
+      );
+      const res = await incidentRoute.POST(req);
+
+      expect(res.status).toBe(201);
+      expect(res.headers.get('Idempotency-Replayed')).toBe('true');
+      expect(mocks.executeIdempotentIncidentCreation).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceId: 'svc-1' }),
+        { key: 'deploy-42', principalId: 'key-1' }
+      );
     });
 
     it('should return 400 for invalid data', async () => {
@@ -197,7 +231,7 @@ describe('API Routes - Incidents', () => {
 
       expect(status).toBe(400);
       expect(data.error).toBeDefined();
-      expect(mocks.executeIncidentCreation).not.toHaveBeenCalled();
+      expect(mocks.executeIdempotentIncidentCreation).not.toHaveBeenCalled();
     });
 
     it('denies incident writes when an old write key belongs to an Auditor', async () => {
@@ -227,7 +261,7 @@ describe('API Routes - Incidents', () => {
 
       expect(res.status).toBe(403);
       expect(data.error).toContain('Incident creation access denied');
-      expect(mocks.executeIncidentCreation).not.toHaveBeenCalled();
+      expect(mocks.executeIdempotentIncidentCreation).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/components/IncidentsListTable.test.tsx
+++ b/tests/components/IncidentsListTable.test.tsx
@@ -24,7 +24,7 @@ vi.mock('@/components/ToastProvider', () => ({
 }));
 
 vi.mock('@/app/(app)/incidents/actions', () => ({
-  updateIncidentStatus: vi.fn().mockResolvedValue(undefined),
+  updateIncidentStatus: vi.fn().mockResolvedValue({ replayed: false }),
 }));
 
 vi.mock('@/app/(app)/incidents/bulk-actions', () => ({

--- a/tests/components/mobile/MobileIncidentActions.test.tsx
+++ b/tests/components/mobile/MobileIncidentActions.test.tsx
@@ -7,95 +7,98 @@ import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.
 
 // Mock dependencies
 vi.mock('next/navigation', () => ({
-    useRouter: vi.fn(),
+  useRouter: vi.fn(),
 }));
 
 vi.mock('@/app/(app)/incidents/actions', () => ({
-    updateIncidentStatus: vi.fn(),
-    addNote: vi.fn(),
-    updateIncidentUrgency: vi.fn(),
-    reassignIncident: vi.fn(),
-    resolveIncidentWithNote: vi.fn(),
+  updateIncidentStatus: vi.fn(),
+  addNote: vi.fn(),
+  updateIncidentUrgency: vi.fn(),
+  reassignIncident: vi.fn(),
+  resolveIncidentWithNote: vi.fn(),
 }));
 
 describe('MobileIncidentActions', () => {
-    const mockRouter = {
-        back: vi.fn(),
-        forward: vi.fn(),
-        push: vi.fn(),
-        replace: vi.fn(),
-        prefetch: vi.fn(),
-        refresh: vi.fn(),
-    } as unknown as AppRouterInstance;
-    const defaultProps = {
-        incidentId: 'inc-123',
-        status: 'OPEN',
-        urgency: 'HIGH',
-        assigneeId: null,
-        currentUserId: 'user-1',
-        users: [{ id: 'user-1', name: 'User 1', email: 'u1@test.com' }],
-        teams: [],
-    };
+  const mockRouter = {
+    back: vi.fn(),
+    forward: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  } as unknown as AppRouterInstance;
+  const defaultProps = {
+    incidentId: 'inc-123',
+    status: 'OPEN',
+    urgency: 'HIGH',
+    assigneeId: null,
+    currentUserId: 'user-1',
+    users: [{ id: 'user-1', name: 'User 1', email: 'u1@test.com' }],
+    teams: [],
+  };
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.mocked(useRouter).mockReturnValue(mockRouter);
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue(mockRouter);
+  });
+
+  it('renders Acknowledge button when status is OPEN', () => {
+    render(<MobileIncidentActions {...defaultProps} status="OPEN" />);
+    expect(screen.getByText('Acknowledge')).toBeInTheDocument();
+  });
+
+  it('calls updateIncidentStatus on Acknowledge click', async () => {
+    vi.mocked(updateIncidentStatus).mockResolvedValue({ replayed: false });
+    render(<MobileIncidentActions {...defaultProps} status="OPEN" />);
+
+    fireEvent.click(screen.getByText('Acknowledge'));
+
+    await waitFor(() => {
+      expect(updateIncidentStatus).toHaveBeenCalledWith('inc-123', 'ACKNOWLEDGED');
+      expect(mockRouter.refresh).toHaveBeenCalled();
     });
+  });
 
-    it('renders Acknowledge button when status is OPEN', () => {
-        render(<MobileIncidentActions {...defaultProps} status="OPEN" />);
-        expect(screen.getByText('Acknowledge')).toBeInTheDocument();
+  it('shows resolution input when Resolve clicked', () => {
+    render(<MobileIncidentActions {...defaultProps} status="ACKNOWLEDGED" />);
+
+    fireEvent.click(screen.getByText('Resolve'));
+    expect(screen.getByPlaceholderText(/Describe root cause/i)).toBeInTheDocument();
+  });
+
+  it('resolves incident with note', async () => {
+    vi.mocked(resolveIncidentWithNote).mockResolvedValue({ replayed: false });
+    render(<MobileIncidentActions {...defaultProps} status="ACKNOWLEDGED" />);
+
+    // Open resolve panel
+    fireEvent.click(screen.getByText('Resolve'));
+
+    // Type note (needs > 10 chars)
+    const input = screen.getByPlaceholderText(/Describe root cause/i);
+    fireEvent.change(input, { target: { value: 'Fixed the issue completely.' } }); // 25 chars
+
+    // Click Resolve incident
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve incident' }));
+
+    await waitFor(() => {
+      expect(resolveIncidentWithNote).toHaveBeenCalledWith(
+        'inc-123',
+        'Fixed the issue completely.'
+      );
+      expect(mockRouter.refresh).toHaveBeenCalled();
     });
+  });
 
-    it('calls updateIncidentStatus on Acknowledge click', async () => {
-        vi.mocked(updateIncidentStatus).mockResolvedValue(undefined);
-        render(<MobileIncidentActions {...defaultProps} status="OPEN" />);
+  it('disables resolve submit when resolution note is too short', () => {
+    render(<MobileIncidentActions {...defaultProps} status="ACKNOWLEDGED" />);
 
-        fireEvent.click(screen.getByText('Acknowledge'));
+    fireEvent.click(screen.getByText('Resolve'));
 
-        await waitFor(() => {
-            expect(updateIncidentStatus).toHaveBeenCalledWith('inc-123', 'ACKNOWLEDGED');
-            expect(mockRouter.refresh).toHaveBeenCalled();
-        });
-    });
+    const input = screen.getByPlaceholderText(/Describe root cause/i);
+    fireEvent.change(input, { target: { value: 'Short' } });
 
-    it('shows resolution input when Resolve clicked', () => {
-        render(<MobileIncidentActions {...defaultProps} status="ACKNOWLEDGED" />);
-
-        fireEvent.click(screen.getByText('Resolve'));
-        expect(screen.getByPlaceholderText(/Describe root cause/i)).toBeInTheDocument();
-    });
-
-    it('resolves incident with note', async () => {
-        vi.mocked(resolveIncidentWithNote).mockResolvedValue(undefined);
-        render(<MobileIncidentActions {...defaultProps} status="ACKNOWLEDGED" />);
-
-        // Open resolve panel
-        fireEvent.click(screen.getByText('Resolve'));
-
-        // Type note (needs > 10 chars)
-        const input = screen.getByPlaceholderText(/Describe root cause/i);
-        fireEvent.change(input, { target: { value: 'Fixed the issue completely.' } }); // 25 chars
-
-        // Click Resolve incident
-        fireEvent.click(screen.getByRole('button', { name: 'Resolve incident' }));
-
-        await waitFor(() => {
-            expect(resolveIncidentWithNote).toHaveBeenCalledWith('inc-123', 'Fixed the issue completely.');
-            expect(mockRouter.refresh).toHaveBeenCalled();
-        });
-    });
-
-    it('disables resolve submit when resolution note is too short', () => {
-        render(<MobileIncidentActions {...defaultProps} status="ACKNOWLEDGED" />);
-
-        fireEvent.click(screen.getByText('Resolve'));
-
-        const input = screen.getByPlaceholderText(/Describe root cause/i);
-        fireEvent.change(input, { target: { value: 'Short' } });
-
-        // Button should be disabled or handle click with check
-        const btn = screen.getByRole('button', { name: 'Resolve incident' });
-        expect(btn).toBeDisabled();
-    });
+    // Button should be disabled or handle click with check
+    const btn = screen.getByRole('button', { name: 'Resolve incident' });
+    expect(btn).toBeDisabled();
+  });
 });

--- a/tests/lib/idempotency.test.ts
+++ b/tests/lib/idempotency.test.ts
@@ -48,7 +48,7 @@ describe('persistent idempotency journal', () => {
     expect(tx.backgroundJob.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          id: expect.stringMatching(/^idem_[a-f0-9]{64}$/),
+          id: 'idem:INCIDENT_CREATION:api-key-1:request-1',
           type: 'SCHEDULED_TASK',
           status: 'COMPLETED',
           maxAttempts: 1,
@@ -66,7 +66,9 @@ describe('persistent idempotency journal', () => {
   });
 
   it('replays the original result without executing the command again', async () => {
-    const firstExecute = vi.fn().mockResolvedValue({ changed: true, at: new Date('2026-08-28T10:00:00Z') });
+    const firstExecute = vi
+      .fn()
+      .mockResolvedValue({ changed: true, at: new Date('2026-08-28T10:00:00Z') });
     await executeIdempotentOperation(asTransactionClient(tx), {
       scope: 'INCIDENT_LIFECYCLE',
       context: { key: 'request-2', principalId: 'user-1' },

--- a/tests/lib/idempotency.test.ts
+++ b/tests/lib/idempotency.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { executeIdempotentOperation } from '@/lib/idempotency';
+
+type Tx = {
+  backgroundJob: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createTx(): Tx {
+  return {
+    backgroundJob: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+function asTransactionClient(tx: Tx) {
+  return tx as unknown as Parameters<typeof executeIdempotentOperation>[0];
+}
+
+describe('persistent idempotency journal', () => {
+  let tx: Tx;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tx = createTx();
+  });
+
+  it('stores the operation result in a completed durable record', async () => {
+    const execute = vi.fn().mockResolvedValue({ id: 'inc-1', outcome: 'CREATED' });
+
+    const result = await executeIdempotentOperation(asTransactionClient(tx), {
+      scope: 'INCIDENT_CREATION',
+      context: { key: 'request-1', principalId: 'api-key-1' },
+      payload: { title: 'Database latency', serviceId: 'svc-1' },
+      execute,
+    });
+
+    expect(result).toEqual({
+      value: { id: 'inc-1', outcome: 'CREATED' },
+      replayed: false,
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(tx.backgroundJob.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          id: expect.stringMatching(/^idem_[a-f0-9]{64}$/),
+          type: 'SCHEDULED_TASK',
+          status: 'COMPLETED',
+          maxAttempts: 1,
+          payload: expect.objectContaining({
+            task: 'IDEMPOTENCY_RECORD',
+            scope: 'INCIDENT_CREATION',
+            principalId: 'api-key-1',
+            requestId: 'request-1',
+            fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+            result: { id: 'inc-1', outcome: 'CREATED' },
+          }),
+        }),
+      })
+    );
+  });
+
+  it('replays the original result without executing the command again', async () => {
+    const firstExecute = vi.fn().mockResolvedValue({ changed: true, at: new Date('2026-08-28T10:00:00Z') });
+    await executeIdempotentOperation(asTransactionClient(tx), {
+      scope: 'INCIDENT_LIFECYCLE',
+      context: { key: 'request-2', principalId: 'user-1' },
+      payload: { incidentId: 'inc-1', command: 'ACKNOWLEDGE' },
+      execute: firstExecute,
+    });
+
+    const persistedPayload = tx.backgroundJob.create.mock.calls[0]?.[0]?.data?.payload;
+    tx.backgroundJob.findUnique.mockResolvedValue({ payload: persistedPayload });
+    const replayExecute = vi.fn().mockRejectedValue(new Error('must not execute'));
+
+    const replay = await executeIdempotentOperation(asTransactionClient(tx), {
+      scope: 'INCIDENT_LIFECYCLE',
+      context: { key: 'request-2', principalId: 'user-1' },
+      payload: { command: 'ACKNOWLEDGE', incidentId: 'inc-1' },
+      execute: replayExecute,
+    });
+
+    expect(replay.replayed).toBe(true);
+    expect(replay.value).toEqual({ changed: true, at: new Date('2026-08-28T10:00:00Z') });
+    expect(replayExecute).not.toHaveBeenCalled();
+    expect(tx.backgroundJob.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects reuse of the same key with a different payload', async () => {
+    await executeIdempotentOperation(asTransactionClient(tx), {
+      scope: 'INCIDENT_REST_PATCH',
+      context: { key: 'request-3', principalId: 'api-key-1' },
+      payload: { incidentId: 'inc-1', urgency: 'HIGH' },
+      execute: vi.fn().mockResolvedValue({ changed: true }),
+    });
+
+    const persistedPayload = tx.backgroundJob.create.mock.calls[0]?.[0]?.data?.payload;
+    tx.backgroundJob.findUnique.mockResolvedValue({ payload: persistedPayload });
+
+    await expect(
+      executeIdempotentOperation(asTransactionClient(tx), {
+        scope: 'INCIDENT_REST_PATCH',
+        context: { key: 'request-3', principalId: 'api-key-1' },
+        payload: { incidentId: 'inc-1', urgency: 'LOW' },
+        execute: vi.fn(),
+      })
+    ).rejects.toMatchObject({ code: 'IDEMPOTENCY_KEY_CONFLICT', status: 409 });
+  });
+
+  it('namespaces identical request keys by principal', async () => {
+    await executeIdempotentOperation(asTransactionClient(tx), {
+      scope: 'INCIDENT_CREATION',
+      context: { key: 'same-key', principalId: 'api-key-1' },
+      payload: { title: 'One' },
+      execute: vi.fn().mockResolvedValue({ id: 'inc-1' }),
+    });
+    const firstId = tx.backgroundJob.create.mock.calls[0]?.[0]?.data?.id;
+
+    tx.backgroundJob.findUnique.mockResolvedValue(null);
+    await executeIdempotentOperation(asTransactionClient(tx), {
+      scope: 'INCIDENT_CREATION',
+      context: { key: 'same-key', principalId: 'api-key-2' },
+      payload: { title: 'One' },
+      execute: vi.fn().mockResolvedValue({ id: 'inc-2' }),
+    });
+    const secondId = tx.backgroundJob.create.mock.calls[1]?.[0]?.data?.id;
+
+    expect(firstId).not.toBe(secondId);
+  });
+
+  it('rejects oversized keys before executing the operation', async () => {
+    const execute = vi.fn();
+    await expect(
+      executeIdempotentOperation(asTransactionClient(tx), {
+        scope: 'INCIDENT_CREATION',
+        context: { key: 'x'.repeat(201), principalId: 'api-key-1' },
+        payload: {},
+        execute,
+      })
+    ).rejects.toMatchObject({ code: 'IDEMPOTENCY_KEY_INVALID', status: 400 });
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/incidents/rest-patch.test.ts
+++ b/tests/lib/incidents/rest-patch.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   runSerializableTransaction: vi.fn(),
   applyIncidentLifecycleTargetStatus: vi.fn(),
+  executeIdempotentOperation: vi.fn(),
 }));
 
 vi.mock('@/lib/db-utils', () => ({
@@ -11,6 +12,10 @@ vi.mock('@/lib/db-utils', () => ({
 
 vi.mock('@/lib/incidents/lifecycle', () => ({
   applyIncidentLifecycleTargetStatus: mocks.applyIncidentLifecycleTargetStatus,
+}));
+
+vi.mock('@/lib/idempotency', () => ({
+  executeIdempotentOperation: mocks.executeIdempotentOperation,
 }));
 
 import { applyRestIncidentPatch } from '@/lib/incidents/rest-patch';
@@ -52,6 +57,12 @@ describe('REST incident patch transaction', () => {
     mocks.runSerializableTransaction.mockImplementation(
       async (callback: (client: Tx) => Promise<unknown>) => callback(tx)
     );
+    mocks.executeIdempotentOperation.mockImplementation(
+      async (_client: Tx, input: { execute: () => Promise<unknown> }) => ({
+        value: await input.execute(),
+        replayed: false,
+      })
+    );
   });
 
   it('keeps lifecycle and non-lifecycle fields in one serializable transaction', async () => {
@@ -88,6 +99,10 @@ describe('REST incident patch transaction', () => {
     });
 
     expect(mocks.runSerializableTransaction).toHaveBeenCalledOnce();
+    expect(mocks.executeIdempotentOperation).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ scope: 'INCIDENT_REST_PATCH', context: undefined })
+    );
     expect(mocks.applyIncidentLifecycleTargetStatus).toHaveBeenCalledWith(
       tx,
       expect.objectContaining({
@@ -111,8 +126,71 @@ describe('REST incident patch transaction', () => {
       changed: true,
       urgencyChanged: true,
       assigneeChanged: true,
+      idempotencyReplayed: false,
       lifecycle: { changed: true, status: 'ACKNOWLEDGED' },
     });
+  });
+
+  it('passes the entire mixed mutation through one persistent idempotency key', async () => {
+    tx.incident.findUnique
+      .mockResolvedValueOnce({ id: 'inc-key', status: 'OPEN', urgency: 'LOW', assigneeId: null })
+      .mockResolvedValueOnce({ id: 'inc-key', status: 'ACKNOWLEDGED', urgency: 'HIGH', assigneeId: null });
+    mocks.applyIncidentLifecycleTargetStatus.mockResolvedValue({
+      incidentId: 'inc-key',
+      command: 'ACKNOWLEDGE',
+      source: 'REST_API',
+      previousStatus: 'OPEN',
+      status: 'ACKNOWLEDGED',
+      changed: true,
+    });
+
+    await applyRestIncidentPatch({
+      incidentId: 'inc-key',
+      status: 'ACKNOWLEDGED',
+      urgency: 'HIGH',
+      hasAssigneeUpdate: false,
+      actor: { id: 'api-user' },
+      idempotency: { key: 'patch-42', principalId: 'api-key-1' },
+    });
+
+    expect(mocks.executeIdempotentOperation).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        scope: 'INCIDENT_REST_PATCH',
+        context: { key: 'patch-42', principalId: 'api-key-1' },
+        payload: expect.objectContaining({
+          incidentId: 'inc-key',
+          status: 'ACKNOWLEDGED',
+          urgency: 'HIGH',
+          hasAssigneeUpdate: false,
+        }),
+      })
+    );
+  });
+
+  it('returns a persisted replay without executing mutation code again', async () => {
+    const replayValue = {
+      incident: { id: 'inc-replay', status: 'ACKNOWLEDGED', urgency: 'HIGH' },
+      lifecycle: { changed: true, status: 'ACKNOWLEDGED' },
+      urgencyChanged: true,
+      assigneeChanged: false,
+      changed: true,
+    };
+    mocks.executeIdempotentOperation.mockResolvedValue({ value: replayValue, replayed: true });
+
+    const result = await applyRestIncidentPatch({
+      incidentId: 'inc-replay',
+      status: 'ACKNOWLEDGED',
+      urgency: 'HIGH',
+      hasAssigneeUpdate: false,
+      actor: { id: 'api-user' },
+      idempotency: { key: 'patch-replay', principalId: 'api-key-1' },
+    });
+
+    expect(result).toEqual({ ...replayValue, idempotencyReplayed: true });
+    expect(tx.incident.findUnique).not.toHaveBeenCalled();
+    expect(tx.incident.update).not.toHaveBeenCalled();
+    expect(mocks.applyIncidentLifecycleTargetStatus).not.toHaveBeenCalled();
   });
 
   it('preserves lifecycle no-op semantics without writing duplicate metadata or events', async () => {


### PR DESCRIPTION
## Summary

Adds a generic persisted idempotency layer for incident commands on top of the centralized lifecycle/creation architecture from #431.

### What changed

- add a transaction-bound idempotency journal backed by durable `BackgroundJob` rows
- namespace keys by operation scope + authenticated principal
- fingerprint canonical request payloads and return typed `409 IDEMPOTENCY_KEY_CONFLICT` when a key is reused for a different request
- persist and replay the original command result without executing the mutation again
- keep the idempotency record in the same database transaction as the incident mutation, so rollback/failure cannot leave a false completed token
- support `Idempotency-Key` for `POST /api/incidents`
- support `Idempotency-Key` for the entire mixed `PATCH /api/incidents/:id` mutation, including lifecycle + urgency + assignment changes
- replace the mobile rate-limit-table idempotency workaround with the same shared transaction-bound primitive
- expose `Idempotency-Replayed: true` on replayed REST/mobile requests
- suppress immediate non-lifecycle REST side effects when returning a persisted replay

### Error contract

Adds typed `IDEMPOTENCY_KEY_INVALID` and `IDEMPOTENCY_KEY_CONFLICT` errors. The English-text error translator cleanup is intentionally not duplicated here because #431 already merged the newer typed user-facing error boundary.

### Tests

- persistent result storage and replay
- stable payload fingerprinting
- same-key/different-payload conflict
- principal namespacing
- oversized key rejection
- REST creation idempotency propagation
- mixed REST PATCH replay suppression
- mobile lifecycle replay behavior

The PR contains exactly one focused commit.