### PR TITLE
refactor(api): centralize response contract

### DIFF
--- a/docs/architecture/api-response-contract.md
+++ b/docs/architecture/api-response-contract.md
@@ -1,0 +1,30 @@
+# API response contract
+
+OpsKnight-owned JSON endpoints use the response boundary in
+`src/lib/api-response.ts`. Protocol endpoints such as OAuth callbacks, Slack
+interactions, streaming responses, webhooks, and binary downloads may retain
+their protocol-defined response shape.
+
+## Success
+
+Every success response carries `success`, `data`, `dataState`, `requestId`, and
+`timestamp`. List responses may add either offset or cursor `pagination` and all
+responses may include structured `warnings`.
+
+During migration, object payload properties are also emitted at the top level
+so existing clients continue to work. New clients must read the `data` field.
+
+## Error
+
+Every error response carries `success: false`, `dataState: "unavailable"`, a
+safe public `error` message, a machine-readable `code`, `retryable`, `requestId`,
+and `timestamp`. Typed `AppError` values remain the only supported way to define
+new error semantics. `LEGACY_API_ERROR` identifies an existing string response
+that still needs conversion to an error-registry code.
+
+## Correlation
+
+Create one response context from the incoming request and reuse it for every
+return path. The request ID is returned in both the envelope and the
+`x-request-id` header. Untrusted request IDs are rejected and replaced with a
+UUID.

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,5 +1,149 @@
 import { NextResponse } from 'next/server';
 import { isAppError, normalizeError, toPublicAppError, type AppError } from './errors';
