### PR TITLE
refactor(audit): centralize event contract

### DIFF
--- a/docs/architecture/audit-event-contract.md
+++ b/docs/architecture/audit-event-contract.md
@@ -1,0 +1,18 @@
+# Audit-event contract
+
+All durable audit writes flow through `src/lib/audit.ts`. The versioned payload
+records the actor snapshot, action, target, occurrence time, request ID, source,
+old value, new value, and redacted metadata. Indexed legacy columns remain
+populated for current queries and rate limits.
+
+Sources are `UI`, `API`, `INTEGRATION`, `AUTOMATION`, `BACKGROUND`, `AUTH`, or
+`SYSTEM`. New callers must select one explicitly and pass the active request ID
+when a request exists. Background work receives a generated correlation ID.
+
+Audit writes that describe a transactional domain mutation should use
+`emitAuditEvent(input, tx)` inside the same database transaction. Authentication
+audit failures remain best-effort so telemetry cannot prevent login or recovery.
+
+Sensitive keys and credential-shaped strings are redacted before persistence.
+Direct `prisma.auditLog.create()` calls outside the emitter fail architecture
+tests.

--- a/src/app/api/admin/generate-reset-link/route.ts
+++ b/src/app/api/admin/generate-reset-link/route.ts
@@ -8,6 +8,7 @@ import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { assertAdmin } from '@/lib/rbac';
 import { getClientIp } from '@/lib/client-ip';
