### PR TITLE
refactor(notifications): centralize delivery contract

### DIFF
--- a/docs/architecture/notification-delivery-contract.md
+++ b/docs/architecture/notification-delivery-contract.md
@@ -1,0 +1,25 @@
+# Notification-delivery contract
+
+`src/lib/notification-delivery.ts` owns channel names, delivery states, provider
+dispatch, retry policy, and deduplication identity. Both first attempts and
+durable retries use `dispatchNotificationAttempt`, so providers cannot behave
+differently merely because an attempt is a retry.
+
+## Guarantees
+
+- Delivery intent identity includes incident, recipient, channel, and message.
+  A resolved message cannot be suppressed by a recent triggered message.
+- Retry uses one bounded exponential schedule and one maximum-attempt policy.
+- Provider results are normalized to success, error, provider message ID, and
+  skipped state.
+- SMS and WhatsApp receive the durable notification ID for provider callback
+  correlation.
+- Slack incident delivery remains owned by the durable lifecycle/event outbox;
+  the dispatcher marks that ownership without sending a duplicate message.
+- Quiet hours, recipient selection, channel preference, and fallback order stay
+  in `user-notifications.ts`; the dispatcher never broadens recipients.
+- Provider callbacks update the same durable `Notification` record.
+
+New channels must be added to the contract dispatcher and tested for both first
+attempt and retry behavior. Channel adapters must not be imported directly by
+`notifications.ts` or `notification-retry.ts`.

