### PR TITLE
fix(incidents): harden reopen lifecycle side effects

### DIFF
--- a/src/lib/event-outbox.ts
+++ b/src/lib/event-outbox.ts
@@ -18,6 +18,7 @@ export type EventSideEffect =
   | 'LIFECYCLE_STATUS_PAGE'
   | 'LIFECYCLE_WEBHOOK'
   | 'LIFECYCLE_WAR_ROOM_SYNC'
+  | 'LIFECYCLE_WAR_ROOM_ENSURE'
   | 'LIFECYCLE_WAR_ROOM_TOPIC'
   | 'LIFECYCLE_WAR_ROOM_ARCHIVE';
 
@@ -124,6 +125,10 @@ export function getLifecycleSideEffects(
 
     if (input.status === 'RESOLVED') {
       effects.add('LIFECYCLE_WAR_ROOM_ARCHIVE');
+    } else if (input.command === 'REOPEN') {
+      // A resolved incident may have an archived war-room. Reopen must ensure a
+      // live room exists instead of trying to post into the archived channel.
+      effects.add('LIFECYCLE_WAR_ROOM_ENSURE');
     } else {
       effects.add('LIFECYCLE_WAR_ROOM_SYNC');
     }
@@ -184,6 +189,7 @@ function getEventSideEffectLane(effect: EventSideEffect): EventSideEffectLane {
     case 'TRIGGER_WAR_ROOM':
     case 'RESOLVE_WAR_ROOM_ARCHIVE':
     case 'LIFECYCLE_WAR_ROOM_SYNC':
+    case 'LIFECYCLE_WAR_ROOM_ENSURE':
     case 'LIFECYCLE_WAR_ROOM_TOPIC':
     case 'LIFECYCLE_WAR_ROOM_ARCHIVE':
       return 'WAR_ROOM';
@@ -248,6 +254,61 @@ async function enqueueSideEffects(
   });
 }
 
