### PR TITLE
refactor(auth): route search through policy filters

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,6 +7,8 @@ import { logger } from '@/lib/logger';
 import { checkRateLimit } from '@/lib/rate-limit';
 import type { IncidentStatus, IncidentUrgency } from '@prisma/client';
 import { CAPABILITIES, hasCapability } from '@/lib/authorization';
+import { incidentReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
 
 const INSENSITIVE_MODE = 'insensitive' as const;
 
@@ -87,23 +89,20 @@ export async function GET(req: NextRequest) {
         teamMemberships: { select: { teamId: true } },
       },
     });
-    if (!currentUser || currentUser.status === 'DISABLED') {
+    if (!currentUser || currentUser.status !== 'ACTIVE') {
       return jsonError('Unauthorized', 401);
     }
 
+    const actor: AuthorizationActor = {
+      id: currentUser.id,
+      role: currentUser.role,
+      status: currentUser.status,
+      teamIds: currentUser.teamMemberships.map(membership => membership.teamId),
+    };
     const isPrivileged = hasCapability(currentUser.role, CAPABILITIES.INCIDENT_READ_ALL);
-    const teamIds = currentUser.teamMemberships.map(membership => membership.teamId);
-    const incidentAccess = isPrivileged
-      ? {}
-      : {
-          OR: [
-            { assigneeId: currentUser.id },
-            { watchers: { some: { userId: currentUser.id } } },
-            {
-              AND: [{ visibility: 'PUBLIC' as const }, { service: { teamId: { in: teamIds } } }],
-            },
-          ],
-        };
+    const teamIds = [...actor.teamIds];
+    const incidentAccess = incidentReadWhere(actor);
+    const serviceAccess = serviceReadWhere(actor);
 
     const rate = await checkRateLimit(`api:search:user:${currentUser.id}`, 30, 60_000);
     if (!rate.allowed) {
@@ -183,7 +182,7 @@ export async function GET(req: NextRequest) {
       prisma.service.findMany({
         where: {
           AND: [
-            isPrivileged ? {} : { teamId: { in: teamIds } },
+            serviceAccess,
             {
               OR: [
                 { name: { contains: sanitizedTerm, mode: INSENSITIVE_MODE } },

--- a/tests/api/search-rbac.test.ts
+++ b/tests/api/search-rbac.test.ts
@@ -40,7 +40,7 @@ describe('global search RBAC', () => {
   it('adds team and assignee scope for regular users', async () => {
     mocks.userFindUnique.mockResolvedValue({
       id: 'user-1',
-      role: 'VIEWER',
+      role: 'USER',
       status: 'ACTIVE',
       teamMemberships: [{ teamId: 'team-1' }],
     });
@@ -54,12 +54,31 @@ describe('global search RBAC', () => {
         { assigneeId: 'user-1' },
         { watchers: { some: { userId: 'user-1' } } },
         {
-          AND: [{ visibility: 'PUBLIC' }, { service: { teamId: { in: ['team-1'] } } }],
+          AND: [
+            { visibility: 'PUBLIC' },
+            {
+              OR: [{ teamId: { in: ['team-1'] } }, { service: { teamId: { in: ['team-1'] } } }],
+            },
+          ],
         },
       ],
     });
     const serviceQuery = mocks.findMany.mock.calls[1][0];
     expect(serviceQuery.where.AND[0]).toEqual({ teamId: { in: ['team-1'] } });
+  });
+
+  it('rejects invited actors before any resource search executes', async () => {
+    mocks.userFindUnique.mockResolvedValue({
+      id: 'invited-1',
+      role: 'USER',
+      status: 'INVITED',
+      teamMemberships: [{ teamId: 'team-1' }],
+    });
+
+    const response = await GET(new NextRequest('http://localhost/api/search?q=database'));
+
+    expect(response.status).toBe(401);
+    expect(mocks.findMany).not.toHaveBeenCalled();
   });
 
   it('preserves global search for responders', async () => {

--- a/tests/architecture/search-authorization-contract.test.ts
+++ b/tests/architecture/search-authorization-contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('global search authorization contract', () => {
+  it('delegates incident and service visibility to canonical policy filters', () => {
+    const source = readFileSync('src/app/api/search/route.ts', 'utf8');
+
+    expect(source).toContain('incidentReadWhere(actor)');
+    expect(source).toContain('serviceReadWhere(actor)');
+    expect(source).not.toMatch(/const incidentAccess\s*=\s*isPrivileged/);
+  });
+});


### PR DESCRIPTION
## Summary
- use incidentReadWhere and serviceReadWhere for global search
- restore assigned incident-team visibility in search results
- reject non-ACTIVE actors before resource queries
- add policy drift architecture coverage

## Validation
- focused authorization/search suites passed
- TypeScript and lint passed