### PR TITLE
fix(dashboard): isolate retention metadata from Prisma filters

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -122,11 +122,11 @@ export default async function Dashboard({
 
   // Main query where clause (includes status filter)
   const dateFilter = await buildRetainedDateFilter(range, customStart, customEnd);
-  const where = buildIncidentWhere(filterParams, { dateFilter });
+  const where = buildIncidentWhere(filterParams, { dateFilter: dateFilter.where });
 
   // Date filter for SLA calculations
-  const metricsStartDate = dateFilter.createdAt.gte;
-  const metricsEndDate = dateFilter.createdAt.lte;
+  const metricsStartDate = dateFilter.window.start;
+  const metricsEndDate = dateFilter.window.end;
   const assigneeFilter = assignee !== undefined ? (assignee === '' ? null : assignee) : undefined;
   const incidentSelect = {
     id: true,

--- a/src/app/api/widgets/data/route.ts
+++ b/src/app/api/widgets/data/route.ts
@@ -51,8 +51,8 @@ export async function GET(req: NextRequest) {
           | 'SUPPRESSED'
           | 'RESOLVED'
           | null) || undefined,
-      startDate: dateFilter.createdAt.gte,
-      endDate: dateFilter.createdAt.lte,
+      startDate: dateFilter.window.start,
+      endDate: dateFilter.window.end,
       includeAllTime: range === 'all',
     });
 

--- a/src/app/api/widgets/stream/route.ts
+++ b/src/app/api/widgets/stream/route.ts
@@ -49,8 +49,8 @@ export async function GET(request: Request) {
           | 'SUPPRESSED'
           | 'RESOLVED'
           | null) || undefined,
-      startDate: dateFilter.createdAt.gte,
-      endDate: dateFilter.createdAt.lte,
+      startDate: dateFilter.window.start,
+      endDate: dateFilter.window.end,
       includeAllTime: range === 'all',
     };
 

--- a/src/lib/dashboard-utils.ts
+++ b/src/lib/dashboard-utils.ts
@@ -19,12 +19,23 @@ interface DateFilter {
   lte?: Date;
 }
 
