### PR TITLE
fix(api): preserve reports metrics response shape

### DIFF
--- a/src/app/api/reports/metrics/route.ts
+++ b/src/app/api/reports/metrics/route.ts
@@ -98,27 +98,28 @@ export async function GET(request: NextRequest) {
     // Serialize dates for JSON response
     const serialized = serializeSlaMetrics(metrics);
 
-    return jsonOk({
-      success: true,
-      data: serialized,
-      meta: {
-        dataState: 'available',
-        calculatedAt: new Date().toISOString(),
-        source: (metrics as { dataSource?: string }).dataSource || 'live',
-        scope: {
-          backlog: 'current',
-          analysis: 'selected_period',
-        },
+    const meta = {
+      dataState: 'available',
+      calculatedAt: new Date().toISOString(),
+      source: (metrics as { dataSource?: string }).dataSource || 'live',
+      scope: {
+        backlog: 'current',
+        analysis: 'selected_period',
       },
-      filters: {
-        windowDays,
-        teamId,
-        serviceId,
-        assigneeId,
-        urgency,
-        status,
-      },
-    });
+    };
+    const filters = {
+      windowDays,
+      teamId,
+      serviceId,
+      assigneeId,
+      urgency,
+      status,
+    };
+
+    // Keep the legacy `data: metrics`, `meta`, and `filters` shape while the
+    // shared helper adds canonical request metadata. Passing an already-wrapped
+    // payload to jsonOk would otherwise turn this into `data.data`.
+    return jsonOk(serialized, 200, undefined, { meta, filters });
   } catch (error) {
     logger.error('api.reports.metrics.error', {
       error: error instanceof Error ? error.message : String(error),

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -212,12 +212,18 @@ export function jsonError(
   );
 }
 
-export function jsonOk<T>(payload: T, status: number = 200, headers?: HeadersInit) {
+export function jsonOk<T>(
+  payload: T,
+  status: number = 200,
+  headers?: HeadersInit,
+  legacyAliases?: Record<string, unknown>
+) {
   const context = createApiResponseContext();
   const aliases =
-    payload !== null && typeof payload === 'object' && !Array.isArray(payload)
+    legacyAliases ??
+    (payload !== null && typeof payload === 'object' && !Array.isArray(payload)
       ? (payload as Record<string, unknown>)
-      : {};
+      : {});
   const body: ApiSuccessEnvelope<T> & Record<string, unknown> = {
     ...aliases,
     success: true,

--- a/tests/api/reports-metrics-response.test.ts
+++ b/tests/api/reports-metrics-response.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/reports/metrics/route';
+
+const mocks = vi.hoisted(() => ({
+  calculateSLAMetrics: vi.fn(),
+  serializeSlaMetrics: vi.fn(),
+}));
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn().mockResolvedValue({ user: { email: 'admin@example.com' } }),
+}));
+vi.mock('@/lib/auth', () => ({ getAuthOptions: vi.fn().mockResolvedValue({}) }));
+vi.mock('@/lib/rbac', () => ({
+  assertCanReadServiceMetrics: vi.fn().mockResolvedValue({ role: 'ADMIN' }),
+}));
+vi.mock('@/lib/authorization', () => ({
+  CAPABILITIES: { INCIDENT_SENSITIVE_READ: 'incident.sensitive.read' },
+  hasCapability: vi.fn().mockReturnValue(true),
+}));
+vi.mock('@/lib/sla-server', () => ({ calculateSLAMetrics: mocks.calculateSLAMetrics }));
+vi.mock('@/lib/sla', () => ({ serializeSlaMetrics: mocks.serializeSlaMetrics }));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+describe('GET /api/reports/metrics response contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.calculateSLAMetrics.mockResolvedValue({ dataSource: 'live' });
+    mocks.serializeSlaMetrics.mockReturnValue({ mtta: 12, mttr: 34 });
+  });
+
+  it('keeps metrics directly under data while adding canonical response metadata', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost/api/reports/metrics?window=7&serviceId=svc-1')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual({ mtta: 12, mttr: 34 });
+    expect(body.data.data).toBeUndefined();
+    expect(body.meta).toMatchObject({ dataState: 'available', source: 'live' });
+    expect(body.filters).toMatchObject({ windowDays: 7, serviceId: 'svc-1' });
+    expect(body).toMatchObject({ success: true, dataState: 'available' });
+    expect(body.requestId).toBeTypeOf('string');
+    expect(body.timestamp).toBeTypeOf('string');
+  });
+});

--- a/tests/lib/api-response.test.ts
+++ b/tests/lib/api-response.test.ts
@@ -160,6 +160,19 @@ describe('API Response Utilities', () => {
 
       expect(response.headers.get('Cache-Control')).toBe('public, max-age=60');
     });
+
+    it('can preserve selected legacy top-level aliases without nesting an existing envelope', async () => {
+      const metrics = { mtta: 12, mttr: 34 };
+      const meta = { source: 'live' };
+      const response = jsonOk(metrics, 200, undefined, { meta });
+
+      await expect(response.json()).resolves.toMatchObject({
+        success: true,
+        data: metrics,
+        dataState: 'available',
+        meta,
+      });
+    });
   });
 
   describe('jsonError', () => {


### PR DESCRIPTION
## Root cause
The API-contract migration passed an already-enveloped `{ success, data, meta, filters }` object to `jsonOk`. Because `jsonOk` creates its own canonical `data` field, metrics moved from `body.data` to `body.data.data`, breaking existing report consumers.

## Fix
- let legacy `jsonOk` callers provide explicit top-level compatibility aliases
- pass serialized metrics as the canonical payload
- preserve the existing top-level `meta` and `filters` fields without double wrapping
- add helper-level and route-level regression coverage

## Validation
- API/architecture tests: 26 passed
- targeted ESLint: passed
- TypeScript: passed