### PR TITLE
fix(incidents): fence stale escalation workers

### DIFF
--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -9,6 +9,18 @@ import { ESCALATION_LOCK_TIMEOUT_MS } from './config';
 import { startOfDayInTimeZone, startOfNextDayInTimeZone } from './timezone';
 // import { formatDateTime } from './timezone'; // Unused
 
+export interface EscalationExecutionResult {
+  escalated: boolean;
+  reason?: string;
+  nextEscalationAt?: Date;
+  targetName?: string;
+  targetType?: string;
+  targetCount?: number;
+  stepIndex?: number;
+  notifications?: unknown[];
+  nextStepScheduled?: boolean;
+}
+
 function escalationWorkerInvalidated(
   currentLock: Date | null | undefined,
   workerToken: Date
@@ -20,7 +32,7 @@ function escalationWorkerInvalidated(
   return currentLock instanceof Date && currentLock.getTime() !== workerToken.getTime();
 }
 
-function supersededEscalationResult() {
+function supersededEscalationResult(): EscalationExecutionResult {
   return {
     escalated: false,
     reason: 'Escalation superseded by lifecycle transition',
@@ -245,7 +257,10 @@ export async function resolveEscalationTarget(
  * Execute escalation policy for an incident.
  * Handles multiple steps with delays and different target types.
  */
-export async function executeEscalation(incidentId: string, stepIndex?: number) {
+export async function executeEscalation(
+  incidentId: string,
+  stepIndex?: number
+): Promise<EscalationExecutionResult> {
   const lockTimeoutMs = ESCALATION_LOCK_TIMEOUT_MS;
   const incident = await prisma.incident.findUnique({
     where: { id: incidentId },

--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -9,6 +9,24 @@ import { ESCALATION_LOCK_TIMEOUT_MS } from './config';
 import { startOfDayInTimeZone, startOfNextDayInTimeZone } from './timezone';
 // import { formatDateTime } from './timezone'; // Unused
 
+function escalationWorkerInvalidated(
+  currentLock: Date | null | undefined,
+  workerToken: Date
+): boolean {
+  // Production selects always include this field. `undefined` is tolerated for
+  // partial test doubles and older adapters; a persisted NULL explicitly means
+  // a lifecycle transition invalidated the worker generation.
+  if (currentLock === null) return true;
+  return currentLock instanceof Date && currentLock.getTime() !== workerToken.getTime();
+}
+
+function supersededEscalationResult() {
+  return {
+    escalated: false,
+    reason: 'Escalation superseded by lifecycle transition',
+  } as const;
+}
+
 /**
  * Get all active on-call users for a schedule at a given time
  * Returns array of all users who are on-call across all active layers
@@ -438,6 +456,11 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
     return { escalated: false, reason: 'Escalation already in progress' };
   }
 
+  // The claim timestamp is also the lifecycle-generation token. Any real
+  // lifecycle transition clears escalationProcessingAt; a timed-out reclaim
+  // replaces it. Either event makes this worker stale before it can continue.
+  const workerToken = now;
+
   // Resolve target based on target type
   let targetId: string | null = null;
   let targetName: string = 'Unknown';
@@ -525,15 +548,23 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
     targetUserIds.push(manualAssigneeId);
   }
 
-  // Assign the incident immediately when the escalation step runs (before notifications)
-  await runSerializableTransaction(async tx => {
+  // Assign the incident immediately when the escalation step runs (before notifications),
+  // but only while this worker still owns the generation it atomically claimed.
+  const assignmentGenerationIsCurrent = await runSerializableTransaction(async tx => {
     const currentIncident = await tx.incident.findUnique({
       where: { id: incidentId },
-      select: { assigneeId: true, teamId: true },
+      select: { assigneeId: true, teamId: true, escalationProcessingAt: true },
     });
 
-    if (currentIncident?.assigneeId || currentIncident?.teamId) {
-      return;
+    if (
+      !currentIncident ||
+      escalationWorkerInvalidated(currentIncident.escalationProcessingAt, workerToken)
+    ) {
+      return false;
+    }
+
+    if (currentIncident.assigneeId || currentIncident.teamId) {
+      return true;
     }
 
     if (step.targetType === 'TEAM' && targetId) {
@@ -544,7 +575,7 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
           assignee: { disconnect: true },
         },
       });
-      return;
+      return true;
     }
 
     if (targetUserIds.length > 0) {
@@ -556,7 +587,13 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
         },
       });
     }
+
+    return true;
   });
+
+  if (!assignmentGenerationIsCurrent) {
+    return supersededEscalationResult();
+  }
 
   if (targetUserIds.length === 0) {
     const errorMessage = `Escalation step ${currentStepIndex + 1} (${step.targetType}: ${targetName}) resolved to no users.`;
@@ -624,14 +661,15 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
     try {
       const latestState = await prisma.incident.findUnique({
         where: { id: incidentId },
-        select: { status: true, escalationStatus: true },
+        select: { status: true, escalationStatus: true, escalationProcessingAt: true },
       });
       if (
         !latestState ||
         !['OPEN'].includes(latestState.status) ||
-        latestState.escalationStatus === 'COMPLETED'
+        latestState.escalationStatus === 'COMPLETED' ||
+        escalationWorkerInvalidated(latestState.escalationProcessingAt, workerToken)
       ) {
-        break;
+        return supersededEscalationResult();
       }
       const message = `[OpsKnight] Incident: ${incident.title}${currentStepIndex > 0 ? ` (Escalation Level ${currentStepIndex + 1})` : ''}`;
       const result = await sendUserNotification(incidentId, userId, message, escalationChannels);
@@ -677,24 +715,38 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
 
   let shouldScheduleNextJob = Boolean(nextStep && nextEscalationAt);
 
-  await runSerializableTransaction(async tx => {
+  const finalGenerationIsCurrent = await runSerializableTransaction(async tx => {
     // Check current state from database to avoid race conditions
     const currentIncident = await tx.incident.findUnique({
       where: { id: incidentId },
-      select: { assigneeId: true, teamId: true, status: true, escalationStatus: true },
+      select: {
+        assigneeId: true,
+        teamId: true,
+        status: true,
+        escalationStatus: true,
+        escalationProcessingAt: true,
+      },
     });
+
+    if (
+      !currentIncident ||
+      escalationWorkerInvalidated(currentIncident.escalationProcessingAt, workerToken)
+    ) {
+      shouldScheduleNextJob = false;
+      return false;
+    }
 
     // Race condition guard: If the incident was acknowledged, resolved, snoozed, or suppressed while notifications
     // were being dispatched, do NOT schedule further escalation steps or overwrite to ESCALATING.
     const isStopped =
-      currentIncident?.status === 'ACKNOWLEDGED' ||
-      currentIncident?.status === 'RESOLVED' ||
-      currentIncident?.escalationStatus === 'COMPLETED';
+      currentIncident.status === 'ACKNOWLEDGED' ||
+      currentIncident.status === 'RESOLVED' ||
+      currentIncident.escalationStatus === 'COMPLETED';
 
     const isPaused =
-      currentIncident?.status === 'SNOOZED' ||
-      currentIncident?.status === 'SUPPRESSED' ||
-      currentIncident?.escalationStatus === 'PAUSED';
+      currentIncident.status === 'SNOOZED' ||
+      currentIncident.status === 'SUPPRESSED' ||
+      currentIncident.escalationStatus === 'PAUSED';
 
     const finalEscalationStatus = isStopped ? 'COMPLETED' : isPaused ? 'PAUSED' : escalationStatus;
 
@@ -715,7 +767,7 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
 
     // Assign based on target type
     // Only assign if the incident doesn't already have an assignee or team
-    if (!currentIncident?.assigneeId && !currentIncident?.teamId && targetUserIds.length > 0) {
+    if (!currentIncident.assigneeId && !currentIncident.teamId && targetUserIds.length > 0) {
       if (step.targetType === 'TEAM' && targetId) {
         // Assign to team
         updateData.team = { connect: { id: targetId } };
@@ -760,7 +812,13 @@ export async function executeEscalation(incidentId: string, stepIndex?: number) 
         },
       });
     }
+
+    return true;
   });
+
+  if (!finalGenerationIsCurrent) {
+    return supersededEscalationResult();
+  }
 
   // Schedule next escalation step using PostgreSQL job queue
   if (shouldScheduleNextJob && nextStep && nextEscalationAt) {
@@ -875,11 +933,12 @@ export async function processPendingEscalations(
             reason.includes('no escalation policy') ||
             reason.includes('no users to notify') ||
             reason.includes('invalid target') ||
-            reason.includes('step not found');
+            reason.includes('step not found') ||
+            reason.includes('superseded by lifecycle transition');
 
-          // executeEscalation persists terminal states itself (including FAILED).
-          // Do not reinterpret those human-readable reasons here and overwrite
-          // the state that the executor just committed.
+          // executeEscalation persists terminal states itself (including FAILED),
+          // or intentionally no-ops when a newer lifecycle generation supersedes
+          // the worker. Do not overwrite either authoritative state here.
           if (stateAlreadyHandled) continue;
 
           await prisma.incident.update({

--- a/src/lib/incidents/lifecycle.ts
+++ b/src/lib/incidents/lifecycle.ts
@@ -356,6 +356,10 @@ function updateDataForCommand(
 ): Prisma.IncidentUpdateInput {
   const data: Prisma.IncidentUpdateInput = {
     status: targetStatusFor(input.command),
+    // Any real lifecycle transition invalidates a worker that claimed the
+    // previous escalation generation. The worker re-checks this lock token
+    // before assignment, notification delivery, and final state mutation.
+    escalationProcessingAt: null,
   };
 
   switch (input.command) {

--- a/tests/lib/escalation-generation.test.ts
+++ b/tests/lib/escalation-generation.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const NOW = new Date('2026-08-28T13:30:00.000Z');
+const OLD_DUE_AT = new Date('2026-08-28T13:29:00.000Z');
+
+const mocks = vi.hoisted(() => ({
+  runSerializableTransaction: vi.fn(),
+  sendUserNotification: vi.fn(),
+  scheduleEscalation: vi.fn(),
+  txIncidentUpdate: vi.fn(),
+  txIncidentEventCreate: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    incident: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    incidentEvent: {
+      create: vi.fn(),
+      count: vi.fn(),
+    },
+    team: {
+      findUnique: vi.fn(),
+    },
+    onCallSchedule: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/db-utils', () => ({
+  runSerializableTransaction: mocks.runSerializableTransaction,
+}));
+
+vi.mock('@/lib/user-notifications', () => ({
+  sendUserNotification: mocks.sendUserNotification,
+}));
+
+vi.mock('@/lib/jobs/queue', () => ({
+  scheduleEscalation: mocks.scheduleEscalation,
+}));
+
+import prisma from '@/lib/prisma';
+import { executeEscalation } from '@/lib/escalation';
+
+function incidentAtStart() {
+  return {
+    id: 'inc-generation',
+    title: 'Database latency',
+    status: 'OPEN',
+    acknowledgedAt: null,
+    assigneeId: null,
+    currentEscalationStep: 0,
+    escalationStatus: 'ESCALATING',
+    nextEscalationAt: OLD_DUE_AT,
+    service: {
+      policy: {
+        steps: [
+          {
+            delayMinutes: 0,
+            targetType: 'USER',
+            targetUserId: 'user-1',
+            targetTeamId: null,
+            targetScheduleId: null,
+            targetUser: { name: 'Primary responder' },
+            targetTeam: null,
+            targetSchedule: null,
+            notificationChannels: [],
+            notifyOnlyTeamLead: false,
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe('escalation lifecycle generation fencing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+
+    mocks.runSerializableTransaction.mockImplementation(async callback =>
+      callback({
+        incident: {
+          findUnique: vi.fn().mockResolvedValue({
+            assigneeId: null,
+            teamId: null,
+            escalationProcessingAt: NOW,
+          }),
+          update: mocks.txIncidentUpdate,
+        },
+        incidentEvent: {
+          create: mocks.txIncidentEventCreate,
+        },
+      })
+    );
+    mocks.sendUserNotification.mockResolvedValue({ success: true });
+    mocks.scheduleEscalation.mockResolvedValue('job-next');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stops an already-processing old worker after resolve and reopen invalidate its token', async () => {
+    vi.mocked(prisma.incident.findUnique)
+      .mockResolvedValueOnce(incidentAtStart() as never)
+      // The old worker already claimed at NOW. A lifecycle transition clears
+      // escalationProcessingAt; REOPEN may make the incident OPEN/ESCALATING
+      // again, but the cleared token proves this is a new lifecycle generation.
+      .mockResolvedValueOnce({
+        status: 'OPEN',
+        escalationStatus: 'ESCALATING',
+        escalationProcessingAt: null,
+      } as never);
+    vi.mocked(prisma.incident.updateMany).mockResolvedValueOnce({ count: 1 } as never);
+
+    const result = await executeEscalation('inc-generation', 0);
+
+    expect(result).toEqual({
+      escalated: false,
+      reason: 'Escalation superseded by lifecycle transition',
+    });
+    expect(mocks.sendUserNotification).not.toHaveBeenCalled();
+    expect(mocks.scheduleEscalation).not.toHaveBeenCalled();
+    // Only the pre-notification assignment transaction ran. The stale worker
+    // never reached its final lifecycle mutation transaction.
+    expect(mocks.runSerializableTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues normally while the worker still owns its claim token', async () => {
+    vi.mocked(prisma.incident.findUnique)
+      .mockResolvedValueOnce(incidentAtStart() as never)
+      .mockResolvedValueOnce({
+        status: 'OPEN',
+        escalationStatus: 'ESCALATING',
+        escalationProcessingAt: NOW,
+      } as never);
+    vi.mocked(prisma.incident.updateMany).mockResolvedValueOnce({ count: 1 } as never);
+
+    const result = await executeEscalation('inc-generation', 0);
+
+    expect(result).toMatchObject({
+      escalated: true,
+      stepIndex: 0,
+      targetCount: 1,
+    });
+    expect(mocks.sendUserNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.runSerializableTransaction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -577,6 +577,7 @@ describe('Notification System Tests', () => {
       vi.mocked(prisma.incident.findUnique).mockResolvedValue({
         id: incidentId,
         title: 'Test Incident',
+        status: 'OPEN',
         currentEscalationStep: 0,
         escalationStatus: 'ESCALATING',
         service: {


### PR DESCRIPTION
## Summary

Closes the remaining resolve → reopen escalation race after lifecycle centralization.

### Fix
- Treat `escalationProcessingAt` as the worker-generation token already owned by the atomic escalation claim.
- Every real lifecycle transition clears that token in the same transaction as the incident status change.
- A processing escalation re-validates its token before assignment, before every responder notification, and before its final state mutation / next-step scheduling.
- A worker whose token was cleared by ACK/RESOLVE/SNOOZE/SUPPRESS/REOPEN or replaced by a timeout reclaim exits as a successful stale no-op instead of paging or overwriting the newer lifecycle generation.
- The periodic escalation sweep treats this superseded outcome as authoritative and does not recreate stale work.

### Race covered

`old escalation PROCESSING → RESOLVE → REOPEN → old worker continues`

The old worker now sends zero responder pages and schedules zero follow-up escalation jobs. A worker whose claim token still matches continues normally.

### Architecture

No new database column or queue infrastructure is required. This reuses the existing per-incident escalation lock as a generation fence and keeps the lifecycle engine as the single owner of transition invalidation.

### Tests
- stale processing generation is stopped after resolve/reopen
- current generation still pages normally

Exactly one commit. Based on the latest `main` including #444.