### PR TITLE
fix(schedules): harden assignment and coverage invariants

### DIFF
--- a/src/app/(app)/schedules/[id]/page.tsx
+++ b/src/app/(app)/schedules/[id]/page.tsx
@@ -60,7 +60,6 @@ import {
 } from 'lucide-react';
 import { getDefaultAvatar } from '@/lib/avatar';
 
-// Revalidate every 30 seconds to ensure current coverage is up-to-date
 export const revalidate = 0;
 
 export default async function ScheduleDetailPage({
@@ -72,58 +71,97 @@ export default async function ScheduleDetailPage({
 }) {
   const { id } = await params;
   const awaitedSearchParams = await searchParams;
-  // Use current time - this will be recalculated on each page load/refresh
   const now = new Date();
   const calendarRangeStart = new Date(now.getTime() - 35 * 86400000);
   const calendarRangeEnd = new Date(now.getTime() + 65 * 86400000);
   const historyPageSize = 8;
   const historyPage = Math.max(1, Number(awaitedSearchParams?.history ?? 1) || 1);
 
-  const [schedule, users, overridesInRange, upcomingOverrides, historyCount, historyOverrides] =
-    await Promise.all([
-      prisma.onCallSchedule.findUnique({
-        where: { id },
+  // Authorize before loading schedule details or the responder directory.
+  // This keeps the server-component payload scoped to data the viewer may see.
+  try {
+    await assertCanViewSchedule(id);
+  } catch {
+    notFound();
+  }
+
+  const permissions = await getUserPermissions();
+  const canManageSchedules = permissions.isAdminOrResponder;
+
+  const schedule = await prisma.onCallSchedule.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      timeZone: true,
+      layers: {
         select: {
           id: true,
           name: true,
-          timeZone: true,
-          layers: {
+          start: true,
+          end: true,
+          rotationLengthHours: true,
+          shiftLengthHours: true,
+          restrictions: true,
+          priority: true,
+          users: {
+            where: {
+              user: { status: 'ACTIVE' },
+            },
+            select: {
+              userId: true,
+              position: true,
+              user: {
+                select: { name: true, avatarUrl: true, gender: true },
+              },
+            },
+            orderBy: [{ position: 'asc' }, { id: 'asc' }],
+          },
+        },
+        orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
+      },
+    },
+  });
+
+  if (!schedule) notFound();
+
+  // Coverage extends farther than the monthly calendar. Query overrides for
+  // the union of every consumer window so future coverage never omits a valid
+  // override merely because it sits outside the calendar's fetch horizon.
+  const todayKey = formatDateKeyInTimeZone(now, schedule.timeZone);
+  const coverageRangeStart = startOfDayFromDateKey(
+    addDaysToDateKey(todayKey, -1),
+    schedule.timeZone
+  );
+  const coverageRangeEnd = startOfDayFromDateKey(addDaysToDateKey(todayKey, 90), schedule.timeZone);
+  const overrideRangeStart = new Date(
+    Math.min(calendarRangeStart.getTime(), coverageRangeStart.getTime())
+  );
+  const overrideRangeEnd = new Date(
+    Math.max(calendarRangeEnd.getTime(), coverageRangeEnd.getTime())
+  );
+
+  const [users, overridesInRange, upcomingOverrides, historyCount, historyOverrides] =
+    await Promise.all([
+      canManageSchedules
+        ? prisma.user.findMany({
+            where: { status: 'ACTIVE' },
             select: {
               id: true,
               name: true,
-              start: true,
-              end: true,
-              rotationLengthHours: true,
-              shiftLengthHours: true,
-              restrictions: true,
-              priority: true,
-              users: {
-                where: {
-                  user: { status: 'ACTIVE' },
-                },
-                select: {
-                  userId: true,
-                  position: true,
-                  user: {
-                    select: { name: true, avatarUrl: true, gender: true },
-                  },
-                },
-                orderBy: { position: 'asc' },
-              },
+              email: true,
+              role: true,
+              avatarUrl: true,
+              gender: true,
             },
-            orderBy: { createdAt: 'asc' },
-          },
-        },
-      }),
-      prisma.user.findMany({
-        select: { id: true, name: true, avatarUrl: true, gender: true },
-        orderBy: { name: 'asc' },
-      }),
+            orderBy: [{ name: 'asc' }, { email: 'asc' }],
+          })
+        : Promise.resolve([]),
       prisma.onCallOverride.findMany({
         where: {
           scheduleId: id,
-          start: { lt: calendarRangeEnd },
-          end: { gt: calendarRangeStart },
+          start: { lt: overrideRangeEnd },
+          end: { gt: overrideRangeStart },
           user: { status: 'ACTIVE' },
         },
         select: {
@@ -174,28 +212,12 @@ export default async function ScheduleDetailPage({
       }),
     ]);
 
-  if (!schedule) notFound();
-
-  try {
-    await assertCanViewSchedule(schedule.id);
-  } catch {
-    notFound();
-  }
-
-  const permissions = await getUserPermissions();
-  const canManageSchedules = permissions.isAdminOrResponder;
-
-  // Timezone-aware coverage windows
-  const todayKey = formatDateKeyInTimeZone(now, schedule.timeZone);
-  const coverageRangeStart = startOfDayFromDateKey(
-    addDaysToDateKey(todayKey, -1),
-    schedule.timeZone
+  const assignedUserIds = new Set(
+    schedule.layers.flatMap(layer => layer.users.map(member => member.userId))
   );
-  const coverageRangeEnd = startOfDayFromDateKey(addDaysToDateKey(todayKey, 90), schedule.timeZone);
+  const assignableUsers = users.filter(user => !assignedUserIds.has(user.id));
+  const layerPriorities = new Map(schedule.layers.map(layer => [layer.id, layer.priority ?? 0]));
 
-  const layerPriorities = new Map(schedule.layers.map(l => [l.id, l.priority ?? 0]));
-
-  // Cast layers with proper restrictions type
   const typedLayers = schedule.layers.map(layer => ({
     ...layer,
     restrictions: layer.restrictions as {
@@ -217,6 +239,9 @@ export default async function ScheduleDetailPage({
     start: block.start.toISOString(),
     end: block.end.toISOString(),
     label: `${block.layerName}: ${block.userName}${block.source === 'override' ? ' (Override)' : ''}`,
+    layerId: block.layerId,
+    userId: block.userId,
+    source: block.source,
     user: {
       name: block.userName,
       avatarUrl: block.userAvatar,
@@ -232,7 +257,6 @@ export default async function ScheduleDetailPage({
     schedule.timeZone
   );
   const finalCoverageBlocks = getFinalScheduleBlocks(coverageBlocks, layerPriorities);
-  // Filter for blocks that are currently active (start <= now < end)
   const nowTime = now.getTime();
   const activeBlocks = finalCoverageBlocks.filter(block => {
     const blockStartTime = block.start.getTime();
@@ -268,7 +292,6 @@ export default async function ScheduleDetailPage({
 
   return (
     <div className="w-full px-4 py-6 space-y-6 [zoom:0.8]">
-      {/* Header with Stats - Matching Teams/Users Pattern */}
       <div className="relative overflow-hidden rounded-2xl border border-primary/20 bg-gradient-to-r from-primary via-primary/90 to-primary/75 text-primary-foreground shadow-lg">
         <div className="absolute inset-0 bg-[radial-gradient(120%_120%_at_0%_0%,rgba(255,255,255,0.25),transparent_55%)]" />
         <div className="relative p-5 md:p-7">
@@ -374,11 +397,8 @@ export default async function ScheduleDetailPage({
 
       <ScheduleTimezoneNotice scheduleTimeZone={schedule.timeZone} />
 
-      {/* Main Grid - 4 columns like teams page */}
       <div className="grid grid-cols-1 xl:grid-cols-4 gap-4 md:gap-6">
-        {/* Main Content - 3 columns */}
         <div className="xl:col-span-3 space-y-4 md:space-y-6">
-          {/* Today's Coverage */}
           <Card className="overflow-hidden border-slate-200/80">
             <CardHeader className="flex flex-col gap-2 border-b border-slate-100 bg-slate-50/70 md:flex-row md:items-center md:justify-between">
               <div>
@@ -416,7 +436,6 @@ export default async function ScheduleDetailPage({
             </CardContent>
           </Card>
 
-          {/* Schedule Timeline - 7/14 Days (has built-in header) */}
           <ScheduleTimeline
             shifts={scheduleBlocks.map(block => ({
               id: block.id,
@@ -434,13 +453,10 @@ export default async function ScheduleDetailPage({
             layerPriorities={layerPriorities}
           />
 
-          {/* Monthly Calendar (has built-in header) */}
           <ScheduleCalendar shifts={calendarShifts} timeZone={schedule.timeZone} />
         </div>
 
-        {/* Sidebar - 1 column */}
         <div className="space-y-4 md:space-y-6">
-          {/* Current On-Call - has its own Card with gradient styling */}
           <CurrentCoverageDisplay
             key={`coverage-${schedule.id}-${schedule.layers.map(l => `${l.id}-${l.start.getTime()}-${l.end?.getTime() || 'null'}`).join('-')}`}
             initialBlocks={activeBlocks.map(block => ({
@@ -455,17 +471,15 @@ export default async function ScheduleDetailPage({
             scheduleTimeZone={schedule.timeZone}
           />
 
-          {/* What are Layers - Info Card */}
           <Alert className="border-blue-200/80 bg-blue-50/70">
             <Info className="h-4 w-4 text-blue-600" />
             <AlertTitle className="text-sm text-blue-900">Layering basics</AlertTitle>
             <AlertDescription className="text-xs text-blue-700">
-              Layers define on-call rotations. Higher layers override lower ones. Use a primary
-              layer for baseline coverage and add secondary layers for backup.
+              Layers define on-call rotations. Higher-priority layers win during overlaps; equal
+              priority layers use a deterministic tie-breaker.
             </AlertDescription>
           </Alert>
 
-          {/* Rotation Layers */}
           <Card className="overflow-hidden border-slate-200/80">
             <CardHeader className="p-4 pb-2 border-b border-slate-100 bg-slate-50/70">
               <div className="flex items-center justify-between">
@@ -482,13 +496,14 @@ export default async function ScheduleDetailPage({
                           variant="ghost"
                           size="icon"
                           className="h-6 w-6 text-slate-500 hover:text-slate-700"
+                          aria-label="How layer priority works"
                         >
                           <Info className="h-3.5 w-3.5" />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-xs text-xs">
-                        Layers are evaluated from top to bottom. Higher layers override lower ones
-                        during overlaps.
+                        Higher numeric priority wins when layers overlap. Equal-priority layers are
+                        resolved deterministically.
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
@@ -522,7 +537,7 @@ export default async function ScheduleDetailPage({
                     }}
                     scheduleId={schedule.id}
                     timeZone={schedule.timeZone}
-                    users={users}
+                    users={assignableUsers}
                     canManageSchedules={canManageSchedules}
                     updateLayer={updateLayer}
                     deleteLayer={deleteLayer}
@@ -536,7 +551,6 @@ export default async function ScheduleDetailPage({
             </CardContent>
           </Card>
 
-          {/* Quick Actions - has its own Card */}
           <ScheduleActionsPanel
             scheduleId={schedule.id}
             users={users}
@@ -547,7 +561,6 @@ export default async function ScheduleDetailPage({
             scheduleTimeZone={schedule.timeZone}
           />
 
-          {/* Schedule Settings */}
           {canManageSchedules && (
             <Card className="overflow-hidden border-slate-200/80">
               <CardHeader className="p-4 pb-2 border-b border-slate-100 bg-slate-50/70">
@@ -568,7 +581,6 @@ export default async function ScheduleDetailPage({
             </Card>
           )}
 
-          {/* Overrides Section */}
           <Card className="overflow-hidden border-slate-200/80">
             <CardHeader className="p-4 pb-2 border-b border-slate-100 bg-slate-50/70">
               <div className="flex items-start justify-between gap-3">
@@ -592,7 +604,6 @@ export default async function ScheduleDetailPage({
               </div>
             </CardHeader>
             <CardContent className="p-4 pt-3 space-y-4">
-              {/* Upcoming */}
               <div>
                 <p className="text-xs font-medium text-muted-foreground mb-2">Upcoming</p>
                 {upcomingOverrides.length === 0 ? (
@@ -639,7 +650,6 @@ export default async function ScheduleDetailPage({
                 )}
               </div>
 
-              {/* History */}
               <div>
                 <p className="text-xs font-medium text-muted-foreground mb-2">
                   History ({historyCount})
@@ -693,7 +703,6 @@ export default async function ScheduleDetailPage({
                 )}
               </div>
 
-              {/* Pagination for history */}
               {historyTotalPages > 1 && (
                 <div className="flex items-center justify-between pt-2 border-t">
                   <div className="text-[10px] text-muted-foreground">

--- a/src/app/(app)/schedules/actions.ts
+++ b/src/app/(app)/schedules/actions.ts
@@ -13,6 +13,12 @@ import {
   scheduleValidationError,
   type ScheduleActionState,
 } from '@/lib/schedule-action-errors';
+import {
+  addScheduleLayerUser,
+  createScheduleOverrideMutation,
+  moveScheduleLayerUser,
+  removeScheduleLayerUser,
+} from '@/lib/schedules/mutations';
 
 type ScheduleFormState = ScheduleActionState;
 
@@ -91,7 +97,7 @@ async function notifyScheduleMembers(
       });
     }
   } catch (_error) {
-    // Non-critical, continue
+    // Notifications are non-critical to the mutation and must not roll it back.
   }
 }
 
@@ -380,7 +386,7 @@ export async function deleteLayer(
     await notifyScheduleMembers(
       scheduleId,
       'Schedule updated',
-      `Layer "${layer?.name || 'Layer'}" removed from ${scheduleName}`
+      `Layer "${layer.name || 'Layer'}" removed from ${scheduleName}`
     );
 
     revalidatePath(`/schedules/${scheduleId}`);
@@ -400,109 +406,37 @@ export async function addLayerUser(
   } catch (error) {
     return scheduleActionError(error, 'Unauthorized. Admin or Responder access required.');
   }
-  const userId = formData.get('userId') as string;
 
+  const userId = (formData.get('userId') as string)?.trim();
   if (!userId) {
     return scheduleValidationError('User is required.', [
       { field: 'userId', code: 'required', message: 'User is required.' },
     ]);
   }
 
-  const layer = await prisma.onCallLayer.findUnique({
-    where: { id: layerId },
-    select: { scheduleId: true, name: true },
-  });
+  try {
+    const assignment = await addScheduleLayerUser(layerId, userId);
+    await logAudit({
+      action: 'schedule.member.added',
+      entityType: 'SCHEDULE',
+      entityId: assignment.scheduleId,
+      actorId,
+      details: { layerId, userId, position: assignment.position },
+    });
 
-  if (!layer) {
-    return scheduleActionError(
-      new AppError({
-        code: 'SCHEDULE_LAYER_NOT_FOUND',
-        userMessage: 'Layer not found.',
-        details: { layerId },
-      }),
-      'Layer not found.'
+    const scheduleName = await getScheduleName(assignment.scheduleId);
+    await notifyScheduleMembers(
+      assignment.scheduleId,
+      'Schedule updated',
+      `You were added to ${scheduleName}`,
+      [userId]
     );
+
+    revalidatePath(`/schedules/${assignment.scheduleId}`);
+    revalidatePath('/schedules');
+  } catch (error) {
+    return scheduleActionError(error, 'Failed to add responder to the schedule.');
   }
-
-  const existingAssignment = await prisma.onCallLayerUser.findFirst({
-    where: {
-      userId,
-      layer: { scheduleId: layer.scheduleId },
-    },
-    select: {
-      layerId: true,
-      layer: { select: { name: true } },
-      user: { select: { name: true } },
-    },
-  });
-
-  if (existingAssignment) {
-    const responderName = existingAssignment.user.name || 'This responder';
-    const userMessage =
-      existingAssignment.layerId === layerId
-        ? `${responderName} is already assigned to "${layer.name}".`
-        : `${responderName} is already assigned to "${existingAssignment.layer.name}" in this schedule. Remove them from that layer before adding them to "${layer.name}".`;
-
-    return scheduleActionError(
-      new AppError({
-        code: 'SCHEDULE_LAYER_USER_DUPLICATE',
-        userMessage,
-        details: {
-          scheduleId: layer.scheduleId,
-          requestedLayerId: layerId,
-          existingLayerId: existingAssignment.layerId,
-          userId,
-        },
-      }),
-      userMessage
-    );
-  }
-
-  const maxPosition = await prisma.onCallLayerUser.aggregate({
-    where: { layerId },
-    _max: { position: true },
-  });
-  const nextPosition = (maxPosition._max.position ?? 0) + 1;
-  const finalPosition = nextPosition;
-
-  await prisma.onCallLayerUser.create({
-    data: {
-      layerId,
-      userId,
-      position: finalPosition,
-    },
-  });
-
-  const ordered = await prisma.onCallLayerUser.findMany({
-    where: { layerId },
-    orderBy: { position: 'asc' },
-  });
-
-  await prisma.$transaction(
-    ordered.map((entry, index) =>
-      prisma.onCallLayerUser.update({
-        where: { id: entry.id },
-        data: { position: index + 1 },
-      })
-    )
-  );
-  await logAudit({
-    action: 'schedule.member.added',
-    entityType: 'SCHEDULE',
-    entityId: layer.scheduleId,
-    actorId,
-    details: { layerId, userId, position: finalPosition },
-  });
-
-  const scheduleName = await getScheduleName(layer.scheduleId);
-  await notifyScheduleMembers(
-    layer.scheduleId,
-    'Schedule updated',
-    `You were added to ${scheduleName}`
-  );
-
-  revalidatePath(`/schedules/${layer.scheduleId}`);
-  revalidatePath('/schedules');
 }
 
 export async function updateLayer(
@@ -635,59 +569,21 @@ export async function moveLayerUser(
   } catch (error) {
     return scheduleActionError(error, 'Unauthorized. Admin or Responder access required.');
   }
+
   try {
-    const layer = await prisma.onCallLayer.findUnique({
-      where: { id: layerId },
-      select: { scheduleId: true },
-    });
-
-    if (!layer) {
-      return scheduleActionError(
-        new AppError({
-          code: 'SCHEDULE_LAYER_NOT_FOUND',
-          userMessage: 'Layer not found.',
-          details: { layerId },
-        }),
-        'Layer not found.'
-      );
-    }
-
-    const users = await prisma.onCallLayerUser.findMany({
-      where: { layerId },
-      orderBy: { position: 'asc' },
-    });
-    const index = users.findIndex(u => u.userId === userId);
-    const targetIndex = direction === 'up' ? index - 1 : index + 1;
-
-    if (index === -1 || targetIndex < 0 || targetIndex >= users.length) {
-      return scheduleValidationError('Cannot move user in that direction.');
-    }
-
-    const current = users[index];
-    const target = users[targetIndex];
-
-    await prisma.$transaction([
-      prisma.onCallLayerUser.update({
-        where: { id: current.id },
-        data: { position: target.position },
-      }),
-      prisma.onCallLayerUser.update({
-        where: { id: target.id },
-        data: { position: current.position },
-      }),
-    ]);
+    const result = await moveScheduleLayerUser(layerId, userId, direction);
     await logAudit({
       action: 'schedule.member.reordered',
       entityType: 'SCHEDULE',
-      entityId: layer.scheduleId,
+      entityId: result.scheduleId,
       actorId,
       details: { layerId, userId, direction },
     });
 
-    revalidatePath(`/schedules/${layer.scheduleId}`);
+    revalidatePath(`/schedules/${result.scheduleId}`);
     revalidatePath('/schedules');
   } catch (error) {
-    return scheduleActionError(error, 'Failed to move user.');
+    return scheduleActionError(error, 'Failed to reorder responder.');
   }
 }
 
@@ -701,59 +597,31 @@ export async function removeLayerUser(
   } catch (error) {
     return scheduleActionError(error, 'Unauthorized. Admin or Responder access required.');
   }
-  try {
-    const layer = await prisma.onCallLayer.findUnique({
-      where: { id: layerId },
-      select: { scheduleId: true },
-    });
 
-    if (!layer) {
-      return scheduleActionError(
-        new AppError({
-          code: 'SCHEDULE_LAYER_NOT_FOUND',
-          userMessage: 'Layer not found.',
-          details: { layerId },
-        }),
-        'Layer not found.'
+  try {
+    const result = await removeScheduleLayerUser(layerId, userId);
+    if (result.removed) {
+      await logAudit({
+        action: 'schedule.member.removed',
+        entityType: 'SCHEDULE',
+        entityId: result.scheduleId,
+        actorId,
+        details: { layerId, userId },
+      });
+
+      const scheduleName = await getScheduleName(result.scheduleId);
+      await notifyScheduleMembers(
+        result.scheduleId,
+        'Schedule updated',
+        `You were removed from ${scheduleName}`,
+        [userId]
       );
     }
 
-    await prisma.onCallLayerUser.delete({
-      where: { layerId_userId: { layerId, userId } },
-    });
-
-    const remaining = await prisma.onCallLayerUser.findMany({
-      where: { layerId },
-      orderBy: { position: 'asc' },
-    });
-
-    await prisma.$transaction(
-      remaining.map((entry, index) =>
-        prisma.onCallLayerUser.update({
-          where: { id: entry.id },
-          data: { position: index + 1 },
-        })
-      )
-    );
-    await logAudit({
-      action: 'schedule.member.removed',
-      entityType: 'SCHEDULE',
-      entityId: layer.scheduleId,
-      actorId,
-      details: { layerId, userId },
-    });
-
-    const scheduleName = await getScheduleName(layer.scheduleId);
-    await notifyScheduleMembers(
-      layer.scheduleId,
-      'Schedule updated',
-      `You were removed from ${scheduleName}`,
-      [userId]
-    );
-
-    revalidatePath(`/schedules/${layer.scheduleId}`);
+    revalidatePath(`/schedules/${result.scheduleId}`);
+    revalidatePath('/schedules');
   } catch (error) {
-    return scheduleActionError(error, 'Failed to remove user from layer.');
+    return scheduleActionError(error, 'Failed to remove responder from the schedule.');
   }
 }
 
@@ -767,8 +635,9 @@ export async function createOverride(
   } catch (error) {
     return scheduleActionError(error, 'Unauthorized. Admin or Responder access required.');
   }
-  const userId = formData.get('userId') as string;
-  const replacesUserId = (formData.get('replacesUserId') as string) || null;
+
+  const userId = (formData.get('userId') as string)?.trim();
+  const replacesUserId = ((formData.get('replacesUserId') as string) || '').trim() || null;
   const start = formData.get('start') as string;
   const end = formData.get('end') as string;
 
@@ -798,36 +667,19 @@ export async function createOverride(
   if (!startDate || !endDate) {
     return scheduleValidationError('Invalid date format.');
   }
-
   if (endDate <= startDate) {
     return scheduleValidationError('End date must be after start date.');
   }
 
-  const targetUser = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { status: true },
-  });
-  if (!targetUser || targetUser.status !== 'ACTIVE') {
-    return scheduleValidationError(
-      'Cannot create an override for a deactivated or non-existent user.',
-      [{
-        field: 'userId',
-        code: 'inactive_or_missing',
-        message: 'Cannot create an override for a deactivated or non-existent user.',
-      }]
-    );
-  }
-
   try {
-    const override = await prisma.onCallOverride.create({
-      data: {
-        scheduleId,
-        userId,
-        replacesUserId: replacesUserId || null,
-        start: startDate,
-        end: endDate,
-      },
+    const override = await createScheduleOverrideMutation({
+      scheduleId,
+      userId,
+      replacesUserId,
+      start: startDate,
+      end: endDate,
     });
+
     await logAudit({
       action: 'schedule.override.created',
       entityType: 'SCHEDULE',
@@ -854,7 +706,7 @@ export async function createOverride(
 
     revalidatePath(`/schedules/${scheduleId}`);
   } catch (error) {
-    return scheduleActionError(error, 'Failed to create override.');
+    return scheduleActionError(error, 'Failed to create schedule override.');
   }
 }
 

--- a/src/components/ScheduleCalendar.tsx
+++ b/src/components/ScheduleCalendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useSyncExternalStore } from 'react';
 import {
   addDaysToDateKey,
   formatDateKeyInTimeZone,
@@ -10,18 +10,19 @@ import {
   startOfDayFromDateKey,
   startOfNextDayFromDateKey,
 } from '@/lib/timezone';
-import { getDefaultAvatar } from '@/lib/avatar';
+import {
+  groupCalendarShiftsForDay,
+  type CalendarDayShift,
+  type CalendarShiftIdentity,
+} from '@/lib/schedules/calendar';
+import UserAvatar from '@/components/UserAvatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
 import { Button } from '@/components/ui/shadcn/button';
 import { Badge } from '@/components/ui/shadcn/badge';
 import { ChevronLeft, ChevronRight, Calendar, Clock, ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-type CalendarShift = {
-  id: string;
-  start: string;
-  end: string;
-  label: string;
+type CalendarShift = CalendarShiftIdentity & {
   user?: {
     name: string;
     avatarUrl?: string | null;
@@ -32,7 +33,7 @@ type CalendarShift = {
 type CalendarCell = {
   date: Date;
   inMonth: boolean;
-  shifts: CalendarShift[];
+  shifts: CalendarDayShift<CalendarShift>[];
 };
 
 type ScheduleCalendarProps = {
@@ -41,6 +42,18 @@ type ScheduleCalendarProps = {
 };
 
 const weekdayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function subscribeToHydration() {
+  return () => undefined;
+}
+
+function getClientSnapshot() {
+  return true;
+}
+
+function getServerSnapshot() {
+  return false;
+}
 
 function getWeekdayIndex(dateKey: string, timeZone: string): number {
   const day = new Intl.DateTimeFormat('en-US', {
@@ -65,43 +78,48 @@ function buildCalendar(baseDate: Date, shifts: CalendarShift[], timeZone: string
   const firstCellKey = addDaysToDateKey(firstDayKey, -firstDayIndex);
   const cells: CalendarCell[] = [];
 
-  const shiftsForDateKey = (dateKey: string) => {
-    const dayStart = startOfDayFromDateKey(dateKey, timeZone);
-    const dayEnd = startOfNextDayFromDateKey(dateKey, timeZone);
-
-    // Filter shifts that overlap with this day
-    const overlapping = shifts.filter(shift => {
-      const start = new Date(shift.start);
-      const end = new Date(shift.end);
-      return start < dayEnd && end > dayStart;
-    });
-
-    // Return all active shifts for this day, sorted by start time and layer name
-    return overlapping.sort((a, b) => {
-      const timeDiff = new Date(a.start).getTime() - new Date(b.start).getTime();
-      if (timeDiff !== 0) return timeDiff;
-      const layerA = a.label.split(':')[0].trim();
-      const layerB = b.label.split(':')[0].trim();
-      return layerA.localeCompare(layerB);
-    });
-  };
-
   for (let i = 0; i < totalCells; i++) {
     const dateKey = addDaysToDateKey(firstCellKey, i);
     const date = startOfDayFromDateKey(dateKey, timeZone);
+    const dayEnd = startOfNextDayFromDateKey(dateKey, timeZone);
     const inMonth = dateKey.startsWith(`${year}-${String(month).padStart(2, '0')}-`);
-    cells.push({ date, inMonth, shifts: shiftsForDateKey(dateKey) });
+
+    cells.push({
+      date,
+      inMonth,
+      shifts: groupCalendarShiftsForDay(shifts, date, dayEnd),
+    });
   }
 
   return cells;
 }
 
-export default function ScheduleCalendar({ shifts, timeZone }: ScheduleCalendarProps) {
-  const [isMounted, setIsMounted] = useState(false);
-  useEffect(() => {
-    setIsMounted(true); // eslint-disable-line react-hooks/set-state-in-effect -- intentional hydration safety
-  }, []);
+function CalendarSkeleton() {
+  return (
+    <Card className="shadow-sm" aria-busy="true" aria-label="Loading on-call calendar">
+      <CardHeader className="pb-3 border-b">
+        <div className="h-6 w-44 rounded bg-muted animate-pulse" />
+        <div className="h-4 w-72 max-w-full rounded bg-muted animate-pulse" />
+      </CardHeader>
+      <CardContent className="p-6 overflow-x-auto">
+        <div className="grid grid-cols-7 gap-1 min-w-[700px]">
+          {Array.from({ length: 35 }, (_, index) => (
+            <div key={index} className="min-h-24 rounded-lg border bg-muted/20 p-2">
+              <div className="h-3 w-4 rounded bg-muted animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
+export default function ScheduleCalendar({ shifts, timeZone }: ScheduleCalendarProps) {
+  const isHydrated = useSyncExternalStore(
+    subscribeToHydration,
+    getClientSnapshot,
+    getServerSnapshot
+  );
   const [cursor, setCursor] = useState(() => new Date());
   const [expandedDates, setExpandedDates] = useState<Set<string>>(new Set());
 
@@ -124,11 +142,8 @@ export default function ScheduleCalendar({ shifts, timeZone }: ScheduleCalendarP
   const toggleExpand = (dateKey: string) => {
     setExpandedDates(prev => {
       const next = new Set(prev);
-      if (next.has(dateKey)) {
-        next.delete(dateKey);
-      } else {
-        next.add(dateKey);
-      }
+      if (next.has(dateKey)) next.delete(dateKey);
+      else next.add(dateKey);
       return next;
     });
   };
@@ -159,7 +174,7 @@ export default function ScheduleCalendar({ shifts, timeZone }: ScheduleCalendarP
     setCursor(startOfDayInTimeZone(new Date(), timeZone));
   };
 
-  if (!isMounted) return null;
+  if (!isHydrated) return <CalendarSkeleton />;
 
   return (
     <Card className="shadow-sm">
@@ -171,7 +186,8 @@ export default function ScheduleCalendar({ shifts, timeZone }: ScheduleCalendarP
               On-call Calendar
             </CardTitle>
             <p className="text-sm text-muted-foreground">
-              Shows all active layers. Multiple layers can be active simultaneously.
+              One entry per responder and layer each day. Overnight coverage is grouped into a
+              single entry.
             </p>
           </div>
           <Badge variant="secondary" size="xs" className="gap-1.5 shrink-0">
@@ -182,153 +198,181 @@ export default function ScheduleCalendar({ shifts, timeZone }: ScheduleCalendarP
       </CardHeader>
 
       <CardContent className="p-6">
-        {/* Navigation Controls */}
         <div className="flex justify-end gap-2 mb-4">
-          <Button variant="outline" size="sm" onClick={handlePrev} className="h-8 px-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handlePrev}
+            className="h-8 px-3"
+            aria-label="Previous month"
+          >
             <ChevronLeft className="h-4 w-4 mr-1" />
             Prev
           </Button>
           <Button variant="outline" size="sm" onClick={handleToday} className="h-8 px-3">
             Today
           </Button>
-          <Button variant="outline" size="sm" onClick={handleNext} className="h-8 px-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleNext}
+            className="h-8 px-3"
+            aria-label="Next month"
+          >
             Next
             <ChevronRight className="h-4 w-4 ml-1" />
           </Button>
         </div>
 
-        {/* Calendar Grid */}
-        <div className="space-y-2">
-          {/* Weekday Headers */}
-          <div className="grid grid-cols-7 gap-1 mb-2">
-            {weekdayLabels.map(day => (
-              <div
-                key={day}
-                className="text-center text-sm font-semibold text-muted-foreground py-2"
-              >
-                {day}
-              </div>
-            ))}
-          </div>
-
-          {/* Calendar Days */}
-          <div className="grid grid-cols-7 gap-1">
-            {calendarCells.map(cell => {
-              const dateKey = formatDateKeyInTimeZone(cell.date, timeZone);
-              const isToday = dateKey === todayKey;
-              const isExpanded = expandedDates.has(dateKey);
-              const preview = cell.shifts.slice(0, 2);
-              const remaining = cell.shifts.length - preview.length;
-              const showAll = isExpanded || cell.shifts.length <= 2;
-
-              return (
+        <div className="overflow-x-auto pb-1">
+          <div className="space-y-2 min-w-[700px]">
+            <div className="grid grid-cols-7 gap-1 mb-2">
+              {weekdayLabels.map(day => (
                 <div
-                  key={dateKey}
-                  className={cn(
-                    'min-h-24 p-2 rounded-lg border transition-all',
-                    cell.inMonth
-                      ? 'bg-card border-border hover:border-primary/30'
-                      : 'bg-muted/30 border-transparent',
-                    isToday && 'ring-2 ring-primary bg-primary/5'
-                  )}
+                  key={day}
+                  className="text-center text-sm font-semibold text-muted-foreground py-2"
                 >
-                  <div className="flex items-center justify-between mb-1">
-                    <span
-                      className={cn(
-                        'text-sm font-medium',
-                        !cell.inMonth && 'text-muted-foreground',
-                        isToday && 'text-primary font-bold'
-                      )}
-                    >
-                      {getDayNumber(dateKey)}
-                    </span>
-                    {isToday && (
-                      <div className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />
+                  {day}
+                </div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-7 gap-1">
+              {calendarCells.map(cell => {
+                const dateKey = formatDateKeyInTimeZone(cell.date, timeZone);
+                const isToday = dateKey === todayKey;
+                const isExpanded = expandedDates.has(dateKey);
+                const preview = cell.shifts.slice(0, 2);
+                const remaining = cell.shifts.length - preview.length;
+                const showAll = isExpanded || cell.shifts.length <= 2;
+
+                return (
+                  <div
+                    key={dateKey}
+                    className={cn(
+                      'min-h-24 p-2 rounded-lg border transition-all',
+                      cell.inMonth
+                        ? 'bg-card border-border hover:border-primary/30'
+                        : 'bg-muted/30 border-transparent',
+                      isToday && 'ring-2 ring-primary bg-primary/5'
                     )}
-                  </div>
-
-                  {cell.shifts.length > 0 && (
-                    <div className="space-y-1.5">
-                      {(showAll ? cell.shifts : preview).map(shift => {
-                        const start = new Date(shift.start);
-                        const end = new Date(shift.end);
-                        const startTime = formatDateTime(start, timeZone, { format: 'time' });
-                        const endTime = formatDateTime(end, timeZone, { format: 'time' });
-                        const isMultiDay =
-                          formatDateTime(start, timeZone, { format: 'date' }) !==
-                          formatDateTime(end, timeZone, { format: 'date' });
-
-                        return (
-                          <div
-                            key={shift.id}
-                            className="group relative rounded-md bg-primary/10 border border-primary/20 p-1.5 text-xs hover:bg-primary/15 transition-colors cursor-default"
-                            title={`${startTime} - ${endTime}${isMultiDay ? ' (spans multiple days)' : ''}`}
-                          >
-                            {shift.user ? (
-                              <div className="flex items-center gap-1.5">
-                                <img
-                                  src={
-                                    shift.user.avatarUrl ||
-                                    getDefaultAvatar(shift.user.gender, shift.user.name)
-                                  }
-                                  alt={`Avatar of ${shift.user.name}`}
-                                  className="h-4 w-4 rounded-full object-cover flex-shrink-0 ring-1 ring-white/50"
-                                />
-                                <span className="font-medium text-foreground truncate flex-1 min-w-0">
-                                  {shift.user.name}
-                                </span>
-                              </div>
-                            ) : (
-                              <span className="font-medium text-foreground truncate block">
-                                {shift.label}
-                              </span>
-                            )}
-                            {isMultiDay && (
-                              <Badge
-                                variant="outline"
-                                size="xs"
-                                className="mt-1 h-4 border-primary/30"
-                              >
-                                multi-day
-                              </Badge>
-                            )}
-                          </div>
-                        );
-                      })}
-
-                      {/* Show More/Less Button */}
-                      {remaining > 0 && !isExpanded && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={e => {
-                            e.stopPropagation();
-                            toggleExpand(dateKey);
-                          }}
-                          className="w-full h-6 text-xs font-medium text-primary hover:text-primary hover:bg-primary/10 gap-1"
-                        >
-                          <ChevronDown className="h-3 w-3" />+{remaining} more
-                        </Button>
-                      )}
-                      {isExpanded && cell.shifts.length > 2 && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={e => {
-                            e.stopPropagation();
-                            toggleExpand(dateKey);
-                          }}
-                          className="w-full h-6 text-xs font-medium text-primary hover:text-primary hover:bg-primary/10 gap-1"
-                        >
-                          <ChevronUp className="h-3 w-3" />
-                          Show less
-                        </Button>
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span
+                        className={cn(
+                          'text-sm font-medium',
+                          !cell.inMonth && 'text-muted-foreground',
+                          isToday && 'text-primary font-bold'
+                        )}
+                      >
+                        {getDayNumber(dateKey)}
+                      </span>
+                      {isToday && (
+                        <div
+                          className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse"
+                          aria-label="Today"
+                        />
                       )}
                     </div>
-                  )}
-                </div>
-              );
-            })}
+
+                    {cell.shifts.length > 0 && (
+                      <div className="space-y-1.5">
+                        {(showAll ? cell.shifts : preview).map(shift => {
+                          const windows = shift.segments.map(segment => {
+                            const startTime = formatDateTime(new Date(segment.start), timeZone, {
+                              format: 'time',
+                            });
+                            const endTime = formatDateTime(new Date(segment.end), timeZone, {
+                              format: 'time',
+                            });
+                            return `${startTime} - ${endTime}`;
+                          });
+                          const coverageLabel = windows.join(', ');
+
+                          return (
+                            <div
+                              key={shift.groupKey}
+                              className="group relative rounded-md bg-primary/10 border border-primary/20 p-1.5 text-xs hover:bg-primary/15 transition-colors cursor-default"
+                              title={coverageLabel}
+                              aria-label={`${shift.label}, ${coverageLabel}`}
+                            >
+                              {shift.user ? (
+                                <div className="flex items-center gap-1.5">
+                                  {shift.userId && (
+                                    <UserAvatar
+                                      userId={shift.userId}
+                                      name={shift.user.name}
+                                      avatarUrl={shift.user.avatarUrl}
+                                      gender={shift.user.gender}
+                                      size="xs"
+                                      className="h-4 w-4 ring-1 ring-white/50"
+                                    />
+                                  )}
+                                  <span className="font-medium text-foreground truncate flex-1 min-w-0">
+                                    {shift.user.name}
+                                  </span>
+                                </div>
+                              ) : (
+                                <span className="font-medium text-foreground truncate block">
+                                  {shift.label}
+                                </span>
+                              )}
+                              {shift.segments.length > 1 ? (
+                                <Badge
+                                  variant="outline"
+                                  size="xs"
+                                  className="mt-1 h-4 border-primary/30"
+                                >
+                                  {shift.segments.length} windows
+                                </Badge>
+                              ) : shift.spansDayBoundary ? (
+                                <Badge
+                                  variant="outline"
+                                  size="xs"
+                                  className="mt-1 h-4 border-primary/30"
+                                >
+                                  overnight
+                                </Badge>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+
+                        {remaining > 0 && !isExpanded && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={event => {
+                              event.stopPropagation();
+                              toggleExpand(dateKey);
+                            }}
+                            className="w-full h-6 text-xs font-medium text-primary hover:text-primary hover:bg-primary/10 gap-1"
+                            aria-label={`Show ${remaining} more on-call entries for ${dateKey}`}
+                          >
+                            <ChevronDown className="h-3 w-3" />+{remaining} more
+                          </Button>
+                        )}
+                        {isExpanded && cell.shifts.length > 2 && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={event => {
+                              event.stopPropagation();
+                              toggleExpand(dateKey);
+                            }}
+                            className="w-full h-6 text-xs font-medium text-primary hover:text-primary hover:bg-primary/10 gap-1"
+                            aria-label={`Show fewer on-call entries for ${dateKey}`}
+                          >
+                            <ChevronUp className="h-3 w-3" />
+                            Show less
+                          </Button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
       </CardContent>

--- a/src/lib/errors/registry.ts
+++ b/src/lib/errors/registry.ts
@@ -342,6 +342,22 @@ export const ERROR_REGISTRY = {
     retryable: false,
     exposure: 'public',
   },
+  SCHEDULE_RESPONDER_NOT_ACTIVE: {
+    status: 409,
+    category: 'conflict',
+    userMessage: 'This responder is not active and cannot be assigned to an on-call schedule.',
+    action: 'Activate the responder or choose an active responder.',
+    retryable: false,
+    exposure: 'public',
+  },
+  SCHEDULE_OVERRIDE_CONFLICT: {
+    status: 409,
+    category: 'conflict',
+    userMessage: 'This override conflicts with an existing override for the same coverage period.',
+    action: 'Choose a non-overlapping period or remove the existing override first.',
+    retryable: false,
+    exposure: 'public',
+  },
   STATUS_PAGE_WEBHOOK_NOT_FOUND: {
     status: 404,
     category: 'not_found',

--- a/src/lib/schedule-action-errors.ts
+++ b/src/lib/schedule-action-errors.ts
@@ -16,8 +16,10 @@ export type ScheduleActionState = {
 };
 
 /**
- * Preserve the existing schedule form contract while exposing stable error
- * metadata to clients that are ready to consume it.
+ * Preserve the schedule form contract while exposing stable error metadata.
+ * Unknown/internal exceptions intentionally use the caller-provided fallback
+ * so Prisma, SQL, stack, and infrastructure details never cross the server
+ * action boundary.
  */
 export function scheduleActionError(error: unknown, fallback: string): ScheduleActionState {
   if (isAppError(error)) {
@@ -31,9 +33,7 @@ export function scheduleActionError(error: unknown, fallback: string): ScheduleA
     };
   }
 
-  return {
-    error: error instanceof Error ? error.message : fallback,
-  };
+  return { error: fallback };
 }
 
 export function scheduleValidationError(

--- a/src/lib/schedules/calendar.ts
+++ b/src/lib/schedules/calendar.ts
@@ -1,0 +1,95 @@
+export type CalendarShiftIdentity = {
+  id: string;
+  start: string;
+  end: string;
+  label: string;
+  layerId?: string | null;
+  userId?: string | null;
+  source?: string | null;
+};
+
+export type CalendarShiftSegment = {
+  start: string;
+  end: string;
+};
+
+export type CalendarDayShift<T extends CalendarShiftIdentity = CalendarShiftIdentity> = T & {
+  groupKey: string;
+  segments: CalendarShiftSegment[];
+  spansDayBoundary: boolean;
+};
+
+function identityPart(value: string | null | undefined, fallback: string): string {
+  return value && value.length > 0 ? value : fallback;
+}
+
+/**
+ * Calendar cells are a summary of logical coverage, not a raw event log.
+ * A single responder/layer can legitimately have two raw blocks touching the
+ * same civil day (for example 00:00-06:30 and 18:30-24:00 for an overnight
+ * rotation). Group those fragments into one cell entry while retaining every
+ * clipped coverage window for tooltips/details.
+ */
+export function groupCalendarShiftsForDay<T extends CalendarShiftIdentity>(
+  shifts: readonly T[],
+  dayStart: Date,
+  dayEnd: Date
+): CalendarDayShift<T>[] {
+  const dayStartMs = dayStart.getTime();
+  const dayEndMs = dayEnd.getTime();
+  if (!Number.isFinite(dayStartMs) || !Number.isFinite(dayEndMs) || dayEndMs <= dayStartMs) {
+    return [];
+  }
+
+  const grouped = new Map<string, CalendarDayShift<T>>();
+
+  for (const shift of shifts) {
+    const shiftStartMs = new Date(shift.start).getTime();
+    const shiftEndMs = new Date(shift.end).getTime();
+    if (!Number.isFinite(shiftStartMs) || !Number.isFinite(shiftEndMs) || shiftEndMs <= shiftStartMs) {
+      continue;
+    }
+    if (shiftStartMs >= dayEndMs || shiftEndMs <= dayStartMs) {
+      continue;
+    }
+
+    const layerKey = identityPart(shift.layerId, shift.label.split(':')[0]?.trim() || shift.label);
+    const userKey = identityPart(shift.userId, shift.label);
+    const sourceKey = identityPart(shift.source, 'layer');
+    const groupKey = `${layerKey}\u0000${userKey}\u0000${sourceKey}`;
+    const segment = {
+      start: new Date(Math.max(shiftStartMs, dayStartMs)).toISOString(),
+      end: new Date(Math.min(shiftEndMs, dayEndMs)).toISOString(),
+    };
+    const spansDayBoundary = shiftStartMs < dayStartMs || shiftEndMs > dayEndMs;
+
+    const existing = grouped.get(groupKey);
+    if (existing) {
+      existing.segments.push(segment);
+      existing.spansDayBoundary = existing.spansDayBoundary || spansDayBoundary;
+      continue;
+    }
+
+    grouped.set(groupKey, {
+      ...shift,
+      groupKey,
+      segments: [segment],
+      spansDayBoundary,
+    });
+  }
+
+  return [...grouped.values()]
+    .map(shift => ({
+      ...shift,
+      segments: [...shift.segments].sort(
+        (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+      ),
+    }))
+    .sort((a, b) => {
+      const timeDiff =
+        new Date(a.segments[0]?.start ?? a.start).getTime() -
+        new Date(b.segments[0]?.start ?? b.start).getTime();
+      if (timeDiff !== 0) return timeDiff;
+      return a.label.localeCompare(b.label);
+    });
+}

--- a/src/lib/schedules/mutations.ts
+++ b/src/lib/schedules/mutations.ts
@@ -1,0 +1,346 @@
+import { Prisma } from '@prisma/client';
+import { runSerializableTransaction } from '@/lib/db-utils';
+import { AppError } from '@/lib/errors';
+
+type TransactionClient = Prisma.TransactionClient;
+
+type LayerPosition = {
+  id: string;
+  userId: string;
+  position: number;
+};
+
+function responderNotActiveError(userId: string, field: string) {
+  const message = 'This responder is not active and cannot be assigned to an on-call schedule.';
+  return new AppError({
+    code: 'SCHEDULE_RESPONDER_NOT_ACTIVE',
+    userMessage: message,
+    action: 'Activate the responder or choose an active responder.',
+    details: { userId },
+    fields: [{ field, code: 'inactive_or_missing', message }],
+  });
+}
+
+function overrideConflictError(details: Record<string, unknown>) {
+  return new AppError({
+    code: 'SCHEDULE_OVERRIDE_CONFLICT',
+    userMessage: 'This override conflicts with an existing override for the same coverage period.',
+    action: 'Choose a non-overlapping period or remove the existing override first.',
+    details,
+  });
+}
+
+async function requireActiveResponder(
+  tx: TransactionClient,
+  userId: string,
+  field: string
+): Promise<{ id: string; name: string }> {
+  const user = await tx.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, status: true },
+  });
+
+  if (!user || user.status !== 'ACTIVE') {
+    throw responderNotActiveError(userId, field);
+  }
+
+  return { id: user.id, name: user.name };
+}
+
+async function normalizeLayerPositions(
+  tx: TransactionClient,
+  layerId: string,
+  entries?: LayerPosition[]
+): Promise<LayerPosition[]> {
+  const ordered =
+    entries ??
+    (await tx.onCallLayerUser.findMany({
+      where: { layerId },
+      select: { id: true, userId: true, position: true },
+      orderBy: [{ position: 'asc' }, { id: 'asc' }],
+    }));
+
+  const normalized = ordered.map((entry, index) => ({ ...entry, position: index + 1 }));
+  for (const entry of normalized) {
+    const persisted = ordered.find(candidate => candidate.id === entry.id);
+    if (persisted?.position === entry.position) continue;
+    await tx.onCallLayerUser.update({
+      where: { id: entry.id },
+      data: { position: entry.position },
+    });
+  }
+
+  return normalized;
+}
+
+export async function addScheduleLayerUser(layerId: string, userId: string) {
+  try {
+    return await runSerializableTransaction(async tx => {
+      const layer = await tx.onCallLayer.findUnique({
+        where: { id: layerId },
+        select: { id: true, name: true, scheduleId: true },
+      });
+
+      if (!layer) {
+        throw new AppError({
+          code: 'SCHEDULE_LAYER_NOT_FOUND',
+          userMessage: 'Layer not found.',
+          details: { layerId },
+        });
+      }
+
+      const responder = await requireActiveResponder(tx, userId, 'userId');
+      const existingAssignment = await tx.onCallLayerUser.findFirst({
+        where: {
+          userId,
+          layer: { scheduleId: layer.scheduleId },
+        },
+        select: {
+          layerId: true,
+          layer: { select: { name: true } },
+        },
+      });
+
+      if (existingAssignment) {
+        const userMessage =
+          existingAssignment.layerId === layerId
+            ? `${responder.name} is already assigned to "${layer.name}".`
+            : `${responder.name} is already assigned to "${existingAssignment.layer.name}" in this schedule. Remove them from that layer before adding them to "${layer.name}".`;
+
+        throw new AppError({
+          code: 'SCHEDULE_LAYER_USER_DUPLICATE',
+          userMessage,
+          details: {
+            scheduleId: layer.scheduleId,
+            requestedLayerId: layerId,
+            existingLayerId: existingAssignment.layerId,
+            userId,
+          },
+        });
+      }
+
+      const ordered = await normalizeLayerPositions(tx, layerId);
+      const position = ordered.length + 1;
+      const assignment = await tx.onCallLayerUser.create({
+        data: { layerId, userId, position },
+        select: { id: true, position: true },
+      });
+
+      return {
+        scheduleId: layer.scheduleId,
+        layerId,
+        layerName: layer.name,
+        userId,
+        userName: responder.name,
+        assignmentId: assignment.id,
+        position: assignment.position,
+      };
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      throw new AppError({
+        code: 'SCHEDULE_LAYER_USER_DUPLICATE',
+        userMessage: 'This responder is already assigned to this schedule.',
+        details: { layerId, userId },
+      });
+    }
+    throw error;
+  }
+}
+
+export async function moveScheduleLayerUser(
+  layerId: string,
+  userId: string,
+  direction: 'up' | 'down'
+) {
+  return runSerializableTransaction(async tx => {
+    const layer = await tx.onCallLayer.findUnique({
+      where: { id: layerId },
+      select: { scheduleId: true },
+    });
+
+    if (!layer) {
+      throw new AppError({
+        code: 'SCHEDULE_LAYER_NOT_FOUND',
+        userMessage: 'Layer not found.',
+        details: { layerId },
+      });
+    }
+
+    const users = await normalizeLayerPositions(tx, layerId);
+    const current = users.find(entry => entry.userId === userId);
+    if (!current) {
+      throw new AppError({
+        code: 'VALIDATION_FAILED',
+        userMessage: 'Cannot move this responder in that direction.',
+        details: { layerId, userId, direction },
+      });
+    }
+
+    const targetPosition = direction === 'up' ? current.position - 1 : current.position + 1;
+    const target = users.find(entry => entry.position === targetPosition);
+    if (!target) {
+      throw new AppError({
+        code: 'VALIDATION_FAILED',
+        userMessage: 'Cannot move this responder in that direction.',
+        details: { layerId, userId, direction },
+      });
+    }
+
+    await tx.onCallLayerUser.update({
+      where: { id: current.id },
+      data: { position: target.position },
+    });
+    await tx.onCallLayerUser.update({
+      where: { id: target.id },
+      data: { position: current.position },
+    });
+
+    return { scheduleId: layer.scheduleId, layerId, userId, direction };
+  });
+}
+
+export async function removeScheduleLayerUser(layerId: string, userId: string) {
+  return runSerializableTransaction(async tx => {
+    const layer = await tx.onCallLayer.findUnique({
+      where: { id: layerId },
+      select: { scheduleId: true },
+    });
+
+    if (!layer) {
+      throw new AppError({
+        code: 'SCHEDULE_LAYER_NOT_FOUND',
+        userMessage: 'Layer not found.',
+        details: { layerId },
+      });
+    }
+
+    const deletion = await tx.onCallLayerUser.deleteMany({
+      where: { layerId, userId },
+    });
+
+    if (deletion.count > 0) {
+      await normalizeLayerPositions(tx, layerId);
+    }
+
+    return {
+      scheduleId: layer.scheduleId,
+      layerId,
+      userId,
+      removed: deletion.count > 0,
+    };
+  });
+}
+
+export type CreateScheduleOverrideInput = {
+  scheduleId: string;
+  userId: string;
+  replacesUserId: string | null;
+  start: Date;
+  end: Date;
+};
+
+export async function createScheduleOverrideMutation(input: CreateScheduleOverrideInput) {
+  if (input.end <= input.start) {
+    throw new AppError({
+      code: 'VALIDATION_FAILED',
+      userMessage: 'End date must be after start date.',
+      details: { scheduleId: input.scheduleId },
+    });
+  }
+
+  if (input.replacesUserId && input.replacesUserId === input.userId) {
+    throw new AppError({
+      code: 'VALIDATION_FAILED',
+      userMessage: 'A responder cannot replace themselves in an override.',
+      fields: [
+        {
+          field: 'replacesUserId',
+          code: 'same_responder',
+          message: 'Choose a different responder to replace.',
+        },
+      ],
+    });
+  }
+
+  try {
+    return await runSerializableTransaction(async tx => {
+      const schedule = await tx.onCallSchedule.findUnique({
+        where: { id: input.scheduleId },
+        select: { id: true },
+      });
+
+      if (!schedule) {
+        throw new AppError({
+          code: 'SCHEDULE_NOT_FOUND',
+          userMessage: 'Schedule not found.',
+          details: { scheduleId: input.scheduleId },
+        });
+      }
+
+      await requireActiveResponder(tx, input.userId, 'userId');
+      if (input.replacesUserId) {
+        await requireActiveResponder(tx, input.replacesUserId, 'replacesUserId');
+      }
+
+      const exactDuplicate = await tx.onCallOverride.findFirst({
+        where: {
+          scheduleId: input.scheduleId,
+          userId: input.userId,
+          start: input.start,
+          end: input.end,
+        },
+        select: { id: true },
+      });
+
+      if (exactDuplicate) {
+        throw overrideConflictError({
+          scheduleId: input.scheduleId,
+          existingOverrideId: exactDuplicate.id,
+          userId: input.userId,
+        });
+      }
+
+      if (input.replacesUserId) {
+        const overlappingReplacement = await tx.onCallOverride.findFirst({
+          where: {
+            scheduleId: input.scheduleId,
+            replacesUserId: input.replacesUserId,
+            start: { lt: input.end },
+            end: { gt: input.start },
+          },
+          select: { id: true, start: true, end: true },
+        });
+
+        if (overlappingReplacement) {
+          throw overrideConflictError({
+            scheduleId: input.scheduleId,
+            replacesUserId: input.replacesUserId,
+            existingOverrideId: overlappingReplacement.id,
+            existingStart: overlappingReplacement.start.toISOString(),
+            existingEnd: overlappingReplacement.end.toISOString(),
+          });
+        }
+      }
+
+      return tx.onCallOverride.create({
+        data: {
+          scheduleId: input.scheduleId,
+          userId: input.userId,
+          replacesUserId: input.replacesUserId,
+          start: input.start,
+          end: input.end,
+        },
+      });
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      throw overrideConflictError({
+        scheduleId: input.scheduleId,
+        userId: input.userId,
+        replacesUserId: input.replacesUserId,
+      });
+    }
+    throw error;
+  }
+}

--- a/tests/integration/schedule-assignment-concurrency.test.ts
+++ b/tests/integration/schedule-assignment-concurrency.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  addScheduleLayerUser,
+  createScheduleOverrideMutation,
+} from '@/lib/schedules/mutations';
+import { isAppError } from '@/lib/errors';
+import { createTestUser, resetDatabase, testPrisma } from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+async function createScheduleWithTwoLayers() {
+  return testPrisma.onCallSchedule.create({
+    data: {
+      name: `Schedule concurrency ${Math.random().toString(36).slice(2)}`,
+      timeZone: 'UTC',
+      layers: {
+        create: [
+          {
+            name: 'Primary',
+            start: new Date('2026-08-28T00:00:00.000Z'),
+            rotationLengthHours: 24,
+          },
+          {
+            name: 'Secondary',
+            start: new Date('2026-08-28T00:00:00.000Z'),
+            rotationLengthHours: 24,
+          },
+        ],
+      },
+    },
+    include: { layers: { orderBy: { createdAt: 'asc' } } },
+  });
+}
+
+function appErrorCodes(results: PromiseSettledResult<unknown>[]) {
+  return results.flatMap(result => {
+    if (result.status !== 'rejected' || !isAppError(result.reason)) return [];
+    return [result.reason.code];
+  });
+}
+
+describeIfRealDB('schedule mutation concurrency', () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it('serializes simultaneous attempts to assign one responder to different layers', async () => {
+    const [schedule, responder] = await Promise.all([
+      createScheduleWithTwoLayers(),
+      createTestUser({ email: 'same-responder@example.com', name: 'Same Responder' }),
+    ]);
+
+    const results = await Promise.allSettled([
+      addScheduleLayerUser(schedule.layers[0].id, responder.id),
+      addScheduleLayerUser(schedule.layers[1].id, responder.id),
+    ]);
+
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+    expect(appErrorCodes(results)).toEqual(['SCHEDULE_LAYER_USER_DUPLICATE']);
+
+    const assignments = await testPrisma.onCallLayerUser.findMany({
+      where: {
+        userId: responder.id,
+        layer: { scheduleId: schedule.id },
+      },
+    });
+    expect(assignments).toHaveLength(1);
+  });
+
+  it('allocates unique contiguous positions for simultaneous additions to one layer', async () => {
+    const [schedule, alex, taylor] = await Promise.all([
+      createScheduleWithTwoLayers(),
+      createTestUser({ email: 'alex-position@example.com', name: 'Alex Position' }),
+      createTestUser({ email: 'taylor-position@example.com', name: 'Taylor Position' }),
+    ]);
+
+    await Promise.all([
+      addScheduleLayerUser(schedule.layers[0].id, alex.id),
+      addScheduleLayerUser(schedule.layers[0].id, taylor.id),
+    ]);
+
+    const assignments = await testPrisma.onCallLayerUser.findMany({
+      where: { layerId: schedule.layers[0].id },
+      orderBy: { position: 'asc' },
+      select: { userId: true, position: true },
+    });
+
+    expect(assignments).toHaveLength(2);
+    expect(assignments.map(entry => entry.position)).toEqual([1, 2]);
+    expect(new Set(assignments.map(entry => entry.userId))).toEqual(new Set([alex.id, taylor.id]));
+  });
+
+  it('rejects inactive responders at the authoritative mutation boundary', async () => {
+    const [schedule, disabled] = await Promise.all([
+      createScheduleWithTwoLayers(),
+      createTestUser({
+        email: 'disabled-schedule@example.com',
+        name: 'Disabled Responder',
+        status: 'DISABLED',
+      }),
+    ]);
+
+    await expect(addScheduleLayerUser(schedule.layers[0].id, disabled.id)).rejects.toMatchObject({
+      code: 'SCHEDULE_RESPONDER_NOT_ACTIVE',
+    });
+
+    expect(
+      await testPrisma.onCallLayerUser.count({ where: { userId: disabled.id } })
+    ).toBe(0);
+  });
+
+  it('rejects an inactive replacement responder before persisting an override', async () => {
+    const [schedule, target, disabledReplacement] = await Promise.all([
+      createScheduleWithTwoLayers(),
+      createTestUser({ email: 'override-target@example.com', name: 'Override Target' }),
+      createTestUser({
+        email: 'override-disabled-replacement@example.com',
+        name: 'Disabled Replacement',
+        status: 'DISABLED',
+      }),
+    ]);
+
+    await expect(
+      createScheduleOverrideMutation({
+        scheduleId: schedule.id,
+        userId: target.id,
+        replacesUserId: disabledReplacement.id,
+        start: new Date('2026-08-29T00:00:00.000Z'),
+        end: new Date('2026-08-29T12:00:00.000Z'),
+      })
+    ).rejects.toMatchObject({ code: 'SCHEDULE_RESPONDER_NOT_ACTIVE' });
+
+    expect(await testPrisma.onCallOverride.count({ where: { scheduleId: schedule.id } })).toBe(0);
+  });
+
+  it('serializes overlapping replacement overrides so only one coverage owner is committed', async () => {
+    const [schedule, replaced, alex, taylor] = await Promise.all([
+      createScheduleWithTwoLayers(),
+      createTestUser({ email: 'replaced@example.com', name: 'Replaced Responder' }),
+      createTestUser({ email: 'override-alex@example.com', name: 'Override Alex' }),
+      createTestUser({ email: 'override-taylor@example.com', name: 'Override Taylor' }),
+    ]);
+
+    const results = await Promise.allSettled([
+      createScheduleOverrideMutation({
+        scheduleId: schedule.id,
+        userId: alex.id,
+        replacesUserId: replaced.id,
+        start: new Date('2026-08-30T00:00:00.000Z'),
+        end: new Date('2026-08-30T12:00:00.000Z'),
+      }),
+      createScheduleOverrideMutation({
+        scheduleId: schedule.id,
+        userId: taylor.id,
+        replacesUserId: replaced.id,
+        start: new Date('2026-08-30T06:00:00.000Z'),
+        end: new Date('2026-08-30T18:00:00.000Z'),
+      }),
+    ]);
+
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+    expect(appErrorCodes(results)).toEqual(['SCHEDULE_OVERRIDE_CONFLICT']);
+    expect(
+      await testPrisma.onCallOverride.count({
+        where: { scheduleId: schedule.id, replacesUserId: replaced.id },
+      })
+    ).toBe(1);
+  });
+});

--- a/tests/lib/schedule-action-errors.test.ts
+++ b/tests/lib/schedule-action-errors.test.ts
@@ -3,7 +3,7 @@ import { AppError } from '@/lib/errors';
 import { scheduleActionError, scheduleValidationError } from '@/lib/schedule-action-errors';
 
 describe('schedule action error adapter', () => {
-  it('preserves the legacy error string while adding machine-readable metadata', () => {
+  it('preserves the visible domain error while adding machine-readable metadata', () => {
     const state = scheduleActionError(
       new AppError({
         code: 'SCHEDULE_LAYER_USER_DUPLICATE',
@@ -31,10 +31,31 @@ describe('schedule action error adapter', () => {
     ]);
   });
 
-  it('keeps legacy non-AppError behavior for compatibility', () => {
-    expect(scheduleActionError(new Error('Legacy schedule failure.'), 'fallback')).toEqual({
-      error: 'Legacy schedule failure.',
+  it('does not expose unexpected database or infrastructure errors to the client', () => {
+    expect(
+      scheduleActionError(
+        new Error('Prisma P2002: Unique constraint failed on internal_table_secret'),
+        'Failed to update schedule.'
+      )
+    ).toEqual({ error: 'Failed to update schedule.' });
+
+    expect(scheduleActionError('unknown', 'Failed to update schedule.')).toEqual({
+      error: 'Failed to update schedule.',
     });
-    expect(scheduleActionError('unknown', 'fallback')).toEqual({ error: 'fallback' });
+  });
+
+  it('exposes the new schedule conflict codes through the centralized error registry', () => {
+    expect(
+      scheduleActionError(new AppError({ code: 'SCHEDULE_RESPONDER_NOT_ACTIVE' }), 'fallback')
+    ).toMatchObject({
+      code: 'SCHEDULE_RESPONDER_NOT_ACTIVE',
+      retryable: false,
+    });
+    expect(
+      scheduleActionError(new AppError({ code: 'SCHEDULE_OVERRIDE_CONFLICT' }), 'fallback')
+    ).toMatchObject({
+      code: 'SCHEDULE_OVERRIDE_CONFLICT',
+      retryable: false,
+    });
   });
 });

--- a/tests/lib/schedules/calendar.test.ts
+++ b/tests/lib/schedules/calendar.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { groupCalendarShiftsForDay } from '@/lib/schedules/calendar';
+
+describe('schedule calendar day grouping', () => {
+  const dayStart = new Date('2026-08-28T00:00:00.000Z');
+  const dayEnd = new Date('2026-08-29T00:00:00.000Z');
+
+  it('coalesces overnight fragments for the same responder and layer into one day entry', () => {
+    const grouped = groupCalendarShiftsForDay(
+      [
+        {
+          id: 'previous-night',
+          layerId: 'layer-primary',
+          userId: 'user-admin',
+          source: 'layer',
+          label: 'Primary: OpsKnight Admin',
+          start: '2026-08-27T18:30:00.000Z',
+          end: '2026-08-28T06:30:00.000Z',
+        },
+        {
+          id: 'next-night',
+          layerId: 'layer-primary',
+          userId: 'user-admin',
+          source: 'layer',
+          label: 'Primary: OpsKnight Admin',
+          start: '2026-08-28T18:30:00.000Z',
+          end: '2026-08-29T06:30:00.000Z',
+        },
+      ],
+      dayStart,
+      dayEnd
+    );
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].segments).toEqual([
+      {
+        start: '2026-08-28T00:00:00.000Z',
+        end: '2026-08-28T06:30:00.000Z',
+      },
+      {
+        start: '2026-08-28T18:30:00.000Z',
+        end: '2026-08-29T00:00:00.000Z',
+      },
+    ]);
+    expect(grouped[0].spansDayBoundary).toBe(true);
+  });
+
+  it('keeps the same responder separate when they belong to different layers', () => {
+    const grouped = groupCalendarShiftsForDay(
+      [
+        {
+          id: 'primary',
+          layerId: 'layer-primary',
+          userId: 'user-alex',
+          source: 'layer',
+          label: 'Primary: Alex',
+          start: '2026-08-28T06:30:00.000Z',
+          end: '2026-08-28T12:00:00.000Z',
+        },
+        {
+          id: 'secondary',
+          layerId: 'layer-secondary',
+          userId: 'user-alex',
+          source: 'layer',
+          label: 'Secondary: Alex',
+          start: '2026-08-28T12:00:00.000Z',
+          end: '2026-08-28T18:30:00.000Z',
+        },
+      ],
+      dayStart,
+      dayEnd
+    );
+
+    expect(grouped).toHaveLength(2);
+    expect(new Set(grouped.map(entry => entry.layerId))).toEqual(
+      new Set(['layer-primary', 'layer-secondary'])
+    );
+  });
+
+  it('does not collapse an override into a raw layer entry', () => {
+    const grouped = groupCalendarShiftsForDay(
+      [
+        {
+          id: 'layer',
+          layerId: 'layer-primary',
+          userId: 'user-alex',
+          source: 'layer',
+          label: 'Primary: Alex',
+          start: '2026-08-28T06:30:00.000Z',
+          end: '2026-08-28T12:00:00.000Z',
+        },
+        {
+          id: 'override',
+          layerId: 'layer-primary',
+          userId: 'user-alex',
+          source: 'override',
+          label: 'Primary: Alex (Override)',
+          start: '2026-08-28T12:00:00.000Z',
+          end: '2026-08-28T18:30:00.000Z',
+        },
+      ],
+      dayStart,
+      dayEnd
+    );
+
+    expect(grouped).toHaveLength(2);
+    expect(new Set(grouped.map(entry => entry.source))).toEqual(new Set(['layer', 'override']));
+  });
+
+  it('ignores invalid and non-overlapping blocks instead of poisoning the calendar', () => {
+    const grouped = groupCalendarShiftsForDay(
+      [
+        {
+          id: 'before',
+          layerId: 'layer-primary',
+          userId: 'user-alex',
+          source: 'layer',
+          label: 'Primary: Alex',
+          start: '2026-08-27T01:00:00.000Z',
+          end: '2026-08-27T02:00:00.000Z',
+        },
+        {
+          id: 'invalid',
+          layerId: 'layer-primary',
+          userId: 'user-alex',
+          source: 'layer',
+          label: 'Primary: Alex',
+          start: 'invalid',
+          end: '2026-08-28T02:00:00.000Z',
+        },
+      ],
+      dayStart,
+      dayEnd
+    );
+
+    expect(grouped).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Hardens the on-call schedule write path and calendar presentation without changing the canonical rotation/DST engine.

## Reliability and correctness
- serialize responder add/reorder/remove operations with the existing Serializable transaction + retry utility
- enforce the schedule-wide single-layer responder invariant inside the transaction
- allocate/normalize responder positions atomically
- reject inactive or missing responders at the authoritative server mutation boundary
- validate both override target and replacement responders
- reject self-replacement and overlapping replacement overrides with stable domain conflicts
- make repeated responder removal an idempotent no-op
- load overrides over the union of calendar and 90-day coverage windows so future coverage cannot silently omit an override
- coalesce same responder + layer + source fragments within a calendar day, fixing duplicate overnight entries while preserving the real coverage windows

## Security and data minimization
- authorize schedule access before loading detail data
- only fetch the active responder directory for users who can manage schedules
- do not return unexpected Prisma/database exception messages through server actions
- add centralized public error codes for inactive responders and override conflicts

## UI safety
- calendar shows one logical entry per responder/layer/day rather than duplicate midnight fragments
- preserves multi-window/overnight detail in the cell tooltip/badge
- replaces the hydration blank with a stable loading skeleton
- fixes layer-priority help text to match the actual engine semantics

## Tests
- calendar overnight-fragment regression coverage
- different-layer and override-source grouping guards
- real PostgreSQL concurrent same-responder/different-layer assignment test
- real PostgreSQL concurrent position-allocation test
- inactive responder and inactive override-replacement tests
- real PostgreSQL overlapping replacement-override race test
- server-action error redaction tests

No schema migration. No changes to `src/lib/oncall.ts`.