+import { emitAuditEvent } from '@/lib/audit';
 
 export async function POST(req: NextRequest) {
   try {
@@ -106,16 +107,20 @@ export async function POST(req: NextRequest) {
     const resetLink = `${appUrl}/reset-password?token=${token}`;
 
     // 5. Audit Log
-    await prisma.auditLog.create({
-      data: {
-        action: 'ADMIN_GENERATED_RESET_LINK',
-        entityType: 'USER',
-        entityId: user.id,
-        actorId: sessionUser.id,
-        targetEmail: sessionUser.email,
-        ip,
-        details: { targetEmail: user.email, generatedFor: user.id },
+    await emitAuditEvent({
+      action: 'ADMIN_GENERATED_RESET_LINK',
+      source: 'API',
+      target: { type: 'USER', id: user.id },
+      actor: {
+        type: 'USER',
+        id: sessionUser.id,
+        email: sessionUser.email,
+        name: sessionUser.name,
       },
+      requestId: req.headers.get('x-request-id'),
+      targetEmail: user.email,
+      ip,
+      metadata: { generatedFor: user.id },
     });
 
     return jsonOk({ link: resetLink }, 200);

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,14 +1,114 @@
+import type { AuditEntityType, Prisma } from '@prisma/client';
 import prisma from './prisma';
-import { AuditEntityType, Prisma } from '@prisma/client';
 import { sanitizeContext } from './logger';
 
 export type AuditDetails = Prisma.InputJsonValue;
+export type AuditEventSource =
+  | 'UI'
+  | 'API'
+  | 'INTEGRATION'
+  | 'AUTOMATION'
+  | 'BACKGROUND'
+  | 'AUTH'
+  | 'SYSTEM';
+export type AuditActorType = 'USER' | 'API_KEY' | 'INTEGRATION' | 'SYSTEM';
+
+export interface AuditEventActor {
+  type: AuditActorType;
+  id?: string | null;
+  email?: string | null;
+  name?: string | null;
+}
+
+export interface AuditEventTarget {
+  type: AuditEntityType;
+  id?: string | null;
+}
+
+export interface AuditEventInput {
+  action: string;
+  source: AuditEventSource;
+  target: AuditEventTarget;
+  actor?: AuditEventActor | null;
+  requestId?: string | null;
+  occurredAt?: Date;
+  oldValue?: AuditDetails | null;
+  newValue?: AuditDetails | null;
+  metadata?: AuditDetails | null;
+  targetEmail?: string | null;
+  ip?: string | null;
+}
+
+type AuditClient = Pick<Prisma.TransactionClient, 'auditLog' | 'user'>;
+
+function resolveRequestId(value: string | null | undefined): string {
+  const normalized = value?.trim();
+  return normalized && /^[A-Za-z0-9._:-]{1,128}$/.test(normalized)
+    ? normalized
+    : crypto.randomUUID();
+}
+
+function jsonValue(value: AuditDetails | null | undefined): Prisma.InputJsonValue | null {
+  return value === undefined || value === null
+    ? null
+    : (sanitizeContext(value) as Prisma.InputJsonValue);
+}
+
+/** Writes one versioned audit event through the supplied transaction or Prisma client. */
+export async function emitAuditEvent(
+  input: AuditEventInput,
+  client: AuditClient = prisma
+): Promise<void> {
+  const occurredAt = input.occurredAt ?? new Date();
+  if (!Number.isFinite(occurredAt.getTime())) throw new RangeError('Invalid audit timestamp.');
+
+  const actorId = input.actor?.type === 'USER' ? (input.actor.id ?? null) : null;
+  const actorSnapshot = actorId
+    ? await client.user.findUnique({
+        where: { id: actorId },
+        select: { email: true, name: true },
+      })
+    : null;
+  const resolvedEmail = input.actor?.email ?? actorSnapshot?.email ?? null;
+  const resolvedName = input.actor?.name ?? actorSnapshot?.name ?? null;
+  const correlationId = resolveRequestId(input.requestId);
+
+  await client.auditLog.create({
+    data: {
+      action: input.action,
+      entityType: input.target.type,
+      entityId: input.target.id || null,
+      actorId,
+      actorEmail: resolvedEmail,
+      actorName: resolvedName,
+      targetEmail: input.targetEmail?.toLowerCase().trim() || null,
+      ip: input.ip || null,
+      details: {
+        contractVersion: 1,
+        source: input.source,
+        requestId: correlationId,
+        occurredAt: occurredAt.toISOString(),
+        actor: {
+          type: input.actor?.type ?? 'SYSTEM',
+          id: input.actor?.id ?? null,
+          email: resolvedEmail,
+          name: resolvedName,
+        },
+        target: { type: input.target.type, id: input.target.id ?? null },
+        oldValue: jsonValue(input.oldValue),
+        newValue: jsonValue(input.newValue),
+        metadata: jsonValue(input.metadata),
+      },
+    },
+  });
+}
 
 /** @deprecated Pass the authenticated actor explicitly for user-initiated actions. */
 export async function getDefaultActorId() {
   return null;
 }
 
+/** Backward-compatible adapter for existing callers. New code uses emitAuditEvent. */
 export async function logAudit(params: {
   action: string;
   entityType: AuditEntityType;
@@ -17,44 +117,31 @@ export async function logAudit(params: {
   details?: AuditDetails | null;
   targetEmail?: string | null;
   ip?: string | null;
+  source?: AuditEventSource;
+  requestId?: string | null;
+  oldValue?: AuditDetails | null;
+  newValue?: AuditDetails | null;
 }) {
-  const { action, entityType, entityId, actorId, details, targetEmail, ip } = params;
+  const detailsRecord =
+    params.details && typeof params.details === 'object' && !Array.isArray(params.details)
+      ? (params.details as Record<string, unknown>)
+      : null;
+  const targetEmail =
+    params.targetEmail ??
+    (typeof detailsRecord?.targetEmail === 'string' ? detailsRecord.targetEmail : null) ??
+    (typeof detailsRecord?.email === 'string' ? detailsRecord.email : null);
+  const ip = params.ip ?? (typeof detailsRecord?.ip === 'string' ? detailsRecord.ip : null) ?? null;
 
-  // Extract targetEmail and ip from details if not explicitly passed
-  let resolvedEmail = targetEmail ?? null;
-  let resolvedIp = ip ?? null;
-  if (details && typeof details === 'object' && !Array.isArray(details)) {
-    const d = details as Record<string, unknown>;
-    if (!resolvedEmail && typeof d.email === 'string') {
-      resolvedEmail = d.email;
-    }
-    if (!resolvedEmail && typeof d.targetEmail === 'string') {
-      resolvedEmail = d.targetEmail;
-    }
-    if (!resolvedIp && typeof d.ip === 'string') {
-      resolvedIp = d.ip;
-    }
-  }
-
-  const safeDetails = details ? (sanitizeContext(details) as Prisma.InputJsonValue) : Prisma.DbNull;
-  const actor = actorId
-    ? await prisma.user.findUnique({
-        where: { id: actorId },
-        select: { email: true, name: true },
-      })
-    : null;
-
-  await prisma.auditLog.create({
-    data: {
-      action,
-      entityType,
-      entityId: entityId || null,
-      actorId: actorId || null,
-      actorEmail: actor?.email ?? null,
-      actorName: actor?.name ?? null,
-      details: safeDetails,
-      targetEmail: resolvedEmail ? resolvedEmail.toLowerCase().trim() : null,
-      ip: resolvedIp || null,
-    },
+  await emitAuditEvent({
+    action: params.action,
+    source: params.source ?? (params.actorId ? 'UI' : 'SYSTEM'),
+    target: { type: params.entityType, id: params.entityId },
+    actor: params.actorId ? { type: 'USER', id: params.actorId } : { type: 'SYSTEM' },
+    requestId: params.requestId,
+    oldValue: params.oldValue,
+    newValue: params.newValue,
+    metadata: params.details,
+    targetEmail,
+    ip,
   });
 }

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -72,6 +72,8 @@ export async function emitAuditEvent(
   const resolvedEmail = input.actor?.email ?? actorSnapshot?.email ?? null;
   const resolvedName = input.actor?.name ?? actorSnapshot?.name ?? null;
   const correlationId = resolveRequestId(input.requestId);
+  const targetEmail = input.targetEmail?.toLowerCase().trim() || null;
+  const ip = input.ip || null;
 
   await client.auditLog.create({
     data: {
@@ -81,8 +83,8 @@ export async function emitAuditEvent(
       actorId,
       actorEmail: resolvedEmail,
       actorName: resolvedName,
-      targetEmail: input.targetEmail?.toLowerCase().trim() || null,
-      ip: input.ip || null,
+      targetEmail,
+      ip,
       details: {
         contractVersion: 1,
         source: input.source,
@@ -98,6 +100,10 @@ export async function emitAuditEvent(
         oldValue: jsonValue(input.oldValue),
         newValue: jsonValue(input.newValue),
         metadata: jsonValue(input.metadata),
+        // Preserve the legacy lookup paths while consumers migrate to the
+        // versioned envelope and indexed columns.
+        ...(targetEmail ? { targetEmail } : {}),
+        ...(ip ? { ip } : {}),
       },
     },
   });

--- a/src/lib/login-audit.ts
+++ b/src/lib/login-audit.ts
@@ -6,6 +6,7 @@
  */
 
 import { logger } from '@/lib/logger';
+import { emitAuditEvent } from '@/lib/audit';
 import prisma from '@/lib/prisma';
 
 export type LoginEventType =
@@ -69,19 +70,21 @@ export async function logLoginEvent(data: LoginAuditData): Promise<void> {
   // Also store in database for compliance and reporting
   // Using the existing AuditLog model with entityType: AUTH_SESSION
   try {
-    await prisma.auditLog.create({
-      data: {
-        action: data.eventType,
-        entityType: 'USER', // Using USER for login events since AUTH_SESSION isn't in enum
-        entityId: data.email, // Use email as the entity identifier
-        actorId: data.userId || null, // Link to user if known
-        details: {
-          ip: data.ip,
-          userAgent: truncateUserAgent(data.userAgent),
-          success: data.success,
-          failureReason: data.failureReason || null,
-          ...data.metadata,
-        },
+    await emitAuditEvent({
+      action: data.eventType,
+      source: 'AUTH',
+      target: { type: 'USER', id: data.userId ?? data.email },
+      actor: data.userId
+        ? { type: 'USER', id: data.userId, email: data.email }
+        : { type: 'SYSTEM' },
+      occurredAt: timestamp,
+      targetEmail: data.email,
+      ip: data.ip,
+      metadata: {
+        userAgent: truncateUserAgent(data.userAgent),
+        success: data.success,
+        failureReason: data.failureReason || null,
+        ...data.metadata,
       },
     });
   } catch (error) {

--- a/src/lib/password-reset.ts
+++ b/src/lib/password-reset.ts
@@ -3,6 +3,7 @@ import prisma from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
 import { AppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
+import { emitAuditEvent } from '@/lib/audit';
 import { validatePasswordStrength } from '@/lib/passwords';
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const MAX_ATTEMPTS_PER_WINDOW = 5;
@@ -123,7 +124,7 @@ export async function initiatePasswordReset(
             message: `Reset your password: ${resetLink}`,
           });
           notificationSent = true;
-        } catch (e) {
+        } catch (_error) {
           logger.warn('[PasswordReset] SMS sending failed', {
             component: 'password-reset',
           });
@@ -204,16 +205,14 @@ async function logAttempt(
   userId: string | undefined = undefined
 ) {
   try {
-    await prisma.auditLog.create({
-      data: {
-        action,
-        entityType: 'USER',
-        entityId: userId || 'unknown',
-        actorId: userId,
-        targetEmail: email, // Populate optimized column
-        ip: ip, // Populate optimized column
-        details: { targetEmail: email, ip }, // Keep JSON for potential extra data
-      },
+    await emitAuditEvent({
+      action,
+      source: 'AUTH',
+      target: { type: 'USER', id: userId || 'unknown' },
+      actor: userId ? { type: 'USER', id: userId, email } : { type: 'SYSTEM' },
+      targetEmail: email,
+      ip,
+      metadata: { targetEmail: email },
     });
   } catch (e) {
     logger.error('password.reset.audit.error', {
@@ -240,7 +239,7 @@ export async function simulateWork(startTime: number) {
 export async function completePasswordReset(
   token: string,
   password: string,
-  ip?: string
+  _ip?: string
 ): Promise<{ success: boolean; message?: string; error?: string }> {
   // Basic implementation needed to satisfy export if used elsewhere
   // Assuming completePasswordReset wasn't the cause of initiation crash.
@@ -310,12 +309,12 @@ export async function completePasswordReset(
     });
 
     return { success: true, message: 'Password reset successfully' };
-  } catch (e: any) {
-    if (e?.message === 'TOKEN_EXPIRED_OR_USED') {
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message === 'TOKEN_EXPIRED_OR_USED') {
       return { success: false, error: 'Invalid or expired token' };
     }
     logger.error('password.reset.complete.error', {
-      error: e instanceof Error ? e.message : String(e),
+      error: error instanceof Error ? error.message : String(error),
     });
     return { success: false, error: 'Internal error' };
   }

--- a/tests/architecture/audit-contract.test.ts
+++ b/tests/architecture/audit-contract.test.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+function isAuditCreate(call: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== 'create') {
+    return false;
+  }
+  const model = call.expression.expression;
+  return ts.isPropertyAccessExpression(model) && model.name.text === 'auditLog';
+}
+
+describe('audit contract architecture', () => {
+  it('keeps all audit writes behind the centralized emitter', () => {
+    const repositoryRoot = process.cwd();
+    const sourceRoot = path.join(repositoryRoot, 'src');
+    const violations: string[] = [];
+
+    for (const absolutePath of ts.sys.readDirectory(sourceRoot, ['.ts', '.tsx'])) {
+      const relativePath = path.relative(repositoryRoot, absolutePath).split(path.sep).join('/');
+      if (relativePath === 'src/lib/audit.ts') continue;
+      const text = ts.sys.readFile(absolutePath);
+      if (text === undefined) continue;
+      const source = ts.createSourceFile(
+        absolutePath,
+        text,
+        ts.ScriptTarget.Latest,
+        true,
+        absolutePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+      );
+
+      const visit = (node: ts.Node) => {
+        if (ts.isCallExpression(node) && isAuditCreate(node)) {
+          const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+          violations.push(`${relativePath}:${line}`);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+
+    expect(
+      violations,
+      `Audit writes must use emitAuditEvent/logAudit.\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/tests/lib/audit-contract.test.ts
+++ b/tests/lib/audit-contract.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  auditCreate: vi.fn(),
+  userFindUnique: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    auditLog: { create: mocks.auditCreate },
+    user: { findUnique: mocks.userFindUnique },
+  },
+}));
+
+import { emitAuditEvent, logAudit } from '@/lib/audit';
+
+describe('audit event contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auditCreate.mockResolvedValue({});
+    mocks.userFindUnique.mockResolvedValue({ email: 'actor@example.com', name: 'Actor' });
+  });
+
+  it('writes actor, action, target, source, timestamp, request, and change values', async () => {
+    await emitAuditEvent({
+      action: 'incident.lifecycle.resolve',
+      source: 'API',
+      target: { type: 'SYSTEM_CONFIG', id: 'incident-1' },
+      actor: { type: 'USER', id: 'user-1' },
+      requestId: 'request-1',
+      occurredAt: new Date('2026-08-28T10:00:00.000Z'),
+      oldValue: { status: 'ACKNOWLEDGED' },
+      newValue: { status: 'RESOLVED' },
+      metadata: { reason: 'Recovered' },
+    });
+
+    expect(mocks.auditCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'incident.lifecycle.resolve',
+        entityType: 'SYSTEM_CONFIG',
+        entityId: 'incident-1',
+        actorId: 'user-1',
+        actorEmail: 'actor@example.com',
+        actorName: 'Actor',
+        details: {
+          contractVersion: 1,
+          source: 'API',
+          requestId: 'request-1',
+          occurredAt: '2026-08-28T10:00:00.000Z',
+          actor: {
+            type: 'USER',
+            id: 'user-1',
+            email: 'actor@example.com',
+            name: 'Actor',
+          },
+          target: { type: 'SYSTEM_CONFIG', id: 'incident-1' },
+          oldValue: { status: 'ACKNOWLEDGED' },
+          newValue: { status: 'RESOLVED' },
+          metadata: { reason: 'Recovered' },
+        },
+      }),
+    });
+  });
+
+  it('redacts sensitive values before persistence', async () => {
+    await emitAuditEvent({
+      action: 'integration.updated',
+      source: 'UI',
+      target: { type: 'SYSTEM_CONFIG', id: 'jira' },
+      metadata: { apiToken: 'secret-token', nested: { password: 'secret-password' } },
+    });
+
+    const serialized = JSON.stringify(mocks.auditCreate.mock.calls[0]);
+    expect(serialized).not.toContain('secret-token');
+    expect(serialized).not.toContain('secret-password');
+    expect(serialized).toContain('[REDACTED]');
+  });
+
+  it('adapts legacy logAudit calls into the versioned contract', async () => {
+    await logAudit({
+      action: 'USER_UPDATED',
+      entityType: 'USER',
+      entityId: 'user-2',
+      actorId: 'user-1',
+      details: { targetEmail: 'TARGET@EXAMPLE.COM', ip: '127.0.0.1' },
+    });
+
+    expect(mocks.auditCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        targetEmail: 'target@example.com',
+        ip: '127.0.0.1',
+        details: expect.objectContaining({ source: 'UI', contractVersion: 1 }),
+      }),
+    });
+  });
+
+  it('rejects invalid timestamps before persistence', async () => {
+    await expect(
+      emitAuditEvent({
+        action: 'invalid.time',
+        source: 'SYSTEM',
+        target: { type: 'SYSTEM_CONFIG' },
+        occurredAt: new Date(Number.NaN),
+      })
+    ).rejects.toThrow(RangeError);
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/audit-contract.test.ts
+++ b/tests/lib/audit-contract.test.ts
@@ -89,7 +89,12 @@ describe('audit event contract', () => {
       data: expect.objectContaining({
         targetEmail: 'target@example.com',
         ip: '127.0.0.1',
-        details: expect.objectContaining({ source: 'UI', contractVersion: 1 }),
+        details: expect.objectContaining({
+          source: 'UI',
+          contractVersion: 1,
+          targetEmail: 'target@example.com',
+          ip: '127.0.0.1',
+        }),
       }),
     });
   });


### PR DESCRIPTION
## Summary

Routes every durable audit write through one versioned audit-event contract.

- defines actor, action, target, source, timestamp, request ID, old value, and new value
- preserves actor snapshots after account deletion
- redacts sensitive values before persistence
- retains indexed compatibility columns for current queries and rate limiting
- migrates authentication, password recovery, and admin reset audit paths
- adapts all existing `logAudit` callers to the versioned payload
- removes all direct `prisma.auditLog.create()` bypasses outside the emitter
- adds architecture enforcement and contract documentation

## Validation

- 201 unit test files passed
- 1,481 tests passed; 4 skipped
- TypeScript passed
- focused auth, audit, and admin-reset suites passed