### PR TITLE
feat(schedules): improve responder management UX

### DIFF
--- a/src/components/LayerCard.tsx
+++ b/src/components/LayerCard.tsx
@@ -103,19 +103,39 @@ function formatShortTime(date: Date, timeZone: string): string {
   }).format(date);
 }
 
+function getDayName(day: number): string {
+  switch (day) {
+    case 0:
+      return 'Sun';
+    case 1:
+      return 'Mon';
+    case 2:
+      return 'Tue';
+    case 3:
+      return 'Wed';
+    case 4:
+      return 'Thu';
+    case 5:
+      return 'Fri';
+    case 6:
+      return 'Sat';
+    default:
+      return '';
+  }
+}
+
 function formatRestrictions(restrictions: LayerRestrictions | null | undefined): string[] {
   if (!restrictions) return [];
 
   const badges: string[] = [];
   if (restrictions.daysOfWeek && restrictions.daysOfWeek.length > 0) {
     const days = [...restrictions.daysOfWeek].sort((a, b) => a - b);
-    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
     const isWeekdays = days.length === 5 && [1, 2, 3, 4, 5].every(d => days.includes(d));
     const isWeekends = days.length === 2 && days.includes(0) && days.includes(6);
 
     if (isWeekdays) badges.push('Mon-Fri');
     else if (isWeekends) badges.push('Sat-Sun');
-    else if (days.length <= 3) badges.push(days.map(d => dayNames[d]).join(', '));
+    else if (days.length <= 3) badges.push(days.map(d => getDayName(d)).filter(Boolean).join(', '));
     else badges.push(`${days.length} days`);
   }
 

--- a/src/components/LayerCard.tsx
+++ b/src/components/LayerCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useTransition, useState, useMemo, useCallback } from 'react';
+import { useTransition, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-product-notification';
 import LayerEditSheet from './LayerEditSheet';
+import ResponderCombobox, { type ResponderOption } from './ResponderCombobox';
 import { Card, CardContent } from '@/components/ui/shadcn/card';
 import UserAvatar from '@/components/UserAvatar';
 import { Button } from '@/components/ui/shadcn/button';
@@ -34,7 +35,6 @@ import {
   Layers,
   Info,
   X,
-  ChevronDown,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { notify } from '@/lib/toast';
@@ -62,7 +62,7 @@ type LayerCardProps = {
   };
   scheduleId: string;
   timeZone: string;
-  users: Array<{ id: string; name: string }>;
+  users: ResponderOption[];
   canManageSchedules: boolean;
   updateLayer: (layerId: string, formData: FormData) => Promise<{ error?: string } | undefined>;
   deleteLayer: (scheduleId: string, layerId: string) => Promise<{ error?: string } | undefined>;
@@ -99,7 +99,7 @@ function formatShortTime(date: Date, timeZone: string): string {
     hour: 'numeric',
     minute: '2-digit',
     hour12: false,
-    timeZone: timeZone,
+    timeZone,
   }).format(date);
 }
 
@@ -107,28 +107,18 @@ function formatRestrictions(restrictions: LayerRestrictions | null | undefined):
   if (!restrictions) return [];
 
   const badges: string[] = [];
-
-  // Format days
   if (restrictions.daysOfWeek && restrictions.daysOfWeek.length > 0) {
-    const days = restrictions.daysOfWeek.sort((a, b) => a - b);
+    const days = [...restrictions.daysOfWeek].sort((a, b) => a - b);
     const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-    // Check for common patterns
     const isWeekdays = days.length === 5 && [1, 2, 3, 4, 5].every(d => days.includes(d));
     const isWeekends = days.length === 2 && days.includes(0) && days.includes(6);
 
-    if (isWeekdays) {
-      badges.push('Mon-Fri');
-    } else if (isWeekends) {
-      badges.push('Sat-Sun');
-    } else if (days.length <= 3) {
-      badges.push(days.map(d => dayNames[d]).join(', '));
-    } else {
-      badges.push(`${days.length} days`);
-    }
+    if (isWeekdays) badges.push('Mon-Fri');
+    else if (isWeekends) badges.push('Sat-Sun');
+    else if (days.length <= 3) badges.push(days.map(d => dayNames[d]).join(', '));
+    else badges.push(`${days.length} days`);
   }
 