+async function enqueueReopenEscalation(
+  tx: Prisma.TransactionClient,
+  input: LifecycleOutboxInput
+): Promise<void> {
+  if (input.command !== 'REOPEN') return;
+
+  const incident = await tx.incident.findUnique({
+    where: { id: input.incidentId },
+    select: {
+      status: true,
+      escalationStatus: true,
+      currentEscalationStep: true,
+      nextEscalationAt: true,
+    },
+  });
+
+  if (
+    !incident ||
+    incident.status !== 'OPEN' ||
+    incident.escalationStatus !== 'ESCALATING' ||
+    !incident.nextEscalationAt
+  ) {
+    return;
+  }
+
+  // Resolve/reopen can leave an older delayed escalation job behind. Cancel
+  // pending copies before persisting the canonical post-reopen job so an old
+  // generation cannot page responders early after the incident becomes OPEN.
+  await tx.backgroundJob.updateMany({
+    where: {
+      type: 'ESCALATION',
+      status: 'PENDING',
+      payload: { path: ['incidentId'], equals: input.incidentId },
+    },
+    data: {
+      status: 'CANCELLED',
+      error: 'Superseded by incident reopen',
+    },
+  });
+
+  await tx.backgroundJob.create({
+    data: {
+      type: 'ESCALATION',
+      status: 'PENDING',
+      scheduledAt: incident.nextEscalationAt,
+      maxAttempts: 3,
+      payload: {
+        incidentId: input.incidentId,
+        stepIndex: incident.currentEscalationStep ?? 0,
+        lifecycleTransitionAt: input.transitionAt.toISOString(),
+      },
+    },
+  });
+}
+
 /**
  * Persist event-ingestion side-effects in the same database transaction as the
  * incident state change/creation. The existing SCHEDULED_TASK job type is the
@@ -296,6 +357,7 @@ export async function enqueueLifecycleSideEffects(
   };
 
   await enqueueSideEffects(tx, input.incidentId, getLifecycleSideEffects(input), lifecycle);
+  await enqueueReopenEscalation(tx, input);
 
   if (input.command === 'SNOOZE' && input.snoozedUntil) {
     await tx.backgroundJob.create({

--- a/src/lib/event-side-effects.ts
+++ b/src/lib/event-side-effects.ts
@@ -263,6 +263,75 @@ async function syncLifecycleWarRoom(payload: EventSideEffectPayload): Promise<vo
   ]);
 }
 
+async function ensureLifecycleWarRoom(payload: EventSideEffectPayload): Promise<void> {
+  const lifecycle = lifecycleContext(payload);
+  if (lifecycle.command !== 'REOPEN' || lifecycle.status !== 'OPEN') {
+    throw new Error('War-room ensure is only valid for an OPEN reopen transition');
+  }
+
+  // A later resolve may already have committed while this job was waiting in
+  // the WAR_ROOM lane. Do not recreate a room for a stale reopen effect.
+  const incident = await prisma.incident.findUnique({
+    where: { id: payload.incidentId },
+    select: { status: true },
+  });
+  if (!incident || incident.status !== 'OPEN') {
+    logger.info('lifecycle.outbox.stale_war_room_ensure_skipped', {
+      incidentId: payload.incidentId,
+      currentStatus: incident?.status,
+      transitionAt: lifecycle.transitionAt,
+    });
+    return;
+  }
+
+  const { createIncidentWarRoom } = await import('./chatops/war-room');
+  const result = await createIncidentWarRoom(payload.incidentId);
+  if (!result.success) {
+    logger.info('lifecycle.outbox.war_room_ensure_not_applicable', {
+      incidentId: payload.incidentId,
+      error: result.error,
+    });
+    return;
+  }
+
+  await syncLifecycleWarRoom(payload);
+}
+
+async function archiveWarRoomIfStillResolved(payload: EventSideEffectPayload): Promise<void> {
+  const lifecycle = payload.lifecycle;
+  const incident = await prisma.incident.findUnique({
+    where: { id: payload.incidentId },
+    select: { status: true, resolvedAt: true },
+  });
+
+  if (!incident || incident.status !== 'RESOLVED') {
+    logger.info('lifecycle.outbox.stale_war_room_archive_skipped', {
+      incidentId: payload.incidentId,
+      currentStatus: incident?.status,
+      transitionAt: lifecycle?.transitionAt,
+    });
+    return;
+  }
+
+  // Lifecycle archives are tied to the exact resolve commit. If the incident
+  // was resolved, reopened, and resolved again while this job was delayed, the
+  // old archive must not act on the newer lifecycle generation.
+  if (
+    lifecycle?.status === 'RESOLVED' &&
+    incident.resolvedAt?.toISOString() !== lifecycle.transitionAt
+  ) {
+    logger.info('lifecycle.outbox.superseded_war_room_archive_skipped', {
+      incidentId: payload.incidentId,
+      resolvedAt: incident.resolvedAt?.toISOString(),
+      transitionAt: lifecycle.transitionAt,
+    });
+    return;
+  }
+
+  const { archiveWarRoomChannel } = await import('./chatops/war-room');
+  await archiveWarRoomChannel(payload.incidentId);
+}
+
 export async function processEventSideEffect(payload: EventSideEffectPayload): Promise<void> {
   if (
     payload.task !== 'EVENT_SIDE_EFFECT' ||
@@ -311,11 +380,9 @@ export async function processEventSideEffect(payload: EventSideEffectPayload): P
       await notifySlackForIncident(payload.incidentId, 'resolved');
       return;
 
-    case 'RESOLVE_WAR_ROOM_ARCHIVE': {
-      const { archiveWarRoomChannel } = await import('./chatops/war-room');
-      await archiveWarRoomChannel(payload.incidentId);
+    case 'RESOLVE_WAR_ROOM_ARCHIVE':
+      await archiveWarRoomIfStillResolved(payload);
       return;
-    }
 
     case 'ACK_SLACK':
       await notifySlackForIncident(payload.incidentId, 'acknowledged');
@@ -357,6 +424,10 @@ export async function processEventSideEffect(payload: EventSideEffectPayload): P
       await syncLifecycleWarRoom(payload);
       return;
 
+    case 'LIFECYCLE_WAR_ROOM_ENSURE':
+      await ensureLifecycleWarRoom(payload);
+      return;
+
     case 'LIFECYCLE_WAR_ROOM_TOPIC': {
       const lifecycle = lifecycleContext(payload);
       const { updateWarRoomTopic } = await import('./chatops/war-room');
@@ -364,11 +435,9 @@ export async function processEventSideEffect(payload: EventSideEffectPayload): P
       return;
     }
 
-    case 'LIFECYCLE_WAR_ROOM_ARCHIVE': {
-      const { archiveWarRoomChannel } = await import('./chatops/war-room');
-      await archiveWarRoomChannel(payload.incidentId);
+    case 'LIFECYCLE_WAR_ROOM_ARCHIVE':
+      await archiveWarRoomIfStillResolved(payload);
       return;
-    }
   }
 
   throw new Error(

--- a/tests/integration/incident-creation-concurrency.test.ts
+++ b/tests/integration/incident-creation-concurrency.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { executeIncidentCreation } from '@/lib/incidents/creation';
+import { createTestUser, resetDatabase, testPrisma } from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+describeIfRealDB('incident creation concurrency', () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it('serializes simultaneous requests for the same service/dedup key into one incident', async () => {
+    const [service, actor] = await Promise.all([
+      testPrisma.service.create({ data: { name: 'Concurrent Creation Service' } }),
+      createTestUser({ email: 'creation-concurrency@example.com', name: 'Concurrency Tester' }),
+    ]);
+
+    const input = {
+      title: 'Database latency',
+      description: 'Write latency above threshold',
+      serviceId: service.id,
+      urgency: 'HIGH' as const,
+      dedupKey: 'db-latency-concurrent',
+      source: 'REST_API' as const,
+      actor: { id: actor.id, name: actor.name },
+      now: new Date('2026-08-28T10:00:00.000Z'),
+    };
+
+    const results = await Promise.all([
+      executeIncidentCreation(input),
+      executeIncidentCreation(input),
+    ]);
+
+    const incidents = await testPrisma.incident.findMany({
+      where: { serviceId: service.id, dedupKey: input.dedupKey },
+      select: { id: true },
+    });
+
+    expect(incidents).toHaveLength(1);
+    expect(results.map(result => result.id)).toEqual([incidents[0].id, incidents[0].id]);
+    expect(results.map(result => result.outcome).sort()).toEqual(['CREATED', 'MERGED']);
+  });
+});

--- a/tests/lib/event-side-effects.test.ts
+++ b/tests/lib/event-side-effects.test.ts
@@ -3,6 +3,12 @@ import { executeEscalation as mockedExecuteEscalation } from '@/lib/notification
 import { sendServiceNotifications as mockedSendServiceNotifications } from '@/lib/service-notifications';
 import { sendIncidentNotifications as mockedSendIncidentNotifications } from '@/lib/user-notifications';
 import { triggerWebhooksForService as mockedTriggerWebhooksForService } from '@/lib/status-page-webhooks';
+import {
+  archiveWarRoomChannel as mockedArchiveWarRoomChannel,
+  createIncidentWarRoom as mockedCreateIncidentWarRoom,
+  postWarRoomUpdate as mockedPostWarRoomUpdate,
+  updateWarRoomTopic as mockedUpdateWarRoomTopic,
+} from '@/lib/chatops/war-room';
 import prisma from '@/lib/prisma';
 import { processEventSideEffect } from '@/lib/event-side-effects';
 import type { EventSideEffectPayload } from '@/lib/event-outbox';
@@ -62,6 +68,10 @@ const executeEscalationMock = mockedExecuteEscalation as unknown as TestMock;
 const sendServiceNotificationsMock = mockedSendServiceNotifications as unknown as TestMock;
 const sendIncidentNotificationsMock = mockedSendIncidentNotifications as unknown as TestMock;
 const triggerWebhooksForServiceMock = mockedTriggerWebhooksForService as unknown as TestMock;
+const archiveWarRoomChannelMock = mockedArchiveWarRoomChannel as unknown as TestMock;
+const createIncidentWarRoomMock = mockedCreateIncidentWarRoom as unknown as TestMock;
+const postWarRoomUpdateMock = mockedPostWarRoomUpdate as unknown as TestMock;
+const updateWarRoomTopicMock = mockedUpdateWarRoomTopic as unknown as TestMock;
 const prismaMock = prisma as unknown as { incident: { findUnique: TestMock } };
 
 function payload(
@@ -188,6 +198,111 @@ describe('event durable side effects', () => {
         })
       )
     ).rejects.toThrow('notification unavailable');
+  });
+
+  it('recreates an archived war-room on reopen before syncing the OPEN state', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue({ status: 'OPEN' });
+    createIncidentWarRoomMock.mockResolvedValue({
+      success: true,
+      channelId: 'C123',
+      channelName: 'incident-123',
+    });
+    postWarRoomUpdateMock.mockResolvedValue({ success: true });
+    updateWarRoomTopicMock.mockResolvedValue({ success: true });
+
+    await processEventSideEffect(
+      payload('LIFECYCLE_WAR_ROOM_ENSURE', 'WAR_ROOM', {
+        command: 'REOPEN',
+        source: 'WEB',
+        previousStatus: 'RESOLVED',
+        status: 'OPEN',
+        transitionAt: '2026-08-28T07:00:00.000Z',
+        snoozedUntil: null,
+      })
+    );
+
+    expect(createIncidentWarRoomMock).toHaveBeenCalledWith('inc-1');
+    expect(postWarRoomUpdateMock).toHaveBeenCalledWith(
+      'inc-1',
+      '🔄 *Status updated to OPEN*'
+    );
+    expect(updateWarRoomTopicMock).toHaveBeenCalledWith('inc-1', 'OPEN');
+  });
+
+  it('does not recreate a war-room for a stale reopen after the incident resolved again', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue({ status: 'RESOLVED' });
+
+    await processEventSideEffect(
+      payload('LIFECYCLE_WAR_ROOM_ENSURE', 'WAR_ROOM', {
+        command: 'REOPEN',
+        source: 'WEB',
+        previousStatus: 'RESOLVED',
+        status: 'OPEN',
+        transitionAt: '2026-08-28T07:00:00.000Z',
+        snoozedUntil: null,
+      })
+    );
+
+    expect(createIncidentWarRoomMock).not.toHaveBeenCalled();
+    expect(postWarRoomUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not archive a war-room when an old resolve effect runs after reopen', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue({ status: 'OPEN', resolvedAt: null });
+
+    await processEventSideEffect(
+      payload('LIFECYCLE_WAR_ROOM_ARCHIVE', 'WAR_ROOM', {
+        command: 'RESOLVE',
+        source: 'WEB',
+        previousStatus: 'ACKNOWLEDGED',
+        status: 'RESOLVED',
+        transitionAt: '2026-08-28T06:02:00.000Z',
+        snoozedUntil: null,
+      })
+    );
+
+    expect(archiveWarRoomChannelMock).not.toHaveBeenCalled();
+  });
+
+  it('does not let an older resolve archive a newer resolve generation', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue({
+      status: 'RESOLVED',
+      resolvedAt: new Date('2026-08-28T07:10:00.000Z'),
+    });
+
+    await processEventSideEffect(
+      payload('LIFECYCLE_WAR_ROOM_ARCHIVE', 'WAR_ROOM', {
+        command: 'RESOLVE',
+        source: 'WEB',
+        previousStatus: 'ACKNOWLEDGED',
+        status: 'RESOLVED',
+        transitionAt: '2026-08-28T06:02:00.000Z',
+        snoozedUntil: null,
+      })
+    );
+
+    expect(archiveWarRoomChannelMock).not.toHaveBeenCalled();
+  });
+
+  it('archives the war-room only for the still-current resolve transition', async () => {
+    prismaMock.incident.findUnique.mockResolvedValue({
+      status: 'RESOLVED',
+      resolvedAt: new Date('2026-08-28T06:02:00.000Z'),
+    });
+    archiveWarRoomChannelMock.mockResolvedValue({ success: true });
+
+    await processEventSideEffect(
+      payload('LIFECYCLE_WAR_ROOM_ARCHIVE', 'WAR_ROOM', {
+        command: 'RESOLVE',
+        source: 'WEB',
+        previousStatus: 'ACKNOWLEDGED',
+        status: 'RESOLVED',
+        transitionAt: '2026-08-28T06:02:00.000Z',
+        snoozedUntil: null,
+      })
+    );
+
+    expect(archiveWarRoomChannelMock).toHaveBeenCalledWith('inc-1');
   });
 
   it('rejects an unknown effect instead of silently completing it', async () => {

--- a/tests/lib/incidents/lifecycle-outbox.test.ts
+++ b/tests/lib/incidents/lifecycle-outbox.test.ts
@@ -12,9 +12,13 @@ const DB_NOW = new Date('2026-08-28T07:00:00.000Z');
 function createTx() {
   return {
     $queryRaw: vi.fn().mockResolvedValue([{ now: DB_NOW }]),
+    incident: {
+      findUnique: vi.fn(),
+    },
     backgroundJob: {
       createMany: vi.fn().mockResolvedValue({ count: 0 }),
-      create: vi.fn().mockResolvedValue({ id: 'job-unsnooze' }),
+      create: vi.fn().mockResolvedValue({ id: 'job-1' }),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
   };
 }
@@ -40,6 +44,21 @@ describe('durable lifecycle outbox', () => {
       'LIFECYCLE_WEBHOOK',
       'LIFECYCLE_USER_NOTIFICATION',
       'LIFECYCLE_WAR_ROOM_SYNC',
+    ]);
+  });
+
+  it('ensures a live war-room when an interactive incident is reopened', () => {
+    expect(
+      getLifecycleSideEffects({
+        command: 'REOPEN',
+        source: 'WEB',
+        status: 'OPEN',
+      })
+    ).toEqual([
+      'LIFECYCLE_STATUS_PAGE',
+      'LIFECYCLE_WEBHOOK',
+      'LIFECYCLE_USER_NOTIFICATION',
+      'LIFECYCLE_WAR_ROOM_ENSURE',
     ]);
   });
 
@@ -96,6 +115,52 @@ describe('durable lifecycle outbox', () => {
           job.payload.eventOrderAt === DB_NOW.toISOString()
       )
     ).toBe(true);
+  });
+
+  it('replaces stale delayed escalation work with the canonical reopen escalation job', async () => {
+    const tx = createTx();
+    const nextEscalationAt = new Date('2026-08-28T07:05:00.000Z');
+    const transitionAt = new Date('2026-08-28T07:00:01.000Z');
+    tx.incident.findUnique.mockResolvedValue({
+      status: 'OPEN',
+      escalationStatus: 'ESCALATING',
+      currentEscalationStep: 0,
+      nextEscalationAt,
+    });
+
+    await enqueueLifecycleSideEffects(asTransactionClient(tx), {
+      incidentId: 'inc-reopen',
+      command: 'REOPEN',
+      source: 'WEB',
+      previousStatus: 'RESOLVED',
+      status: 'OPEN',
+      transitionAt,
+    });
+
+    expect(tx.backgroundJob.updateMany).toHaveBeenCalledWith({
+      where: {
+        type: 'ESCALATION',
+        status: 'PENDING',
+        payload: { path: ['incidentId'], equals: 'inc-reopen' },
+      },
+      data: {
+        status: 'CANCELLED',
+        error: 'Superseded by incident reopen',
+      },
+    });
+    expect(tx.backgroundJob.create).toHaveBeenCalledWith({
+      data: {
+        type: 'ESCALATION',
+        status: 'PENDING',
+        scheduledAt: nextEscalationAt,
+        maxAttempts: 3,
+        payload: {
+          incidentId: 'inc-reopen',
+          stepIndex: 0,
+          lifecycleTransitionAt: transitionAt.toISOString(),
+        },
+      },
+    });
   });
 
   it('persists finite auto-unsnooze timing in the same transaction as snooze effects', async () => {


### PR DESCRIPTION
## Summary

Hardens the centralized incident lifecycle after the recent creation/outbox/notification refactors without reintroducing adapter-owned side effects.

### Fixes
- Reopening an incident now uses a dedicated durable `LIFECYCLE_WAR_ROOM_ENSURE` effect so an archived Slack war-room is recreated before OPEN-state sync.
- War-room archive effects are transition-aware: an old resolve cannot archive after a reopen, and an older resolve generation cannot archive a room belonging to a later resolve.
- Reopen now persists the canonical escalation job in the same transaction as the lifecycle transition.
- Pending escalation jobs from the pre-resolve generation are cancelled before the canonical reopen job is inserted, preventing stale delayed work from paging early.
- Active dedup merges remain side-effect-free by design; a resolved recurrence re-enters lifecycle and durable escalation instead of replaying the whole creation bundle.

### Tests
- Reopen maps to war-room ensure rather than archived-room sync.
- Reopen replaces stale pending escalation jobs with the authoritative scheduled escalation.
- Reopen recreates/syncs a live war-room only while the incident is still OPEN.
- Old/superseded resolve archive jobs are harmless no-ops.
- Current resolve still archives normally.
- Real-DB concurrency coverage verifies two simultaneous same-service/same-dedup creations result in exactly one incident (`CREATED` + `MERGED`).

## Architecture

The lifecycle engine remains the single state owner. All external behavior stays behind the durable outbox, and the cron escalation sweep remains the recovery path if a job is missing or delayed.

## Commit history

Exactly one focused commit.