### PR TITLE
refactor(time): centralize reporting and retention bounds

### DIFF
--- a/docs/architecture/time-retention-contract.md
+++ b/docs/architecture/time-retention-contract.md
@@ -1,0 +1,22 @@
+# Time and retention contract
+
+`src/lib/time-retention-contract.ts` is the pure boundary for reporting clocks,
+timezone roles, query windows, and retention clipping. Database-backed policy
+loading remains in `src/lib/retention-policy.ts`, which delegates its date bounds
+to the contract.
+
+## Rules
+
+- Capture `now` once at the entry point and inject it into every calculation.
+- User timezone controls display and user-selected calendar boundaries.
+- Business timezone controls business-hours and operational classification.
+- Retention is an absolute duration and cannot depend on the server timezone.
+- Never silently swap an inverted interval. Collapse it and report
+  `start_after_end`.
+- Consumers must surface `clipReasons` when the requested interval was not fully
+  honored.
+- Invalid or missing IANA timezone values normalize to UTC.
+
+The reporting window is inclusive at both ends for current Prisma query
+compatibility. Consumers implementing cursor or SQL half-open intervals must do
+that conversion after resolving the canonical window.

--- a/src/lib/retention-policy.ts
+++ b/src/lib/retention-policy.ts
@@ -1,5 +1,11 @@
 // import 'server-only';
 import { logger } from './logger';