-  // Format hours
   if (restrictions.startHour != null && restrictions.endHour != null) {
     const start = restrictions.startHour.toString().padStart(2, '0');
     const end = restrictions.endHour.toString().padStart(2, '0');
@@ -142,7 +132,6 @@ function formatRestrictions(restrictions: LayerRestrictions | null | undefined):
   return badges;
 }
 
-// Info Tooltip Component for consistent help icons
 function HelpTip({ children }: { children: React.ReactNode }) {
   return (
     <TooltipProvider delayDuration={300}>
@@ -150,7 +139,9 @@ function HelpTip({ children }: { children: React.ReactNode }) {
         <TooltipTrigger asChild>
           <span
             role="button"
-            className="inline-flex h-4 w-4 items-center justify-center rounded-full text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors cursor-help"
+            tabIndex={0}
+            aria-label="Layer help"
+            className="inline-flex h-4 w-4 items-center justify-center rounded-full text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           >
             <Info className="h-3 w-3" />
           </span>
@@ -201,8 +192,10 @@ export default function LayerCard({
   }, [scheduleId, layer.id, deleteLayer, showToast, router]);
 
   const handleAddUser = useCallback(
-    async (formData: FormData) => {
+    (userId: string) => {
       startTransition(async () => {
+        const formData = new FormData();
+        formData.set('userId', userId);
         const result = await addLayerUser(layer.id, formData);
         if (result?.error) {
           notify.error('Responder could not be added', { description: result.error });
@@ -244,9 +237,11 @@ export default function LayerCard({
     [layer.id, removeLayerUser, showToast, router]
   );
 
-  const availableUsers = useMemo(
-    () => users.filter(user => !layer.users.some(layerUser => layerUser.userId === user.id)),
-    [users, layer.users]
+  // Parent pages should already supply schedule-wide assignable users. Keep a
+  // local guard as defense in depth so this component never offers a current
+  // layer member even if reused elsewhere.
+  const availableUsers = users.filter(
+    user => !layer.users.some(layerUser => layerUser.userId === user.id)
   );
 
   return (
@@ -254,7 +249,6 @@ export default function LayerCard({
       <Card
         className={cn('overflow-hidden border-l-4 border-slate-200/80 shadow-sm', color.border)}
       >
-        {/* Compact Header */}
         <div className="flex items-start justify-between gap-3 p-3 bg-slate-50/70">
           <div className="flex items-start gap-3 min-w-0 flex-1">
             <div className={cn('h-9 w-9 rounded-lg flex items-center justify-center', color.light)}>
@@ -285,20 +279,17 @@ export default function LayerCard({
                 )}
                 {layer.restrictions &&
                   (layer.restrictions.daysOfWeek?.length ||
-                    layer.restrictions.startHour != null) && (
-                    <>
-                      {formatRestrictions(layer.restrictions).map((badge, i) => (
-                        <Badge
-                          key={i}
-                          variant="outline"
-                          size="xs"
-                          className="border-purple-200 bg-purple-50 text-purple-700"
-                        >
-                          {badge}
-                        </Badge>
-                      ))}
-                    </>
-                  )}
+                    layer.restrictions.startHour != null) &&
+                  formatRestrictions(layer.restrictions).map((badge, index) => (
+                    <Badge
+                      key={index}
+                      variant="outline"
+                      size="xs"
+                      className="border-purple-200 bg-purple-50 text-purple-700"
+                    >
+                      {badge}
+                    </Badge>
+                  ))}
                 <span className="flex items-center gap-1">
                   <Clock className="h-3 w-3" />
                   {formatShortTime(new Date(layer.start), timeZone)}
@@ -317,6 +308,7 @@ export default function LayerCard({
                 size="icon"
                 onClick={() => setIsEditOpen(!isEditOpen)}
                 className={cn('h-7 w-7', isEditOpen && 'bg-slate-200')}
+                aria-label={`Edit ${layer.name}`}
               >
                 <Edit3 className="h-3 w-3" />
               </Button>
@@ -325,6 +317,7 @@ export default function LayerCard({
                 size="icon"
                 onClick={() => setShowDeleteConfirm(true)}
                 className="h-7 w-7 text-slate-400 hover:text-red-600 hover:bg-red-50"
+                aria-label={`Delete ${layer.name}`}
               >
                 <Trash2 className="h-3 w-3" />
               </Button>
@@ -333,7 +326,6 @@ export default function LayerCard({
         </div>
 
         <CardContent className="p-0">
-          {/* Edit Sheet - same UI as Create form */}
           <LayerEditSheet
             layer={{
               id: layer.id,
@@ -350,46 +342,35 @@ export default function LayerCard({
             onOpenChange={setIsEditOpen}
           />
 
-          {/* Responders Section - Always visible */}
           <div className="border-t border-slate-100">
-            {/* Header with Add button */}
-            <div className="flex items-center justify-between p-2.5 px-3 bg-slate-50/50">
-              <div className="flex items-center gap-2 text-xs text-slate-600">
-                <Users className="h-3.5 w-3.5" />
+            <div className="flex items-center justify-between gap-3 p-2.5 px-3 bg-slate-50/50">
+              <div className="flex items-center gap-2 text-xs text-slate-600 min-w-0">
+                <Users className="h-3.5 w-3.5 shrink-0" />
                 <span className="font-medium">Responders</span>
                 <Badge variant="secondary" className="h-4 px-1.5 text-[9px] bg-slate-100">
                   {layer.users.length}
                 </Badge>
               </div>
-              {canManageSchedules && availableUsers.length > 0 && (
-                <form action={handleAddUser}>
-                  <div className="relative">
-                    <select
-                      name="userId"
-                      required
-                      disabled={isPending}
-                      onChange={e => {
-                        if (e.target.value) {
-                          e.target.form?.requestSubmit();
-                        }
-                      }}
-                      className="h-7 text-xs rounded-md border border-primary/50 bg-primary/5 pl-2 pr-7 hover:border-primary hover:bg-primary/10 focus:border-primary focus:ring-1 focus:ring-primary/20 cursor-pointer font-medium text-primary appearance-none"
-                    >
-                      <option value="">+ Add Responder</option>
-                      {availableUsers.map(user => (
-                        <option key={user.id} value={user.id}>
-                          {user.name}
-                        </option>
-                      ))}
-                    </select>
-                    <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 text-primary pointer-events-none opacity-70" />
-                  </div>
-                </form>
+              {canManageSchedules && (
+                <ResponderCombobox
+                  users={availableUsers}
+                  onSelect={handleAddUser}
+                  disabled={isPending}
+                />
               )}
             </div>
 
-            {/* Responders List - only show if there are responders */}
-            {layer.users.length > 0 && (
+            {layer.users.length === 0 ? (
+              <div className="px-4 py-5 text-center">
+                <Users className="mx-auto mb-1.5 h-5 w-5 text-slate-300" />
+                <p className="text-xs font-medium text-slate-500">No responders in this rotation</p>
+                {canManageSchedules && (
+                  <p className="mt-0.5 text-[10px] text-slate-400">
+                    Add an active responder to start coverage.
+                  </p>
+                )}
+              </div>
+            ) : (
               <div className="px-3 pb-3 pt-2 space-y-2">
                 {layer.users.map((layerUser, index) => (
                   <div
@@ -399,10 +380,10 @@ export default function LayerCard({
                       isPending && 'opacity-50'
                     )}
                   >
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
                       <span
                         className={cn(
-                          'w-5 h-5 rounded text-[10px] font-bold flex items-center justify-center',
+                          'w-5 h-5 rounded text-[10px] font-bold flex items-center justify-center shrink-0',
                           index === 0
                             ? `${color.light} ${color.text}`
                             : 'bg-slate-100 text-slate-500'
@@ -416,28 +397,29 @@ export default function LayerCard({
                         gender={layerUser.user.gender}
                         avatarUrl={layerUser.user.avatarUrl}
                         size="xs"
-                        className="h-6 w-6"
+                        className="h-6 w-6 shrink-0"
                       />
-                      <span className="text-sm font-medium text-slate-700">
+                      <span className="text-sm font-medium text-slate-700 truncate">
                         {layerUser.user.name}
                       </span>
                       {index === 0 && (
                         <Badge
                           variant="secondary"
-                          className="h-4 px-1.5 text-[8px] bg-emerald-50 text-emerald-600 border-emerald-100"
+                          className="h-4 px-1.5 text-[8px] bg-emerald-50 text-emerald-600 border-emerald-100 shrink-0"
                         >
                           NEXT
                         </Badge>
                       )}
                     </div>
                     {canManageSchedules && (
-                      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className="flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shrink-0">
                         <Button
                           variant="ghost"
                           size="icon"
                           onClick={() => handleMoveUser(layerUser.userId, 'up')}
                           disabled={index === 0 || isPending}
-                          className="h-6 w-6"
+                          className="h-7 w-7"
+                          aria-label={`Move ${layerUser.user.name} up`}
                         >
                           <ArrowUp className="h-3 w-3" />
                         </Button>
@@ -446,7 +428,8 @@ export default function LayerCard({
                           size="icon"
                           onClick={() => handleMoveUser(layerUser.userId, 'down')}
                           disabled={index === layer.users.length - 1 || isPending}
-                          className="h-6 w-6"
+                          className="h-7 w-7"
+                          aria-label={`Move ${layerUser.user.name} down`}
                         >
                           <ArrowDown className="h-3 w-3" />
                         </Button>
@@ -455,7 +438,8 @@ export default function LayerCard({
                           size="icon"
                           onClick={() => handleRemoveUser(layerUser.userId)}
                           disabled={isPending}
-                          className="h-6 w-6 text-slate-400 hover:text-red-500"
+                          className="h-7 w-7 text-slate-400 hover:text-red-500"
+                          aria-label={`Remove ${layerUser.user.name} from ${layer.name}`}
                         >
                           <X className="h-3 w-3" />
                         </Button>
@@ -469,7 +453,6 @@ export default function LayerCard({
         </CardContent>
       </Card>
 
-      {/* Delete Dialog */}
       <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <AlertDialogContent className="max-w-sm">
           <AlertDialogHeader>

--- a/src/components/ResponderCombobox.tsx
+++ b/src/components/ResponderCombobox.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import UserAvatar from '@/components/UserAvatar';
+import { Button } from '@/components/ui/shadcn/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/shadcn/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/shadcn/popover';
+import { Badge } from '@/components/ui/shadcn/badge';
+import { ChevronsUpDown, UserPlus } from 'lucide-react';
+
+export type ResponderOption = {
+  id: string;
+  name: string;
+  email?: string | null;
+  role?: string | null;
+  avatarUrl?: string | null;
+  gender?: string | null;
+};
+
+type ResponderComboboxProps = {
+  users: ResponderOption[];
+  onSelect: (userId: string) => void;
+  disabled?: boolean;
+};
+
+export default function ResponderCombobox({
+  users,
+  onSelect,
+  disabled = false,
+}: ResponderComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const hasUsers = users.length > 0;
+  const isDisabled = disabled || !hasUsers;
+
+  return (
+    <Popover open={open} onOpenChange={nextOpen => !isDisabled && setOpen(nextOpen)}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          role="combobox"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-label={hasUsers ? 'Add responder' : 'All active responders are already assigned'}
+          disabled={isDisabled}
+          title={hasUsers ? 'Search and add a responder' : 'All active responders are already assigned'}
+          className="h-8 gap-1.5 border-primary/40 bg-primary/5 px-2.5 text-xs font-medium text-primary hover:border-primary hover:bg-primary/10"
+        >
+          <UserPlus className="h-3.5 w-3.5" />
+          {hasUsers ? 'Add Responder' : 'All Assigned'}
+          {hasUsers && <ChevronsUpDown className="h-3 w-3 opacity-60" />}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-[320px] p-0" align="end" sideOffset={6}>
+        <Command className="rounded-lg">
+          <CommandInput
+            placeholder="Search by name, email, or role..."
+            aria-label="Search available responders"
+          />
+          <CommandList className="max-h-[320px]">
+            <CommandEmpty className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No active responders match your search.
+            </CommandEmpty>
+            <CommandGroup heading={`Available responders (${users.length})`} className="p-1.5">
+              {users.map(user => (
+                <CommandItem
+                  key={user.id}
+                  value={`${user.name}|${user.email ?? ''}|${user.role ?? ''}|${user.id}`}
+                  onSelect={() => {
+                    setOpen(false);
+                    onSelect(user.id);
+                  }}
+                  className="my-0.5 cursor-pointer rounded-md px-2 py-2"
+                >
+                  <UserAvatar
+                    userId={user.id}
+                    name={user.name}
+                    avatarUrl={user.avatarUrl}
+                    gender={user.gender}
+                    size="sm"
+                    className="mr-2 shrink-0 border-slate-200"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-xs font-semibold text-slate-800">
+                        {user.name}
+                      </span>
+                      {user.role && (
+                        <Badge variant="secondary" size="xs" className="shrink-0 text-[9px]">
+                          {user.role.toLowerCase()}
+                        </Badge>
+                      )}
+                    </div>
+                    <span className="block truncate text-[10px] text-muted-foreground">
+                      {user.email || 'Active responder'}
+                    </span>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/tests/components/ResponderCombobox.test.tsx
+++ b/tests/components/ResponderCombobox.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ResponderCombobox from '@/components/ResponderCombobox';
+
+vi.mock('@/components/UserAvatar', () => ({
+  default: ({ name }: { name: string }) => <span aria-hidden="true">{name.slice(0, 1)}</span>,
+}));
+
+const responders = [
+  {
+    id: 'user-alex',
+    name: 'Alex Vance',
+    email: 'alex@example.com',
+    role: 'RESPONDER',
+  },
+  {
+    id: 'user-taylor',
+    name: 'Taylor Reed',
+    email: 'taylor@example.com',
+    role: 'ADMIN',
+  },
+];
+
+describe('ResponderCombobox', () => {
+  it('shows a disabled, explanatory state when every active responder is assigned', () => {
+    render(<ResponderCombobox users={[]} onSelect={vi.fn()} />);
+
+    const trigger = screen.getByRole('combobox', {
+      name: 'All active responders are already assigned',
+    });
+    expect(trigger).toHaveProperty('disabled', true);
+    expect(screen.getByText('All Assigned')).toBeDefined();
+  });
+
+  it('opens a searchable responder picker with identity context', () => {
+    render(<ResponderCombobox users={responders} onSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Add responder' }));
+
+    expect(screen.getByLabelText('Search available responders')).toBeDefined();
+    expect(screen.getByText('Alex Vance')).toBeDefined();
+    expect(screen.getByText('alex@example.com')).toBeDefined();
+    expect(screen.getByText('Taylor Reed')).toBeDefined();
+  });
+
+  it('returns the stable user id when a responder is selected', () => {
+    const onSelect = vi.fn();
+    render(<ResponderCombobox users={responders} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Add responder' }));
+    fireEvent.click(screen.getByText('Alex Vance'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('user-alex');
+  });
+});


### PR DESCRIPTION
## Summary
Upgrades schedule responder management from a native select to a searchable, accessible operator-focused combobox.

Built directly on the merged #450 schedule hardening boundary, so UI filtering remains convenience-only while the server continues to enforce ACTIVE responder and schedule-wide assignment invariants.

## UX improvements
- searchable responder picker using the app's existing Command + Popover primitives
- search identity includes name, email, role, and stable user id
- avatar, email, and role context for similarly named responders
- explicit `All Assigned` state when no active schedule-wide responders remain
- meaningful no-search-results state
- keyboard-friendly combobox semantics and accessible labels
- mutation pending state prevents duplicate submissions
- responsive responder controls remain visible on touch/small screens and appear on hover/focus on desktop
- empty layer state explains how to establish coverage
- accessible labels on edit/delete/reorder/remove controls
- keyboard-focusable layer help

## Safety
- selected values submit only the stable user id to the existing server action
- UI filtering is convenience only; #450 is the authoritative server-side ACTIVE/invariant boundary
- no new UI library or dependency
- no scheduling/rotation algorithm changes

## Tests
- disabled all-assigned state
- picker opens with responder identity context
- selecting a responder emits the stable user id

Exactly one commit and three changed files.