+import { getRequestContext } from './request-context';
+
+export const API_DATA_STATES = ['available', 'partial', 'no_data', 'stale', 'unavailable'] as const;
+
+export type ApiDataState = (typeof API_DATA_STATES)[number];
+
+export interface ApiWarning {
+  code: string;
+  message: string;
+  action?: string;
+}
+
+export interface ApiOffsetPagination {
+  mode: 'offset';
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface ApiCursorPagination {
+  mode: 'cursor';
+  limit: number;
+  nextCursor: string | null;
+  previousCursor?: string | null;
+  hasMore: boolean;
+}
+
+export type ApiPagination = ApiOffsetPagination | ApiCursorPagination;
+
+export interface ApiResponseContext {
+  requestId: string;
+  timestamp: string;
+}
+
+export interface ApiSuccessEnvelope<T> extends ApiResponseContext {
+  success: true;
+  data: T;
+  dataState: Exclude<ApiDataState, 'unavailable'>;
+  pagination?: ApiPagination;
+  warnings?: ApiWarning[];
+}
+
+export interface ApiErrorEnvelope extends ApiResponseContext {
+  success: false;
+  dataState: 'unavailable';
+  error: string;
+  code: string;
+  action?: string;
+  retryable: boolean;
+  fields?: ReturnType<typeof toPublicAppError>['fields'];
+  meta?: Record<string, unknown>;
+  warnings?: ApiWarning[];
+}
+
+interface CanonicalResponseOptions {
+  context?: ApiResponseContext;
+  headers?: HeadersInit;
+  warnings?: ApiWarning[];
+}
+
+export interface ApiSuccessOptions extends CanonicalResponseOptions {
+  status?: number;
+  dataState?: Exclude<ApiDataState, 'unavailable'>;
+  pagination?: ApiPagination;
+}
+
+export interface ApiErrorOptions extends CanonicalResponseOptions {
+  meta?: Record<string, unknown>;
+}
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+function validRequestId(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized && REQUEST_ID_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+/**
+ * Creates immutable response metadata once per request. Pass the returned
+ * context to every response path so success and error responses correlate to
+ * the same request and timestamp source.
+ */
+export function createApiResponseContext(
+  request?: Pick<Request, 'headers'>,
+  now: Date = new Date()
+): ApiResponseContext {
+  const requestId =
+    validRequestId(request?.headers.get('x-request-id')) ??
+    validRequestId(getRequestContext().requestId) ??
+    crypto.randomUUID();
+
+  return { requestId, timestamp: now.toISOString() };
+}
+
+function responseHeaders(context: ApiResponseContext, init?: HeadersInit): Headers {
+  const headers = new Headers(init);
+  headers.set('x-request-id', context.requestId);
+  return headers;
+}
+
+/** Canonical success response. Legacy endpoints may continue using jsonOk during migration. */
+export function jsonApiOk<T>(payload: T, options: ApiSuccessOptions = {}) {
+  const context = options.context ?? createApiResponseContext();
+  const body: ApiSuccessEnvelope<T> = {
+    success: true,
+    data: payload,
+    dataState: options.dataState ?? (payload === null ? 'no_data' : 'available'),
+    requestId: context.requestId,
+    timestamp: context.timestamp,
+    ...(options.pagination ? { pagination: options.pagination } : {}),
+    ...(options.warnings?.length ? { warnings: options.warnings } : {}),
+  };
+
+  return NextResponse.json(body, {
+    status: options.status ?? 200,
+    headers: responseHeaders(context, options.headers),
+  });
+}
+
+/** Canonical typed error response. Unknown exceptions are safely normalized. */
+export function jsonApiError(error: AppError | unknown, options: ApiErrorOptions = {}) {
+  const context = options.context ?? createApiResponseContext();
+  const normalized = isAppError(error) ? error : normalizeError(error);
+  const publicError = toPublicAppError(normalized);
+  const body: ApiErrorEnvelope = {
+    success: false,
+    dataState: 'unavailable',
+    error: publicError.message,
+    code: publicError.code,
+    action: publicError.action,
+    retryable: publicError.retryable,
+    fields: publicError.fields,
+    requestId: context.requestId,
+    timestamp: context.timestamp,
+    meta: options.meta,
+    ...(options.warnings?.length ? { warnings: options.warnings } : {}),
+  };
+
+  return NextResponse.json(body, {
+    status: normalized.status,
+    headers: responseHeaders(context, options.headers),
+  });
+}
 
 export function jsonError(
   error: string | AppError | unknown,
@@ -7,11 +151,14 @@ export function jsonError(
   meta?: Record<string, unknown>,
   headers?: HeadersInit
 ) {
+  const context = createApiResponseContext();
   if (isAppError(error)) {
     const publicError = toPublicAppError(error);
 
     return NextResponse.json(
       {
+        success: false,
+        dataState: 'unavailable',
         // Preserve the existing string field for backward compatibility while
         // exposing stable machine-readable semantics to new clients.
         error: publicError.message,
@@ -20,8 +167,10 @@ export function jsonError(
         retryable: publicError.retryable,
         fields: publicError.fields,
         meta,
+        requestId: context.requestId,
+        timestamp: context.timestamp,
       },
-      { status: error.status, headers }
+      { status: error.status, headers: responseHeaders(context, headers) }
     );
   }
 
@@ -29,7 +178,19 @@ export function jsonError(
   // their English wording. Unexpected exceptions are normalized to the safe
   // INTERNAL_ERROR contract instead of passing through a text translator.
   if (typeof error === 'string') {
-    return NextResponse.json({ error, meta }, { status: status ?? 500, headers });
+    return NextResponse.json(
+      {
+        success: false,
+        dataState: 'unavailable',
+        error,
+        code: 'LEGACY_API_ERROR',
+        retryable: (status ?? 500) >= 500,
+        meta,
+        requestId: context.requestId,
+        timestamp: context.timestamp,
+      },
+      { status: status ?? 500, headers: responseHeaders(context, headers) }
+    );
   }
 
   const normalized = normalizeError(error);
@@ -42,11 +203,29 @@ export function jsonError(
       retryable: publicError.retryable,
       fields: publicError.fields,
       meta,
+      success: false,
+      dataState: 'unavailable',
+      requestId: context.requestId,
+      timestamp: context.timestamp,
     },
-    { status: normalized.status, headers }
+    { status: normalized.status, headers: responseHeaders(context, headers) }
   );
 }
 
 export function jsonOk<T>(payload: T, status: number = 200, headers?: HeadersInit) {
-  return NextResponse.json(payload, { status, headers });
+  const context = createApiResponseContext();
+  const aliases =
+    payload !== null && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {};
+  const body: ApiSuccessEnvelope<T> & Record<string, unknown> = {
+    ...aliases,
+    success: true,
+    data: payload,
+    dataState: payload === null ? 'no_data' : 'available',
+    requestId: context.requestId,
+    timestamp: context.timestamp,
+  };
+
+  return NextResponse.json(body, { status, headers: responseHeaders(context, headers) });
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,60 +1,16 @@
-export interface RequestContext {
-  requestId?: string;
-  userId?: string;
-  component?: string;
-}
+import {
+  getRequestContext,
+  runWithContext,
+  requestContextStorage,
+  type RequestContext,
+} from './request-context';
 
-interface AsyncLocalStorageLike<T> {
-  run<R>(store: T, callback: () => R): R;
-  getStore(): T | undefined;
-}
-
-class FallbackAsyncLocalStorage<T> implements AsyncLocalStorageLike<T> {
-  private store: T | undefined;
-  run<R>(store: T, callback: () => R): R {
-    const prev = this.store;
-    this.store = store;
-    try {
-      return callback();
-    } finally {
-      this.store = prev;
-    }
-  }
-  getStore(): T | undefined {
-    return this.store;
-  }
-}
-
-function createAsyncLocalStorage<T>(): AsyncLocalStorageLike<T> {
-  try {
-    // Avoid a static node:async_hooks import because this logger is also used
-    // by browser and Edge bundles. Node 20 exposes built-ins synchronously.
-    const runtimeProcess = (
-      globalThis as unknown as {
-        process?: { getBuiltinModule?: (id: string) => unknown };
-      }
-    ).process;
-    const asyncHooks = runtimeProcess?.getBuiltinModule?.('node:async_hooks') as
-      | { AsyncLocalStorage?: new <V>() => AsyncLocalStorageLike<V> }
-      | undefined;
-    if (typeof asyncHooks?.AsyncLocalStorage === 'function') {
-      return new asyncHooks.AsyncLocalStorage<T>();
-    }
-  } catch {
-    // Fallback if not available
-  }
-  return new FallbackAsyncLocalStorage<T>();
-}
-
-export const requestContextStorage = createAsyncLocalStorage<RequestContext>();
-
-export function runWithContext<T>(context: RequestContext, fn: () => T): T {
-  return requestContextStorage.run(context, fn);
-}
-
-export function getRequestContext(): RequestContext {
-  return requestContextStorage.getStore() ?? {};
-}
+export {
+  getRequestContext,
+  runWithContext,
+  requestContextStorage,
+  type RequestContext,
+} from './request-context';
 
 function trustedRequestId(request: Request): string {
   const supplied = request.headers.get('x-request-id')?.trim();

--- a/src/lib/request-context.ts
+++ b/src/lib/request-context.ts
@@ -1,0 +1,59 @@
+export interface RequestContext {
+  requestId?: string;
+  userId?: string;
+  component?: string;
+}
+
+interface AsyncLocalStorageLike<T> {
+  run<R>(store: T, callback: () => R): R;
+  getStore(): T | undefined;
+}
+
+class FallbackAsyncLocalStorage<T> implements AsyncLocalStorageLike<T> {
+  private store: T | undefined;
+
+  run<R>(store: T, callback: () => R): R {
+    const previous = this.store;
+    this.store = store;
+    try {
+      return callback();
+    } finally {
+      this.store = previous;
+    }
+  }
+
+  getStore(): T | undefined {
+    return this.store;
+  }
+}
+
+function createAsyncLocalStorage<T>(): AsyncLocalStorageLike<T> {
+  try {
+    // Avoid a static node:async_hooks import because request correlation is
+    // also bundled for browser and Edge consumers.
+    const runtimeProcess = (
+      globalThis as unknown as {
+        process?: { getBuiltinModule?: (id: string) => unknown };
+      }
+    ).process;
+    const asyncHooks = runtimeProcess?.getBuiltinModule?.('node:async_hooks') as
+      | { AsyncLocalStorage?: new <V>() => AsyncLocalStorageLike<V> }
+      | undefined;
+    if (typeof asyncHooks?.AsyncLocalStorage === 'function') {
+      return new asyncHooks.AsyncLocalStorage<T>();
+    }
+  } catch {
+    // Use the synchronous fallback when AsyncLocalStorage is unavailable.
+  }
+  return new FallbackAsyncLocalStorage<T>();
+}
+
+export const requestContextStorage = createAsyncLocalStorage<RequestContext>();
+
+export function runWithContext<T>(context: RequestContext, fn: () => T): T {
+  return requestContextStorage.run(context, fn);
+}
+
+export function getRequestContext(): RequestContext {
+  return requestContextStorage.getStore() ?? {};
+}

--- a/tests/api/mobile-incident-status.test.ts
+++ b/tests/api/mobile-incident-status.test.ts
@@ -49,7 +49,7 @@ describe('mobile incident status idempotency', () => {
 
     const response = await PATCH(request(), props);
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ success: true, duplicate: true });
+    expect(await response.json()).toMatchObject({ success: true, duplicate: true });
     expect(updateIncidentStatus).not.toHaveBeenCalled();
   });
 });

--- a/tests/architecture/api-response-contract.test.ts
+++ b/tests/architecture/api-response-contract.test.ts
@@ -1,0 +1,91 @@
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+// These routes intentionally implement protocols or response types that cannot
+// use the OpsKnight JSON envelope, or still need migration in this PR. Keeping
+// the inventory explicit prevents new contract bypasses from appearing.
+const DIRECT_RESPONSE_ALLOWLIST = new Set([
+  'src/app/api/admin/rollups/backfill/route.ts',
+  'src/app/api/admin/rollups/health/route.ts',
+  'src/app/api/admin/rollups/route.ts',
+  'src/app/api/admin/sla-drift/route.ts',
+  'src/app/api/admin/sla-performance/route.ts',
+  'src/app/api/auth/forgot-password/route.ts',
+  'src/app/api/auth/reset-password/route.ts',
+  'src/app/api/dashboards/[id]/route.ts',
+  'src/app/api/dashboards/route.ts',
+  'src/app/api/health/route.ts',
+  'src/app/api/incidents/[id]/context/route.ts',
+  'src/app/api/incidents/export/route.ts',
+  'src/app/api/jira/webhook/route.ts',
+  'src/app/api/logs/ingest/route.ts',
+  'src/app/api/public-logs/route.ts',
+  'src/app/api/reports/metrics/route.ts',
+  'src/app/api/schedules/[id]/oncall/route.ts',
+  'src/app/api/schedules/[id]/route.ts',
+  'src/app/api/schedules/route.ts',
+  'src/app/api/sla-definitions/[id]/route.ts',
+  'src/app/api/sla-definitions/route.ts',
+  'src/app/api/sla/compliance/route.ts',
+  'src/app/api/sla/stream/route.ts',
+  'src/app/api/slack/actions/route.ts',
+  'src/app/api/slack/commands/route.ts',
+  'src/app/api/slack/disconnect/route.ts',
+  'src/app/api/slack/events/route.ts',
+  'src/app/api/slack/oauth/callback/route.ts',
+  'src/app/api/slack/oauth/route.ts',
+  'src/app/api/status-page/domains/route.ts',
+  'src/app/api/status-page/logo/[id]/route.ts',
+  'src/app/api/status/create-default/route.ts',
+  'src/app/api/status/history/route.ts',
+  'src/app/api/status/route.ts',
+  'src/app/api/system/vapid-public-key/route.ts',
+  'src/app/api/users/[id]/avatar/route.ts',
+  'src/app/api/webhooks/notifications/twilio/route.ts',
+]);
+
+function isDirectJsonResponse(call: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== 'json') {
+    return false;
+  }
+  const owner = call.expression.expression;
+  return ts.isIdentifier(owner) && (owner.text === 'NextResponse' || owner.text === 'Response');
+}
+
+describe('API response contract architecture', () => {
+  it('prevents new route handlers from bypassing the centralized JSON response boundary', () => {
+    const repositoryRoot = process.cwd();
+    const apiRoot = path.join(repositoryRoot, 'src', 'app', 'api');
+    const violations: string[] = [];
+
+    for (const absolutePath of ts.sys.readDirectory(apiRoot, ['.ts'], undefined, ['**/route.ts'])) {
+      const relativePath = path.relative(repositoryRoot, absolutePath).split(path.sep).join('/');
+      if (DIRECT_RESPONSE_ALLOWLIST.has(relativePath)) continue;
+
+      const text = ts.sys.readFile(absolutePath);
+      if (text === undefined) continue;
+      const source = ts.createSourceFile(
+        absolutePath,
+        text,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS
+      );
+
+      const visit = (node: ts.Node) => {
+        if (ts.isCallExpression(node) && isDirectJsonResponse(node)) {
+          const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+          violations.push(`${relativePath}:${line}`);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+
+    expect(
+      violations,
+      `JSON routes must use src/lib/api-response.ts.\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/tests/lib/api-response.test.ts
+++ b/tests/lib/api-response.test.ts
@@ -1,8 +1,107 @@
 import { describe, it, expect } from 'vitest';
-import { jsonOk, jsonError } from '@/lib/api-response';
+import {
+  createApiResponseContext,
+  jsonApiError,
+  jsonApiOk,
+  jsonOk,
+  jsonError,
+} from '@/lib/api-response';
 import { AppError, ERROR_REGISTRY } from '@/lib/errors';
 
 describe('API Response Utilities', () => {
+  describe('canonical contract', () => {
+    it('creates stable request metadata from a trusted incoming request id', () => {
+      const context = createApiResponseContext(
+        new Request('https://opsknight.test/api/test', {
+          headers: { 'x-request-id': 'request-123' },
+        }),
+        new Date('2026-08-28T10:00:00.000Z')
+      );
+
+      expect(context).toEqual({
+        requestId: 'request-123',
+        timestamp: '2026-08-28T10:00:00.000Z',
+      });
+    });
+
+    it('rejects untrusted incoming request ids', () => {
+      const context = createApiResponseContext(
+        new Request('https://opsknight.test/api/test', {
+          headers: { 'x-request-id': 'invalid request id' },
+        })
+      );
+
+      expect(context.requestId).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('returns the canonical success envelope with pagination and warnings', async () => {
+      const context = {
+        requestId: 'request-success',
+        timestamp: '2026-08-28T10:00:00.000Z',
+      };
+      const response = jsonApiOk(
+        { incidents: [{ id: 'incident-1' }] },
+        {
+          context,
+          dataState: 'partial',
+          pagination: {
+            mode: 'offset',
+            page: 2,
+            pageSize: 25,
+            totalItems: 60,
+            totalPages: 3,
+          },
+          warnings: [{ code: 'RETENTION_CLIPPED', message: 'Older records were excluded.' }],
+        }
+      );
+
+      await expect(response.json()).resolves.toEqual({
+        success: true,
+        data: { incidents: [{ id: 'incident-1' }] },
+        dataState: 'partial',
+        requestId: 'request-success',
+        timestamp: '2026-08-28T10:00:00.000Z',
+        pagination: {
+          mode: 'offset',
+          page: 2,
+          pageSize: 25,
+          totalItems: 60,
+          totalPages: 3,
+        },
+        warnings: [{ code: 'RETENTION_CLIPPED', message: 'Older records were excluded.' }],
+      });
+      expect(response.headers.get('x-request-id')).toBe('request-success');
+    });
+
+    it('uses no_data for a null success payload', async () => {
+      const response = jsonApiOk(null, {
+        context: { requestId: 'request-empty', timestamp: '2026-08-28T10:00:00.000Z' },
+      });
+
+      const body = await response.json();
+      expect(body.dataState).toBe('no_data');
+      expect(body.data).toBeNull();
+    });
+
+    it('returns a safe canonical typed error with matching correlation metadata', async () => {
+      const response = jsonApiError(new Error('database-password'), {
+        context: { requestId: 'request-error', timestamp: '2026-08-28T10:00:00.000Z' },
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get('x-request-id')).toBe('request-error');
+      expect(body).toMatchObject({
+        success: false,
+        dataState: 'unavailable',
+        code: 'INTERNAL_ERROR',
+        requestId: 'request-error',
+        timestamp: '2026-08-28T10:00:00.000Z',
+      });
+      expect(JSON.stringify(body)).not.toContain('database-password');
+    });
+  });
+
   describe('jsonOk', () => {
     it('should return successful JSON response with data', () => {
       const data = { message: 'Success', id: '123' };
@@ -23,14 +122,21 @@ describe('API Response Utilities', () => {
       const response = jsonOk(data);
       const body = await response.json();
 
-      expect(body).toEqual(data);
+      expect(body).toMatchObject({
+        ...data,
+        success: true,
+        data,
+        dataState: 'available',
+      });
+      expect(body.requestId).toBeTypeOf('string');
+      expect(body.timestamp).toBeTypeOf('string');
     });
 
     it('should handle null data', async () => {
       const response = jsonOk(null);
       const body = await response.json();
 
-      expect(body).toBeNull();
+      expect(body).toMatchObject({ success: true, data: null, dataState: 'no_data' });
     });
 
     it('should handle arrays', async () => {
@@ -38,7 +144,7 @@ describe('API Response Utilities', () => {
       const response = jsonOk(data);
       const body = await response.json();
 
-      expect(body).toEqual(data);
+      expect(body).toMatchObject({ success: true, data, dataState: 'available' });
     });
 
     it('should allow custom status code', () => {
@@ -140,7 +246,9 @@ describe('API Response Utilities', () => {
 
       expect(response.status).toBe(422);
       expect(body.error).toBe('Unauthorized legacy message');
-      expect(body.code).toBeUndefined();
+      expect(body.code).toBe('LEGACY_API_ERROR');
+      expect(body.success).toBe(false);
+      expect(body.dataState).toBe('unavailable');
     });
 
     it('normalizes an unknown Error to the typed INTERNAL_ERROR contract without leaking its message', async () => {


### PR DESCRIPTION
## Summary

Establishes the canonical OpsKnight JSON response contract and upgrades every route already using the shared API response boundary.

- adds success/error envelopes with `dataState`, request ID, timestamp, warnings, and typed pagination
- preserves existing top-level object fields during client migration
- correlates response bodies and `x-request-id` headers
- safely normalizes unknown exceptions
- separates request context from logging so response correlation cannot be broken by logger mocks
- freezes direct JSON response bypasses behind an explicit architecture inventory
- documents protocol exemptions and migration rules

## Validation

- 200 unit test files passed
- 1,482 tests passed; 4 skipped
- TypeScript passed
- production build passed
- pre-push security checks passed