+import {
+  createTimeContractContext,
+  normalizeContractTimeZone,
+  resolveReportingWindow,
+  type RetainedDataType,
+} from './time-retention-contract';
 
 /**
  * Data Retention Policy Service
@@ -61,7 +67,7 @@ export async function getRetentionPolicy(): Promise<RetentionPolicy> {
     try {
       const prismaModule = await import('./prisma');
       prisma = prismaModule.default;
-    } catch (e) {
+    } catch (_error) {
       // If we can't import prisma, just return default policy (common in unit tests)
       return DEFAULT_POLICY;
     }
@@ -122,8 +128,7 @@ export async function getRetentionPolicy(): Promise<RetentionPolicy> {
         logRetentionDays: settings.logRetentionDays ?? DEFAULT_POLICY.logRetentionDays,
         metricsRetentionDays: settings.metricsRetentionDays ?? DEFAULT_POLICY.metricsRetentionDays,
         realTimeWindowDays: settings.realTimeWindowDays ?? DEFAULT_POLICY.realTimeWindowDays,
-        businessHoursTimeZone:
-          settings.businessHoursTimeZone ?? DEFAULT_POLICY.businessHoursTimeZone,
+        businessHoursTimeZone: normalizeContractTimeZone(settings.businessHoursTimeZone),
       };
     } else {
       // Create default settings if not exists
@@ -199,8 +204,9 @@ export async function updateRetentionPolicy(
   if (policy.businessHoursTimeZone !== undefined) {
     // Defense in depth: only persist values that look like an IANA name.
     // Final validation also happens in the SLA pipeline before use.
-    if (/^[A-Za-z][A-Za-z0-9+\-_/]{0,63}$/.test(policy.businessHoursTimeZone)) {
-      validated.businessHoursTimeZone = policy.businessHoursTimeZone;
+    const normalized = normalizeContractTimeZone(policy.businessHoursTimeZone);
+    if (normalized !== 'UTC' || policy.businessHoursTimeZone.trim() === 'UTC') {
+      validated.businessHoursTimeZone = normalized;
     } else {
       logger.warn('[RetentionPolicy] Rejected businessHoursTimeZone with invalid shape', {
         value: policy.businessHoursTimeZone,
@@ -246,9 +252,13 @@ export async function updateRetentionPolicy(
  */
 export async function getIncidentRetentionStartDate(): Promise<Date> {
   const policy = await getRetentionPolicy();
-  const date = new Date();
-  date.setDate(date.getDate() - policy.incidentRetentionDays);
-  return date;
+  return resolveReportingWindow({
+    context: createTimeContractContext({
+      now: new Date(),
+      businessTimeZone: policy.businessHoursTimeZone,
+    }),
+    policy,
+  }).retentionStart;
 }
 
 /**
@@ -290,60 +300,22 @@ export async function shouldUseRollups(startDate: Date, endDate?: Date): Promise
 export async function getQueryDateBounds(
   requestedStart: Date | undefined,
   requestedEnd: Date | undefined,
-  dataType: 'incident' | 'alert' | 'log' | 'metrics' = 'incident'
+  dataType: RetainedDataType = 'incident',
+  now: Date = new Date()
 ): Promise<{ start: Date; end: Date; isClipped: boolean }> {
   const policy = await getRetentionPolicy();
-  const now = new Date();
+  const window = resolveReportingWindow({
+    context: createTimeContractContext({
+      now,
+      businessTimeZone: policy.businessHoursTimeZone,
+    }),
+    policy,
+    dataType,
+    requestedStart,
+    requestedEnd,
+  });
 
-  // Get retention days based on data type
-  let retentionDays: number;
-  switch (dataType) {
-    case 'alert':
-      retentionDays = policy.alertRetentionDays;
-      break;
-    case 'log':
-      retentionDays = policy.logRetentionDays;
-      break;
-    case 'metrics':
-      retentionDays = policy.metricsRetentionDays;
-      break;
-    case 'incident':
-    default:
-      retentionDays = policy.incidentRetentionDays;
-  }
-
-  // Calculate retention boundary
-  const retentionBoundary = new Date(now);
-  retentionBoundary.setDate(retentionBoundary.getDate() - retentionDays);
-
-  // End date defaults to now. If the caller passed a future end date
-  // (e.g., clock skew between client and server), it gets clamped — and
-  // this counts as clipping so the UI can render a "range was clamped"
-  // banner instead of silently appearing to honor the requested range.
-  const requestedEndExceedsNow = !!requestedEnd && requestedEnd > now;
-  const end = requestedEnd && requestedEnd <= now ? requestedEnd : now;
-
-  // Start date defaults to retention boundary, but can't go before it
-  let start: Date;
-  let isClipped = requestedEndExceedsNow;
-
-  if (requestedStart) {
-    if (requestedStart < retentionBoundary) {
-      start = retentionBoundary;
-      isClipped = true;
-    } else {
-      start = requestedStart;
-    }
-  } else {
-    start = retentionBoundary;
-  }
-
-  // Ensure start is not after end
-  if (start > end) {
-    start = end;
-  }
-
-  return { start, end, isClipped };
+  return { ...window.effective, isClipped: window.isClipped };
 }
 
 /**
@@ -361,7 +333,6 @@ export async function getPaginationRecommendation(
   endDate: Date,
   estimatedIncidentsPerDay: number = 10
 ): Promise<PaginationInfo> {
-  const policy = await getRetentionPolicy();
   const realTimeStart = await getRealTimeWindowStart();
 
   const daySpan = Math.ceil((endDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000));

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -21,6 +21,7 @@ import {
 import { incidentEventSqlPredicate, incidentEventWhereFor } from './incident-event-classifier';
 import { mergeHybridMetrics } from './sla-hybrid-merge';
 import { getActiveOnCallShifts, getWindowOnCallShifts } from './oncall-shifts';
+import { createTimeContractContext, resolveReportingWindow } from './time-retention-contract';
 
 // UUID validation regex - prevents SQL injection in dynamic CASE statements
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -727,35 +728,33 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
   const coverageWindowDays = 14;
   const userTimeZone = normalizeTimeZone(filters.userTimeZone);
 
-  // Calculate time window with retention policy
-  let requestedStart = filters.startDate;
+  // Calculate every reporting boundary from the same clock and retention contract.
+  const requestedStart = filters.startDate;
   const requestedEnd = filters.endDate || now;
-
-  if (!requestedStart) {
-    if (filters.includeAllTime) {
-      // "All Time" means within retention policy - NOT hardcoded!
-      requestedStart = new Date(now);
-      requestedStart.setDate(requestedStart.getDate() - retentionPolicy.incidentRetentionDays);
-    } else {
-      requestedStart = new Date(now);
-      requestedStart.setDate(now.getDate() - windowDays);
-    }
-  }
-  const requestedStartDate = requestedStart ?? now;
+  const timeContext = createTimeContractContext({
+    now,
+    userTimeZone,
+    businessTimeZone: retentionPolicy.businessHoursTimeZone,
+  });
+  const incidentWindow = resolveReportingWindow({
+    context: timeContext,
+    policy: retentionPolicy,
+    dataType: 'incident',
+    requestedStart,
+    requestedEnd,
+    defaultWindowDays: filters.includeAllTime ? undefined : windowDays,
+  });
+  const { start, end } = incidentWindow.effective;
+  const { isClipped } = incidentWindow;
+  const requestedStartDate = incidentWindow.requested.start ?? incidentWindow.effective.start;
   const requestedEndDate = requestedEnd;
-
-  // Apply retention policy bounds - this ensures we never query beyond retained data
-  const { start, end, isClipped } = await getQueryDateBounds(
-    requestedStartDate,
-    requestedEndDate,
-    'incident'
-  );
 
   if (isClipped) {
     logger.info('[SLA] Date range clipped to retention policy', {
       requested: { start: requestedStart?.toISOString(), end: requestedEnd?.toISOString() },
       actual: { start: start.toISOString(), end: end.toISOString() },
       retentionDays: retentionPolicy.incidentRetentionDays,
+      clipReasons: incidentWindow.clipReasons,
     });
   }
 
@@ -767,11 +766,13 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     [finalStart, finalEnd] = [finalEnd, finalStart];
   }
 
-  const { start: alertStart, end: alertEnd } = await getQueryDateBounds(
-    requestedStartDate,
-    requestedEndDate,
-    'alert'
-  );
+  const { start: alertStart, end: alertEnd } = resolveReportingWindow({
+    context: timeContext,
+    policy: retentionPolicy,
+    dataType: 'alert',
+    requestedStart: requestedStartDate,
+    requestedEnd: requestedEndDate,
+  }).effective;
 
   // Check if we should use rollup data for this historical query.
   // Rollups are pre-aggregated daily snapshots — much faster than live queries

--- a/src/lib/time-retention-contract.ts
+++ b/src/lib/time-retention-contract.ts
@@ -1,0 +1,114 @@
+import { isValidTimeZone } from './timezone';
+
+export type RetainedDataType = 'incident' | 'alert' | 'log' | 'metrics';
+export type TimeWindowClipReason = 'retention_start' | 'future_end' | 'start_after_end';
+
+export interface RetentionDurations {
+  incidentRetentionDays: number;
+  alertRetentionDays: number;
+  logRetentionDays: number;
+  metricsRetentionDays: number;
+}
+
+export interface TimeContractContext {
+  now: Date;
+  userTimeZone: string;
+  businessTimeZone: string;
+}
+
+export interface ReportingWindow {
+  requested: { start: Date | null; end: Date | null };
+  effective: { start: Date; end: Date };
+  retentionStart: Date;
+  dataType: RetainedDataType;
+  isClipped: boolean;
+  clipReasons: TimeWindowClipReason[];
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function validDate(value: Date | undefined): Date | undefined {
+  return value && Number.isFinite(value.getTime()) ? new Date(value) : undefined;
+}
+
+export function normalizeContractTimeZone(value: string | null | undefined): string {
+  const normalized = value?.trim();
+  return normalized && isValidTimeZone(normalized) ? normalized : 'UTC';
+}
+
+export function createTimeContractContext(input: {
+  now?: Date;
+  userTimeZone?: string | null;
+  businessTimeZone?: string | null;
+}): TimeContractContext {
+  const now = validDate(input.now ?? new Date());
+  if (!now) throw new RangeError('A valid contract clock is required.');
+
+  return {
+    now,
+    userTimeZone: normalizeContractTimeZone(input.userTimeZone),
+    businessTimeZone: normalizeContractTimeZone(input.businessTimeZone),
+  };
+}
+
+export function getRetentionDays(policy: RetentionDurations, dataType: RetainedDataType): number {
+  switch (dataType) {
+    case 'alert':
+      return policy.alertRetentionDays;
+    case 'log':
+      return policy.logRetentionDays;
+    case 'metrics':
+      return policy.metricsRetentionDays;
+    case 'incident':
+      return policy.incidentRetentionDays;
+  }
+}
+
+/**
+ * Resolves an absolute reporting interval against one injected clock. Retention
+ * is duration-based and therefore independent of the host machine timezone.
+ */
+export function resolveReportingWindow(input: {
+  context: TimeContractContext;
+  policy: RetentionDurations;
+  dataType?: RetainedDataType;
+  requestedStart?: Date;
+  requestedEnd?: Date;
+  defaultWindowDays?: number;
+}): ReportingWindow {
+  const dataType = input.dataType ?? 'incident';
+  const now = new Date(input.context.now);
+  const requestedStart = validDate(input.requestedStart);
+  const requestedEnd = validDate(input.requestedEnd);
+  const retentionDays = Math.max(0, getRetentionDays(input.policy, dataType));
+  const retentionStart = new Date(now.getTime() - retentionDays * DAY_MS);
+  const defaultDays =
+    input.defaultWindowDays === undefined ? retentionDays : Math.max(0, input.defaultWindowDays);
+  const defaultStart = new Date(now.getTime() - defaultDays * DAY_MS);
+  const clipReasons: TimeWindowClipReason[] = [];
+
+  let end = requestedEnd ?? now;
+  if (end > now) {
+    end = now;
+    clipReasons.push('future_end');
+  }
+
+  let start = requestedStart ?? defaultStart;
+  if (start < retentionStart) {
+    start = retentionStart;
+    clipReasons.push('retention_start');
+  }
+  if (start > end) {
+    start = end;
+    clipReasons.push('start_after_end');
+  }
+
+  return {
+    requested: { start: requestedStart ?? defaultStart, end: requestedEnd ?? now },
+    effective: { start, end },
+    retentionStart,
+    dataType,
+    isClipped: clipReasons.length > 0,
+    clipReasons,
+  };
+}