--- a/src/lib/notification-delivery.ts
+++ b/src/lib/notification-delivery.ts
@@ -1,0 +1,157 @@
+import type { IncidentStatus } from '@prisma/client';
+import prisma from './prisma';
+import { CircuitBreakers } from './circuit-breaker';
+
+export const NOTIFICATION_CHANNELS = [
+  'EMAIL',
+  'SMS',
+  'PUSH',
+  'SLACK',
+  'WEBHOOK',
+  'WHATSAPP',
+] as const;
+export type NotificationDeliveryChannel = (typeof NOTIFICATION_CHANNELS)[number];
+
+export const NOTIFICATION_DELIVERY_STATUSES = ['PENDING', 'SENT', 'DELIVERED', 'FAILED'] as const;
+export type NotificationDeliveryStatus = (typeof NOTIFICATION_DELIVERY_STATUSES)[number];
+
+export interface NotificationRetryPolicy {
+  maxAttempts: number;
+  initialDelayMs: number;
+  maximumDelayMs: number;
+  pendingTimeoutMs: number;
+}
+
+export const NOTIFICATION_RETRY_POLICY: Readonly<NotificationRetryPolicy> = Object.freeze({
+  maxAttempts: 3,
+  initialDelayMs: 5_000,
+  maximumDelayMs: 300_000,
+  pendingTimeoutMs: 10 * 60_000,
+});
+
+export interface NotificationAttemptResult {
+  success: boolean;
+  error?: string;
+  providerMessageId?: string;
+  skipped?: boolean;
+}
+
+interface IncidentDeliveryContext {
+  status: IncidentStatus;
+  service?: { webhookUrl: string | null } | null;
+}
+
+export interface NotificationAttemptInput {
+  notificationId: string;
+  incidentId: string;
+  userId: string;
+  channel: NotificationDeliveryChannel;
+  incident?: IncidentDeliveryContext | null;
+}
+
+export function notificationRetryDelayMs(
+  attempts: number,
+  policy: NotificationRetryPolicy = NOTIFICATION_RETRY_POLICY
+): number {
+  return Math.min(policy.initialDelayMs * 2 ** Math.max(0, attempts), policy.maximumDelayMs);
+}
+
+export function notificationDedupeKey(input: {
+  incidentId: string;
+  userId: string;
+  channel: NotificationDeliveryChannel;
+  message: string;
+}): string {
+  return [input.incidentId, input.userId, input.channel, input.message].join('\u001f');
+}
+
+function eventType(status: IncidentStatus | undefined): 'triggered' | 'acknowledged' | 'resolved' {
+  return status === 'RESOLVED'
+    ? 'resolved'
+    : status === 'ACKNOWLEDGED'
+      ? 'acknowledged'
+      : 'triggered';
+}
+
+function unavailablePush(error: string | undefined): boolean {
+  const normalized = error?.toLowerCase() ?? '';
+  return [
+    'no web push subscriptions',
+    'no device tokens',
+    'disabled by user',
+    'user has no phone',
+  ].some(message => normalized.includes(message));
+}
+
+/** One channel dispatcher shared by first attempts and durable retries. */
+export async function dispatchNotificationAttempt(
+  input: NotificationAttemptInput
+): Promise<NotificationAttemptResult> {
+  const incident =
+    input.incident ??
+    (await prisma.incident.findUnique({
+      where: { id: input.incidentId },
+      select: { status: true, service: { select: { webhookUrl: true } } },
+    }));
+  const type = eventType(incident?.status);
+
+  switch (input.channel) {
+    case 'EMAIL': {
+      const { sendIncidentEmail } = await import('./email');
+      return CircuitBreakers.email().execute(async () => {
+        const result = await sendIncidentEmail(input.userId, input.incidentId, type);
+        if (!result.success) throw new Error(result.error || 'Email delivery failed');
+        return result;
+      });
+    }
+    case 'SMS': {
+      const { sendIncidentSMS } = await import('./sms');
+      return CircuitBreakers.sms().execute(async () => {
+        const result = await sendIncidentSMS(
+          input.userId,
+          input.incidentId,
+          type,
+          input.notificationId
+        );
+        if (!result.success) throw new Error(result.error || 'SMS delivery failed');
+        return { ...result, providerMessageId: result.messageSid };
+      });
+    }
+    case 'PUSH': {
+      const { sendIncidentPush } = await import('./push');
+      return CircuitBreakers.push().execute(async () => {
+        const result = await sendIncidentPush(input.userId, input.incidentId, type);
+        if (result.success) return result;
+        if (unavailablePush(result.error)) return { ...result, skipped: true };
+        throw new Error(result.error || 'Push delivery failed');
+      });
+    }
+    case 'WEBHOOK': {
+      const webhookUrl = incident?.service?.webhookUrl;
+      if (!webhookUrl) return { success: false, error: 'No webhook URL configured for service' };
+      const { sendIncidentWebhook } = await import('./webhooks');
+      return CircuitBreakers.webhook(webhookUrl).execute(async () => {
+        const result = await sendIncidentWebhook(webhookUrl, input.incidentId, type);
+        if (!result.success) throw new Error(result.error || 'Webhook delivery failed');
+        return result;
+      });
+    }
+    case 'WHATSAPP': {
+      const { sendIncidentWhatsApp } = await import('./whatsapp');
+      return CircuitBreakers.whatsapp().execute(async () => {
+        const result = await sendIncidentWhatsApp(
+          input.userId,
+          input.incidentId,
+          type,
+          input.notificationId
+        );
+        if (!result.success) throw new Error(result.error || 'WhatsApp delivery failed');
+        return { ...result, providerMessageId: result.messageSid };
+      });
+    }
+    case 'SLACK':
+      // Incident Slack delivery is performed by the durable event outbox. This
+      // record acknowledges that ownership rather than contacting Slack twice.
+      return { success: true, skipped: true };
+  }
+}

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -13,6 +13,11 @@
 import { logger } from './logger';
 import { NotificationChannel, sendNotification } from './notifications';
 import { batchArray } from './db-utils';
+import {
+  notificationDedupeKey,
+  notificationRetryDelayMs,
+  NOTIFICATION_RETRY_POLICY,
+} from './notification-delivery';
 
 // Queue configuration
 const BATCH_SIZE = 50; // Process notifications in batches
