### PR TITLE
fix(notifications): avoid deduping permanent failures

### DIFF
--- a/src/app/api/webhooks/notifications/twilio/route.ts
+++ b/src/app/api/webhooks/notifications/twilio/route.ts
@@ -62,6 +62,7 @@ export async function POST(request: NextRequest) {
         userId: true,
         channel: true,
         message: true,
+        eventType: true,
       },
     });
 
@@ -102,6 +103,7 @@ export async function POST(request: NextRequest) {
               message: notification.message || 'Incident notification delivery failed',
               failedChannel: notification.channel,
               sourceNotificationId: notification.id,
+              eventType: notification.eventType,
             },
           },
         });

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -350,8 +350,15 @@ async function processChannelNotifications(
             throw new Error(result.error || `${n.channel} notification delivery failed`);
           }
 
-          // A failed attempt must not suppress a later enqueue of the same
-          // notification. Record the dedupe key only after confirmed delivery.
+          // Permanent failures are terminal for this attempt, but they are not
+          // successful deliveries and must not poison the in-memory dedupe
+          // cache. A configuration fix (for example, adding a webhook URL)
+          // should allow the same notification to be enqueued immediately.
+          if (!result.success && result.terminal && !result.skipped) {
+            return { notification: n, result, terminalFailure: true };
+          }
+
+          // Record dedupe only after confirmed delivery or an intentional skip.
           processedDedupeKeys.set(n.dedupeKey, Date.now());
 
           // Clean old dedupe keys periodically (keep last 10 minutes)
@@ -374,8 +381,23 @@ async function processChannelNotifications(
     state.processing -= toProcess.length;
 
     // Log batch results
-    const succeeded = results.filter(r => r.status === 'fulfilled').length;
-    const failed = results.filter(r => r.status === 'rejected').length;
+    const succeeded = results.filter(
+      r => r.status === 'fulfilled' && !r.value.terminalFailure
+    ).length;
+    const terminalFailures = results.filter(
+      r => r.status === 'fulfilled' && r.value.terminalFailure
+    );
+    const failed = results.filter(r => r.status === 'rejected').length + terminalFailures.length;
+
+    for (const failure of terminalFailures) {
+      if (failure.status !== 'fulfilled') continue;
+      logger.error('[NotificationQueue] Notification permanently failed', {
+        incidentId: failure.value.notification.incidentId,
+        userId: failure.value.notification.userId,
+        channel: failure.value.notification.channel,
+        error: failure.value.result.error,
+      });
+    }
 
     for (const result of results) {
       if (result.status === 'rejected') {

--- a/tests/api/twilio-delivery-webhook.test.ts
+++ b/tests/api/twilio-delivery-webhook.test.ts
@@ -2,10 +2,19 @@ import { createHmac } from 'crypto';
 import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { findFirst, update } = vi.hoisted(() => ({ findFirst: vi.fn(), update: vi.fn() }));
+const { findFirst, update, updateMany, backgroundJobCreate, transaction } = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+  backgroundJobCreate: vi.fn(),
+  transaction: vi.fn(),
+}));
 
 vi.mock('@/lib/prisma', () => ({
-  default: { notification: { findFirst, update } },
+  default: {
+    notification: { findFirst, update },
+    $transaction: transaction,
+  },
 }));
 
 vi.mock('@/lib/notification-providers', () => ({
@@ -46,8 +55,17 @@ describe('Twilio delivery receipt webhook', () => {
       userId: 'user-1',
       channel: 'SMS',
       message: 'message',
+      eventType: 'resolved',
     });
     update.mockResolvedValue({ id: 'notif-1' });
+    updateMany.mockResolvedValue({ count: 1 });
+    backgroundJobCreate.mockResolvedValue({ id: 'job-1' });
+    transaction.mockImplementation(async callback =>
+      callback({
+        notification: { updateMany },
+        backgroundJob: { create: backgroundJobCreate },
+      })
+    );
   });
 
   it('verifies the callback and records delivered messages', async () => {
@@ -75,5 +93,22 @@ describe('Twilio delivery receipt webhook', () => {
 
     expect(response.status).toBe(401);
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('preserves notification intent when scheduling a failed-delivery fallback', async () => {
+    const response = await POST(
+      signedRequest('MessageSid=SM123&MessageStatus=undelivered&ErrorCode=30003')
+    );
+
+    expect(response.status).toBe(204);
+    expect(backgroundJobCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        type: 'NOTIFICATION',
+        payload: expect.objectContaining({
+          sourceNotificationId: 'notif-1',
+          eventType: 'resolved',
+        }),
+      }),
+    });
   });
 });

--- a/tests/lib/notification-queue-reliability.test.ts
+++ b/tests/lib/notification-queue-reliability.test.ts
@@ -75,4 +75,18 @@ describe('notification queue delivery reliability', () => {
       'acknowledged'
     );
   });
+
+  it('does not deduplicate a permanent failure after its configuration is corrected', async () => {
+    sendNotification.mockResolvedValue({
+      success: false,
+      terminal: true,
+      error: 'No webhook URL configured for service',
+    });
+    queueNotification('incident-4', 'user-4', 'WEBHOOK', 'Incident opened');
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(queueNotification('incident-4', 'user-4', 'WEBHOOK', 'Incident opened')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Root causes
1. The in-memory queue stopped retrying permanent failures but then cached their dedupe key as if delivery succeeded. After configuration was corrected, the same notification could remain suppressed for ten minutes.
2. Twilio failed-delivery fallback jobs omitted the original notification event type, so acknowledged/resolved intent could fall back as triggered.

## Fix
- distinguish permanent terminal failures from delivered and intentionally skipped outcomes
- do not add permanent failures to the dedupe cache
- preserve no-retry behavior for terminal outcomes
- count and log permanent failures as failed batches
- propagate eventType from the original Twilio notification into fallback jobs
- add regression tests for immediate re-enqueue and fallback intent

## Validation
- notification/job/webhook suites: 21 passed, 5 skipped
- targeted ESLint: no errors (existing warnings unchanged)
- TypeScript: passed