### PR TITLE
fix(dashboard): whitelist retained date query fields

### DIFF
--- a/src/lib/dashboard-utils.ts
+++ b/src/lib/dashboard-utils.ts
@@ -110,7 +110,12 @@ export function buildIncidentWhere(
   const dateFilter =
     options.dateFilter ?? buildDateFilter(filters.range, filters.customStart, filters.customEnd);
 
-  const where: Prisma.IncidentWhereInput = { ...dateFilter };
+  // Copy only the Prisma field we explicitly support. TypeScript permits values
+  // with additional properties to satisfy IncidentDateWhere, so spreading the
+  // caller object would let retention metadata leak back into a Prisma query.
+  const where: Prisma.IncidentWhereInput = dateFilter.createdAt
+    ? { createdAt: dateFilter.createdAt }
+    : {};
 
   if (includeStatus && filters.status && filters.status !== 'ALL') {
     where.status =

--- a/tests/architecture/dashboard-date-filter-boundary.test.ts
+++ b/tests/architecture/dashboard-date-filter-boundary.test.ts
@@ -8,6 +8,7 @@ describe('dashboard retained date-filter boundary', () => {
     expect(source).toContain('where: IncidentDateWhere');
     expect(source).toContain('window: {');
     expect(source).not.toMatch(/return\s*{\s*createdAt:[\s\S]{0,160}isClipped:/);
+    expect(source).not.toContain('{ ...dateFilter }');
   });
 
   it('passes only the nested Prisma filter into buildIncidentWhere', () => {

--- a/tests/unit/dashboard-utils.test.ts
+++ b/tests/unit/dashboard-utils.test.ts
@@ -71,6 +71,18 @@ describe('dashboard-utils', () => {
       expect(where.status).toEqual({ in: ['OPEN', 'ACKNOWLEDGED'] });
       expect(where.urgency).toBe('HIGH');
     });
+
+    it('copies only supported Prisma fields from caller-supplied date filters', () => {
+      const unsafeFilter = {
+        createdAt: { gte: new Date('2026-08-01T00:00:00.000Z') },
+        isClipped: true,
+      };
+
+      const where = buildIncidentWhere({}, { dateFilter: unsafeFilter });
+
+      expect(where).toEqual({ createdAt: unsafeFilter.createdAt });
+      expect(where).not.toHaveProperty('isClipped');
+    });
   });
 
   describe('buildDateFilter', () => {


### PR DESCRIPTION
## Why
Bugbot found that TypeScript structural typing still allows an object with extra metadata fields to satisfy the narrowed date-filter type. Spreading that value could therefore reintroduce the same Prisma crash class fixed in #444.

## Fix
- construct `IncidentWhereInput` from the explicit `createdAt` field instead of spreading caller input
- add a regression test proving extra `isClipped` metadata is discarded
- add an architecture guard against spreading `dateFilter` at this boundary

## Validation
- targeted tests: 29 passed
- targeted ESLint: passed
- TypeScript: passed
- Security Review: no findings