### PR TITLE
fix(auth): scope dashboard data through policy filters

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -41,6 +41,13 @@ import {
 import { IncidentHeatmapWidget } from '@/components/dashboard/widgets/IncidentHeatmapWidget';
 import { IncidentStatus, IncidentUrgency } from '@prisma/client';
 import { buildIncidentListHref } from '@/lib/incident-links';
+import {
+  dashboardMetricsScope,
+  dashboardUserReadWhere,
+  incidentReadWhere,
+  serviceReadWhere,
+} from '@/lib/authorization-filters';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
 
 export const revalidate = 0;
 
@@ -102,11 +109,31 @@ export default async function Dashboard({
   const user = email
     ? await prisma.user.findUnique({
         where: { email },
-        select: { id: true, name: true, timeZone: true },
+        select: {
+          id: true,
+          name: true,
+          timeZone: true,
+          role: true,
+          status: true,
+          teamMemberships: { select: { teamId: true } },
+        },
       })
     : null;
   const userName = user?.name || 'there';
   const userTimeZone = user?.timeZone || 'UTC';
+  if (!user || user.status !== 'ACTIVE') {
+    throw new Error('Authenticated dashboard user is unavailable.');
+  }
+  const actor: AuthorizationActor = {
+    id: user.id,
+    role: user.role,
+    status: user.status,
+    teamIds: user.teamMemberships.map(membership => membership.teamId),
+  };
+  const incidentAccess = incidentReadWhere(actor);
+  const serviceAccess = serviceReadWhere(actor);
+  const userAccess = dashboardUserReadWhere(actor);
+  const metricsScope = dashboardMetricsScope(actor);
 
   // Build filters using utility functions
   const filterParams: DashboardFilterParams = {
@@ -122,7 +149,8 @@ export default async function Dashboard({
 
   // Main query where clause (includes status filter)
   const dateFilter = await buildRetainedDateFilter(range, customStart, customEnd);
-  const where = buildIncidentWhere(filterParams, { dateFilter: dateFilter.where });
+  const dashboardWhere = buildIncidentWhere(filterParams, { dateFilter: dateFilter.where });
+  const where = { AND: [incidentAccess, dashboardWhere] };
 
   // Date filter for SLA calculations
   const metricsStartDate = dateFilter.window.start;
@@ -178,6 +206,7 @@ export default async function Dashboard({
       take: DASHBOARD_RECENT_INCIDENTS_LIMIT,
     }),
     prisma.service.findMany({
+      where: serviceAccess,
       select: {
         id: true,
         name: true,
@@ -185,6 +214,7 @@ export default async function Dashboard({
       },
     }),
     prisma.user.findMany({
+      where: userAccess,
       select: {
         id: true,
         name: true,
@@ -208,6 +238,7 @@ export default async function Dashboard({
       includeIncidents: true,
       includeActiveIncidents: true,
       incidentLimit: 5,
+      ...metricsScope,
     }).catch(err => {
       console.error('Failed to load SLA metrics:', err);
       // Return safe default object matching return type
@@ -260,6 +291,7 @@ export default async function Dashboard({
             startDate: metricsStartDate,
             endDate: metricsEndDate,
             includeAllTime: range === 'all',
+            ...metricsScope,
           },
           slaMetrics
         ).catch(err => {

--- a/src/app/api/widgets/data/route.ts
+++ b/src/app/api/widgets/data/route.ts
@@ -6,6 +6,8 @@ import { logger } from '@/lib/logger';
 import { getWidgetData } from '@/lib/widget-data-provider';
 import prisma from '@/lib/prisma';
 import { buildRetainedDateFilter } from '@/lib/dashboard-utils';
+import { dashboardMetricsScope } from '@/lib/authorization-filters';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
 
 /**
  * Unified Widget Data API
@@ -23,12 +25,22 @@ export async function GET(req: NextRequest) {
       select: {
         id: true,
         role: true,
+        status: true,
+        teamMemberships: { select: { teamId: true } },
       },
     });
 
-    if (!user) {
-      return jsonError('User not found', 404);
+    if (!user || user.status !== 'ACTIVE') {
+      return jsonError('Unauthorized', 401);
     }
+
+    const actor: AuthorizationActor = {
+      id: user.id,
+      role: user.role,
+      status: user.status,
+      teamIds: user.teamMemberships.map(membership => membership.teamId),
+    };
+    const metricsScope = dashboardMetricsScope(actor);
 
     const searchParams = new URL(req.url).searchParams;
     const range = searchParams.get('range') || '30';
@@ -54,6 +66,7 @@ export async function GET(req: NextRequest) {
       startDate: dateFilter.window.start,
       endDate: dateFilter.window.end,
       includeAllTime: range === 'all',
+      ...metricsScope,
     });
 
     return jsonOk(widgetData, 200, {

--- a/src/app/api/widgets/stream/route.ts
+++ b/src/app/api/widgets/stream/route.ts
@@ -4,6 +4,8 @@ import { logger } from '@/lib/logger';
 import { getCachedWidgetData } from '@/lib/widget-data-cache';
 import prisma from '@/lib/prisma';
 import { buildRetainedDateFilter } from '@/lib/dashboard-utils';
+import { dashboardMetricsScope } from '@/lib/authorization-filters';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
 
 /**
  * Server-Sent Events (SSE) Stream for Real-time Widget Updates
@@ -21,12 +23,22 @@ export async function GET(request: Request) {
       select: {
         id: true,
         role: true,
+        status: true,
+        teamMemberships: { select: { teamId: true } },
       },
     });
 
-    if (!user) {
-      return new Response('User not found', { status: 404 });
+    if (!user || user.status !== 'ACTIVE') {
+      return new Response('Unauthorized', { status: 401 });
     }
+
+    const actor: AuthorizationActor = {
+      id: user.id,
+      role: user.role,
+      status: user.status,
+      teamIds: user.teamMemberships.map(membership => membership.teamId),
+    };
+    const metricsScope = dashboardMetricsScope(actor);
 
     const encoder = new TextEncoder();
     const searchParams = new URL(request.url).searchParams;
@@ -52,6 +64,7 @@ export async function GET(request: Request) {
       startDate: dateFilter.window.start,
       endDate: dateFilter.window.end,
       includeAllTime: range === 'all',
+      ...metricsScope,
     };
 
     let cleanup: () => void = () => {};

--- a/src/lib/authorization-filters.ts
+++ b/src/lib/authorization-filters.ts
@@ -44,3 +44,36 @@ export function serviceReadWhere(actor: AuthorizationActor): Prisma.ServiceWhere
   }
   return decision.scope === 'global' ? {} : { teamId: { in: [...actor.teamIds] } };
 }
+
+export function dashboardUserReadWhere(actor: AuthorizationActor): Prisma.UserWhereInput {
+  const incidentDecision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ });
+  if (!incidentDecision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Dashboard access denied.',
+      CAPABILITIES.INCIDENT_READ_SCOPED
+    );
+  }
+  if (incidentDecision.scope === 'global') return {};
+  return {
+    OR: [
+      { id: actor.id },
+      { teamMemberships: { some: { teamId: { in: [...actor.teamIds] } } } },
+    ],
+  };
+}
+
+export function dashboardMetricsScope(actor: AuthorizationActor): {
+  teamId?: string[];
+  useOrScope?: boolean;
+} {
+  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ });
+  if (!decision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Dashboard metrics access denied.',
+      CAPABILITIES.INCIDENT_READ_SCOPED
+    );
+  }
+  return decision.scope === 'global'
+    ? {}
+    : { teamId: [...actor.teamIds], useOrScope: true };
+}

--- a/src/lib/widget-data-provider.ts
+++ b/src/lib/widget-data-provider.ts
@@ -3,6 +3,7 @@ import { calculateSLAMetrics } from '@/lib/sla-server';
 import type { SLAMetricsFilter } from '@/lib/sla-server';
 import type { SLAMetrics as SLAServerMetrics } from '@/lib/sla';
 import { getActiveOnCallShifts } from '@/lib/oncall-shifts';
+import type { Prisma } from '@prisma/client';
 
 /**
  * Centralized Widget Data Provider
@@ -83,6 +84,32 @@ const OVERLOAD_THRESHOLD = 5;
 // SLA breach alert windows (in milliseconds)
 const ACK_BREACH_ALERT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 const RESOLVE_BREACH_ALERT_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+
+export function buildWidgetActivityIncidentWhere(
+  filters: SLAMetricsFilter
+): Prisma.IncidentWhereInput | undefined {
+  const activityScope: Prisma.IncidentWhereInput[] = [];
+  if (filters.serviceId) {
+    activityScope.push({
+      serviceId: Array.isArray(filters.serviceId) ? { in: filters.serviceId } : filters.serviceId,
+    });
+  }
+  if (filters.teamId) {
+    const teamIds = Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId];
+    activityScope.push(
+      filters.useOrScope
+        ? {
+            OR: [{ teamId: { in: teamIds } }, { service: { teamId: { in: teamIds } } }],
+          }
+        : { service: { teamId: { in: teamIds } } }
+    );
+  }
+  return activityScope.length === 0
+    ? undefined
+    : activityScope.length === 1
+      ? activityScope[0]
+      : { AND: activityScope };
+}
 
 /**
  * Determines trend direction based on current and previous values
@@ -234,38 +261,7 @@ export async function getWidgetData(
   }));
 
   // Recent activity from IncidentEvents (minimal query, sla-server doesn't include this)
-  const activityIncidentWhere = filters.serviceId
-    ? {
-        serviceId: Array.isArray(filters.serviceId)
-          ? { in: filters.serviceId }
-          : filters.serviceId,
-      }
-    : filters.teamId
-      ? filters.useOrScope
-        ? {
-            OR: [
-              {
-                teamId: {
-                  in: Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId],
-                },
-              },
-              {
-                service: {
-                  teamId: {
-                    in: Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId],
-                  },
-                },
-              },
-            ],
-          }
-        : {
-            service: {
-              teamId: {
-                in: Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId],
-              },
-            },
-          }
-      : undefined;
+  const activityIncidentWhere = buildWidgetActivityIncidentWhere(filters);
   const recentIncidentEvents = await prisma.incidentEvent.findMany({
     ...(activityIncidentWhere ? { where: { incident: activityIncidentWhere } } : {}),
     take: 10,

--- a/src/lib/widget-data-provider.ts
+++ b/src/lib/widget-data-provider.ts
@@ -234,7 +234,40 @@ export async function getWidgetData(
   }));
 
   // Recent activity from IncidentEvents (minimal query, sla-server doesn't include this)
+  const activityIncidentWhere = filters.serviceId
+    ? {
+        serviceId: Array.isArray(filters.serviceId)
+          ? { in: filters.serviceId }
+          : filters.serviceId,
+      }
+    : filters.teamId
+      ? filters.useOrScope
+        ? {
+            OR: [
+              {
+                teamId: {
+                  in: Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId],
+                },
+              },
+              {
+                service: {
+                  teamId: {
+                    in: Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId],
+                  },
+                },
+              },
+            ],
+          }
+        : {
+            service: {
+              teamId: {
+                in: Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId],
+              },
+            },
+          }
+      : undefined;
   const recentIncidentEvents = await prisma.incidentEvent.findMany({
+    ...(activityIncidentWhere ? { where: { incident: activityIncidentWhere } } : {}),
     take: 10,
     orderBy: { createdAt: 'desc' },
     select: {

--- a/tests/architecture/dashboard-authorization-contract.test.ts
+++ b/tests/architecture/dashboard-authorization-contract.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('dashboard authorization contract', () => {
+  it('routes dashboard pages and widget APIs through canonical authorization filters', () => {
+    const page = readFileSync('src/app/(app)/page.tsx', 'utf8');
+    const dataRoute = readFileSync('src/app/api/widgets/data/route.ts', 'utf8');
+    const streamRoute = readFileSync('src/app/api/widgets/stream/route.ts', 'utf8');
+
+    expect(page).toContain('incidentReadWhere(actor)');
+    expect(page).toContain('serviceReadWhere(actor)');
+    expect(page).toContain('dashboardUserReadWhere(actor)');
+    expect(page).toContain('dashboardMetricsScope(actor)');
+    expect(dataRoute).toContain('dashboardMetricsScope(actor)');
+    expect(streamRoute).toContain('dashboardMetricsScope(actor)');
+  });
+});

--- a/tests/lib/dashboard-authorization-filters.test.ts
+++ b/tests/lib/dashboard-authorization-filters.test.ts
@@ -4,6 +4,7 @@ import {
   dashboardUserReadWhere,
 } from '@/lib/authorization-filters';
 import type { AuthorizationActor } from '@/lib/authorization-policy';
+import { buildWidgetActivityIncidentWhere } from '@/lib/widget-data-provider';
 
 const user: AuthorizationActor = {
   id: 'user-1',
@@ -36,5 +37,25 @@ describe('dashboard authorization filters', () => {
 
     expect(dashboardMetricsScope(responder)).toEqual({});
     expect(dashboardUserReadWhere(responder)).toEqual({});
+  });
+
+  it('intersects a requested service with the caller team scope for widget activity', () => {
+    expect(
+      buildWidgetActivityIncidentWhere({
+        serviceId: 'service-outside-team',
+        teamId: ['team-1'],
+        useOrScope: true,
+      })
+    ).toEqual({
+      AND: [
+        { serviceId: 'service-outside-team' },
+        {
+          OR: [
+            { teamId: { in: ['team-1'] } },
+            { service: { teamId: { in: ['team-1'] } } },
+          ],
+        },
+      ],
+    });
   });
 });

--- a/tests/lib/dashboard-authorization-filters.test.ts
+++ b/tests/lib/dashboard-authorization-filters.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dashboardMetricsScope,
+  dashboardUserReadWhere,
+} from '@/lib/authorization-filters';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
+
+const user: AuthorizationActor = {
+  id: 'user-1',
+  role: 'USER',
+  status: 'ACTIVE',
+  teamIds: ['team-1'],
+};
+
+describe('dashboard authorization filters', () => {
+  it('limits regular-user metric calculations to their teams', () => {
+    expect(dashboardMetricsScope(user)).toEqual({ teamId: ['team-1'], useOrScope: true });
+  });
+
+  it('limits the dashboard user picker to self and teammates', () => {
+    expect(dashboardUserReadWhere(user)).toEqual({
+      OR: [
+        { id: 'user-1' },
+        { teamMemberships: { some: { teamId: { in: ['team-1'] } } } },
+      ],
+    });
+  });
+
+  it('preserves organization-wide dashboard visibility for responders', () => {
+    const responder: AuthorizationActor = {
+      id: 'responder-1',
+      role: 'RESPONDER',
+      status: 'ACTIVE',
+      teamIds: [],
+    };
+
+    expect(dashboardMetricsScope(responder)).toEqual({});
+    expect(dashboardUserReadWhere(responder)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Root cause
The dashboard page and widget APIs authenticated users but did not apply the centralized resource-visibility policy. A regular USER could therefore receive organization-wide incident, service, user, metric, and recent-activity data. Invited users were also accepted by widget endpoints.

## Fix
- route incident, service, user-picker, and metric scopes through centralized authorization helpers
- apply team scope to dashboard SLA and widget calculations for regular users
- intersect user-selected services with team scope for widget recent activity
- reject non-active widget users
- preserve global dashboard visibility for Admin, Responder, and Auditor roles
- add policy and architecture regression tests

## Validation
- complete unit suite: 212 files, 1,547 passed, 4 skipped
- focused dashboard/auth/cache/search suites: 39 passed
- TypeScript: passed
- targeted ESLint: no errors (2 pre-existing warnings in widget-data-provider)