### PR TITLE
refactor(schedules): centralize detail presentation and capabilities

### DIFF
--- a/src/app/(app)/schedules/actions.ts
+++ b/src/app/(app)/schedules/actions.ts
@@ -2,7 +2,7 @@
 
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
-import { assertAdminOrResponder, getCurrentUser } from '@/lib/rbac';
+import { assertAdminOrResponder, assertCanCreateScheduleOverride } from '@/lib/rbac';
 import { logAudit } from '@/lib/audit';
 import { createInAppNotifications, getScheduleUserIds } from '@/lib/in-app-notifications';
 import { parseDateTimeInTimeZone, isValidTimeZone } from '@/lib/timezone';
@@ -28,44 +28,6 @@ async function getScheduleName(scheduleId: string) {
     select: { name: true },
   });
   return schedule?.name || 'On-call schedule';
-}
-
-async function assertCanCreateScheduleOverride(scheduleId: string) {
-  const user = await getCurrentUser();
-  if (user.role === 'ADMIN') return user;
-
-  const accessible = await prisma.onCallSchedule.findFirst({
-    where: {
-      id: scheduleId,
-      OR: [
-        { layers: { some: { users: { some: { userId: user.id } } } } },
-        {
-          escalationRules: {
-            some: {
-              policy: {
-                services: {
-                  some: {
-                    team: { members: { some: { userId: user.id, role: 'OWNER' } } },
-                  },
-                },
-              },
-            },
-          },
-        },
-      ],
-    },
-    select: { id: true },
-  });
-
-  if (!accessible) {
-    throw new AppError({
-      code: 'SCHEDULE_OVERRIDE_ACCESS_DENIED',
-      userMessage:
-        'Unauthorized. Only an administrator, owning team lead, or assigned schedule member can create overrides.',
-      details: { scheduleId, userId: user.id },
-    });
-  }
-  return user;
 }
 
 async function notifyScheduleMembers(

--- a/src/components/schedules/ScheduleDetailTabs.tsx
+++ b/src/components/schedules/ScheduleDetailTabs.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/shadcn/tabs';
+import { CalendarClock, Layers3, Settings2, ShieldPlus } from 'lucide-react';
+
+type ScheduleDetailTab = 'overview' | 'rotation' | 'overrides' | 'settings';
+
+type ScheduleDetailTabsProps = {
+  defaultTab?: string;
+  overview: ReactNode;
+  rotation: ReactNode;
+  overrides: ReactNode;
+  settings: ReactNode;
+};
+
+function normalizeTab(tab?: string): ScheduleDetailTab {
+  return tab === 'rotation' || tab === 'overrides' || tab === 'settings' ? tab : 'overview';
+}
+
+export default function ScheduleDetailTabs({
+  defaultTab,
+  overview,
+  rotation,
+  overrides,
+  settings,
+}: ScheduleDetailTabsProps) {
+  return (
+    <Tabs defaultValue={normalizeTab(defaultTab)} className="space-y-5">
+      <div className="overflow-x-auto pb-1">
+        <TabsList className="grid h-auto min-w-[520px] grid-cols-4 bg-muted/60 p-1">
+          <TabsTrigger value="overview" className="gap-2 py-2.5">
+            <CalendarClock className="h-4 w-4" />
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="rotation" className="gap-2 py-2.5">
+            <Layers3 className="h-4 w-4" />
+            Rotation
+          </TabsTrigger>
+          <TabsTrigger value="overrides" className="gap-2 py-2.5">
+            <ShieldPlus className="h-4 w-4" />
+            Overrides
+          </TabsTrigger>
+          <TabsTrigger value="settings" className="gap-2 py-2.5">
+            <Settings2 className="h-4 w-4" />
+            Settings
+          </TabsTrigger>
+        </TabsList>
+      </div>
+      <TabsContent value="overview" className="mt-0 space-y-5">
+        {overview}
+      </TabsContent>
+      <TabsContent value="rotation" className="mt-0 space-y-5">
+        {rotation}
+      </TabsContent>
+      <TabsContent value="overrides" className="mt-0 space-y-5">
+        {overrides}
+      </TabsContent>
+      <TabsContent value="settings" className="mt-0 space-y-5">
+        {settings}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -15,6 +15,10 @@ import {
 } from '@/lib/authorization';
 import { resolveUserActor } from '@/lib/authorization-actors';
 import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
+import {
+  deriveScheduleUICapabilities,
+  type ScheduleUICapabilities,
+} from '@/lib/schedules/capabilities';
 
 function appError(
   code:
@@ -395,12 +399,23 @@ export async function assertCanModifyService(serviceId: string) {
 
 export async function assertCanViewSchedule(scheduleId: string) {
   const user = await getCurrentUser();
-  if (hasCapability(user.role as AppRole, CAPABILITIES.SCHEDULE_READ_ALL)) return user;
+  const capabilities = await resolveScheduleUICapabilities(scheduleId, user);
+  if (capabilities.canViewSchedule) return { user, capabilities };
 
+  throw appError(
+    'SCHEDULE_ACCESS_DENIED',
+    'Unauthorized. You do not have permission to view this schedule.',
+    { scheduleId, userId: user.id }
+  );
+}
+
+async function resolveScheduleUICapabilities(
+  scheduleId: string,
+  user: Awaited<ReturnType<typeof getCurrentUser>>
+): Promise<ScheduleUICapabilities> {
   const schedule = await prisma.onCallSchedule.findUnique({
     where: { id: scheduleId },
     select: {
-      id: true,
       layers: {
         select: {
           users: { where: { userId: user.id }, select: { id: true } },
@@ -409,6 +424,20 @@ export async function assertCanViewSchedule(scheduleId: string) {
       overrides: {
         where: { OR: [{ userId: user.id }, { replacesUserId: user.id }] },
         select: { id: true },
+        take: 1,
+      },
+      escalationRules: {
+        where: {
+          policy: {
+            services: {
+              some: {
+                team: { members: { some: { userId: user.id, role: 'OWNER' } } },
+              },
+            },
+          },
+        },
+        select: { id: true },
+        take: 1,
       },
     },
   });
@@ -417,12 +446,31 @@ export async function assertCanViewSchedule(scheduleId: string) {
     throw appError('SCHEDULE_NOT_FOUND', 'Schedule not found', { scheduleId });
   }
 
-  const hasLayerAccess = schedule.layers.some(layer => layer.users.length > 0);
-  if (hasLayerAccess || schedule.overrides.length > 0) return user;
+  const isAssignedMember = schedule.layers.some(layer => layer.users.length > 0);
+  const isOwningTeamLead = schedule.escalationRules.length > 0;
+  return deriveScheduleUICapabilities({
+    capabilities: getRoleCapabilities(user.role as AppRole),
+    isAdmin: user.role === 'ADMIN',
+    isAssignedMember,
+    isOwningTeamLead,
+    hasScopedView: isAssignedMember || schedule.overrides.length > 0,
+  });
+}
 
-  throw appError(
-    'SCHEDULE_ACCESS_DENIED',
-    'Unauthorized. You do not have permission to view this schedule.',
-    { scheduleId, userId: user.id }
-  );
+export async function getScheduleUICapabilities(scheduleId: string) {
+  const user = await getCurrentUser();
+  return resolveScheduleUICapabilities(scheduleId, user);
+}
+
+export async function assertCanCreateScheduleOverride(scheduleId: string) {
+  const user = await getCurrentUser();
+  const capabilities = await resolveScheduleUICapabilities(scheduleId, user);
+  if (capabilities.canCreateOverride) return user;
+
+  throw new AppError({
+    code: 'SCHEDULE_OVERRIDE_ACCESS_DENIED',
+    userMessage:
+      'Unauthorized. Only an administrator, owning team lead, or assigned schedule member can create overrides.',
+    details: { scheduleId, userId: user.id },
+  });
 }

--- a/src/lib/schedules/capabilities.ts
+++ b/src/lib/schedules/capabilities.ts
@@ -1,0 +1,37 @@
+import { CAPABILITIES, type Capability } from '@/lib/authorization';
+
+export type ScheduleUICapabilities = {
+  canViewSchedule: boolean;
+  canManageRotation: boolean;
+  canManageScheduleSettings: boolean;
+  canCreateOverride: boolean;
+  canDeleteOverride: boolean;
+};
+
+type ScheduleCapabilityContext = {
+  capabilities: readonly Capability[];
+  isAdmin: boolean;
+  isAssignedMember: boolean;
+  isOwningTeamLead: boolean;
+  hasScopedView: boolean;
+};
+
+export function deriveScheduleUICapabilities({
+  capabilities,
+  isAdmin,
+  isAssignedMember,
+  isOwningTeamLead,
+  hasScopedView,
+}: ScheduleCapabilityContext): ScheduleUICapabilities {
+  const canManageRotation = capabilities.includes(CAPABILITIES.OPERATIONS_MANAGE);
+  const canManageOverrides = isAdmin || isAssignedMember || isOwningTeamLead;
+
+  return {
+    canViewSchedule:
+      capabilities.includes(CAPABILITIES.SCHEDULE_READ_ALL) || hasScopedView || canManageOverrides,
+    canManageRotation,
+    canManageScheduleSettings: canManageRotation,
+    canCreateOverride: canManageOverrides,
+    canDeleteOverride: canManageOverrides,
+  };
+}

--- a/src/lib/schedules/detail-view-model.ts
+++ b/src/lib/schedules/detail-view-model.ts
@@ -1,0 +1,130 @@
+import type { OnCallBlock } from '@/lib/oncall';
+
+export type OverrideStatus = 'ACTIVE' | 'UPCOMING' | 'COMPLETED';
+export type OverrideKind = 'REPLACEMENT' | 'ADDITIVE';
+
+export type ScheduleOverridePresentation = {
+  id: string;
+  start: Date;
+  end: Date;
+  userId: string;
+  replacesUserId: string | null;
+  status: OverrideStatus;
+  kind: OverrideKind;
+};
+
+export type ScheduleDetailViewModel = {
+  currentCoverage: OnCallBlock[];
+  nextCoverageChange: {
+    at: Date;
+    coverage: OnCallBlock[];
+  } | null;
+  nextCoverage: OnCallBlock | null;
+  activeOverrides: ScheduleOverridePresentation[];
+  upcomingOverrides: ScheduleOverridePresentation[];
+  completedOverrides: ScheduleOverridePresentation[];
+  coverageGap: boolean;
+  participantCount: number;
+  layerCount: number;
+  summary: string;
+};
+
+type OverrideInput = {
+  id: string;
+  start: Date;
+  end: Date;
+  userId: string;
+  replacesUserId: string | null;
+};
+
+type ScheduleDetailViewModelInput = {
+  now: Date;
+  finalCoverageBlocks: OnCallBlock[];
+  overrides: OverrideInput[];
+  layerCount: number;
+  participantIds: string[];
+};
+
+export function classifyOverride(
+  override: Pick<OverrideInput, 'start' | 'end'>,
+  now: Date
+): OverrideStatus {
+  if (override.end.getTime() <= now.getTime()) return 'COMPLETED';
+  if (override.start.getTime() > now.getTime()) return 'UPCOMING';
+  return 'ACTIVE';
+}
+
+export function getOverrideKind(override: Pick<OverrideInput, 'replacesUserId'>): OverrideKind {
+  return override.replacesUserId ? 'REPLACEMENT' : 'ADDITIVE';
+}
+
+function activeAt(blocks: OnCallBlock[], instant: Date): OnCallBlock[] {
+  const time = instant.getTime();
+  return blocks.filter(block => block.start.getTime() <= time && block.end.getTime() > time);
+}
+
+function coverageIdentity(blocks: OnCallBlock[]): string {
+  return blocks
+    .map(block => `${block.userId}:${block.source}:${Boolean(block.isAdditiveOverride)}`)
+    .sort()
+    .join('|');
+}
+
+function findNextCoverageChange(blocks: OnCallBlock[], now: Date) {
+  const currentIdentity = coverageIdentity(activeAt(blocks, now));
+  const boundaries = Array.from(
+    new Set(
+      blocks
+        .flatMap(block => [block.start.getTime(), block.end.getTime()])
+        .filter(time => time > now.getTime())
+    )
+  ).sort((a, b) => a - b);
+
+  for (const boundary of boundaries) {
+    const at = new Date(boundary);
+    const coverage = activeAt(blocks, at);
+    if (coverageIdentity(coverage) !== currentIdentity) return { at, coverage };
+  }
+  return null;
+}
+
+export function buildScheduleDetailViewModel({
+  now,
+  finalCoverageBlocks,
+  overrides,
+  layerCount,
+  participantIds,
+}: ScheduleDetailViewModelInput): ScheduleDetailViewModel {
+  const currentCoverage = activeAt(finalCoverageBlocks, now);
+  const nextCoverageChange = findNextCoverageChange(finalCoverageBlocks, now);
+  const nextCoverage =
+    finalCoverageBlocks
+      .filter(block => block.start.getTime() > now.getTime())
+      .sort((a, b) => a.start.getTime() - b.start.getTime())[0] ?? null;
+  const presentedOverrides = overrides.map(override => ({
+    ...override,
+    status: classifyOverride(override, now),
+    kind: getOverrideKind(override),
+  }));
+  const participantCount = new Set(participantIds).size;
+  const coverageGap = currentCoverage.length === 0;
+
+  return {
+    currentCoverage,
+    nextCoverageChange,
+    nextCoverage,
+    activeOverrides: presentedOverrides.filter(override => override.status === 'ACTIVE'),
+    upcomingOverrides: presentedOverrides.filter(override => override.status === 'UPCOMING'),
+    completedOverrides: presentedOverrides.filter(override => override.status === 'COMPLETED'),
+    coverageGap,
+    participantCount,
+    layerCount,
+    summary: coverageGap
+      ? nextCoverage
+        ? `Coverage resumes with ${nextCoverage.userName}`
+        : 'No effective coverage is scheduled'
+      : currentCoverage.length === 1
+        ? `${currentCoverage[0].userName} is on call`
+        : `${currentCoverage.length} responders are on call`,
+  };
+}

--- a/tests/lib/schedules/capabilities.test.ts
+++ b/tests/lib/schedules/capabilities.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { CAPABILITIES } from '@/lib/authorization';
+import { deriveScheduleUICapabilities } from '@/lib/schedules/capabilities';
+
+describe('schedule UI capability contract', () => {
+  it('allows administrators to manage rotation, settings, and overrides', () => {
+    expect(
+      deriveScheduleUICapabilities({
+        capabilities: [CAPABILITIES.SCHEDULE_READ_ALL, CAPABILITIES.OPERATIONS_MANAGE],
+        isAdmin: true,
+        isAssignedMember: false,
+        isOwningTeamLead: false,
+        hasScopedView: false,
+      })
+    ).toEqual({
+      canViewSchedule: true,
+      canManageRotation: true,
+      canManageScheduleSettings: true,
+      canCreateOverride: true,
+      canDeleteOverride: true,
+    });
+  });
+
+  it('keeps responder rotation access separate from unrelated override access', () => {
+    const capabilities = deriveScheduleUICapabilities({
+      capabilities: [CAPABILITIES.SCHEDULE_READ_ALL, CAPABILITIES.OPERATIONS_MANAGE],
+      isAdmin: false,
+      isAssignedMember: false,
+      isOwningTeamLead: false,
+      hasScopedView: false,
+    });
+
+    expect(capabilities.canManageRotation).toBe(true);
+    expect(capabilities.canCreateOverride).toBe(false);
+  });
+
+  it.each([
+    ['assigned schedule member', true, false],
+    ['owning team lead', false, true],
+  ])('allows %s to manage overrides without rotation settings', (_label, assigned, owner) => {
+    const capabilities = deriveScheduleUICapabilities({
+      capabilities: [],
+      isAdmin: false,
+      isAssignedMember: assigned,
+      isOwningTeamLead: owner,
+      hasScopedView: assigned,
+    });
+
+    expect(capabilities.canViewSchedule).toBe(true);
+    expect(capabilities.canManageRotation).toBe(false);
+    expect(capabilities.canCreateOverride).toBe(true);
+    expect(capabilities.canDeleteOverride).toBe(true);
+  });
+
+  it('leaves an unrelated viewer without schedule actions', () => {
+    expect(
+      deriveScheduleUICapabilities({
+        capabilities: [],
+        isAdmin: false,
+        isAssignedMember: false,
+        isOwningTeamLead: false,
+        hasScopedView: false,
+      })
+    ).toEqual({
+      canViewSchedule: false,
+      canManageRotation: false,
+      canManageScheduleSettings: false,
+      canCreateOverride: false,
+      canDeleteOverride: false,
+    });
+  });
+});

--- a/tests/lib/schedules/detail-view-model.test.ts
+++ b/tests/lib/schedules/detail-view-model.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { OnCallBlock } from '@/lib/oncall';
+import {
+  buildScheduleDetailViewModel,
+  classifyOverride,
+  getOverrideKind,
+} from '@/lib/schedules/detail-view-model';
+import { parseDateTimeInTimeZone } from '@/lib/timezone';
+
+function block(
+  id: string,
+  userId: string,
+  userName: string,
+  start: string,
+  end: string,
+  extra: Partial<OnCallBlock> = {}
+): OnCallBlock {
+  return {
+    id,
+    userId,
+    userName,
+    start: new Date(start),
+    end: new Date(end),
+    layerId: 'primary',
+    layerName: 'Final Schedule',
+    source: 'rotation',
+    ...extra,
+  };
+}
+
+describe('schedule detail view model', () => {
+  const now = new Date('2026-08-29T10:00:00.000Z');
+
+  it('derives current responders and the next effective handoff from canonical blocks', () => {
+    const model = buildScheduleDetailViewModel({
+      now,
+      finalCoverageBlocks: [
+        block('alex', 'alex', 'Alex', '2026-08-29T08:00:00Z', '2026-08-29T12:00:00Z'),
+        block('sam', 'sam', 'Sam', '2026-08-29T12:00:00Z', '2026-08-29T16:00:00Z'),
+      ],
+      overrides: [],
+      layerCount: 1,
+      participantIds: ['alex', 'sam'],
+    });
+
+    expect(model.currentCoverage.map(item => item.userName)).toEqual(['Alex']);
+    expect(model.nextCoverageChange?.at.toISOString()).toBe('2026-08-29T12:00:00.000Z');
+    expect(model.nextCoverageChange?.coverage.map(item => item.userName)).toEqual(['Sam']);
+    expect(model.summary).toBe('Alex is on call');
+  });
+
+  it('preserves multiple current responders including additive coverage', () => {
+    const model = buildScheduleDetailViewModel({
+      now,
+      finalCoverageBlocks: [
+        block('alex', 'alex', 'Alex', '2026-08-29T08:00:00Z', '2026-08-29T12:00:00Z'),
+        block('extra', 'sam', 'Sam', '2026-08-29T09:00:00Z', '2026-08-29T11:00:00Z', {
+          source: 'override',
+          isAdditiveOverride: true,
+        }),
+      ],
+      overrides: [],
+      layerCount: 2,
+      participantIds: ['alex', 'sam', 'alex'],
+    });
+
+    expect(model.currentCoverage.map(item => item.userName)).toEqual(['Alex', 'Sam']);
+    expect(model.nextCoverageChange?.at.toISOString()).toBe('2026-08-29T11:00:00.000Z');
+    expect(model.nextCoverageChange?.coverage.map(item => item.userName)).toEqual(['Alex']);
+    expect(model.participantCount).toBe(2);
+  });
+
+  it('classifies replacement and additive overrides at exact boundaries', () => {
+    const activeAtStart = { start: now, end: new Date('2026-08-29T11:00:00Z') };
+    const completedAtEnd = { start: new Date('2026-08-29T09:00:00Z'), end: now };
+
+    expect(classifyOverride(activeAtStart, now)).toBe('ACTIVE');
+    expect(classifyOverride(completedAtEnd, now)).toBe('COMPLETED');
+    expect(
+      classifyOverride(
+        { start: new Date('2026-08-29T10:00:00.001Z'), end: new Date('2026-08-29T11:00:00Z') },
+        now
+      )
+    ).toBe('UPCOMING');
+    expect(getOverrideKind({ replacesUserId: 'alex' })).toBe('REPLACEMENT');
+    expect(getOverrideKind({ replacesUserId: null })).toBe('ADDITIVE');
+  });
+
+  it('reports a gap and the next future coverage block', () => {
+    const model = buildScheduleDetailViewModel({
+      now,
+      finalCoverageBlocks: [
+        block('future', 'sam', 'Sam', '2026-08-29T11:00:00Z', '2026-08-29T12:00:00Z'),
+      ],
+      overrides: [],
+      layerCount: 1,
+      participantIds: ['sam'],
+    });
+
+    expect(model.coverageGap).toBe(true);
+    expect(model.nextCoverage?.userName).toBe('Sam');
+    expect(model.nextCoverageChange?.coverage.map(item => item.userName)).toEqual(['Sam']);
+  });
+
+  it('uses timezone-resolved instants across DST and fractional offsets', () => {
+    const dstStart = parseDateTimeInTimeZone('2026-11-01T01:30', 'America/New_York');
+    const fractionalStart = parseDateTimeInTimeZone('2026-08-29T15:45', 'Asia/Kathmandu');
+
+    expect(dstStart).toBeNull();
+    expect(fractionalStart?.toISOString()).toBe('2026-08-29T10:00:00.000Z');
+    expect(
+      classifyOverride(
+        {
+          start: fractionalStart!,
+          end: new Date('2026-08-29T11:00:00.000Z'),
+        },
+        now
+      )
+    ).toBe('ACTIVE');
+  });
+});


### PR DESCRIPTION
## What changed
- Added a pure schedule detail view model for current coverage, next effective change, gaps, participant counts, and exact override classification.
- Added a centralized schedule UI capability contract and reused it in both the view gate and override server authorization.
- Added the accessible Overview / Rotation / Overrides / Settings navigation primitive.

## Centralization and preserved behavior
Presentation derives exclusively from canonical `OnCallBlock` output. Rotation, DST, timezone, override, API on-call, escalation, notification, audit, and concurrency semantics are unchanged; `src/lib/oncall.ts` is untouched.

## Security
Server authorization remains authoritative. The shared resolver preserves admin, assigned-member, and owning-team-lead override rules while preventing unrelated responders from seeing override controls the mutation would reject.

## Tests and safety
Added boundary, multi-responder, additive/replacement, gap, next-handoff, DST/fractional-timezone, and permission-matrix tests. This is stacked PR 1/4 and contains one commit.
