### PR TITLE
fix(notifications): preserve intent and terminal outcomes

### DIFF
--- a/prisma/migrations/20260828162000_notification_intent_outcomes/migration.sql
+++ b/prisma/migrations/20260828162000_notification_intent_outcomes/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "NotificationStatus" ADD VALUE IF NOT EXISTS 'SKIPPED';

--- a/prisma/migrations/20260828162100_notification_event_type/migration.sql
+++ b/prisma/migrations/20260828162100_notification_event_type/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Notification"
+ADD COLUMN "eventType" TEXT NOT NULL DEFAULT 'triggered';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ enum NotificationStatus {
   SENT
   DELIVERED
   FAILED
+  SKIPPED
 }
 
 enum NotificationChannel {
@@ -852,6 +853,7 @@ model Notification {
   channel           NotificationChannel
   status            NotificationStatus  @default(PENDING)
   message           String?
+  eventType         String              @default("triggered")
   sentAt            DateTime?
   deliveredAt       DateTime?
   failedAt          DateTime?

--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -15,10 +15,7 @@ import {
   updateIncidentStatus as updateIncidentStatusWithLifecycle,
   resolveIncidentWithNote as resolveIncidentWithLifecycleNote,
 } from '@/lib/incidents/operator-lifecycle';
-import {
-  executeIncidentCreation,
-  type IncidentCreationSource,
-} from '@/lib/incidents/creation';
+import { executeIncidentCreation, type IncidentCreationSource } from '@/lib/incidents/creation';
 
 const LEGACY_NOT_FOUND_MESSAGE =
   'The requested item could not be found. It may have been deleted or you may not have access to it.';
@@ -315,7 +312,9 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
 
         const message = `[OpsKnight] ${incident?.title || 'Incident'} assigned to your team: ${teamWithMembers.name}`;
         for (const member of teamWithMembers.members) {
-          await sendUserNotification(incidentId, member.userId, message);
+          await sendUserNotification(incidentId, member.userId, message, undefined, {
+            eventType: 'updated',
+          });
         }
 
         // --- ADDED: Send Service-Level Notification for Reassignment (Team) ---

--- a/src/app/api/notifications/history/route.ts
+++ b/src/app/api/notifications/history/route.ts
@@ -16,7 +16,9 @@ export async function GET(req: NextRequest) {
   try {
     const session = await getServerSession(await getAuthOptions());
     if (!session?.user?.email) {
-      return jsonError(new AppError({ code: 'AUTHENTICATION_REQUIRED', userMessage: LEGACY_UNAUTHORIZED_MESSAGE }));
+      return jsonError(
+        new AppError({ code: 'AUTHENTICATION_REQUIRED', userMessage: LEGACY_UNAUTHORIZED_MESSAGE })
+      );
     }
 
     const user = await prisma.user.findUnique({
@@ -25,7 +27,9 @@ export async function GET(req: NextRequest) {
     });
 
     if (!user) {
-      return jsonError(new AppError({ code: 'RESOURCE_NOT_FOUND', userMessage: LEGACY_NOT_FOUND_MESSAGE }));
+      return jsonError(
+        new AppError({ code: 'RESOURCE_NOT_FOUND', userMessage: LEGACY_NOT_FOUND_MESSAGE })
+      );
     }
 
     const userTimeZone = getUserTimeZone(user ?? undefined);
@@ -42,7 +46,7 @@ export async function GET(req: NextRequest) {
     const toParam = searchParams.get('to');
 
     const allowedChannels = new Set(['EMAIL', 'SMS', 'PUSH', 'SLACK', 'WEBHOOK', 'WHATSAPP']);
-    const allowedStatuses = new Set(['PENDING', 'SENT', 'FAILED']);
+    const allowedStatuses = new Set(['PENDING', 'SENT', 'DELIVERED', 'FAILED', 'SKIPPED']);
 
     const baseWhere: any = {
       userId: user.id,
@@ -113,6 +117,7 @@ export async function GET(req: NextRequest) {
       sent: 0,
       pending: 0,
       failed: 0,
+      skipped: 0,
     };
     for (const entry of grouped) {
       const count = entry._count._all;
@@ -123,6 +128,8 @@ export async function GET(req: NextRequest) {
         stats.pending += count;
       } else if (entry.status === 'FAILED') {
         stats.failed += count;
+      } else if (entry.status === 'SKIPPED') {
+        stats.skipped += count;
       }
     }
 

--- a/src/components/settings/NotificationHistory.tsx
+++ b/src/components/settings/NotificationHistory.tsx
@@ -34,6 +34,7 @@ import {
   Clock,
   XCircle,
   Loader2,
+  MinusCircle,
 } from 'lucide-react';
 import Link from 'next/link';
 
@@ -78,6 +79,7 @@ export default function NotificationHistory() {
     sent: 0,
     pending: 0,
     failed: 0,
+    skipped: 0,
   });
 
   const resolveDateToIso = (value: string, endOfDay: boolean) => {
@@ -132,6 +134,7 @@ export default function NotificationHistory() {
           sent: 0,
           pending: 0,
           failed: 0,
+          skipped: 0,
         }
       );
       setLastUpdated(new Date().toLocaleTimeString());
@@ -187,6 +190,13 @@ export default function NotificationHistory() {
             Failed
           </Badge>
         );
+      case 'SKIPPED':
+        return (
+          <Badge variant="outline" size="xs">
+            <MinusCircle className="h-3 w-3 mr-1" />
+            Skipped
+          </Badge>
+        );
       default:
         return (
           <Badge variant="outline" size="xs">
@@ -218,7 +228,7 @@ export default function NotificationHistory() {
   return (
     <div className="space-y-6">
       {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Notifications</CardTitle>
@@ -262,6 +272,16 @@ export default function NotificationHistory() {
           <CardContent>
             <div className="text-2xl font-bold text-destructive">{stats.failed}</div>
             <p className="text-xs text-muted-foreground">Delivery errors</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Skipped</CardTitle>
+            <MinusCircle className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-extrabold">{stats.skipped}</div>
+            <p className="text-xs text-muted-foreground">Terminal policy outcomes</p>
           </CardContent>
         </Card>
       </div>
@@ -330,6 +350,7 @@ export default function NotificationHistory() {
                   <SelectItem value="PENDING">Pending</SelectItem>
                   <SelectItem value="SENT">Sent</SelectItem>
                   <SelectItem value="FAILED">Failed</SelectItem>
+                  <SelectItem value="SKIPPED">Skipped</SelectItem>
                 </SelectContent>
               </Select>
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -389,7 +389,7 @@ export function generateIncidentEmailHTML(
     incidentUrl?: string;
   },
   timeZone: string = 'UTC',
-  eventType?: 'triggered' | 'acknowledged' | 'resolved'
+  eventType?: 'triggered' | 'acknowledged' | 'resolved' | 'updated'
 ): string {
   const baseUrl = getBaseUrl();
   const incidentUrl = incident.incidentUrl || `${baseUrl}/incidents/${incident.id}`;
@@ -635,7 +635,7 @@ export function generateIncidentEmailHTML(
 export async function sendIncidentEmail(
   userId: string,
   incidentId: string,
-  eventType: 'triggered' | 'acknowledged' | 'resolved'
+  eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated'
 ): Promise<{ success: boolean; error?: string }> {
   try {
     const [user, incident] = await Promise.all([
@@ -662,11 +662,13 @@ export async function sendIncidentEmail(
         ? 'RESOLVED'
         : eventType === 'acknowledged'
           ? 'ACKNOWLEDGED'
-          : incident.urgency === 'HIGH'
-            ? 'CRITICAL'
-            : incident.urgency === 'MEDIUM'
-              ? 'ELEVATED'
-              : 'NEW';
+          : eventType === 'updated'
+            ? 'UPDATED'
+            : incident.urgency === 'HIGH'
+              ? 'CRITICAL'
+              : incident.urgency === 'MEDIUM'
+                ? 'ELEVATED'
+                : 'NEW';
     const subject = `[${subjectTag}] ${incident.title}`;
     const userTimeZone = getUserTimeZone(user ?? undefined);
     const html = generateIncidentEmailHTML(

--- a/src/lib/jobs/queue.ts
+++ b/src/lib/jobs/queue.ts
@@ -313,6 +313,7 @@ export async function processJob(job: any): Promise<boolean> {
           success: boolean;
           error?: string;
           terminal?: boolean;
+          skipped?: boolean;
         };
         if (job.payload.mode === 'CHANNEL_FALLBACK') {
           const { getUserNotificationChannels, sendUserNotification } =
@@ -368,9 +369,21 @@ export async function processJob(job: any): Promise<boolean> {
             job.payload.eventType || 'triggered'
           );
         }
-        if (notificationResult.success || notificationResult.terminal) {
+        if (notificationResult.success || notificationResult.skipped) {
           await markJobCompleted(job.id);
           return true;
+        }
+
+        if (notificationResult.terminal) {
+          await prisma.backgroundJob.update({
+            where: { id: job.id },
+            data: {
+              status: 'FAILED',
+              failedAt: new Date(),
+              error: notificationResult.error || 'Notification permanently failed',
+            },
+          });
+          return false;
         }
 
         // Cap notification retries to avoid infinite loops on bad payloads or spamming users

--- a/src/lib/jobs/queue.ts
+++ b/src/lib/jobs/queue.ts
@@ -84,7 +84,8 @@ export async function scheduleNotification(
   userId: string,
   channel: string,
   message: string,
-  delayMs: number = 0
+  delayMs: number = 0,
+  eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated' = 'triggered'
 ): Promise<string> {
   const scheduledAt = new Date(Date.now() + delayMs);
 
@@ -93,6 +94,7 @@ export async function scheduleNotification(
     userId,
     channel,
     message,
+    eventType,
   });
 }
 
@@ -161,9 +163,7 @@ export async function claimPendingJobs(limit: number = 50, type?: JobType): Prom
     )
     .catch(err => logger.warn('[Queue] Failed to sweep zombie processing jobs', { error: err }));
 
-  const typeFilter = type
-    ? Prisma.sql`AND candidate."type" = ${type}::"JobType"`
-    : Prisma.empty;
+  const typeFilter = type ? Prisma.sql`AND candidate."type" = ${type}::"JobType"` : Prisma.empty;
   const jobs = await prisma.$queryRaw<any[]>( // eslint-disable-line @typescript-eslint/no-explicit-any
     Prisma.sql`
       WITH cte AS (
@@ -309,7 +309,11 @@ export async function processJob(job: any): Promise<boolean> {
         }
 
       case 'NOTIFICATION':
-        let notificationResult: { success: boolean; error?: string };
+        let notificationResult: {
+          success: boolean;
+          error?: string;
+          terminal?: boolean;
+        };
         if (job.payload.mode === 'CHANNEL_FALLBACK') {
           const { getUserNotificationChannels, sendUserNotification } =
             await import('../user-notifications');
@@ -342,7 +346,11 @@ export async function processJob(job: any): Promise<boolean> {
               job.payload.userId,
               job.payload.message,
               availableChannels,
-              { excludedChannels, createInApp: false }
+              {
+                excludedChannels,
+                createInApp: false,
+                eventType: job.payload.eventType || 'triggered',
+              }
             );
             notificationResult = {
               success: fallbackResult.success,
@@ -355,10 +363,12 @@ export async function processJob(job: any): Promise<boolean> {
             job.payload.incidentId,
             job.payload.userId,
             job.payload.channel as NotificationChannel,
-            job.payload.message
+            job.payload.message,
+            undefined,
+            job.payload.eventType || 'triggered'
           );
         }
-        if (notificationResult.success) {
+        if (notificationResult.success || notificationResult.terminal) {
           await markJobCompleted(job.id);
           return true;
         }

--- a/src/lib/notification-delivery.ts
+++ b/src/lib/notification-delivery.ts
@@ -1,6 +1,6 @@
 import type { IncidentStatus } from '@prisma/client';
 import prisma from './prisma';
-import { CircuitBreakers } from './circuit-breaker';
+import { CircuitBreakerError, CircuitBreakers } from './circuit-breaker';
 
 export const NOTIFICATION_CHANNELS = [
   'EMAIL',
@@ -12,8 +12,27 @@ export const NOTIFICATION_CHANNELS = [
 ] as const;
 export type NotificationDeliveryChannel = (typeof NOTIFICATION_CHANNELS)[number];
 
-export const NOTIFICATION_DELIVERY_STATUSES = ['PENDING', 'SENT', 'DELIVERED', 'FAILED'] as const;
+export const NOTIFICATION_DELIVERY_STATUSES = [
+  'PENDING',
+  'SENT',
+  'DELIVERED',
+  'FAILED',
+  'SKIPPED',
+] as const;
 export type NotificationDeliveryStatus = (typeof NOTIFICATION_DELIVERY_STATUSES)[number];
+export const NOTIFICATION_EVENT_TYPES = [
+  'triggered',
+  'acknowledged',
+  'resolved',
+  'updated',
+] as const;
+export type NotificationEventType = (typeof NOTIFICATION_EVENT_TYPES)[number];
+export type NotificationDeliveryOutcome =
+  | 'DELIVERED'
+  | 'SKIPPED'
+  | 'RETRYABLE_FAILURE'
+  | 'PERMANENT_FAILURE'
+  | 'CIRCUIT_OPEN';
 
 export interface NotificationRetryPolicy {
   maxAttempts: number;
@@ -31,6 +50,7 @@ export const NOTIFICATION_RETRY_POLICY: Readonly<NotificationRetryPolicy> = Obje
 
 export interface NotificationAttemptResult {
   success: boolean;
+  outcome: NotificationDeliveryOutcome;
   error?: string;
   providerMessageId?: string;
   skipped?: boolean;
@@ -46,6 +66,7 @@ export interface NotificationAttemptInput {
   incidentId: string;
   userId: string;
   channel: NotificationDeliveryChannel;
+  eventType: NotificationEventType;
   incident?: IncidentDeliveryContext | null;
 }
 
@@ -65,22 +86,14 @@ export function notificationDedupeKey(input: {
   return [input.incidentId, input.userId, input.channel, input.message].join('\u001f');
 }
 
-function eventType(status: IncidentStatus | undefined): 'triggered' | 'acknowledged' | 'resolved' {
+export function notificationEventTypeFromStatus(
+  status: IncidentStatus | undefined
+): Exclude<NotificationEventType, 'updated'> {
   return status === 'RESOLVED'
     ? 'resolved'
     : status === 'ACKNOWLEDGED'
       ? 'acknowledged'
       : 'triggered';
-}
-
-function unavailablePush(error: string | undefined): boolean {
-  const normalized = error?.toLowerCase() ?? '';
-  return [
-    'no web push subscriptions',
-    'no device tokens',
-    'disabled by user',
-    'user has no phone',
-  ].some(message => normalized.includes(message));
 }
 
 /** One channel dispatcher shared by first attempts and durable retries. */
@@ -93,65 +106,98 @@ export async function dispatchNotificationAttempt(
       where: { id: input.incidentId },
       select: { status: true, service: { select: { webhookUrl: true } } },
     }));
-  const type = eventType(incident?.status);
+  const type = input.eventType;
 
-  switch (input.channel) {
-    case 'EMAIL': {
-      const { sendIncidentEmail } = await import('./email');
-      return CircuitBreakers.email().execute(async () => {
-        const result = await sendIncidentEmail(input.userId, input.incidentId, type);
-        if (!result.success) throw new Error(result.error || 'Email delivery failed');
-        return result;
-      });
+  try {
+    switch (input.channel) {
+      case 'EMAIL': {
+        const { sendIncidentEmail } = await import('./email');
+        return await CircuitBreakers.email().execute(async () => {
+          const result = await sendIncidentEmail(input.userId, input.incidentId, type);
+          if (!result.success) throw new Error(result.error || 'Email delivery failed');
+          return { ...result, success: true, outcome: 'DELIVERED' };
+        });
+      }
+      case 'SMS': {
+        const { sendIncidentSMS } = await import('./sms');
+        return await CircuitBreakers.sms().execute(async () => {
+          const result = await sendIncidentSMS(
+            input.userId,
+            input.incidentId,
+            type,
+            input.notificationId
+          );
+          if (!result.success) throw new Error(result.error || 'SMS delivery failed');
+          return {
+            ...result,
+            success: true,
+            outcome: 'DELIVERED',
+            providerMessageId: result.messageSid,
+          };
+        });
+      }
+      case 'PUSH': {
+        const { sendIncidentPush } = await import('./push');
+        return await CircuitBreakers.push().execute(async () => {
+          const result = await sendIncidentPush(input.userId, input.incidentId, type);
+          if (result.success) return { ...result, success: true, outcome: 'DELIVERED' };
+          if (result.code === 'NO_DEVICE_TOKENS' || result.code === 'NO_WEB_SUBSCRIPTIONS') {
+            return { ...result, outcome: 'SKIPPED', skipped: true };
+          }
+          throw new Error(result.error || 'Push delivery failed');
+        });
+      }
+      case 'WEBHOOK': {
+        const webhookUrl = incident?.service?.webhookUrl;
+        if (!webhookUrl) {
+          return {
+            success: false,
+            outcome: 'PERMANENT_FAILURE',
+            error: 'No webhook URL configured for service',
+          };
+        }
+        const { sendIncidentWebhook } = await import('./webhooks');
+        return await CircuitBreakers.webhook(webhookUrl).execute(async () => {
+          const result = await sendIncidentWebhook(webhookUrl, input.incidentId, type);
+          if (!result.success) throw new Error(result.error || 'Webhook delivery failed');
+          return { ...result, success: true, outcome: 'DELIVERED' };
+        });
+      }
+      case 'WHATSAPP': {
+        const { sendIncidentWhatsApp } = await import('./whatsapp');
+        return await CircuitBreakers.whatsapp().execute(async () => {
+          const result = await sendIncidentWhatsApp(
+            input.userId,
+            input.incidentId,
+            type,
+            input.notificationId
+          );
+          if (!result.success) throw new Error(result.error || 'WhatsApp delivery failed');
+          return {
+            ...result,
+            success: true,
+            outcome: 'DELIVERED',
+            providerMessageId: result.messageSid,
+          };
+        });
+      }
+      case 'SLACK':
+        // Incident Slack delivery is performed by the durable event outbox. This
+        // record acknowledges that ownership rather than contacting Slack twice.
+        return { success: true, outcome: 'SKIPPED', skipped: true };
     }
-    case 'SMS': {
-      const { sendIncidentSMS } = await import('./sms');
-      return CircuitBreakers.sms().execute(async () => {
-        const result = await sendIncidentSMS(
-          input.userId,
-          input.incidentId,
-          type,
-          input.notificationId
-        );
-        if (!result.success) throw new Error(result.error || 'SMS delivery failed');
-        return { ...result, providerMessageId: result.messageSid };
-      });
+  } catch (error) {
+    if (error instanceof CircuitBreakerError) {
+      return {
+        success: false,
+        outcome: 'CIRCUIT_OPEN',
+        error: `Service unavailable (circuit open): ${error.serviceName}`,
+      };
     }
-    case 'PUSH': {
-      const { sendIncidentPush } = await import('./push');
-      return CircuitBreakers.push().execute(async () => {
-        const result = await sendIncidentPush(input.userId, input.incidentId, type);
-        if (result.success) return result;
-        if (unavailablePush(result.error)) return { ...result, skipped: true };
-        throw new Error(result.error || 'Push delivery failed');
-      });
-    }
-    case 'WEBHOOK': {
-      const webhookUrl = incident?.service?.webhookUrl;
-      if (!webhookUrl) return { success: false, error: 'No webhook URL configured for service' };
-      const { sendIncidentWebhook } = await import('./webhooks');
-      return CircuitBreakers.webhook(webhookUrl).execute(async () => {
-        const result = await sendIncidentWebhook(webhookUrl, input.incidentId, type);
-        if (!result.success) throw new Error(result.error || 'Webhook delivery failed');
-        return result;
-      });
-    }
-    case 'WHATSAPP': {
-      const { sendIncidentWhatsApp } = await import('./whatsapp');
-      return CircuitBreakers.whatsapp().execute(async () => {
-        const result = await sendIncidentWhatsApp(
-          input.userId,
-          input.incidentId,
-          type,
-          input.notificationId
-        );
-        if (!result.success) throw new Error(result.error || 'WhatsApp delivery failed');
-        return { ...result, providerMessageId: result.messageSid };
-      });
-    }
-    case 'SLACK':
-      // Incident Slack delivery is performed by the durable event outbox. This
-      // record acknowledges that ownership rather than contacting Slack twice.
-      return { success: true, skipped: true };
+    return {
+      success: false,
+      outcome: 'RETRYABLE_FAILURE',
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -17,6 +17,7 @@ import {
   notificationDedupeKey,
   notificationRetryDelayMs,
   NOTIFICATION_RETRY_POLICY,
+  type NotificationEventType,
 } from './notification-delivery';
 
 // Queue configuration
@@ -44,6 +45,7 @@ interface QueuedNotification {
   createdAt: number;
   dedupeKey: string;
   retryCount?: number;
+  eventType: NotificationEventType;
 }
 
 interface ChannelState {
@@ -134,7 +136,8 @@ export function queueNotification(
   userId: string,
   channel: NotificationChannel,
   message: string,
-  priority: number = 2
+  priority: number = 2,
+  eventType: NotificationEventType = 'triggered'
 ): boolean {
   // Check queue size limit
   if (queue.length >= MAX_QUEUE_SIZE) {
@@ -176,6 +179,7 @@ export function queueNotification(
     priority,
     createdAt: Date.now(),
     dedupeKey,
+    eventType,
   });
 
   // Start flush timer if not running
@@ -194,6 +198,7 @@ export function queueBulkNotifications(
     channel: NotificationChannel;
     message: string;
     priority?: number;
+    eventType?: NotificationEventType;
   }>
 ): { queued: number; dropped: number; duplicates: number } {
   let queued = 0;
@@ -222,6 +227,7 @@ export function queueBulkNotifications(
       priority: n.priority || 2,
       createdAt: Date.now(),
       dedupeKey,
+      eventType: n.eventType ?? 'triggered',
     });
     queued++;
   }
@@ -328,12 +334,19 @@ async function processChannelNotifications(
     const results = await Promise.allSettled(
       toProcess.map(async n => {
         try {
-          const result = await sendNotification(n.incidentId, n.userId, n.channel, n.message);
+          const result = await sendNotification(
+            n.incidentId,
+            n.userId,
+            n.channel,
+            n.message,
+            undefined,
+            n.eventType
+          );
 
           // Notification providers report expected delivery failures in their
           // result instead of throwing. Treat those results as failures so the
           // queue's retry policy is actually applied.
-          if (!result.success) {
+          if (!result.success && !result.terminal) {
             throw new Error(result.error || `${n.channel} notification delivery failed`);
           }
 

--- a/src/lib/notification-retry.ts
+++ b/src/lib/notification-retry.ts
@@ -9,6 +9,7 @@ import {
   dispatchNotificationAttempt,
   notificationRetryDelayMs,
   NOTIFICATION_RETRY_POLICY,
+  type NotificationEventType,
 } from './notification-delivery';
 
 /**
@@ -111,17 +112,18 @@ export async function retryFailedNotifications(): Promise<{
               incidentId: notification.incidentId,
               userId: notification.userId,
               channel: notification.channel,
+              eventType: notification.eventType as NotificationEventType,
               incident: notification.incident,
             });
-          } catch (cbError) {
+          } catch (dispatchError) {
             result = {
               success: false,
-              error:
-                cbError instanceof Error ? cbError.message : 'Circuit breaker / provider error',
+              outcome: 'RETRYABLE_FAILURE' as const,
+              error: dispatchError instanceof Error ? dispatchError.message : 'Provider error',
             };
           }
 
-          if (result.success) {
+          if (result.outcome === 'DELIVERED') {
             await prisma.notification.update({
               where: { id: notification.id },
               data: {
@@ -135,14 +137,33 @@ export async function retryFailedNotifications(): Promise<{
               channel: notification.channel,
             });
             return { success: true, claimed: true };
-          } else {
+          }
+
+          if (result.outcome === 'SKIPPED') {
+            await prisma.notification.update({
+              where: { id: notification.id },
+              data: {
+                status: 'SKIPPED',
+                errorMsg: result.error || 'Delivery skipped by notification policy.',
+              },
+            });
+            return { success: true, claimed: true, skipped: true };
+          }
+
+          {
+            const circuitOpen = result.outcome === 'CIRCUIT_OPEN';
+            const permanentFailure = result.outcome === 'PERMANENT_FAILURE';
             await prisma.notification.update({
               where: { id: notification.id },
               data: {
                 status: 'FAILED',
                 failedAt: new Date(),
                 errorMsg: result.error || 'Retry failed',
-                attempts: (notification.attempts || 0) + 1,
+                attempts: circuitOpen
+                  ? notification.attempts
+                  : permanentFailure
+                    ? NOTIFICATION_RETRY_POLICY.maxAttempts
+                    : (notification.attempts || 0) + 1,
               },
             });
             return { success: false, claimed: true };

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,10 +1,11 @@
 import { Incident, Service } from '@prisma/client';
 import prisma from './prisma';
-import { CircuitBreakerError } from './circuit-breaker';
 import {
   dispatchNotificationAttempt,
   NOTIFICATION_CHANNELS,
+  NOTIFICATION_RETRY_POLICY,
   type NotificationDeliveryChannel,
+  type NotificationEventType,
 } from './notification-delivery';
 
 export type NotificationChannel = NotificationDeliveryChannel;
@@ -21,7 +22,8 @@ export async function sendNotification(
   userId: string,
   channel: NotificationChannel,
   message: string,
-  incident?: Incident & { service?: Service | null }
+  incident?: Incident & { service?: Service | null },
+  eventType: NotificationEventType = 'triggered'
 ) {
   if (!NOTIFICATION_CHANNELS.includes(channel)) {
     return { success: false, error: `Unknown channel: ${String(channel)}` };
@@ -57,6 +59,7 @@ export async function sendNotification(
       userId,
       channel,
       message,
+      eventType,
       status: 'PENDING',
       attempts: 0,
     },
@@ -68,10 +71,11 @@ export async function sendNotification(
       incidentId,
       userId,
       channel,
+      eventType,
       incident,
     });
 
-    if (result.success) {
+    if (result.outcome === 'DELIVERED') {
       await prisma.notification.update({
         where: { id: notification.id },
         data: {
@@ -106,17 +110,49 @@ export async function sendNotification(
       } catch (_) {}
 
       return { success: true, notificationId: notification.id };
-    } else {
-      throw new Error(result.error || 'Notification delivery failed');
     }
+
+    if (result.outcome === 'SKIPPED') {
+      await prisma.notification.update({
+        where: { id: notification.id },
+        data: {
+          status: 'SKIPPED',
+          errorMsg: result.error || 'Delivery skipped by notification policy.',
+        },
+      });
+      return {
+        success: false,
+        skipped: true,
+        terminal: true,
+        error: result.error,
+        notificationId: notification.id,
+      };
+    }
+
+    const circuitOpen = result.outcome === 'CIRCUIT_OPEN';
+    const permanentFailure = result.outcome === 'PERMANENT_FAILURE';
+    await prisma.notification.update({
+      where: { id: notification.id },
+      data: {
+        status: 'FAILED',
+        failedAt: new Date(),
+        errorMsg: result.error || 'Notification delivery failed',
+        attempts: circuitOpen
+          ? notification.attempts
+          : permanentFailure
+            ? NOTIFICATION_RETRY_POLICY.maxAttempts
+            : (notification.attempts || 0) + 1,
+      },
+    });
+    return {
+      success: false,
+      terminal: permanentFailure,
+      circuitOpen,
+      error: result.error || 'Notification delivery failed',
+      notificationId: notification.id,
+    };
   } catch (error: unknown) {
-    // Handle circuit breaker errors specially - don't count as attempt failure
-    const isCircuitOpen = error instanceof CircuitBreakerError;
-    const errorMessage = isCircuitOpen
-      ? `Service unavailable (circuit open): ${error.serviceName}`
-      : error instanceof Error
-        ? error.message
-        : String(error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
 
     await prisma.notification.update({
       where: { id: notification.id },
@@ -124,8 +160,7 @@ export async function sendNotification(
         status: 'FAILED',
         failedAt: new Date(),
         errorMsg: errorMessage,
-        // Don't increment attempts for circuit breaker failures (will retry when circuit closes)
-        attempts: isCircuitOpen ? notification.attempts : (notification.attempts || 0) + 1,
+        attempts: (notification.attempts || 0) + 1,
       },
     });
 
@@ -133,7 +168,7 @@ export async function sendNotification(
       success: false,
       error: errorMessage,
       notificationId: notification.id,
-      circuitOpen: isCircuitOpen,
+      circuitOpen: false,
     };
   }
 }

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -32,13 +32,21 @@ export type PushOptions = {
   badge?: number;
 };
 
+export type PushFailureCode =
+  | 'NO_DEVICE_TOKENS'
+  | 'NO_WEB_SUBSCRIPTIONS'
+  | 'PROVIDER_NOT_CONFIGURED'
+  | 'VAPID_NOT_CONFIGURED'
+  | 'RECIPIENT_NOT_FOUND'
+  | 'DELIVERY_FAILED';
+
+export type PushResult = { success: boolean; error?: string; code?: PushFailureCode };
+
 /**
  * Send push notification
  * Uses logger output for development mode
  */
-export async function sendPush(
-  options: PushOptions
-): Promise<{ success: boolean; error?: string }> {
+export async function sendPush(options: PushOptions): Promise<PushResult> {
   try {
     // Get push configuration
     const pushConfig = await getPushConfig();
@@ -50,7 +58,11 @@ export async function sendPush(
     });
 
     if (devices.length === 0) {
-      return { success: false, error: 'No device tokens found for user' };
+      return {
+        success: false,
+        code: 'NO_DEVICE_TOKENS',
+        error: 'No device tokens found for user',
+      };
     }
 
     // If provider is not enabled, log and return failure
@@ -62,7 +74,11 @@ export async function sendPush(
         provider: pushConfig.provider,
       });
 
-      return { success: false, error: 'Push notifications are not enabled or configured' };
+      return {
+        success: false,
+        code: 'PROVIDER_NOT_CONFIGURED',
+        error: 'Push notifications are not enabled or configured',
+      };
     }
 
     // Production: Use configured provider
@@ -281,16 +297,28 @@ export async function sendPush(
     };
 
     if (pushConfig.provider !== 'web-push') {
-      return { success: false, error: 'No push notification provider configured' };
+      return {
+        success: false,
+        code: 'PROVIDER_NOT_CONFIGURED',
+        error: 'No push notification provider configured',
+      };
     }
 
     const webDevices = devices.filter(device => device.platform === 'web');
     if (webDevices.length === 0) {
-      return { success: false, error: 'No web push subscriptions found for user' };
+      return {
+        success: false,
+        code: 'NO_WEB_SUBSCRIPTIONS',
+        error: 'No web push subscriptions found for user',
+      };
     }
 
     if (vapidDetailsList.length === 0) {
-      return { success: false, error: 'VAPID keys not configured' };
+      return {
+        success: false,
+        code: 'VAPID_NOT_CONFIGURED',
+        error: 'VAPID keys not configured',
+      };
     }
 
     await Promise.allSettled(webDevices.map(device => sendWebPush(device)));
@@ -298,11 +326,15 @@ export async function sendPush(
     if (successCount > 0) {
       return { success: true };
     } else {
-      return { success: false, error: errorMessages.join('; ') || 'Failed to send to all devices' };
+      return {
+        success: false,
+        code: 'DELIVERY_FAILED',
+        error: errorMessages.join('; ') || 'Failed to send to all devices',
+      };
     }
   } catch (error: any) {
     logger.error('Push send error', { component: 'push', error, userId: options.userId });
-    return { success: false, error: error.message };
+    return { success: false, code: 'DELIVERY_FAILED', error: error.message };
   }
 }
 
@@ -312,8 +344,8 @@ export async function sendPush(
 export async function sendIncidentPush(
   userId: string,
   incidentId: string,
-  eventType: 'triggered' | 'acknowledged' | 'resolved'
-): Promise<{ success: boolean; error?: string }> {
+  eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated'
+): Promise<PushResult> {
   try {
     const [user, incident] = await Promise.all([
       prisma.user.findUnique({ where: { id: userId } }),
@@ -328,7 +360,11 @@ export async function sendIncidentPush(
     ]);
 
     if (!user || !incident) {
-      return { success: false, error: 'User or incident not found' };
+      return {
+        success: false,
+        code: 'RECIPIENT_NOT_FOUND',
+        error: 'User or incident not found',
+      };
     }
 
     const baseUrl = getBaseUrl();
@@ -357,7 +393,9 @@ export async function sendIncidentPush(
         ? 'Triggered'
         : eventType === 'acknowledged'
           ? 'Acknowledged'
-          : 'Resolved';
+          : eventType === 'resolved'
+            ? 'Resolved'
+            : 'Updated';
 
     const title =
       eventType === 'triggered'
@@ -369,7 +407,7 @@ export async function sendIncidentPush(
         ? incident.acknowledgedAt || incident.updatedAt || incident.createdAt
         : eventType === 'resolved'
           ? incident.resolvedAt || incident.updatedAt || incident.createdAt
-          : incident.createdAt;
+          : incident.updatedAt || incident.createdAt;
 
     const timeLabel = formatPushTimestamp(eventTime, userTimeZone);
     const ownerLabel =
@@ -432,6 +470,6 @@ export async function sendIncidentPush(
       userId,
       eventType,
     });
-    return { success: false, error: error.message };
+    return { success: false, code: 'DELIVERY_FAILED', error: error.message };
   }
 }

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -342,7 +342,7 @@ export async function sendSMS(
 export async function sendIncidentSMS(
   userId: string,
   incidentId: string,
-  eventType: 'triggered' | 'acknowledged' | 'resolved',
+  eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated',
   notificationId?: string
 ): Promise<{ success: boolean; error?: string; messageSid?: string }> {
   try {
@@ -423,13 +423,15 @@ export async function sendIncidentSMS(
         ? `[OpsKnight] ${eventEmoji} Resolved: ${title}\n✓ ${service}\n${incidentUrl}`
         : eventType === 'acknowledged'
           ? `[OpsKnight] ${eventEmoji} Acknowledged: ${title}\n⚡ ${service}\n${incidentUrl}`
-          : `[OpsKnight] ${eventEmoji} ${
-              incident.urgency === 'HIGH'
-                ? 'CRITICAL'
-                : incident.urgency === 'MEDIUM'
-                  ? 'Elevated'
-                  : 'Incident'
-            }: ${title}\n⚠ ${service}\n${incidentUrl}`;
+          : eventType === 'updated'
+            ? `[OpsKnight] ${eventEmoji} Updated: ${title}\nℹ ${service}\n${incidentUrl}`
+            : `[OpsKnight] ${eventEmoji} ${
+                incident.urgency === 'HIGH'
+                  ? 'CRITICAL'
+                  : incident.urgency === 'MEDIUM'
+                    ? 'Elevated'
+                    : 'Incident'
+              }: ${title}\n⚠ ${service}\n${incidentUrl}`;
 
     // Format phone number to E.164 format if needed
     let phoneNumber = user.phoneNumber.trim();

--- a/src/lib/user-notifications.ts
+++ b/src/lib/user-notifications.ts
@@ -14,6 +14,7 @@ import { isChannelAvailable } from './notification-providers';
 import { createInAppNotifications } from './in-app-notifications';
 import { logger } from './logger';
 import { filterChannelsForQuietHours } from './quiet-hours';
+import type { NotificationEventType } from './notification-delivery';
 
 /**
  * Get user's enabled notification channels based on their preferences
@@ -95,6 +96,7 @@ export async function sendUserNotification(
   options: {
     excludedChannels?: NotificationChannel[];
     createInApp?: boolean;
+    eventType?: NotificationEventType;
   } = {}
 ): Promise<{
   success: boolean;
@@ -176,7 +178,14 @@ export async function sendUserNotification(
       break;
     }
 
-    const result = await sendNotification(incidentId, userId, channel, message);
+    const result = await sendNotification(
+      incidentId,
+      userId,
+      channel,
+      message,
+      undefined,
+      options.eventType ?? 'triggered'
+    );
     if (result.success) {
       channelsUsed.push(channel);
       logger.info(`[UserNotification] Successfully delivered via ${channel}`, {
@@ -197,7 +206,14 @@ export async function sendUserNotification(
       ch => !channels.includes(ch) && !quietHoursBlockedChannels.has(ch)
     );
     for (const fbChannel of fallbackChannels) {
-      const fbResult = await sendNotification(incidentId, userId, fbChannel, message);
+      const fbResult = await sendNotification(
+        incidentId,
+        userId,
+        fbChannel,
+        message,
+        undefined,
+        options.eventType ?? 'triggered'
+      );
       if (fbResult.success) {
         channelsUsed.push(fbChannel);
         logger.warn(`[UserNotification] Fallback delivery succeeded via ${fbChannel}`, {
@@ -442,7 +458,14 @@ export async function sendIncidentNotifications(
             }
           }
 
-          const result = await sendNotification(incidentId, userId, channel, message);
+          const result = await sendNotification(
+            incidentId,
+            userId,
+            channel,
+            message,
+            incidentRecord,
+            eventType
+          );
 
           if (result.success) {
             successful.push({ channel, result });

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -12,7 +12,7 @@ import { formatToE164 } from './sms';
 export type WhatsAppOptions = {
   userId: string;
   incidentId: string;
-  eventType: 'triggered' | 'acknowledged' | 'resolved';
+  eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated';
 };
 
 const normalizeWhatsAppNumber = (value: string) => formatToE164(value.replace(/^whatsapp:/i, ''));
@@ -24,7 +24,7 @@ const normalizeWhatsAppNumber = (value: string) => formatToE164(value.replace(/^
 export async function sendIncidentWhatsApp(
   userId: string,
   incidentId: string,
-  eventType: 'triggered' | 'acknowledged' | 'resolved',
+  eventType: 'triggered' | 'acknowledged' | 'resolved' | 'updated',
   notificationId?: string
 ): Promise<{ success: boolean; error?: string; messageSid?: string }> {
   try {
@@ -83,6 +83,8 @@ export async function sendIncidentWhatsApp(
       statusLine = '👀 Incident Acknowledged';
     } else if (eventType === 'resolved') {
       statusLine = '✅ Incident Resolved';
+    } else {
+      statusLine = 'ℹ️ Incident Updated';
     }
 
     // Truncate for sanity, though WhatsApp limit is 1600 chars

--- a/tests/integration/job-queue.test.ts
+++ b/tests/integration/job-queue.test.ts
@@ -87,7 +87,7 @@ describeIfRealDB('Job Queue Resilience Tests', { timeout: 30000 }, () => {
     it('gives notification delivery all three claimed attempts', async () => {
       const user = await createTestUser();
       const service = await testPrisma.service.create({
-        data: { name: `Retry Service ${Date.now()}` },
+        data: { name: `Retry Service ${Date.now()}`, webhookUrl: 'http://127.0.0.1:9' },
       });
       const incident = await testPrisma.incident.create({
         data: { title: 'Retry notification incident', status: 'OPEN', serviceId: service.id },

--- a/tests/lib/notification-queue-reliability.test.ts
+++ b/tests/lib/notification-queue-reliability.test.ts
@@ -53,4 +53,26 @@ describe('notification queue delivery reliability', () => {
 
     expect(queueNotification('incident-2', 'user-2', 'SMS', 'Incident opened')).toBe(true);
   });
+
+  it('does not retry a terminally skipped delivery', async () => {
+    sendNotification.mockResolvedValue({
+      success: false,
+      skipped: true,
+      terminal: true,
+      error: 'No registered device',
+    });
+    queueNotification('incident-3', 'user-3', 'PUSH', 'Incident acknowledged', 2, 'acknowledged');
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotification).toHaveBeenCalledWith(
+      'incident-3',
+      'user-3',
+      'PUSH',
+      'Incident acknowledged',
+      undefined,
+      'acknowledged'
+    );
+  });
 });

--- a/tests/lib/notification-retry.test.ts
+++ b/tests/lib/notification-retry.test.ts
@@ -3,6 +3,7 @@ import { retryFailedNotifications } from '@/lib/notification-retry';
 import prisma from '@/lib/prisma';
 
 const sendIncidentEmail = vi.fn();
+const circuitExecute = vi.fn((fn: () => unknown) => fn());
 
 vi.mock('@/lib/prisma', () => ({
   default: {
@@ -18,8 +19,15 @@ vi.mock('@/lib/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('@/lib/circuit-breaker', () => ({
+  CircuitBreakerError: class CircuitBreakerError extends Error {
+    serviceName: string;
+    constructor(message: string, serviceName: string) {
+      super(message);
+      this.serviceName = serviceName;
+    }
+  },
   CircuitBreakers: {
-    email: () => ({ execute: (fn: () => unknown) => fn() }),
+    email: () => ({ execute: circuitExecute }),
     sms: () => ({ execute: (fn: () => unknown) => fn() }),
     push: () => ({ execute: (fn: () => unknown) => fn() }),
     whatsapp: () => ({ execute: (fn: () => unknown) => fn() }),
@@ -42,12 +50,30 @@ const failedNotification = {
   attempts: 1,
   failedAt: new Date(Date.now() - 60_000),
   incident: { id: 'incident-1', status: 'OPEN', service: { webhookUrl: null } },
+  eventType: 'acknowledged',
 };
 
 describe('notification retry claiming', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    circuitExecute.mockImplementation((fn: () => unknown) => fn());
     vi.mocked(prisma.notification.findMany).mockResolvedValue([failedNotification] as never);
+  });
+
+  it('does not consume an attempt while the provider circuit is open', async () => {
+    const { CircuitBreakerError } = await import('@/lib/circuit-breaker');
+    vi.mocked(prisma.notification.updateMany).mockResolvedValue({ count: 1 });
+    circuitExecute.mockRejectedValue(new CircuitBreakerError('Circuit is open', 'email'));
+    vi.mocked(prisma.notification.update).mockResolvedValue({} as never);
+
+    const result = await retryFailedNotifications();
+
+    expect(result).toEqual({ retried: 1, succeeded: 0, failed: 1 });
+    expect(prisma.notification.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'FAILED', attempts: 1 }),
+      })
+    );
   });
 
   it('does not send when another worker already claimed the notification', async () => {

--- a/tests/lib/notifications.test.ts
+++ b/tests/lib/notifications.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendNotification } from '@/lib/notifications';
 import prisma from '@/lib/prisma';
 import * as emailModule from '@/lib/email';
+import * as pushModule from '@/lib/push';
 
 type NotificationFindResult = Awaited<ReturnType<typeof prisma.notification.findFirst>>;
 type NotificationCreateResult = Awaited<ReturnType<typeof prisma.notification.create>>;
@@ -62,9 +63,9 @@ describe('Notifications Library', () => {
 
   it('should debounce an identical recent notification payload', async () => {
     const message = '[API] Incident triggered: CPU high';
-    vi.mocked(prisma.notification.findFirst).mockResolvedValue(
-      { id: 'notif-existing' } as unknown as NotificationFindResult
-    );
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue({
+      id: 'notif-existing',
+    } as unknown as NotificationFindResult);
 
     const result = await sendNotification('inc-1', 'user-1', 'EMAIL', message);
 
@@ -90,18 +91,24 @@ describe('Notifications Library', () => {
   it('should not let a recent trigger notification suppress a resolved lifecycle message', async () => {
     const resolvedMessage = '[API] Incident resolved: CPU high';
     vi.mocked(prisma.notification.findFirst).mockResolvedValue(null);
-    vi.mocked(prisma.notification.create).mockResolvedValue(
-      { id: 'notif-resolved', attempts: 0 } as unknown as NotificationCreateResult
-    );
-    vi.mocked(prisma.incident.findUnique).mockResolvedValue(
-      {
-        id: 'inc-1',
-        status: 'RESOLVED',
-      } as unknown as IncidentFindResult
-    );
+    vi.mocked(prisma.notification.create).mockResolvedValue({
+      id: 'notif-resolved',
+      attempts: 0,
+    } as unknown as NotificationCreateResult);
+    vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+      id: 'inc-1',
+      status: 'RESOLVED',
+    } as unknown as IncidentFindResult);
     vi.mocked(emailModule.sendIncidentEmail).mockResolvedValue({ success: true });
 
-    const result = await sendNotification('inc-1', 'user-1', 'EMAIL', resolvedMessage);
+    const result = await sendNotification(
+      'inc-1',
+      'user-1',
+      'EMAIL',
+      resolvedMessage,
+      undefined,
+      'resolved'
+    );
 
     expect(result.success).toBe(true);
     expect(prisma.notification.findFirst).toHaveBeenCalledWith(
@@ -111,6 +118,62 @@ describe('Notifications Library', () => {
     );
     expect(prisma.notification.create).toHaveBeenCalled();
     expect(emailModule.sendIncidentEmail).toHaveBeenCalledWith('user-1', 'inc-1', 'resolved');
+  });
+
+  it('preserves acknowledged intent when the incident is already resolved', async () => {
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.notification.create).mockResolvedValue({
+      id: 'notif-ack',
+      attempts: 0,
+    } as unknown as NotificationCreateResult);
+    vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+      id: 'inc-1',
+      status: 'RESOLVED',
+    } as unknown as IncidentFindResult);
+    vi.mocked(emailModule.sendIncidentEmail).mockResolvedValue({ success: true });
+
+    await sendNotification(
+      'inc-1',
+      'user-1',
+      'EMAIL',
+      'Incident acknowledged',
+      undefined,
+      'acknowledged'
+    );
+
+    expect(emailModule.sendIncidentEmail).toHaveBeenCalledWith('user-1', 'inc-1', 'acknowledged');
+    expect(prisma.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ eventType: 'acknowledged' }) })
+    );
+  });
+
+  it('records an unavailable push recipient as terminally skipped', async () => {
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.notification.create).mockResolvedValue({
+      id: 'notif-push',
+      attempts: 0,
+    } as unknown as NotificationCreateResult);
+    vi.mocked(pushModule.sendIncidentPush).mockResolvedValue({
+      success: false,
+      code: 'NO_DEVICE_TOKENS',
+      error: 'No device tokens found for user',
+    });
+
+    const result = await sendNotification(
+      'inc-1',
+      'user-1',
+      'PUSH',
+      'Incident acknowledged',
+      undefined,
+      'acknowledged'
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({ success: false, skipped: true, terminal: true })
+    );
+    expect(prisma.notification.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'SKIPPED' }) })
+    );
   });
 
   it('should route to WHATSAPP channel correctly', async () => {


### PR DESCRIPTION
## Summary
- persist lifecycle intent through initial delivery and durable retries
- centralize machine outcomes for delivered, skipped, retryable, permanent, and circuit-open attempts
- record skipped delivery as a terminal status without consuming retries
- replace push error-string classification with structured failure codes

## Validation
- 205 unit test files passed (1,506 passed, 4 skipped)
- TypeScript passed
- Prisma migration validation passed