@@ -121,14 +126,6 @@ function incrementRateLimit(channel: NotificationChannel): void {
 /**
  * Generate deduplication key
  */
-function generateDedupeKey(
-  incidentId: string,
-  userId: string,
-  channel: NotificationChannel
-): string {
-  return `${incidentId}:${userId}:${channel}`;
-}
-
 /**
  * Add notification to queue
  */
@@ -150,7 +147,7 @@ export function queueNotification(
     return false;
   }
 
-  const dedupeKey = generateDedupeKey(incidentId, userId, channel);
+  const dedupeKey = notificationDedupeKey({ incidentId, userId, channel, message });
 
   // Check for duplicates
   if (
@@ -204,7 +201,7 @@ export function queueBulkNotifications(
   let duplicates = 0;
 
   for (const n of notifications) {
-    const dedupeKey = generateDedupeKey(n.incidentId, n.userId, n.channel);
+    const dedupeKey = notificationDedupeKey(n);
 
     if (
       (processedDedupeKeys.has(dedupeKey) &&
@@ -310,8 +307,8 @@ async function processChannelNotifications(
       } else {
         // Re-queue rate-limited notifications with backoff
         const retryCount = (n.retryCount || 0) + 1;
-        if (retryCount <= 5) {
-          const delayMs = Math.pow(2, retryCount) * 1000;
+        if (retryCount <= NOTIFICATION_RETRY_POLICY.maxAttempts) {
+          const delayMs = notificationRetryDelayMs(retryCount);
           scheduleRetry({ ...n, priority: Math.min(n.priority + 1, 3), retryCount }, delayMs);
         } else {
           logger.error('[NotificationQueue] Notification permanently dropped due to rate limits', {
@@ -372,11 +369,8 @@ async function processChannelNotifications(
         const { notification, error } = result.reason;
         const retryCount = (notification.retryCount || 0) + 1;
 
-        if (retryCount <= 3) {
-          scheduleRetry(
-            { ...notification, retryCount },
-            Math.min(Math.pow(2, retryCount) * 1000, 30_000)
-          );
+        if (retryCount <= NOTIFICATION_RETRY_POLICY.maxAttempts) {
+          scheduleRetry({ ...notification, retryCount }, notificationRetryDelayMs(retryCount));
         } else {
           logger.error('[NotificationQueue] Notification permanently dropped after 3 retries', {
             incidentId: notification.incidentId,

--- a/src/lib/notification-retry.ts
+++ b/src/lib/notification-retry.ts
@@ -5,11 +5,11 @@
 
 import prisma from './prisma';
 import { logger } from './logger';
-import { CircuitBreakers } from './circuit-breaker';
-
-const _MAX_RETRY_ATTEMPTS = 3;
-const INITIAL_RETRY_DELAY_MS = 5000; // 5 seconds
-const MAX_RETRY_DELAY_MS = 300000; // 5 minutes
+import {
+  dispatchNotificationAttempt,
+  notificationRetryDelayMs,
+  NOTIFICATION_RETRY_POLICY,
+} from './notification-delivery';
 
 /**
  * Retry failed notifications
@@ -26,8 +26,8 @@ export async function retryFailedNotifications(): Promise<{
   await prisma.notification.updateMany({
     where: {
       status: 'PENDING',
-      createdAt: { lt: new Date(Date.now() - 10 * 60_000) },
-      attempts: { lt: _MAX_RETRY_ATTEMPTS },
+      createdAt: { lt: new Date(Date.now() - NOTIFICATION_RETRY_POLICY.pendingTimeoutMs) },
+      attempts: { lt: NOTIFICATION_RETRY_POLICY.maxAttempts },
     },
     data: {
       status: 'FAILED',
@@ -43,7 +43,7 @@ export async function retryFailedNotifications(): Promise<{
         not: null,
       },
       attempts: {
-        lt: _MAX_RETRY_ATTEMPTS,
+        lt: NOTIFICATION_RETRY_POLICY.maxAttempts,
       },
     },
     take: 100, // Process in batches
@@ -73,23 +73,9 @@ export async function retryFailedNotifications(): Promise<{
   const now = Date.now();
   const readyToRetry = failedNotifications.filter(notification => {
     const timeSinceFailure = now - (notification.failedAt?.getTime() || 0);
-    const retryDelay = Math.min(
-      INITIAL_RETRY_DELAY_MS * Math.pow(2, notification.attempts || 0),
-      MAX_RETRY_DELAY_MS
-    );
+    const retryDelay = notificationRetryDelayMs(notification.attempts || 0);
     return timeSinceFailure >= retryDelay;
   });
-
-  // Pre-load channel handlers to avoid repeated dynamic imports
-  const emailModule = await import('./email');
-  const smsModule = await import('./sms');
-  const pushModule = await import('./push');
-  const whatsappModule = await import('./whatsapp');
-  const webhooksModule = await import('./webhooks');
-
-  // Helper to determine event type from incident status
-  const getEventType = (status?: string) =>
-    status === 'RESOLVED' ? 'resolved' : status === 'ACKNOWLEDGED' ? 'acknowledged' : 'triggered';
 
   // Process in parallel batches of 10 for better throughput
   const BATCH_SIZE = 10;
@@ -118,88 +104,15 @@ export async function retryFailedNotifications(): Promise<{
             return { success: false, claimed: false };
           }
 
-          let result: { success: boolean; error?: string; messageSid?: string } = {
-            success: false,
-            error: 'Unknown channel',
-          };
-
-          const eventType = getEventType(notification.incident?.status);
-
-          // Re-dispatch based on channel with circuit breaker protection
+          let result;
           try {
-            switch (notification.channel) {
-              case 'EMAIL':
-                result = await CircuitBreakers.email().execute(async () => {
-                  const res = await emailModule.sendIncidentEmail(
-                    notification.userId,
-                    notification.incidentId,
-                    eventType
-                  );
-                  if (!res.success) throw new Error(res.error || 'Email retry delivery failed');
-                  return res;
-                });
-                break;
-              case 'SMS':
-                result = await CircuitBreakers.sms().execute(async () => {
-                  const res = await smsModule.sendIncidentSMS(
-                    notification.userId,
-                    notification.incidentId,
-                    eventType,
-                    notification.id
-                  );
-                  if (!res.success) throw new Error(res.error || 'SMS retry delivery failed');
-                  return res;
-                });
-                break;
-              case 'PUSH':
-                result = await CircuitBreakers.push().execute(async () => {
-                  const res = await pushModule.sendIncidentPush(
-                    notification.userId,
-                    notification.incidentId,
-                    eventType
-                  );
-                  if (!res.success) throw new Error(res.error || 'Push retry delivery failed');
-                  return res;
-                });
-                break;
-              case 'WHATSAPP':
-                result = await CircuitBreakers.whatsapp().execute(async () => {
-                  const res = await whatsappModule.sendIncidentWhatsApp(
-                    notification.userId,
-                    notification.incidentId,
-                    eventType,
-                    notification.id
-                  );
-                  if (!res.success) throw new Error(res.error || 'WhatsApp retry delivery failed');
-                  return res;
-                });
-                break;
-              case 'WEBHOOK':
-                if (notification.incident?.service?.webhookUrl) {
-                  result = await CircuitBreakers.webhook(
-                    notification.incident.service.webhookUrl
-                  ).execute(async () => {
-                    const res = await webhooksModule.sendIncidentWebhook(
-                      notification.incident!.service!.webhookUrl!,
-                      notification.incidentId,
-                      eventType
-                    );
-                    if (!res.success) throw new Error(res.error || 'Webhook retry delivery failed');
-                    return res;
-                  });
-                } else {
-                  result = {
-                    success: false,
-                    error: 'No webhook URL configured on incident service',
-                  };
-                }
-                break;
-              default:
-                result = {
-                  success: false,
-                  error: `Retry not implemented for channel: ${notification.channel}`,
-                };
-            }
+            result = await dispatchNotificationAttempt({
+              notificationId: notification.id,
+              incidentId: notification.incidentId,
+              userId: notification.userId,
+              channel: notification.channel,
+              incident: notification.incident,
+            });
           } catch (cbError) {
             result = {
               success: false,
@@ -214,7 +127,7 @@ export async function retryFailedNotifications(): Promise<{
               data: {
                 status: 'SENT',
                 sentAt: new Date(),
-                providerMessageId: result.messageSid,
+                providerMessageId: result.providerMessageId,
               },
             });
             logger.info('notification.retry.success', {
@@ -234,10 +147,10 @@ export async function retryFailedNotifications(): Promise<{
             });
             return { success: false, claimed: true };
           }
-        } catch (error: any) {
+        } catch (error: unknown) {
           logger.error('notification.retry.error', {
             notificationId: notification.id,
-            error: error.message,
+            error: error instanceof Error ? error.message : String(error),
           });
 
           await prisma.notification.update({
@@ -245,7 +158,7 @@ export async function retryFailedNotifications(): Promise<{
             data: {
               status: 'FAILED',
               failedAt: new Date(),
-              errorMsg: error.message,
+              errorMsg: error instanceof Error ? error.message : String(error),
               attempts: (notification.attempts || 0) + 1,
             },
           });

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,9 +1,13 @@
 import { Incident, Service } from '@prisma/client';
 import prisma from './prisma';
-import { sendIncidentEmail } from './email';
-import { CircuitBreakers, CircuitBreakerError } from './circuit-breaker';
+import { CircuitBreakerError } from './circuit-breaker';
+import {
+  dispatchNotificationAttempt,
+  NOTIFICATION_CHANNELS,
+  type NotificationDeliveryChannel,
+} from './notification-delivery';
 
-export type NotificationChannel = 'EMAIL' | 'SMS' | 'PUSH' | 'SLACK' | 'WEBHOOK' | 'WHATSAPP';
+export type NotificationChannel = NotificationDeliveryChannel;
 
 /**
  * Send notifications to escalation policy targets for an incident.
@@ -19,6 +23,9 @@ export async function sendNotification(
   message: string,
   incident?: Incident & { service?: Service | null }
 ) {
+  if (!NOTIFICATION_CHANNELS.includes(channel)) {
+    return { success: false, error: `Unknown channel: ${String(channel)}` };
+  }
   // Check for duplicate pending/sent notification with the same payload within debounce window (60s)
   if (typeof prisma.notification?.findFirst === 'function') {
     const debounceWindow = new Date(Date.now() - 60_000);
@@ -56,154 +63,13 @@ export async function sendNotification(
   });
 
   try {
-    let result: { success: boolean; error?: string; messageSid?: string };
-
-    // Route to appropriate notification service with circuit breaker protection
-    // Circuit breakers prevent cascade failures when external services are slow/down
-    switch (channel) {
-      case 'EMAIL':
-        // Determine event type from message or incident status
-        // Use passed incident if available, otherwise fetch
-        const incidentData =
-          incident || (await prisma.incident.findUnique({ where: { id: incidentId } }));
-        const eventType =
-          incidentData?.status === 'RESOLVED'
-            ? 'resolved'
-            : incidentData?.status === 'ACKNOWLEDGED'
-              ? 'acknowledged'
-              : 'triggered';
-        // Use circuit breaker to prevent cascade failures
-        result = await CircuitBreakers.email().execute(async () => {
-          const res = await sendIncidentEmail(userId, incidentId, eventType);
-          if (!res.success) {
-            throw new Error(res.error || 'Email delivery failed');
-          }
-          return res;
-        });
-        break;
-
-      case 'SMS':
-        const { sendIncidentSMS } = await import('./sms');
-        const incidentForSMS =
-          incident || (await prisma.incident.findUnique({ where: { id: incidentId } }));
-        const eventTypeSMS =
-          incidentForSMS?.status === 'RESOLVED'
-            ? 'resolved'
-            : incidentForSMS?.status === 'ACKNOWLEDGED'
-              ? 'acknowledged'
-              : 'triggered';
-        result = await CircuitBreakers.sms().execute(async () => {
-          const res = await sendIncidentSMS(userId, incidentId, eventTypeSMS, notification.id);
-          if (!res.success) {
-            throw new Error(res.error || 'SMS delivery failed');
-          }
-          return res;
-        });
-        break;
-
-      case 'PUSH':
-        const { sendIncidentPush } = await import('./push');
-        const incidentForPush =
-          incident || (await prisma.incident.findUnique({ where: { id: incidentId } }));
-        const eventTypePush =
-          incidentForPush?.status === 'RESOLVED'
-            ? 'resolved'
-            : incidentForPush?.status === 'ACKNOWLEDGED'
-              ? 'acknowledged'
-              : 'triggered';
-        result = await CircuitBreakers.push().execute(async () => {
-          const res = await sendIncidentPush(userId, incidentId, eventTypePush);
-          if (!res.success) {
-            const err = (res.error || '').toLowerCase();
-            if (
-              err.includes('no web push subscriptions') ||
-              err.includes('no device tokens') ||
-              err.includes('disabled by user') ||
-              err.includes('user has no phone')
-            ) {
-              return { success: false, skipped: true, error: res.error };
-            }
-            throw new Error(res.error || 'Push delivery failed');
-          }
-          return res;
-        });
-        break;
-
-      case 'SLACK':
-        // Slack is handled separately via slack.ts
-        result = { success: true };
-        break;
-
-      case 'WEBHOOK':
-        // Webhooks are typically configured per-service or per-escalation-policy
-        // For now, we'll need the webhook URL from the escalation policy or service
-        // This is a placeholder - webhook URLs should be stored in escalation policy config
-        const { sendIncidentWebhook } = await import('./webhooks');
-        // Webhooks need service relation
-        const incidentForWebhook =
-          incident && incident.service
-            ? incident
-            : await prisma.incident.findUnique({
-                where: { id: incidentId },
-                include: { service: true },
-              });
-
-        if (!incidentForWebhook || !incidentForWebhook.service) {
-          result = { success: false, error: 'Incident or Service not found' };
-          break;
-        }
-
-        // Try to get webhook URL from service or escalation policy
-        // For now, we'll check if there's a webhook URL in the service config
-        // In a full implementation, this would come from the escalation policy
-        const webhookUrl = incidentForWebhook.service.webhookUrl;
-
-        if (!webhookUrl) {
-          result = { success: false, error: 'No webhook URL configured for this service' };
-          break;
-        }
-
-        const eventTypeWebhook =
-          incidentForWebhook.status === 'RESOLVED'
-            ? 'resolved'
-            : incidentForWebhook.status === 'ACKNOWLEDGED'
-              ? 'acknowledged'
-              : 'triggered';
-
-        const webhookResult = await sendIncidentWebhook(webhookUrl, incidentId, eventTypeWebhook);
-
-        result = webhookResult.success
-          ? { success: true }
-          : { success: false, error: webhookResult.error };
-        break;
-
-      case 'WHATSAPP':
-        const { sendIncidentWhatsApp } = await import('./whatsapp');
-        const incidentForWhatsApp =
-          incident || (await prisma.incident.findUnique({ where: { id: incidentId } }));
-        const eventTypeWhatsApp =
-          incidentForWhatsApp?.status === 'RESOLVED'
-            ? 'resolved'
-            : incidentForWhatsApp?.status === 'ACKNOWLEDGED'
-              ? 'acknowledged'
-              : 'triggered';
-        result = await CircuitBreakers.whatsapp().execute(async () => {
-          const res = await sendIncidentWhatsApp(
-            userId,
-            incidentId,
-            eventTypeWhatsApp,
-            notification.id
-          );
-          if (!res.success) {
-            throw new Error(res.error || 'WhatsApp delivery failed');
-          }
-          return res;
-        });
-        break;
-
-      default:
-        result = { success: false, error: `Unknown channel: ${channel}` };
-    }
+    const result = await dispatchNotificationAttempt({
+      notificationId: notification.id,
+      incidentId,
+      userId,
+      channel,
+      incident,
+    });
 
     if (result.success) {
       await prisma.notification.update({
@@ -211,7 +77,7 @@ export async function sendNotification(
         data: {
           status: 'SENT',
           sentAt: new Date(),
-          providerMessageId: result.messageSid,
+          providerMessageId: result.providerMessageId,
         },
       });
 
@@ -241,14 +107,16 @@ export async function sendNotification(
 
       return { success: true, notificationId: notification.id };
     } else {
-      throw new Error((result as any).error || 'Notification delivery failed');
+      throw new Error(result.error || 'Notification delivery failed');
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
     // Handle circuit breaker errors specially - don't count as attempt failure
     const isCircuitOpen = error instanceof CircuitBreakerError;
     const errorMessage = isCircuitOpen
       ? `Service unavailable (circuit open): ${error.serviceName}`
-      : error.message;
+      : error instanceof Error
+        ? error.message
+        : String(error);
 
     await prisma.notification.update({
       where: { id: notification.id },

--- a/tests/architecture/notification-delivery-contract.test.ts
+++ b/tests/architecture/notification-delivery-contract.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('notification delivery architecture', () => {
+  it('keeps initial sends and retries on the same channel dispatcher', () => {
+    const initialDelivery = readFileSync('src/lib/notifications.ts', 'utf8');
+    const retryDelivery = readFileSync('src/lib/notification-retry.ts', 'utf8');
+
+    for (const source of [initialDelivery, retryDelivery]) {
+      expect(source).toContain('dispatchNotificationAttempt');
+      expect(source).not.toMatch(/import\(['"]\.\/(?:email|sms|push|whatsapp|webhooks)['"]\)/);
+      expect(source).not.toMatch(/sendIncident(?:Email|SMS|Push|WhatsApp|Webhook)/);
+    }
+  });
+
+  it('keeps retry and idempotency policy centralized', () => {
+    const queue = readFileSync('src/lib/notification-queue.ts', 'utf8');
+    const retry = readFileSync('src/lib/notification-retry.ts', 'utf8');
+
+    expect(queue).toContain('notificationDedupeKey');
+    expect(queue).toContain('notificationRetryDelayMs');
+    expect(retry).toContain('notificationRetryDelayMs');
+    expect(queue).not.toMatch(/Math\.pow\(2,\s*retryCount\)/);
+    expect(retry).not.toContain('INITIAL_RETRY_DELAY_MS');
+  });
+});

--- a/tests/lib/notification-delivery-contract.test.ts
+++ b/tests/lib/notification-delivery-contract.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  notificationDedupeKey,
+  notificationRetryDelayMs,
+  NOTIFICATION_RETRY_POLICY,
+} from '@/lib/notification-delivery';
+
+describe('notification delivery contract', () => {
+  it('deduplicates the same delivery intent but not a different lifecycle message', () => {
+    const base = { incidentId: 'incident-1', userId: 'user-1', channel: 'EMAIL' as const };
+
+    expect(notificationDedupeKey({ ...base, message: 'Incident triggered' })).toBe(
+      notificationDedupeKey({ ...base, message: 'Incident triggered' })
+    );
+    expect(notificationDedupeKey({ ...base, message: 'Incident triggered' })).not.toBe(
+      notificationDedupeKey({ ...base, message: 'Incident resolved' })
+    );
+  });
+
+  it('applies one bounded exponential retry schedule', () => {
+    expect(notificationRetryDelayMs(0)).toBe(5_000);
+    expect(notificationRetryDelayMs(1)).toBe(10_000);
+    expect(notificationRetryDelayMs(2)).toBe(20_000);
+    expect(notificationRetryDelayMs(20)).toBe(NOTIFICATION_RETRY_POLICY.maximumDelayMs);
+  });
+
+  it('does not mutate the shared retry policy', () => {
+    expect(Object.isFrozen(NOTIFICATION_RETRY_POLICY)).toBe(true);
+  });
+});

--- a/tests/lib/notification-queue-reliability.test.ts
+++ b/tests/lib/notification-queue-reliability.test.ts
@@ -35,8 +35,9 @@ describe('notification queue delivery reliability', () => {
     expect(sendNotification).toHaveBeenCalledTimes(1);
     expect(getQueueStats().pending).toBe(0);
 
-    // First retry uses a two-second backoff, then the restarted flush timer.
-    await vi.advanceTimersByTimeAsync(3_000);
+    // All delivery paths share the contract's ten-second delay after attempt one,
+    // followed by the restarted one-second flush timer.
+    await vi.advanceTimersByTimeAsync(11_000);
     expect(sendNotification).toHaveBeenCalledTimes(2);
 
     await forceFlush();


### PR DESCRIPTION
## Summary

Creates one delivery contract for notification channels, provider dispatch, retry policy, deduplication, and durable status updates.

- routes both first attempts and retries through one channel dispatcher
- centralizes channels, delivery states, retry budget, backoff, timeout, and dedupe identity
- makes deduplication message-aware so resolved updates are not suppressed by triggered messages
- normalizes provider success, error, skip, and provider-message identifiers
- preserves SMS/WhatsApp callback correlation through durable notification IDs
- makes Slack event-outbox ownership explicit to prevent duplicate sends
- preserves recipient selection, quiet hours, preferences, and fallback behavior
- adds architecture enforcement and contract documentation

## Validation

- 201 unit test files passed
- 1,481 tests passed; 4 skipped
- TypeScript passed
- focused notification, queue, retry, callback, and architecture suites passed