+type IncidentDateWhere = Pick<Prisma.IncidentWhereInput, 'createdAt'>;
+
+export interface RetainedDateFilterResult {
+  where: IncidentDateWhere;
+  window: {
+    start: Date;
+    end: Date;
+    isClipped: boolean;
+  };
+}
+
 export async function buildRetainedDateFilter(
   range?: string,
   customStart?: string,
   customEnd?: string,
   now: Date = new Date()
-): Promise<{ createdAt: DateFilter; isClipped: boolean }> {
+): Promise<RetainedDateFilterResult> {
   let bounds;
   if (range === 'custom') {
     const requestedStart = customStart ? new Date(customStart) : undefined;
@@ -39,8 +50,12 @@ export async function buildRetainedDateFilter(
       : await getReportingWindowForDays(30, 'incident', now);
   }
   return {
-    createdAt: { gte: bounds.start, lte: bounds.end },
-    isClipped: bounds.isClipped,
+    where: { createdAt: { gte: bounds.start, lte: bounds.end } },
+    window: {
+      start: bounds.start,
+      end: bounds.end,
+      isClipped: bounds.isClipped,
+    },
   };
 }
 
@@ -87,15 +102,17 @@ export function buildIncidentWhere(
   options: {
     includeStatus?: boolean;
     includeUrgency?: boolean;
-    dateFilter?: { createdAt?: DateFilter };
-  } = { includeStatus: true, includeUrgency: true }
+    dateFilter?: IncidentDateWhere;
+  } = {}
 ): Prisma.IncidentWhereInput {
+  const includeStatus = options.includeStatus ?? true;
+  const includeUrgency = options.includeUrgency ?? true;
   const dateFilter =
     options.dateFilter ?? buildDateFilter(filters.range, filters.customStart, filters.customEnd);
 
   const where: Prisma.IncidentWhereInput = { ...dateFilter };
 
-  if (options.includeStatus && filters.status && filters.status !== 'ALL') {
+  if (includeStatus && filters.status && filters.status !== 'ALL') {
     where.status =
       filters.status === 'ACTIVE'
         ? { in: ['OPEN', 'ACKNOWLEDGED'] }
@@ -110,7 +127,7 @@ export function buildIncidentWhere(
     where.serviceId = filters.service;
   }
 
-  if (options.includeUrgency && filters.urgency) {
+  if (includeUrgency && filters.urgency) {
     where.urgency = filters.urgency as Prisma.EnumIncidentUrgencyFilter;
   }
 

--- a/tests/architecture/dashboard-date-filter-boundary.test.ts
+++ b/tests/architecture/dashboard-date-filter-boundary.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('dashboard retained date-filter boundary', () => {
+  it('separates Prisma query fields from retention metadata', () => {
+    const source = readFileSync('src/lib/dashboard-utils.ts', 'utf8');
+
+    expect(source).toContain('where: IncidentDateWhere');
+    expect(source).toContain('window: {');
+    expect(source).not.toMatch(/return\s*{\s*createdAt:[\s\S]{0,160}isClipped:/);
+  });
+
+  it('passes only the nested Prisma filter into buildIncidentWhere', () => {
+    const source = readFileSync('src/app/(app)/page.tsx', 'utf8');
+
+    expect(source).toContain('dateFilter: dateFilter.where');
+    expect(source).not.toContain('buildIncidentWhere(filterParams, { dateFilter })');
+  });
+});

--- a/tests/unit/dashboard-utils.test.ts
+++ b/tests/unit/dashboard-utils.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/retention-policy', () => ({
+  getQueryDateBounds: vi.fn(),
+  getReportingWindowForDays: vi.fn(async (days: number, _dataType: string, now: Date) => ({
+    start: new Date(now.getTime() - days * 24 * 60 * 60 * 1000),
+    end: now,
+    isClipped: false,
+  })),
+}));
 import {
   buildDateFilter,
+  buildRetainedDateFilter,
   buildIncidentWhere,
   buildIncidentOrderBy,
   getDaysFromRange,
@@ -8,6 +18,61 @@ import {
 } from '@/lib/dashboard-utils';
 
 describe('dashboard-utils', () => {
+  describe('buildRetainedDateFilter', () => {
+    it('keeps retention metadata outside the Prisma where object', async () => {
+      const now = new Date('2026-08-28T13:07:49.809Z');
+      const result = await buildRetainedDateFilter('30', undefined, undefined, now);
+
+      expect(result.where).toEqual({
+        createdAt: {
+          gte: new Date('2026-07-29T13:07:49.809Z'),
+          lte: now,
+        },
+      });
+      expect(result.window).toEqual({
+        start: new Date('2026-07-29T13:07:49.809Z'),
+        end: now,
+        isClipped: false,
+      });
+      expect(result.where).not.toHaveProperty('isClipped');
+    });
+
+    it('builds a Prisma-safe incident query from the retained filter', async () => {
+      const retained = await buildRetainedDateFilter(
+        '30',
+        undefined,
+        undefined,
+        new Date('2026-08-28T13:07:49.809Z')
+      );
+
+      const where = buildIncidentWhere({ status: 'OPEN' }, { dateFilter: retained.where });
+
+      expect(where).toEqual({
+        createdAt: retained.where.createdAt,
+        status: 'OPEN',
+      });
+      expect(where).not.toHaveProperty('isClipped');
+      expect(Object.keys(where)).toEqual(['createdAt', 'status']);
+    });
+
+    it('retains default status and urgency behavior when a date filter is supplied', async () => {
+      const retained = await buildRetainedDateFilter(
+        '7',
+        undefined,
+        undefined,
+        new Date('2026-08-28T13:07:49.809Z')
+      );
+
+      const where = buildIncidentWhere(
+        { status: 'ACTIVE', urgency: 'HIGH' },
+        { dateFilter: retained.where }
+      );
+
+      expect(where.status).toEqual({ in: ['OPEN', 'ACKNOWLEDGED'] });
+      expect(where.urgency).toBe('HIGH');
+    });
+  });
+
   describe('buildDateFilter', () => {
     it('returns empty object when range is "all"', () => {
       const result = buildDateFilter('all');


### PR DESCRIPTION
## Root cause
`buildRetainedDateFilter` returned Prisma query fields and `isClipped` at the same object level. Passing that object into `buildIncidentWhere` allowed structural typing to accept it, and spreading it produced an invalid `IncidentWhereInput` containing `isClipped`.

The same call also replaced the default options object, silently disabling status and urgency filters.

## Fix
- return retained filters as `{ where, window }` so Prisma fields and metadata cannot be confused
- pass only `dateFilter.where` to `buildIncidentWhere`
- consume `dateFilter.window` in dashboard and widget metrics
- default `includeStatus` and `includeUrgency` independently when other options are supplied
- add query-shape and architecture regression tests

## Validation
- TypeScript passed
- targeted time/dashboard suites: 72 tests passed
- complete unit suite: 210 files, 1,541 passed, 4 skipped
- focused ESLint passed