--- a/tests/lib/time-retention-contract.test.ts
+++ b/tests/lib/time-retention-contract.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTimeContractContext,
+  normalizeContractTimeZone,
+  resolveReportingWindow,
+  type RetentionDurations,
+} from '@/lib/time-retention-contract';
+
+const policy: RetentionDurations = {
+  incidentRetentionDays: 730,
+  alertRetentionDays: 365,
+  logRetentionDays: 90,
+  metricsRetentionDays: 365,
+};
+const now = new Date('2026-08-28T12:00:00.000Z');
+
+describe('time and retention contract', () => {
+  it.each([
+    ['UTC', 'UTC'],
+    ['Asia/Kolkata', 'Asia/Kolkata'],
+    ['America/New_York', 'America/New_York'],
+    ['not/a-zone', 'UTC'],
+    ['', 'UTC'],
+  ])('normalizes timezone %s to %s', (input, expected) => {
+    expect(normalizeContractTimeZone(input)).toBe(expected);
+  });
+
+  it('keeps user and business timezone responsibilities explicit', () => {
+    expect(
+      createTimeContractContext({
+        now,
+        userTimeZone: 'Asia/Kolkata',
+        businessTimeZone: 'America/Los_Angeles',
+      })
+    ).toEqual({
+      now,
+      userTimeZone: 'Asia/Kolkata',
+      businessTimeZone: 'America/Los_Angeles',
+    });
+  });
+
+  it.each([
+    ['incident', 730],
+    ['alert', 365],
+    ['log', 90],
+    ['metrics', 365],
+  ] as const)('uses the configured %s retention duration', (dataType, retentionDays) => {
+    const window = resolveReportingWindow({
+      context: createTimeContractContext({ now }),
+      policy,
+      dataType,
+    });
+
+    expect(now.getTime() - window.retentionStart.getTime()).toBe(
+      retentionDays * 24 * 60 * 60 * 1000
+    );
+    expect(window.effective.start).toEqual(window.retentionStart);
+  });
+
+  it('clips both an expired start and a future end with exact reasons', () => {
+    const window = resolveReportingWindow({
+      context: createTimeContractContext({ now }),
+      policy,
+      dataType: 'log',
+      requestedStart: new Date('2025-01-01T00:00:00.000Z'),
+      requestedEnd: new Date('2026-09-01T00:00:00.000Z'),
+    });
+
+    expect(window.effective.start).toEqual(new Date(now.getTime() - 90 * 86_400_000));
+    expect(window.effective.end).toEqual(now);
+    expect(window.clipReasons).toEqual(['future_end', 'retention_start']);
+    expect(window.isClipped).toBe(true);
+  });
+
+  it('collapses an inverted range instead of silently swapping its meaning', () => {
+    const requestedEnd = new Date('2026-08-20T12:00:00.000Z');
+    const window = resolveReportingWindow({
+      context: createTimeContractContext({ now }),
+      policy,
+      requestedStart: new Date('2026-08-21T12:00:00.000Z'),
+      requestedEnd,
+    });
+
+    expect(window.effective).toEqual({ start: requestedEnd, end: requestedEnd });
+    expect(window.clipReasons).toEqual(['start_after_end']);
+  });
+
+  it('uses one injected clock regardless of user timezone or DST boundaries', () => {
+    const contexts = ['UTC', 'America/New_York', 'Europe/London', 'Asia/Kolkata'].map(
+      userTimeZone => createTimeContractContext({ now, userTimeZone })
+    );
+    const starts = contexts.map(context =>
+      resolveReportingWindow({
+        context,
+        policy,
+        defaultWindowDays: 30,
+      }).effective.start.toISOString()
+    );
+
+    expect(new Set(starts)).toEqual(new Set(['2026-07-29T12:00:00.000Z']));
+  });
+
+  it('reports clipping when a default reporting window exceeds retention', () => {
+    const window = resolveReportingWindow({
+      context: createTimeContractContext({ now }),
+      policy: { ...policy, incidentRetentionDays: 1 },
+      defaultWindowDays: 7,
+    });
+
+    expect(window.requested.start).toEqual(new Date(now.getTime() - 7 * 86_400_000));
+    expect(window.effective.start).toEqual(new Date(now.getTime() - 86_400_000));
+    expect(window.clipReasons).toEqual(['retention_start']);
+  });
+
+  it('rejects an invalid injected clock', () => {
+    expect(() => createTimeContractContext({ now: new Date(Number.NaN) })).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## Summary

Creates one pure contract for clocks, timezone roles, reporting windows, and retention clipping.

- injects one clock across each calculation
- distinguishes user timezone from business timezone
- normalizes invalid IANA zones to UTC
- makes retention boundaries independent of server-local timezone and DST
- reports exact clipping reasons for expired, future, and inverted ranges
- routes existing retention bounds and SLA windows through the contract
- documents inclusive interval compatibility and consumer rules
- adds timezone/data-type/retention matrix coverage

## Validation

- 200 unit test files passed
- 1,491 tests passed; 4 skipped
- TypeScript passed
- focused time, retention, SLA, and verification suites passed