### PR TITLE
feat(schedules): simplify effective coverage experience

### DIFF
--- a/src/app/(app)/schedules/[id]/page.tsx
+++ b/src/app/(app)/schedules/[id]/page.tsx
@@ -1,14 +1,16 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 import prisma from '@/lib/prisma';
-import { assertCanViewSchedule, getUserPermissions } from '@/lib/rbac';
+import { assertCanViewSchedule } from '@/lib/rbac';
+import type { ScheduleUICapabilities } from '@/lib/schedules/capabilities';
 import { buildScheduleBlocks, getFinalScheduleBlocks } from '@/lib/oncall';
 import {
-  formatDateForInput,
-  formatDateTime,
-  getTimeZoneLabel,
-  formatDateKeyInTimeZone,
   addDaysToDateKey,
+  formatDateForInput,
+  formatDateKeyInTimeZone,
   startOfDayFromDateKey,
 } from '@/lib/timezone';
+import { buildScheduleDetailViewModel } from '@/lib/schedules/detail-view-model';
 import {
   addLayerUser,
   createLayer,
@@ -20,45 +22,32 @@ import {
   updateLayer,
   updateSchedule,
 } from '../actions';
-import { notFound } from 'next/navigation';
-import Link from 'next/link';
 import ScheduleCalendar from '@/components/ScheduleCalendar';
-import LayerCard from '@/components/LayerCard';
-import CurrentCoverageDisplay from '@/components/CurrentCoverageDisplay';
-import CoverageTimeline from '@/components/CoverageTimeline';
-import ScheduleEditForm from '@/components/ScheduleEditForm';
-import ScheduleActionsPanel from '@/components/ScheduleActionsPanel';
 import ScheduleTimeline from '@/components/ScheduleTimeline';
+import CoverageTimeline from '@/components/CoverageTimeline';
+import CurrentCoverageDisplay from '@/components/CurrentCoverageDisplay';
+import LayerCard from '@/components/LayerCard';
+import LayerCreateForm from '@/components/LayerCreateForm';
+import OverrideForm from '@/components/OverrideForm';
+import OverrideList from '@/components/OverrideList';
+import ScheduleEditForm from '@/components/ScheduleEditForm';
 import ScheduleTimezoneNotice from '@/components/ScheduleTimezoneNotice';
+import ScheduleDetailTabs from '@/components/schedules/ScheduleDetailTabs';
+import ScheduleCoverageExplorer from '@/components/schedules/ScheduleCoverageExplorer';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/shadcn/alert';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcn/avatar';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcn/card';
-import { Button } from '@/components/ui/shadcn/button';
 import { Badge } from '@/components/ui/shadcn/badge';
-import { Separator } from '@/components/ui/shadcn/separator';
+import { Button } from '@/components/ui/shadcn/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/shadcn/tooltip';
-import {
-  Calendar,
-  Clock,
-  Users,
-  Layers,
-  AlertTriangle,
   ArrowLeft,
+  Calendar,
+  CheckCircle2,
+  Clock3,
   Info,
-  ShieldCheck,
+  Layers3,
+  ShieldAlert,
+  Users,
 } from 'lucide-react';
-import { getDefaultAvatar } from '@/lib/avatar';
 
 export const revalidate = 0;
 
@@ -67,27 +56,20 @@ export default async function ScheduleDetailPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams?: Promise<{ history?: string }>;
+  searchParams?: Promise<{ history?: string; tab?: string }>;
 }) {
   const { id } = await params;
-  const awaitedSearchParams = await searchParams;
+  const query = await searchParams;
   const now = new Date();
-  const calendarRangeStart = new Date(now.getTime() - 35 * 86400000);
-  const calendarRangeEnd = new Date(now.getTime() + 65 * 86400000);
   const historyPageSize = 8;
-  const historyPage = Math.max(1, Number(awaitedSearchParams?.history ?? 1) || 1);
+  const historyPage = Math.max(1, Number(query?.history ?? 1) || 1);
 
-  // Authorize before loading schedule details or the responder directory.
-  // This keeps the server-component payload scoped to data the viewer may see.
+  let capabilities: ScheduleUICapabilities;
   try {
-    await assertCanViewSchedule(id);
+    ({ capabilities } = await assertCanViewSchedule(id));
   } catch {
     notFound();
   }
-
-  const permissions = await getUserPermissions();
-  const canManageSchedules = permissions.isAdminOrResponder;
-
   const schedule = await prisma.onCallSchedule.findUnique({
     where: { id },
     select: {
@@ -105,15 +87,11 @@ export default async function ScheduleDetailPage({
           restrictions: true,
           priority: true,
           users: {
-            where: {
-              user: { status: 'ACTIVE' },
-            },
+            where: { user: { status: 'ACTIVE' } },
             select: {
               userId: true,
               position: true,
-              user: {
-                select: { name: true, avatarUrl: true, gender: true },
-              },
+              user: { select: { name: true, avatarUrl: true, gender: true } },
             },
             orderBy: [{ position: 'asc' }, { id: 'asc' }],
           },
@@ -122,28 +100,19 @@ export default async function ScheduleDetailPage({
       },
     },
   });
-
   if (!schedule) notFound();
 
-  // Coverage extends farther than the monthly calendar. Query overrides for
-  // the union of every consumer window so future coverage never omits a valid
-  // override merely because it sits outside the calendar's fetch horizon.
   const todayKey = formatDateKeyInTimeZone(now, schedule.timeZone);
   const coverageRangeStart = startOfDayFromDateKey(
-    addDaysToDateKey(todayKey, -1),
+    addDaysToDateKey(todayKey, -35),
     schedule.timeZone
   );
-  const coverageRangeEnd = startOfDayFromDateKey(addDaysToDateKey(todayKey, 90), schedule.timeZone);
-  const overrideRangeStart = new Date(
-    Math.min(calendarRangeStart.getTime(), coverageRangeStart.getTime())
-  );
-  const overrideRangeEnd = new Date(
-    Math.max(calendarRangeEnd.getTime(), coverageRangeEnd.getTime())
-  );
+  const coverageRangeEnd = startOfDayFromDateKey(addDaysToDateKey(todayKey, 95), schedule.timeZone);
 
-  const [users, overridesInRange, upcomingOverrides, historyCount, historyOverrides] =
+  const canMutate = capabilities.canManageRotation || capabilities.canCreateOverride;
+  const [users, overridesInRange, currentAndFutureOverrides, historyCount, historyOverrides] =
     await Promise.all([
-      canManageSchedules
+      canMutate
         ? prisma.user.findMany({
             where: { status: 'ACTIVE' },
             select: {
@@ -160,8 +129,8 @@ export default async function ScheduleDetailPage({
       prisma.onCallOverride.findMany({
         where: {
           scheduleId: id,
-          start: { lt: overrideRangeEnd },
-          end: { gt: overrideRangeStart },
+          start: { lt: coverageRangeEnd },
+          end: { gt: coverageRangeStart },
           user: { status: 'ACTIVE' },
         },
         select: {
@@ -171,15 +140,11 @@ export default async function ScheduleDetailPage({
           userId: true,
           replacesUserId: true,
           user: { select: { name: true, avatarUrl: true, gender: true } },
-          replacesUser: { select: { name: true, avatarUrl: true, gender: true } },
+          replacesUser: { select: { name: true } },
         },
       }),
       prisma.onCallOverride.findMany({
-        where: {
-          scheduleId: id,
-          end: { gte: now },
-          user: { status: 'ACTIVE' },
-        },
+        where: { scheduleId: id, end: { gt: now }, user: { status: 'ACTIVE' } },
         select: {
           id: true,
           start: true,
@@ -187,16 +152,14 @@ export default async function ScheduleDetailPage({
           userId: true,
           replacesUserId: true,
           user: { select: { name: true, avatarUrl: true, gender: true } },
-          replacesUser: { select: { name: true, avatarUrl: true, gender: true } },
+          replacesUser: { select: { name: true } },
         },
         orderBy: { start: 'asc' },
-        take: 6,
+        take: 100,
       }),
-      prisma.onCallOverride.count({
-        where: { scheduleId: id, end: { lt: now } },
-      }),
+      prisma.onCallOverride.count({ where: { scheduleId: id, end: { lte: now } } }),
       prisma.onCallOverride.findMany({
-        where: { scheduleId: id, end: { lt: now } },
+        where: { scheduleId: id, end: { lte: now } },
         select: {
           id: true,
           start: true,
@@ -204,19 +167,13 @@ export default async function ScheduleDetailPage({
           userId: true,
           replacesUserId: true,
           user: { select: { name: true, avatarUrl: true, gender: true } },
-          replacesUser: { select: { name: true, avatarUrl: true, gender: true } },
+          replacesUser: { select: { name: true } },
         },
         orderBy: { end: 'desc' },
         skip: (historyPage - 1) * historyPageSize,
         take: historyPageSize,
       }),
     ]);
-
-  const assignedUserIds = new Set(
-    schedule.layers.flatMap(layer => layer.users.map(member => member.userId))
-  );
-  const assignableUsers = users.filter(user => !assignedUserIds.has(user.id));
-  const layerPriorities = new Map(schedule.layers.map(layer => [layer.id, layer.priority ?? 0]));
 
   const typedLayers = schedule.layers.map(layer => ({
     ...layer,
@@ -226,14 +183,61 @@ export default async function ScheduleDetailPage({
       endHour?: number;
     } | null,
   }));
-
+  const layerPriorities = new Map(schedule.layers.map(layer => [layer.id, layer.priority ?? 0]));
   const scheduleBlocks = buildScheduleBlocks(
     typedLayers,
     overridesInRange,
-    calendarRangeStart,
-    calendarRangeEnd,
+    coverageRangeStart,
+    coverageRangeEnd,
     schedule.timeZone
   );
+  const effectiveBlocks = getFinalScheduleBlocks(scheduleBlocks, layerPriorities);
+  const viewModel = buildScheduleDetailViewModel({
+    now,
+    finalCoverageBlocks: effectiveBlocks,
+    overrides: currentAndFutureOverrides,
+    layerCount: schedule.layers.length,
+    participantIds: schedule.layers.flatMap(layer => layer.users.map(user => user.userId)),
+  });
+
+  const activeOverrideIds = new Set(viewModel.activeOverrides.map(override => override.id));
+  const upcomingOverrideIds = new Set(viewModel.upcomingOverrides.map(override => override.id));
+  const activeOverrides = currentAndFutureOverrides.filter(override =>
+    activeOverrideIds.has(override.id)
+  );
+  const upcomingOverrides = currentAndFutureOverrides.filter(override =>
+    upcomingOverrideIds.has(override.id)
+  );
+  const historyTotalPages = Math.max(1, Math.ceil(historyCount / historyPageSize));
+  const assignedUserIds = new Set(
+    schedule.layers.flatMap(layer => layer.users.map(member => member.userId))
+  );
+  const assignableUsers = users.filter(user => !assignedUserIds.has(user.id));
+
+  const timelineShifts = scheduleBlocks.map(block => ({
+    id: block.id,
+    start: block.start,
+    end: block.end,
+    layerName: block.layerName,
+    layerId: block.layerId,
+    userId: block.userId,
+    userName: block.userName,
+    userAvatar: block.userAvatar,
+    userGender: block.userGender,
+    source: block.source,
+  }));
+  const effectiveShifts = effectiveBlocks.map(block => ({
+    id: block.id,
+    start: block.start,
+    end: block.end,
+    layerName: block.layerName,
+    layerId: block.layerId,
+    userId: block.userId,
+    userName: block.userName,
+    userAvatar: block.userAvatar,
+    userGender: block.userGender,
+    source: block.source,
+  }));
   const calendarShifts = scheduleBlocks.map(block => ({
     id: block.id,
     start: block.start.toISOString(),
@@ -249,497 +253,336 @@ export default async function ScheduleDetailPage({
     },
   }));
 
-  const coverageBlocks = buildScheduleBlocks(
-    typedLayers,
-    overridesInRange,
-    coverageRangeStart,
-    coverageRangeEnd,
-    schedule.timeZone
-  );
-  const finalCoverageBlocks = getFinalScheduleBlocks(coverageBlocks, layerPriorities);
-  const nowTime = now.getTime();
-  const activeBlocks = finalCoverageBlocks.filter(block => {
-    const blockStartTime = block.start.getTime();
-    const blockEndTime = block.end.getTime();
-    return blockStartTime <= nowTime && blockEndTime > nowTime;
-  });
-  const totalParticipants = schedule.layers.reduce((acc, layer) => acc + layer.users.length, 0);
-  const historyTotalPages = Math.max(1, Math.ceil(historyCount / historyPageSize));
-
-  const scheduleTimezoneLabel = new Intl.DateTimeFormat('en-US', {
+  const overrideListProps = {
+    scheduleId: schedule.id,
+    canDeleteOverride: capabilities.canDeleteOverride,
+    deleteOverride,
     timeZone: schedule.timeZone,
-    timeZoneName: 'short',
-  }).format(new Date());
+  };
 
-  const formatShortTime = (date: Date) =>
-    new Intl.DateTimeFormat('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: false,
-      timeZone: schedule.timeZone,
-    }).format(date);
-  const scheduleNowLabel = formatShortTime(now);
-  const scheduleTimezoneLongLabel = getTimeZoneLabel(schedule.timeZone);
-  const formatOverrideRange = (start: Date, end: Date) =>
-    `${formatDateTime(start, schedule.timeZone, { format: 'short', hour12: false })} - ${formatDateTime(end, schedule.timeZone, { format: 'short', hour12: false })}`;
-  const getInitials = (name: string) =>
-    name
-      .split(' ')
-      .map(part => part[0])
-      .join('')
-      .toUpperCase()
-      .slice(0, 2);
-
-  return (
-    <div className="w-full px-4 py-6 space-y-6 [zoom:0.8]">
-      <div className="relative overflow-hidden rounded-2xl border border-primary/20 bg-gradient-to-r from-primary via-primary/90 to-primary/75 text-primary-foreground shadow-lg">
-        <div className="absolute inset-0 bg-[radial-gradient(120%_120%_at_0%_0%,rgba(255,255,255,0.25),transparent_55%)]" />
-        <div className="relative p-5 md:p-7">
-          <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-5">
-            <div className="space-y-2">
-              <Link
-                href="/schedules"
-                className="inline-flex items-center gap-1 text-xs opacity-80 hover:opacity-100 transition-opacity"
-              >
-                <ArrowLeft className="h-3 w-3" />
-                Back to Schedules
-              </Link>
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/15 ring-1 ring-white/25">
-                  <Calendar className="h-5 w-5" />
-                </div>
-                <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight text-white">
-                  {schedule.name}
-                </h1>
-              </div>
-              <div className="flex flex-wrap items-center gap-2 text-xs md:text-sm text-white/80">
-                <Badge variant="secondary" className="bg-white/15 text-white border-white/20">
-                  {schedule.timeZone}
-                </Badge>
-                <Separator orientation="vertical" className="h-4 bg-white/30" />
-                <span className="flex items-center gap-1">
-                  <Clock className="h-3.5 w-3.5" />
-                  {scheduleNowLabel} ({scheduleTimezoneLabel})
-                </span>
-                <Separator orientation="vertical" className="h-4 bg-white/30" />
-                <span className="flex items-center gap-1">
-                  <Users className="h-3.5 w-3.5" />
-                  {totalParticipants} participants
-                </span>
-              </div>
+  const overview = (
+    <>
+      <ScheduleTimezoneNotice scheduleTimeZone={schedule.timeZone} />
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+        <CurrentCoverageDisplay
+          currentCoverage={viewModel.currentCoverage}
+          nextCoverageChange={viewModel.nextCoverageChange}
+          scheduleTimeZone={schedule.timeZone}
+        />
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Coverage health</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm text-muted-foreground">Current state</span>
+              <Badge variant={viewModel.coverageGap ? 'warning' : 'success'}>
+                {viewModel.coverageGap ? 'Gap detected' : 'Covered'}
+              </Badge>
             </div>
-
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4 w-full lg:w-auto">
-              <Card className="bg-white/10 border-white/20 backdrop-blur transition hover:bg-white/15">
-                <CardContent className="p-3 md:p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/25">
-                      <Layers className="h-4 w-4 text-white" />
-                    </div>
-                    <div>
-                      <div className="text-xl md:text-2xl font-extrabold">
-                        {schedule.layers.length}
-                      </div>
-                      <div className="text-[10px] md:text-xs opacity-80">Layers</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-              <Card className="bg-white/10 border-white/20 backdrop-blur transition hover:bg-white/15">
-                <CardContent className="p-3 md:p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/25">
-                      <Users className="h-4 w-4 text-white" />
-                    </div>
-                    <div>
-                      <div className="text-xl md:text-2xl font-extrabold">{totalParticipants}</div>
-                      <div className="text-[10px] md:text-xs opacity-80">Participants</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-              <Card className="bg-white/10 border-white/20 backdrop-blur transition hover:bg-white/15">
-                <CardContent className="p-3 md:p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/25">
-                      <ShieldCheck className="h-4 w-4 text-white" />
-                    </div>
-                    <div>
-                      <div
-                        className={`text-xl md:text-2xl font-extrabold ${activeBlocks.length > 0 ? 'text-emerald-200' : 'text-red-200'}`}
-                      >
-                        {activeBlocks.length}
-                      </div>
-                      <div className="text-[10px] md:text-xs opacity-80">On-Call Now</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-              <Card className="bg-white/10 border-white/20 backdrop-blur transition hover:bg-white/15">
-                <CardContent className="p-3 md:p-4">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/25">
-                      <AlertTriangle className="h-4 w-4 text-white" />
-                    </div>
-                    <div>
-                      <div className="text-xl md:text-2xl font-extrabold text-amber-200">
-                        {upcomingOverrides.length}
-                      </div>
-                      <div className="text-[10px] md:text-xs opacity-80">Upcoming Overrides</div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm text-muted-foreground">Active overrides</span>
+              <span className="font-semibold">{activeOverrides.length}</span>
             </div>
-          </div>
-        </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm text-muted-foreground">Upcoming overrides</span>
+              <span className="font-semibold">{upcomingOverrides.length}</span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm text-muted-foreground">Schedule timezone</span>
+              <span className="text-sm font-medium">{schedule.timeZone}</span>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
-      <ScheduleTimezoneNotice scheduleTimeZone={schedule.timeZone} />
-
-      <div className="grid grid-cols-1 xl:grid-cols-4 gap-4 md:gap-6">
-        <div className="xl:col-span-3 space-y-4 md:space-y-6">
-          <Card className="overflow-hidden border-slate-200/80">
-            <CardHeader className="flex flex-col gap-2 border-b border-slate-100 bg-slate-50/70 md:flex-row md:items-center md:justify-between">
-              <div>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Clock className="h-4 w-4 text-primary" />
-                  Today&apos;s Coverage
-                </CardTitle>
-                <CardDescription>24-hour view in the schedule timezone</CardDescription>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant={activeBlocks.length > 0 ? 'success' : 'warning'} size="xs">
-                  {activeBlocks.length > 0 ? 'Active coverage' : 'No coverage'}
-                </Badge>
-                <Badge variant="outline" size="xs">
-                  {schedule.timeZone}
-                </Badge>
-                <span className="text-xs text-slate-500 flex items-center gap-1">
-                  <Clock className="h-3 w-3" />
-                  {scheduleNowLabel}
-                </span>
-              </div>
-            </CardHeader>
-            <CardContent className="p-4">
-              <CoverageTimeline
-                shifts={scheduleBlocks.map(block => ({
-                  userName: block.userName,
-                  userAvatar: block.userAvatar,
-                  userGender: block.userGender,
-                  layerName: block.layerName,
-                  start: block.start,
-                  end: block.end,
-                }))}
-                timeZone={schedule.timeZone}
-              />
-            </CardContent>
-          </Card>
-
-          <ScheduleTimeline
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Clock3 className="h-4 w-4 text-primary" /> Today&apos;s coverage
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CoverageTimeline
             shifts={scheduleBlocks.map(block => ({
-              id: block.id,
+              userName: block.userName,
+              userAvatar: block.userAvatar,
+              userGender: block.userGender,
+              layerName: block.layerName,
               start: block.start,
               end: block.end,
-              layerName: block.layerName,
-              layerId: block.layerId,
-              userId: block.userId,
-              userName: block.userName,
-              userAvatar: block.userAvatar,
-              userGender: block.userGender,
-              source: block.source,
             }))}
             timeZone={schedule.timeZone}
-            layerPriorities={layerPriorities}
           />
+        </CardContent>
+      </Card>
 
-          <ScheduleCalendar shifts={calendarShifts} timeZone={schedule.timeZone} />
+      <ScheduleCoverageExplorer
+        timeline={
+          <ScheduleTimeline
+            shifts={timelineShifts}
+            effectiveShifts={effectiveShifts}
+            timeZone={schedule.timeZone}
+          />
+        }
+        calendar={<ScheduleCalendar shifts={calendarShifts} timeZone={schedule.timeZone} />}
+      />
+    </>
+  );
+
+  const rotation = (
+    <>
+      <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+        <div>
+          <h2 className="text-lg font-semibold">Rotation layers</h2>
+          <p className="text-sm text-muted-foreground">
+            Configure handoff order, shift timing, and coverage restrictions.
+          </p>
         </div>
-
-        <div className="space-y-4 md:space-y-6">
-          <CurrentCoverageDisplay
-            key={`coverage-${schedule.id}-${schedule.layers.map(l => `${l.id}-${l.start.getTime()}-${l.end?.getTime() || 'null'}`).join('-')}`}
-            initialBlocks={activeBlocks.map(block => ({
-              id: block.id,
-              userName: block.userName,
-              userAvatar: block.userAvatar,
-              userGender: block.userGender,
-              layerName: block.layerName,
-              start: block.start.toISOString(),
-              end: block.end.toISOString(),
-            }))}
-            scheduleTimeZone={schedule.timeZone}
-          />
-
-          <Alert className="border-blue-200/80 bg-blue-50/70">
-            <Info className="h-4 w-4 text-blue-600" />
-            <AlertTitle className="text-sm text-blue-900">Layering basics</AlertTitle>
-            <AlertDescription className="text-xs text-blue-700">
-              Layers define on-call rotations. Higher-priority layers win during overlaps; equal
-              priority layers use a deterministic tie-breaker.
-            </AlertDescription>
-          </Alert>
-
-          <Card className="overflow-hidden border-slate-200/80">
-            <CardHeader className="p-4 pb-2 border-b border-slate-100 bg-slate-50/70">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <CardTitle className="text-sm flex items-center gap-2">
-                    <Layers className="h-4 w-4 text-indigo-600" />
-                    Rotation Layers
-                  </CardTitle>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="h-6 w-6 text-slate-500 hover:text-slate-700"
-                          aria-label="How layer priority works"
-                        >
-                          <Info className="h-3.5 w-3.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs text-xs">
-                        Higher numeric priority wins when layers overlap. Equal-priority layers are
-                        resolved deterministically.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-                <Badge variant="secondary">{schedule.layers.length}</Badge>
-              </div>
-            </CardHeader>
-            <CardContent className="p-4 pt-3 space-y-2">
-              {schedule.layers.length === 0 ? (
-                <div className="text-center py-6 text-muted-foreground">
-                  <Layers className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                  <p className="text-xs font-medium">No layers defined</p>
-                </div>
-              ) : (
-                schedule.layers.map((layer, index) => (
-                  <LayerCard
-                    key={layer.id}
-                    layer={{
-                      id: layer.id,
-                      name: layer.name,
-                      start: new Date(layer.start),
-                      end: layer.end ? new Date(layer.end) : null,
-                      rotationLengthHours: layer.rotationLengthHours,
-                      shiftLengthHours: layer.shiftLengthHours,
-                      restrictions: layer.restrictions as {
-                        daysOfWeek?: number[];
-                        startHour?: number;
-                        endHour?: number;
-                      } | null,
-                      users: layer.users,
-                    }}
-                    scheduleId={schedule.id}
-                    timeZone={schedule.timeZone}
-                    users={assignableUsers}
-                    canManageSchedules={canManageSchedules}
-                    updateLayer={updateLayer}
-                    deleteLayer={deleteLayer}
-                    addLayerUser={addLayerUser}
-                    moveLayerUser={moveLayerUser}
-                    removeLayerUser={removeLayerUser}
-                    colorIndex={index}
-                  />
-                ))
-              )}
-            </CardContent>
-          </Card>
-
-          <ScheduleActionsPanel
+        {capabilities.canManageRotation && (
+          <LayerCreateForm
             scheduleId={schedule.id}
-            users={users}
-            canManageSchedules={canManageSchedules}
+            canManageSchedules={capabilities.canManageRotation}
             createLayer={createLayer}
-            createOverride={createOverride}
             defaultStartDate={formatDateForInput(now, schedule.timeZone)}
-            scheduleTimeZone={schedule.timeZone}
           />
-
-          {canManageSchedules && (
-            <Card className="overflow-hidden border-slate-200/80">
-              <CardHeader className="p-4 pb-2 border-b border-slate-100 bg-slate-50/70">
-                <CardTitle className="text-sm">Schedule Settings</CardTitle>
-                <CardDescription className="text-xs">
-                  Rename the schedule or change its timezone
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="p-4 pt-3">
-                <ScheduleEditForm
-                  scheduleId={schedule.id}
-                  currentName={schedule.name}
-                  currentTimeZone={schedule.timeZone}
-                  updateSchedule={updateSchedule}
-                  canManageSchedules={canManageSchedules}
-                />
-              </CardContent>
-            </Card>
-          )}
-
-          <Card className="overflow-hidden border-slate-200/80">
-            <CardHeader className="p-4 pb-2 border-b border-slate-100 bg-slate-50/70">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <CardTitle className="text-sm flex items-center gap-2">
-                    <AlertTriangle className="h-4 w-4 text-amber-600" />
-                    Overrides
-                  </CardTitle>
-                  <CardDescription className="text-xs">
-                    Temporary swaps and coverage changes
-                  </CardDescription>
-                </div>
-                <div className="flex flex-wrap gap-1">
-                  <Badge variant="warning" size="xs">
-                    {upcomingOverrides.length} upcoming
-                  </Badge>
-                  <Badge variant="secondary" size="xs">
-                    {historyCount} past
-                  </Badge>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="p-4 pt-3 space-y-4">
-              <div>
-                <p className="text-xs font-medium text-muted-foreground mb-2">Upcoming</p>
-                {upcomingOverrides.length === 0 ? (
-                  <p className="text-xs text-muted-foreground italic">No upcoming overrides</p>
-                ) : (
-                  <div className="space-y-2">
-                    {upcomingOverrides.map(o => (
-                      <div
-                        key={o.id}
-                        className="flex items-center justify-between gap-3 rounded-lg border border-amber-100 bg-amber-50/70 px-3 py-2"
-                      >
-                        <div className="flex items-center gap-3 min-w-0">
-                          <Avatar className="h-7 w-7">
-                            <AvatarImage
-                              src={
-                                o.user.avatarUrl ||
-                                getDefaultAvatar(o.user.gender, o.userId || o.user.name)
-                              }
-                            />
-                            <AvatarFallback className="text-[10px] font-semibold">
-                              {getInitials(o.user.name)}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div className="min-w-0">
-                            <p className="text-xs font-semibold text-slate-800 truncate">
-                              {o.user.name}
-                            </p>
-                            <p className="text-[10px] text-slate-500 truncate">
-                              {formatOverrideRange(new Date(o.start), new Date(o.end))}
-                            </p>
-                            {o.replacesUser?.name && (
-                              <p className="text-[10px] text-slate-400 truncate">
-                                Replaces {o.replacesUser.name}
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                        <Badge variant="warning" size="xs">
-                          Upcoming
-                        </Badge>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div>
-                <p className="text-xs font-medium text-muted-foreground mb-2">
-                  History ({historyCount})
-                </p>
-                {historyOverrides.length === 0 ? (
-                  <p className="text-xs text-muted-foreground italic">No past overrides</p>
-                ) : (
-                  <div className="space-y-2">
-                    {historyOverrides.slice(0, 3).map(o => (
-                      <div
-                        key={o.id}
-                        className="flex items-center justify-between gap-3 rounded-lg border border-slate-100 bg-white px-3 py-2"
-                      >
-                        <div className="flex items-center gap-3 min-w-0">
-                          <Avatar className="h-7 w-7">
-                            <AvatarImage
-                              src={
-                                o.user.avatarUrl ||
-                                getDefaultAvatar(o.user.gender, o.userId || o.user.name)
-                              }
-                            />
-                            <AvatarFallback className="text-[10px] font-semibold">
-                              {getInitials(o.user.name)}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div className="min-w-0">
-                            <p className="text-xs font-semibold text-slate-700 truncate">
-                              {o.user.name}
-                            </p>
-                            <p className="text-[10px] text-slate-500 truncate">
-                              {formatOverrideRange(new Date(o.start), new Date(o.end))}
-                            </p>
-                            {o.replacesUser?.name && (
-                              <p className="text-[10px] text-slate-400 truncate">
-                                Replaced {o.replacesUser.name}
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                        <Badge variant="secondary" size="xs">
-                          Completed
-                        </Badge>
-                      </div>
-                    ))}
-                    {historyCount > 3 && (
-                      <p className="text-[10px] text-muted-foreground text-center">
-                        +{historyCount - 3} more
-                      </p>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {historyTotalPages > 1 && (
-                <div className="flex items-center justify-between pt-2 border-t">
-                  <div className="text-[10px] text-muted-foreground">
-                    Page {historyPage}/{historyTotalPages}
-                  </div>
-                  <div className="flex gap-1">
-                    <Link
-                      href={`/schedules/${schedule.id}?history=${Math.max(1, historyPage - 1)}`}
-                    >
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 text-[10px]"
-                        disabled={historyPage === 1}
-                      >
-                        Prev
-                      </Button>
-                    </Link>
-                    <Link
-                      href={`/schedules/${schedule.id}?history=${Math.min(historyTotalPages, historyPage + 1)}`}
-                    >
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 text-[10px]"
-                        disabled={historyPage === historyTotalPages}
-                      >
-                        Next
-                      </Button>
-                    </Link>
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+        )}
       </div>
-    </div>
+      <Alert>
+        <Info className="h-4 w-4" />
+        <AlertTitle>Order is configuration, not a live prediction</AlertTitle>
+        <AlertDescription>
+          Responder numbers show rotation order. Effective on-call and the next real change are
+          calculated from all layers, restrictions, priorities, and overrides in Overview.
+        </AlertDescription>
+      </Alert>
+      {schedule.layers.length === 0 ? (
+        <Card className="border-dashed p-10 text-center">
+          <Layers3 className="mx-auto h-10 w-10 text-muted-foreground" />
+          <h3 className="mt-3 font-semibold">No rotation layers yet</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Add a rotation layer, then assign active responders.
+          </p>
+        </Card>
+      ) : (
+        <div className="grid gap-4 xl:grid-cols-2">
+          {schedule.layers.map((layer, index) => (
+            <LayerCard
+              key={layer.id}
+              layer={{
+                id: layer.id,
+                name: layer.name,
+                start: new Date(layer.start),
+                end: layer.end ? new Date(layer.end) : null,
+                rotationLengthHours: layer.rotationLengthHours,
+                shiftLengthHours: layer.shiftLengthHours,
+                restrictions: layer.restrictions as {
+                  daysOfWeek?: number[];
+                  startHour?: number;
+                  endHour?: number;
+                } | null,
+                users: layer.users,
+              }}
+              scheduleId={schedule.id}
+              timeZone={schedule.timeZone}
+              users={assignableUsers}
+              canManageSchedules={capabilities.canManageRotation}
+              updateLayer={updateLayer}
+              deleteLayer={deleteLayer}
+              addLayerUser={addLayerUser}
+              moveLayerUser={moveLayerUser}
+              removeLayerUser={removeLayerUser}
+              colorIndex={index}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+
+  const overrides = (
+    <>
+      <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+        <div>
+          <h2 className="text-lg font-semibold">Coverage overrides</h2>
+          <p className="text-sm text-muted-foreground">
+            Replace one responder or add extra coverage without changing the rotation.
+          </p>
+        </div>
+        <OverrideForm
+          scheduleId={schedule.id}
+          users={users}
+          canCreateOverride={capabilities.canCreateOverride}
+          createOverride={createOverride}
+          scheduleTimeZone={schedule.timeZone}
+        />
+      </div>
+
+      {!capabilities.canCreateOverride && (
+        <Alert>
+          <ShieldAlert className="h-4 w-4" />
+          <AlertTitle>Read-only override access</AlertTitle>
+          <AlertDescription>
+            Assigned schedule members, owning team leads, and administrators can manage overrides.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <section className="space-y-3" aria-labelledby="active-overrides-title">
+        <div className="flex items-center gap-2">
+          <h3 id="active-overrides-title" className="font-semibold">
+            Active
+          </h3>
+          <Badge variant="success" size="xs">
+            {activeOverrides.length}
+          </Badge>
+        </div>
+        <OverrideList
+          {...overrideListProps}
+          overrides={activeOverrides}
+          status="ACTIVE"
+          emptyMessage="No overrides are active right now."
+        />
+      </section>
+
+      <section className="space-y-3" aria-labelledby="upcoming-overrides-title">
+        <div className="flex items-center gap-2">
+          <h3 id="upcoming-overrides-title" className="font-semibold">
+            Upcoming
+          </h3>
+          <Badge variant="warning" size="xs">
+            {upcomingOverrides.length}
+          </Badge>
+        </div>
+        <OverrideList
+          {...overrideListProps}
+          overrides={upcomingOverrides}
+          status="UPCOMING"
+          emptyMessage="No upcoming overrides."
+        />
+      </section>
+
+      <section className="space-y-3" aria-labelledby="override-history-title">
+        <div className="flex items-center gap-2">
+          <h3 id="override-history-title" className="font-semibold">
+            History
+          </h3>
+          <Badge variant="secondary" size="xs">
+            {historyCount}
+          </Badge>
+        </div>
+        <OverrideList
+          {...overrideListProps}
+          overrides={historyOverrides}
+          status="COMPLETED"
+          emptyMessage="No completed overrides."
+        />
+        {historyTotalPages > 1 && (
+          <nav className="flex items-center justify-between" aria-label="Override history pages">
+            <p className="text-xs text-muted-foreground">
+              Page {historyPage} of {historyTotalPages}
+            </p>
+            <div className="flex gap-2">
+              <Button asChild variant="outline" size="sm" aria-disabled={historyPage === 1}>
+                <Link
+                  href={`/schedules/${schedule.id}?tab=overrides&history=${Math.max(1, historyPage - 1)}`}
+                  tabIndex={historyPage === 1 ? -1 : undefined}
+                >
+                  Previous
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                aria-disabled={historyPage === historyTotalPages}
+              >
+                <Link
+                  href={`/schedules/${schedule.id}?tab=overrides&history=${Math.min(historyTotalPages, historyPage + 1)}`}
+                  tabIndex={historyPage === historyTotalPages ? -1 : undefined}
+                >
+                  Next
+                </Link>
+              </Button>
+            </div>
+          </nav>
+        )}
+      </section>
+    </>
+  );
+
+  const settings = capabilities.canManageScheduleSettings ? (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <CardTitle>Schedule settings</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Rename the schedule or change the timezone used by every rotation and override.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <ScheduleEditForm
+          scheduleId={schedule.id}
+          currentName={schedule.name}
+          currentTimeZone={schedule.timeZone}
+          updateSchedule={updateSchedule}
+          canManageSchedules={capabilities.canManageScheduleSettings}
+        />
+      </CardContent>
+    </Card>
+  ) : (
+    <Alert className="max-w-2xl">
+      <Info className="h-4 w-4" />
+      <AlertTitle>Schedule settings are read-only</AlertTitle>
+      <AlertDescription>
+        This schedule uses {schedule.timeZone}. Admins and responders can change schedule settings.
+      </AlertDescription>
+    </Alert>
+  );
+
+  return (
+    <main className="mx-auto w-full max-w-[1600px] space-y-6 px-4 py-6 md:px-6">
+      <header className="space-y-4">
+        <Link
+          href="/schedules"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground transition hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" /> Back to schedules
+        </Link>
+        <div className="flex flex-col justify-between gap-4 rounded-2xl border bg-card p-5 shadow-sm md:flex-row md:items-center md:p-6">
+          <div className="flex items-start gap-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <Calendar className="h-5 w-5" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight md:text-3xl">{schedule.name}</h1>
+              <p className="mt-1 text-sm text-muted-foreground">{viewModel.summary}</p>
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-2 sm:flex">
+            <Badge variant="outline" className="justify-center gap-1.5 px-3 py-2">
+              <Users className="h-3.5 w-3.5" /> {viewModel.participantCount} responders
+            </Badge>
+            <Badge variant="outline" className="justify-center gap-1.5 px-3 py-2">
+              <Layers3 className="h-3.5 w-3.5" /> {viewModel.layerCount} layers
+            </Badge>
+            <Badge
+              variant={viewModel.coverageGap ? 'warning' : 'success'}
+              className="justify-center gap-1.5 px-3 py-2"
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              {viewModel.coverageGap ? 'Gap' : 'Covered'}
+            </Badge>
+          </div>
+        </div>
+      </header>
+
+      <ScheduleDetailTabs
+        defaultTab={query?.tab}
+        overview={overview}
+        rotation={rotation}
+        overrides={overrides}
+        settings={settings}
+      />
+    </main>
   );
 }

--- a/src/components/CurrentCoverageDisplay.tsx
+++ b/src/components/CurrentCoverageDisplay.tsx
@@ -1,12 +1,9 @@
-'use client';
-
-import { useEffect, useState } from 'react';
 import { formatDateTime } from '@/lib/timezone';
 import { getDefaultAvatar } from '@/lib/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
 import { DirectUserAvatar } from '@/components/UserAvatar';
 import { Badge } from '@/components/ui/shadcn/badge';
-import { Clock, UserCheck, ShieldCheck, AlertTriangle } from 'lucide-react';
+import { ArrowRight, Clock, ShieldCheck, TriangleAlert } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type CoverageBlock = {
@@ -18,154 +15,131 @@ type CoverageBlock = {
   layerName: string;
   start: Date | string;
   end: Date | string;
+  source?: 'rotation' | 'override';
+  isAdditiveOverride?: boolean;
 };
 
 type CurrentCoverageDisplayProps = {
-  initialBlocks: CoverageBlock[];
+  currentCoverage: CoverageBlock[];
+  nextCoverageChange: { at: Date | string; coverage: CoverageBlock[] } | null;
   scheduleTimeZone: string;
 };
 
 export default function CurrentCoverageDisplay({
-  initialBlocks,
+  currentCoverage,
+  nextCoverageChange,
   scheduleTimeZone,
 }: CurrentCoverageDisplayProps) {
-  const formatTime = (date: Date) => {
-    return formatDateTime(date, scheduleTimeZone, { format: 'time' });
-  };
-
-  const normalizedBlocks = initialBlocks.map(block => ({
-    ...block,
-    start: new Date(block.start),
-    end: new Date(block.end),
-  }));
-
-  const [activeBlocks, setActiveBlocks] = useState(normalizedBlocks);
-  const [currentTime, setCurrentTime] = useState(new Date());
-
-  useEffect(() => {
-    const calculateActive = () => {
-      const now = new Date();
-      setCurrentTime(now);
-      const nowTime = now.getTime();
-      const normalized = initialBlocks.map(block => ({
-        ...block,
-        start: new Date(block.start),
-        end: new Date(block.end),
-      }));
-      const active = normalized.filter(block => {
-        return block.start.getTime() <= nowTime && block.end.getTime() > nowTime;
-      });
-      setActiveBlocks(active);
-    };
-    calculateActive();
-    const interval = setInterval(calculateActive, 30000);
-    return () => clearInterval(interval);
-  }, [initialBlocks]);
-
-  const hasCoverage = activeBlocks.length > 0;
+  const hasCoverage = currentCoverage.length > 0;
 
   return (
-    <Card className="overflow-hidden border-slate-200/80">
+    <Card className="overflow-hidden border-border/70 shadow-sm">
       <CardHeader
         className={cn(
-          'pb-3 border-b',
-          hasCoverage ? 'bg-emerald-50/70 border-emerald-100' : 'bg-amber-50/70 border-amber-100'
+          'border-b',
+          hasCoverage
+            ? 'border-emerald-500/20 bg-emerald-500/5'
+            : 'border-amber-500/20 bg-amber-500/5'
         )}
       >
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex items-center gap-3">
             <div
               className={cn(
-                'flex h-10 w-10 items-center justify-center rounded-xl',
+                'flex h-11 w-11 items-center justify-center rounded-xl',
                 hasCoverage
                   ? 'bg-emerald-500/15 text-emerald-600'
                   : 'bg-amber-500/15 text-amber-600'
               )}
             >
               {hasCoverage ? (
-                <ShieldCheck className="h-5 w-5" />
+                <ShieldCheck className="h-6 w-6" />
               ) : (
-                <AlertTriangle className="h-5 w-5" />
+                <TriangleAlert className="h-6 w-6" />
               )}
             </div>
             <div>
-              <CardTitle className="text-sm font-semibold">On-Call Now</CardTitle>
-              <p className="text-xs text-slate-500 flex items-center gap-1 mt-0.5">
-                <Clock className="h-3 w-3" />
-                {formatTime(currentTime)}
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                On call now
               </p>
+              <CardTitle className="mt-0.5 text-xl">
+                {hasCoverage
+                  ? currentCoverage.length === 1
+                    ? currentCoverage[0].userName
+                    : `${currentCoverage.length} responders`
+                  : 'Coverage gap'}
+              </CardTitle>
             </div>
           </div>
-          <div className="flex flex-col items-end gap-1.5">
-            <Badge variant={hasCoverage ? 'success' : 'warning'} size="xs">
-              {hasCoverage ? 'Active' : 'No coverage'}
-            </Badge>
-            <Badge variant="outline" size="xs">
-              {scheduleTimeZone}
-            </Badge>
-          </div>
+          <Badge variant={hasCoverage ? 'success' : 'warning'}>
+            {hasCoverage ? 'Covered' : 'Needs attention'}
+          </Badge>
         </div>
       </CardHeader>
 
-      <CardContent className="p-0 bg-white">
-        {!hasCoverage ? (
-          <div className="flex flex-col items-center justify-center py-8 text-center px-4">
-            <div className="h-10 w-10 rounded-full bg-slate-100 flex items-center justify-center mb-3">
-              <UserCheck className="h-5 w-5 text-slate-400" />
-            </div>
-            <p className="text-sm font-semibold text-slate-700">No active responders</p>
-            <p className="text-xs text-slate-500 mt-1 max-w-[200px]">
-              No shifts are currently scheduled. Check configuration.
-            </p>
-          </div>
-        ) : (
-          <div className="divide-y divide-slate-100">
-            {activeBlocks.map(block => (
-              <div
-                key={block.id}
-                className="flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors"
-              >
+      <CardContent className="p-0">
+        {hasCoverage ? (
+          <div className="divide-y">
+            {currentCoverage.map(block => (
+              <div key={block.id} className="flex items-center gap-3 px-5 py-4">
                 <DirectUserAvatar
                   avatarUrl={
                     block.userAvatar ||
                     getDefaultAvatar(block.userGender, block.userId || block.userName)
                   }
                   name={block.userName}
-                  size="sm"
-                  className="h-9 w-9 ring-1 ring-slate-200 shadow-sm"
-                  fallbackClassName="bg-emerald-50 text-emerald-700"
+                  size="md"
+                  className="h-10 w-10"
                 />
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center justify-between gap-2">
-                    <h4 className="text-sm font-semibold text-slate-800 truncate">
-                      {block.userName}
-                    </h4>
-                    <Badge variant="secondary" size="xs">
-                      {block.layerName}
-                    </Badge>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-semibold">{block.userName}</p>
+                    {block.source === 'override' && (
+                      <Badge variant="warning" size="xs">
+                        {block.isAdditiveOverride ? 'Extra coverage' : 'Override'}
+                      </Badge>
+                    )}
                   </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                    <span className="inline-flex items-center gap-1">
-                      <Clock className="h-3 w-3" />
-                      Ends {formatTime(new Date(block.end))}
-                    </span>
-                    <span className="inline-flex items-center gap-1">
-                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                      Active
-                    </span>
-                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Until{' '}
+                    {formatDateTime(new Date(block.end), scheduleTimeZone, { format: 'short' })}
+                  </p>
                 </div>
               </div>
             ))}
           </div>
-        )}
-        {hasCoverage && (
-          <div className="bg-slate-50 px-4 py-2 border-t border-slate-100 text-center">
-            <p className="text-[10px] text-slate-400 font-medium uppercase tracking-wider">
-              Updates every 30 seconds
+        ) : (
+          <div className="px-5 py-7">
+            <p className="text-sm font-medium">No responder is currently scheduled.</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Review rotation restrictions, layer dates, or add temporary coverage.
             </p>
           </div>
         )}
+
+        <div className="border-t bg-muted/30 px-5 py-3">
+          <div className="flex items-start gap-2 text-sm">
+            <Clock className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+            {nextCoverageChange ? (
+              <div>
+                <p className="font-medium">
+                  Next change{' '}
+                  {formatDateTime(new Date(nextCoverageChange.at), scheduleTimeZone, {
+                    format: 'short',
+                  })}
+                </p>
+                <p className="mt-0.5 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+                  {currentCoverage.map(block => block.userName).join(', ') || 'No coverage'}
+                  <ArrowRight className="h-3 w-3" />
+                  {nextCoverageChange.coverage.map(block => block.userName).join(', ') ||
+                    'No coverage'}
+                </p>
+              </div>
+            ) : (
+              <p className="text-muted-foreground">No later coverage change in this window.</p>
+            )}
+          </div>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/OverrideForm.tsx
+++ b/src/components/OverrideForm.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useMemo, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-product-notification';
-
 import {
   Sheet,
   SheetContent,
@@ -14,13 +13,15 @@ import {
 } from '@/components/ui/shadcn/sheet';
 import { Button } from '@/components/ui/shadcn/button';
 import { Label } from '@/components/ui/shadcn/label';
-import { AlertCircle, Clock, Loader2 } from 'lucide-react';
-import { addHours, format } from 'date-fns';
+import ResponderCombobox, { type ResponderOption } from './ResponderCombobox';
+import { formatDateForInput, formatDateTime, parseDateTimeInTimeZone } from '@/lib/timezone';
+import { AlertCircle, Clock, Loader2, ShieldPlus, UserRoundCog } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 type OverrideFormProps = {
   scheduleId: string;
-  users: Array<{ id: string; name: string; avatarUrl?: string | null; gender?: string | null }>;
-  canManageSchedules: boolean;
+  users: ResponderOption[];
+  canCreateOverride: boolean;
   createOverride: (
     scheduleId: string,
     formData: FormData
@@ -28,10 +29,12 @@ type OverrideFormProps = {
   scheduleTimeZone: string;
 };
 
+type OverrideMode = 'replacement' | 'additive';
+
 export default function OverrideForm({
   scheduleId,
   users,
-  canManageSchedules,
+  canCreateOverride,
   createOverride,
   scheduleTimeZone,
 }: OverrideFormProps) {
@@ -39,263 +42,239 @@ export default function OverrideForm({
   const { showToast } = useToast();
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<OverrideMode>('replacement');
+  const [selectedUserId, setSelectedUserId] = useState('');
+  const [replacesUserId, setReplacesUserId] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
 
-  // Form state
-  const [selectedUserId, setSelectedUserId] = useState<string>('');
-  const [replacesUserId, setReplacesUserId] = useState<string>('');
-  const [startTime, setStartTime] = useState<string>('');
-  const [endTime, setEndTime] = useState<string>('');
-
-  // Format date for datetime-local input in the schedule's timezone
-  const toScheduleISOString = (date: Date) => {
-    const formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: scheduleTimeZone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-      hourCycle: 'h23',
-    });
-    const parts = formatter.formatToParts(date);
-    const get = (type: string) => parts.find(p => p.type === type)?.value || '00';
-    return `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}`;
-  };
+  const replacementCandidates = useMemo(
+    () => users.filter(user => user.id !== selectedUserId),
+    [selectedUserId, users]
+  );
+  const startInstant = useMemo(
+    () => parseDateTimeInTimeZone(startTime, scheduleTimeZone),
+    [scheduleTimeZone, startTime]
+  );
+  const endInstant = useMemo(
+    () => parseDateTimeInTimeZone(endTime, scheduleTimeZone),
+    [endTime, scheduleTimeZone]
+  );
+  const hasValidRange = Boolean(startInstant && endInstant && endInstant > startInstant);
 
   const handleQuickDuration = (hours: number) => {
-    const now = new Date();
-    // Round up to next 15 mins for cleanliness
-    const remainder = 15 - (now.getMinutes() % 15);
-    now.setMinutes(now.getMinutes() + remainder);
-    now.setSeconds(0);
-    now.setMilliseconds(0);
-
-    const end = addHours(now, hours);
-
-    setStartTime(toScheduleISOString(now));
-    setEndTime(toScheduleISOString(end));
+    const start = new Date();
+    const minutesToQuarter = (15 - (start.getMinutes() % 15)) % 15;
+    start.setMinutes(start.getMinutes() + minutesToQuarter, 0, 0);
+    const end = new Date(start.getTime() + hours * 60 * 60 * 1000);
+    setStartTime(formatDateForInput(start, scheduleTimeZone));
+    setEndTime(formatDateForInput(end, scheduleTimeZone));
   };
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const reset = () => {
+    setMode('replacement');
+    setSelectedUserId('');
+    setReplacesUserId('');
+    setStartTime('');
+    setEndTime('');
+  };
 
-    if (!selectedUserId) {
-      showToast('Please select a responder', 'error');
-      return;
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedUserId) return showToast('Select the responder taking coverage.', 'error');
+    if (mode === 'replacement' && !replacesUserId) {
+      return showToast('Select the responder being replaced.', 'error');
     }
-    if (!startTime || !endTime) {
-      showToast('Please set start and end times', 'error');
-      return;
+    if (!hasValidRange) {
+      return showToast('Enter a valid schedule-timezone range with end after start.', 'error');
     }
 
-    const formData = new FormData(e.currentTarget);
-
+    const formData = new FormData(event.currentTarget);
     startTransition(async () => {
       try {
         const result = await createOverride(scheduleId, formData);
-        if (result?.error) {
-          showToast(result.error, 'error');
-        } else {
-          const userName = users.find(u => u.id === selectedUserId)?.name || 'User';
-          showToast(`Override created for ${userName}`, 'success');
-          // Reset form
-          setSelectedUserId('');
-          setReplacesUserId('');
-          setStartTime('');
-          setEndTime('');
-          router.refresh();
-          setOpen(false);
-        }
+        if (result?.error) return showToast(result.error, 'error');
+        showToast(
+          mode === 'replacement' ? 'Replacement created.' : 'Extra coverage added.',
+          'success'
+        );
+        reset();
+        setOpen(false);
+        router.refresh();
       } catch {
-        showToast('Failed to create override', 'error');
+        showToast('Failed to create override.', 'error');
       }
     });
   };
 
-  if (!canManageSchedules) return null;
+  if (!canCreateOverride) return null;
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
-        <Button
-          variant="outline"
-          className="w-full h-10 gap-2 text-sm font-medium border-amber-200 bg-amber-50/50 text-amber-700 hover:bg-amber-100 hover:text-amber-800 shadow-sm"
-        >
-          <Clock className="h-4 w-4" />
-          Add Override
+        <Button className="gap-2">
+          <ShieldPlus className="h-4 w-4" />
+          Add override
         </Button>
       </SheetTrigger>
-      <SheetContent className="w-[400px] sm:w-[540px] overflow-y-auto">
-        {/* Header */}
-        <SheetHeader className="pb-4 mb-4 border-b border-slate-100">
-          <div className="flex items-center gap-3">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-amber-100 text-amber-600">
-              <AlertCircle className="h-5 w-5" />
-            </div>
-            <div>
-              <SheetTitle className="text-lg font-semibold">Add Coverage Override</SheetTitle>
-              <SheetDescription>Temporarily replace the on-call responder</SheetDescription>
-            </div>
-          </div>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader className="border-b pb-4 text-left">
+          <SheetTitle>Add coverage override</SheetTitle>
+          <SheetDescription>
+            Times are interpreted in {scheduleTimeZone}, regardless of your browser timezone.
+          </SheetDescription>
         </SheetHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
-          {/* Hidden inputs for FormData */}
+        <form onSubmit={handleSubmit} className="space-y-6 py-5">
           <input type="hidden" name="userId" value={selectedUserId} />
-          <input type="hidden" name="replacesUserId" value={replacesUserId} />
+          <input
+            type="hidden"
+            name="replacesUserId"
+            value={mode === 'replacement' ? replacesUserId : ''}
+          />
           <input type="hidden" name="start" value={startTime} />
           <input type="hidden" name="end" value={endTime} />
 
-          {/* Who takes coverage - Dropdown */}
-          <div className="space-y-3">
-            <Label>Who takes coverage? *</Label>
-            <div className="relative">
-              <select
-                value={selectedUserId}
-                onChange={e => setSelectedUserId(e.target.value)}
-                className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white pl-4 pr-10 hover:border-primary focus:border-primary focus:ring-2 focus:ring-primary/20 cursor-pointer font-medium appearance-none"
-                required
-              >
-                <option value="">Select responder...</option>
-                {users.map(user => (
-                  <option key={user.id} value={user.id}>
-                    {user.name}
-                  </option>
-                ))}
-              </select>
-              {/* Dropdown arrow */}
-              <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
-                <svg
-                  className="h-4 w-4 text-slate-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </div>
-            </div>
-          </div>
-
-          {/* Who are they replacing (Optional) - Dropdown */}
-          <div className="space-y-3">
-            <Label>
-              Replacing <span className="text-slate-400 font-normal">(Optional)</span>
-            </Label>
-            <div className="relative">
-              <select
-                value={replacesUserId}
-                onChange={e => setReplacesUserId(e.target.value)}
-                className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white pl-4 pr-10 hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20 cursor-pointer font-medium appearance-none"
-              >
-                <option value="">Everyone (override all)</option>
-                {users.map(user => (
-                  <option key={user.id} value={user.id}>
-                    {user.name}
-                  </option>
-                ))}
-              </select>
-              {/* Dropdown arrow */}
-              <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
-                <svg
-                  className="h-4 w-4 text-slate-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </div>
-            </div>
-          </div>
-
-          {/* Quick Duration */}
-          <div className="space-y-3">
-            <Label>Quick Duration</Label>
-            <div className="grid grid-cols-4 gap-2">
+          <fieldset className="space-y-3">
+            <legend className="text-sm font-medium">What should change?</legend>
+            <div className="grid gap-3 sm:grid-cols-2">
               {[
-                { label: '1h', hours: 1 },
-                { label: '4h', hours: 4 },
-                { label: '8h', hours: 8 },
-                { label: '24h', hours: 24 },
-              ].map(({ label, hours }) => (
+                {
+                  value: 'replacement' as const,
+                  title: 'Replace someone',
+                  description: 'Swap one scheduled responder for another.',
+                  icon: UserRoundCog,
+                },
+                {
+                  value: 'additive' as const,
+                  title: 'Add extra coverage',
+                  description: 'Add a responder without removing anyone.',
+                  icon: ShieldPlus,
+                },
+              ].map(option => (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={mode === option.value}
+                  onClick={() => {
+                    setMode(option.value);
+                    if (option.value === 'additive') setReplacesUserId('');
+                  }}
+                  className={cn(
+                    'rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    mode === option.value
+                      ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                      : 'hover:border-primary/50'
+                  )}
+                >
+                  <option.icon className="mb-2 h-5 w-5 text-primary" />
+                  <span className="block text-sm font-semibold">{option.title}</span>
+                  <span className="mt-1 block text-xs text-muted-foreground">
+                    {option.description}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="space-y-2">
+            <Label>Responder taking coverage</Label>
+            <ResponderCombobox
+              users={users}
+              selectedUserId={selectedUserId}
+              onSelect={setSelectedUserId}
+              label="Select responder"
+              className="w-full justify-between"
+              disabled={isPending}
+            />
+          </div>
+
+          {mode === 'replacement' && (
+            <div className="space-y-2">
+              <Label>Responder being replaced</Label>
+              <ResponderCombobox
+                users={replacementCandidates}
+                selectedUserId={replacesUserId}
+                onSelect={setReplacesUserId}
+                label="Select scheduled responder"
+                className="w-full justify-between"
+                disabled={isPending}
+              />
+            </div>
+          )}
+
+          <div className="space-y-3">
+            <Label>Quick duration</Label>
+            <div className="grid grid-cols-4 gap-2">
+              {[1, 4, 8, 24].map(hours => (
                 <Button
                   key={hours}
                   type="button"
                   variant="outline"
                   size="sm"
                   onClick={() => handleQuickDuration(hours)}
-                  className="text-xs"
                 >
-                  {label}
+                  {hours}h
                 </Button>
               ))}
             </div>
           </div>
 
-          {/* Date/Time inputs - using native datetime-local */}
-          <div className="space-y-3">
-            <Label>Start Date & Time *</Label>
-            <input
-              type="datetime-local"
-              value={startTime}
-              onChange={e => setStartTime(e.target.value)}
-              required
-              disabled={isPending}
-              className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white px-3 hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20 cursor-pointer"
-            />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="override-start">Starts</Label>
+              <input
+                id="override-start"
+                type="datetime-local"
+                value={startTime}
+                onChange={event => setStartTime(event.target.value)}
+                required
+                disabled={isPending}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="override-end">Ends</Label>
+              <input
+                id="override-end"
+                type="datetime-local"
+                value={endTime}
+                onChange={event => setEndTime(event.target.value)}
+                required
+                disabled={isPending}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
           </div>
 
-          <div className="space-y-3">
-            <Label>End Date & Time *</Label>
-            <input
-              type="datetime-local"
-              value={endTime}
-              onChange={e => setEndTime(e.target.value)}
-              required
-              disabled={isPending}
-              className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white px-3 hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20 cursor-pointer"
-            />
-          </div>
-
-          {/* Timezone indicator */}
-          <p className="text-xs text-slate-500 -mt-1">
-            Times are in schedule timezone: <span className="font-medium">{scheduleTimeZone}</span>
-          </p>
-
-          {/* Preview */}
-          {startTime && endTime && selectedUserId && (
-            <div className="p-4 rounded-xl bg-amber-50/80 border border-amber-200/80">
-              <div className="flex items-center gap-2 mb-1">
-                <Clock className="h-4 w-4 text-amber-600" />
-                <p className="font-medium text-amber-800">
-                  {users.find(u => u.id === selectedUserId)?.name} will be on-call
-                </p>
+          {startTime && endTime && (
+            <div
+              className={cn(
+                'rounded-lg border p-3 text-sm',
+                hasValidRange ? 'bg-muted/40' : 'border-destructive/40 bg-destructive/5'
+              )}
+            >
+              <div className="flex items-center gap-2 font-medium">
+                {hasValidRange ? (
+                  <Clock className="h-4 w-4" />
+                ) : (
+                  <AlertCircle className="h-4 w-4 text-destructive" />
+                )}
+                {hasValidRange ? 'Schedule-timezone preview' : 'Invalid or ambiguous local time'}
               </div>
-              <p className="text-amber-600 text-xs pl-6">
-                {format(new Date(startTime), 'MMM d, h:mm a')} →{' '}
-                {format(new Date(endTime), 'MMM d, h:mm a')}
-              </p>
+              {startInstant && endInstant && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {formatDateTime(startInstant, scheduleTimeZone, { format: 'short' })} →{' '}
+                  {formatDateTime(endInstant, scheduleTimeZone, { format: 'short' })}
+                </p>
+              )}
             </div>
           )}
 
-          {/* Submit */}
-          <div className="flex gap-3 pt-4 mt-2 border-t border-slate-100">
+          <div className="flex justify-end gap-3 border-t pt-4">
             <Button
               type="button"
               variant="outline"
-              className="flex-1 h-10"
               onClick={() => setOpen(false)}
               disabled={isPending}
             >
@@ -303,17 +282,15 @@ export default function OverrideForm({
             </Button>
             <Button
               type="submit"
-              disabled={isPending || !selectedUserId || !startTime || !endTime}
-              className="flex-1 h-10 bg-amber-500 hover:bg-amber-600 shadow-sm"
+              disabled={
+                isPending ||
+                !selectedUserId ||
+                !hasValidRange ||
+                (mode === 'replacement' && !replacesUserId)
+              }
             >
-              {isPending ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Creating...
-                </>
-              ) : (
-                'Confirm Override'
-              )}
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {mode === 'replacement' ? 'Create replacement' : 'Add coverage'}
             </Button>
           </div>
         </form>

--- a/src/components/OverrideList.tsx
+++ b/src/components/OverrideList.tsx
@@ -1,47 +1,55 @@
 'use client';
 
-import { useTransition, useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-product-notification';
 import type { ScheduleActionState } from '@/lib/schedule-action-errors';
-import ConfirmDialog from './ConfirmDialog';
+import type { OverrideStatus } from '@/lib/schedules/detail-view-model';
 import { formatDateTime } from '@/lib/timezone';
+import { getDefaultAvatar } from '@/lib/avatar';
+import ConfirmDialog from './ConfirmDialog';
+import { DirectUserAvatar } from './UserAvatar';
 import { Card } from '@/components/ui/shadcn/card';
 import { Badge } from '@/components/ui/shadcn/badge';
 import { Button } from '@/components/ui/shadcn/button';
-import { Avatar, AvatarFallback } from '@/components/ui/shadcn/avatar';
-import { ArrowRight, Trash2, User } from 'lucide-react';
+import { ArrowRight, Plus, Repeat2, Trash2 } from 'lucide-react';
 
-type Override = {
+export type PresentedOverride = {
   id: string;
   start: Date;
   end: Date;
   userId: string;
   replacesUserId: string | null;
-  user: { name: string };
+  user: { name: string; avatarUrl?: string | null; gender?: string | null };
   replacesUser: { name: string } | null;
 };
 
 type OverrideListProps = {
-  overrides: Override[];
+  overrides: PresentedOverride[];
   scheduleId: string;
-  canManageSchedules: boolean;
+  canDeleteOverride: boolean;
   deleteOverride: (
     scheduleId: string,
     overrideId: string
   ) => Promise<ScheduleActionState | undefined>;
   timeZone: string;
-  title: string;
+  status: OverrideStatus;
   emptyMessage: string;
 };
+
+function getStatusVariant(status: OverrideStatus): 'success' | 'warning' | 'secondary' {
+  if (status === 'ACTIVE') return 'success';
+  if (status === 'UPCOMING') return 'warning';
+  return 'secondary';
+}
 
 export default function OverrideList({
   overrides,
   scheduleId,
-  canManageSchedules,
+  canDeleteOverride,
   deleteOverride,
   timeZone,
-  title,
+  status,
   emptyMessage,
 }: OverrideListProps) {
   const router = useRouter();
@@ -49,121 +57,99 @@ export default function OverrideList({
   const [isPending, startTransition] = useTransition();
   const [deleteOverrideId, setDeleteOverrideId] = useState<string | null>(null);
 
-  const handleDelete = async (overrideId: string) => {
+  const handleDelete = (overrideId: string) => {
     setDeleteOverrideId(null);
     startTransition(async () => {
       try {
         const result = await deleteOverride(scheduleId, overrideId);
-        if (result?.error) {
-          showToast(result, 'error');
-        } else {
-          showToast('Override deleted successfully', 'success');
-          router.refresh();
-        }
+        if (result?.error) return showToast(result, 'error');
+        showToast('Override deleted successfully.', 'success');
+        router.refresh();
       } catch (error) {
         showToast(error, 'error');
       }
     });
   };
 
-  const getInitials = (name: string) => {
-    return name
-      .split(' ')
-      .map(n => n[0])
-      .join('')
-      .toUpperCase()
-      .slice(0, 2);
-  };
+  if (overrides.length === 0) {
+    return (
+      <Card className="border-dashed p-6 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </Card>
+    );
+  }
 
   return (
     <>
-      <div className="mt-6 pt-6 border-t-2">
-        <div className="flex items-center justify-between mb-4">
-          <h4 className="text-base font-semibold">{title}</h4>
-          {overrides.length > 0 && (
-            <Badge variant="secondary" size="xs">
-              {overrides.length}
-            </Badge>
-          )}
-        </div>
-
-        {overrides.length === 0 ? (
-          <Card className="border-dashed">
-            <div className="p-6 text-center">
-              <p className="text-sm text-muted-foreground">{emptyMessage}</p>
-            </div>
-          </Card>
-        ) : (
-          <div className="space-y-3">
-            {overrides.map(override => (
-              <Card key={override.id} className="transition-all duration-200 hover:shadow-md">
-                <div className="p-4 flex items-start justify-between gap-4">
-                  <div className="flex-1 min-w-0 space-y-3">
-                    <div className="flex items-center gap-3">
-                      <Avatar className="h-8 w-8 bg-gradient-to-br from-red-500 to-red-700">
-                        <AvatarFallback className="bg-gradient-to-br from-red-500 to-red-700 text-white text-xs font-semibold">
-                          {getInitials(override.user.name)}
-                        </AvatarFallback>
-                      </Avatar>
-                      <span className="font-semibold text-sm">{override.user.name}</span>
-                    </div>
-
-                    <div className="flex items-center gap-2 text-xs ml-11">
-                      <Badge variant="outline" size="xs">
-                        {formatDateTime(override.start, timeZone, { format: 'short' })}
-                      </Badge>
-                      <ArrowRight className="h-3 w-3 text-muted-foreground" />
-                      <Badge variant="outline" size="xs">
-                        {formatDateTime(override.end, timeZone, { format: 'short' })}
-                      </Badge>
-                    </div>
-
-                    {override.replacesUser && (
-                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground ml-11">
-                        <User className="h-3 w-3" />
-                        <span className="italic">
-                          {title.includes('Upcoming') ? 'Replaces' : 'Replaced'}{' '}
-                          <strong>{override.replacesUser.name}</strong>
+      <div className="space-y-3">
+        {overrides.map(override => {
+          const isReplacement = Boolean(override.replacesUserId);
+          return (
+            <Card key={override.id} className="p-4">
+              <div className="flex items-start gap-3">
+                <DirectUserAvatar
+                  avatarUrl={
+                    override.user.avatarUrl ||
+                    getDefaultAvatar(override.user.gender, override.userId)
+                  }
+                  name={override.user.name}
+                  size="sm"
+                  className="h-9 w-9"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-semibold">{override.user.name}</p>
+                    <Badge variant={isReplacement ? 'outline' : 'secondary'} size="xs">
+                      {isReplacement ? (
+                        <span className="inline-flex items-center gap-1">
+                          <Repeat2 className="h-3 w-3" /> Replacement
                         </span>
-                      </div>
-                    )}
+                      ) : (
+                        <span className="inline-flex items-center gap-1">
+                          <Plus className="h-3 w-3" /> Extra coverage
+                        </span>
+                      )}
+                    </Badge>
+                    <Badge variant={getStatusVariant(status)} size="xs">
+                      {status.toLowerCase()}
+                    </Badge>
                   </div>
-
-                  {canManageSchedules ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setDeleteOverrideId(override.id)}
-                      disabled={isPending}
-                      className="text-red-600 hover:text-red-700 hover:bg-red-50 shrink-0"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      disabled
-                      className="shrink-0"
-                      title="Admin or Responder role required"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  )}
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {formatDateTime(override.start, timeZone, { format: 'short' })}
+                    <ArrowRight className="mx-1 inline h-3 w-3" />
+                    {formatDateTime(override.end, timeZone, { format: 'short' })}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {isReplacement
+                      ? `${status === 'COMPLETED' ? 'Replaced' : 'Replaces'} ${override.replacesUser?.name ?? 'a scheduled responder'}`
+                      : 'Adds coverage without removing scheduled responders'}
+                  </p>
                 </div>
-              </Card>
-            ))}
-          </div>
-        )}
+                {canDeleteOverride && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setDeleteOverrideId(override.id)}
+                    disabled={isPending}
+                    aria-label={`Delete override for ${override.user.name}`}
+                    className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </Card>
+          );
+        })}
       </div>
 
       {deleteOverrideId && (
         <ConfirmDialog
-          isOpen={true}
-          title="Delete Override"
-          message="Are you sure you want to delete this override? This action cannot be undone."
-          confirmText="Delete Override"
-          cancelText="Cancel"
+          isOpen
+          title="Delete override"
+          message="Delete this override? Effective coverage will immediately return to the remaining schedule."
+          confirmText="Delete override"
+          cancelText="Keep override"
           variant="danger"
           onConfirm={() => handleDelete(deleteOverrideId)}
           onCancel={() => setDeleteOverrideId(null)}

--- a/src/components/ResponderCombobox.tsx
+++ b/src/components/ResponderCombobox.tsx
@@ -13,7 +13,8 @@ import {
 } from '@/components/ui/shadcn/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/shadcn/popover';
 import { Badge } from '@/components/ui/shadcn/badge';
-import { ChevronsUpDown, UserPlus } from 'lucide-react';
+import { Check, ChevronsUpDown, UserPlus } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 export type ResponderOption = {
   id: string;
@@ -27,17 +28,32 @@ export type ResponderOption = {
 type ResponderComboboxProps = {
   users: ResponderOption[];
   onSelect: (userId: string) => void;
+  selectedUserId?: string;
   disabled?: boolean;
+  loading?: boolean;
+  label?: string;
+  placeholder?: string;
+  emptyMessage?: string;
+  className?: string;
+  ariaLabel?: string;
 };
 
 export default function ResponderCombobox({
   users,
   onSelect,
+  selectedUserId,
   disabled = false,
+  loading = false,
+  label = 'Add Responder',
+  placeholder = 'Search by name, email, or role...',
+  emptyMessage = 'No active responders match your search.',
+  className,
+  ariaLabel,
 }: ResponderComboboxProps) {
   const [open, setOpen] = useState(false);
   const hasUsers = users.length > 0;
-  const isDisabled = disabled || !hasUsers;
+  const isDisabled = disabled || loading || !hasUsers;
+  const selectedUser = users.find(user => user.id === selectedUserId);
 
   return (
     <Popover open={open} onOpenChange={nextOpen => !isDisabled && setOpen(nextOpen)}>
@@ -49,26 +65,47 @@ export default function ResponderCombobox({
           role="combobox"
           aria-expanded={open}
           aria-haspopup="listbox"
-          aria-label={hasUsers ? 'Add responder' : 'All active responders are already assigned'}
+          aria-label={
+            hasUsers
+              ? (ariaLabel ?? (label === 'Add Responder' ? 'Add responder' : label))
+              : 'All active responders are already assigned'
+          }
           disabled={isDisabled}
-          title={hasUsers ? 'Search and add a responder' : 'All active responders are already assigned'}
-          className="h-8 gap-1.5 border-primary/40 bg-primary/5 px-2.5 text-xs font-medium text-primary hover:border-primary hover:bg-primary/10"
+          title={hasUsers ? label : 'No active responders available'}
+          className={cn(
+            'h-9 gap-1.5 border-primary/40 bg-primary/5 px-2.5 text-xs font-medium text-primary hover:border-primary hover:bg-primary/10',
+            selectedUser && 'justify-between bg-background text-foreground',
+            className
+          )}
         >
-          <UserPlus className="h-3.5 w-3.5" />
-          {hasUsers ? 'Add Responder' : 'All Assigned'}
+          {selectedUser ? (
+            <>
+              <UserAvatar
+                userId={selectedUser.id}
+                name={selectedUser.name}
+                avatarUrl={selectedUser.avatarUrl}
+                gender={selectedUser.gender}
+                size="sm"
+                className="mr-1 h-6 w-6 shrink-0"
+              />
+              <span className="truncate">{selectedUser.name}</span>
+            </>
+          ) : (
+            <>
+              <UserPlus className="h-3.5 w-3.5" />
+              {loading ? 'Loading responders…' : hasUsers ? label : 'All Assigned'}
+            </>
+          )}
           {hasUsers && <ChevronsUpDown className="h-3 w-3 opacity-60" />}
         </Button>
       </PopoverTrigger>
 
       <PopoverContent className="w-[320px] p-0" align="end" sideOffset={6}>
         <Command className="rounded-lg">
-          <CommandInput
-            placeholder="Search by name, email, or role..."
-            aria-label="Search available responders"
-          />
+          <CommandInput placeholder={placeholder} aria-label="Search available responders" />
           <CommandList className="max-h-[320px]">
             <CommandEmpty className="px-4 py-8 text-center text-sm text-muted-foreground">
-              No active responders match your search.
+              {emptyMessage}
             </CommandEmpty>
             <CommandGroup heading={`Available responders (${users.length})`} className="p-1.5">
               {users.map(user => (
@@ -104,6 +141,12 @@ export default function ResponderCombobox({
                       {user.email || 'Active responder'}
                     </span>
                   </div>
+                  <Check
+                    className={cn(
+                      'ml-2 h-4 w-4 shrink-0',
+                      user.id === selectedUserId ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/src/components/ScheduleActionsPanel.tsx
+++ b/src/components/ScheduleActionsPanel.tsx
@@ -62,7 +62,7 @@ export default function ScheduleActionsPanel({
         <OverrideForm
           scheduleId={scheduleId}
           users={users}
-          canManageSchedules={canManageSchedules}
+          canCreateOverride={canManageSchedules}
           createOverride={createOverride}
           scheduleTimeZone={scheduleTimeZone}
         />

--- a/src/components/ScheduleTimeline.tsx
+++ b/src/components/ScheduleTimeline.tsx
@@ -18,7 +18,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/shadcn/tooltip';
 import { getDefaultAvatar } from '@/lib/avatar';
-import { getFinalScheduleBlocks, type OnCallBlock } from '@/lib/oncall';
 import { ChevronLeft, ChevronRight, Calendar, Clock, Users, Shield } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -43,8 +42,8 @@ type TimelineShift = {
 
 type ScheduleTimelineProps = {
   shifts: TimelineShift[];
+  effectiveShifts: TimelineShift[];
   timeZone: string;
-  layerPriorities?: Map<string, number>;
 };
 
 const LAYER_COLORS = [
@@ -88,8 +87,8 @@ const LAYER_COLORS = [
 
 export default function ScheduleTimeline({
   shifts,
+  effectiveShifts,
   timeZone,
-  layerPriorities,
 }: ScheduleTimelineProps) {
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => {
@@ -155,28 +154,11 @@ export default function ScheduleTimeline({
     return [...groups.entries()];
   }, [visibleShifts]);
 
-  // Compute final schedule blocks (merged view with priority resolution)
+  // Effective coverage is calculated once by the canonical server-side engine.
+  // This component only clips that presentation data to the selected window.
   const finalScheduleBlocks = useMemo(() => {
-    if (!layerPriorities || layerPriorities.size === 0 || visibleShifts.length === 0) {
-      return [];
-    }
-
-    // Convert shifts to OnCallBlock format
-    const blocks: OnCallBlock[] = visibleShifts.map(shift => ({
-      id: shift.id,
-      start: shift.start,
-      end: shift.end,
-      userId: shift.userId || '',
-      userName: shift.userName,
-      userAvatar: shift.userAvatar,
-      userGender: shift.userGender,
-      layerId: shift.layerId || shift.layerName,
-      layerName: shift.layerName,
-      source: shift.source === 'override' ? 'override' : 'rotation',
-    }));
-
-    return getFinalScheduleBlocks(blocks, layerPriorities);
-  }, [visibleShifts, layerPriorities]);
+    return effectiveShifts.filter(shift => shift.start < endDate && shift.end > startDate);
+  }, [effectiveShifts, endDate, startDate]);
 
   const handlePrevPeriod = () => {
     setStartDateKey(prev => addDaysToDateKey(prev, -daysToShow));

--- a/src/components/schedules/ScheduleCoverageExplorer.tsx
+++ b/src/components/schedules/ScheduleCoverageExplorer.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/shadcn/tabs';
+import { CalendarDays, GanttChart } from 'lucide-react';
+
+export default function ScheduleCoverageExplorer({
+  timeline,
+  calendar,
+}: {
+  timeline: ReactNode;
+  calendar: ReactNode;
+}) {
+  return (
+    <section aria-labelledby="coverage-explorer-title" className="space-y-3">
+      <div>
+        <h2 id="coverage-explorer-title" className="text-lg font-semibold">
+          Coverage explorer
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Inspect the final effective schedule or drill into configured layers.
+        </p>
+      </div>
+      <Tabs defaultValue="timeline" className="space-y-3">
+        <TabsList>
+          <TabsTrigger value="timeline" className="gap-2">
+            <GanttChart className="h-4 w-4" /> 7 / 14 days
+          </TabsTrigger>
+          <TabsTrigger value="calendar" className="gap-2">
+            <CalendarDays className="h-4 w-4" /> Month
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="timeline" className="mt-0">
+          {timeline}
+        </TabsContent>
+        <TabsContent value="calendar" className="mt-0">
+          {calendar}
+        </TabsContent>
+      </Tabs>
+    </section>
+  );
+}

--- a/tests/components/OverrideForm.test.tsx
+++ b/tests/components/OverrideForm.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import OverrideForm from '@/components/OverrideForm';
+
+const showToast = vi.fn();
+vi.mock('@/hooks/use-product-notification', () => ({
+  useToast: () => ({ showToast }),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+vi.mock('@/components/UserAvatar', () => ({
+  default: ({ name }: { name: string }) => <span aria-hidden="true">{name.slice(0, 1)}</span>,
+}));
+
+const responders = [
+  { id: 'alex', name: 'Alex Vance', email: 'alex@example.com', role: 'RESPONDER' },
+  { id: 'sam', name: 'Sam Reed', email: 'sam@example.com', role: 'RESPONDER' },
+];
+
+describe('OverrideForm', () => {
+  it('makes replacement and additive semantics explicit', () => {
+    render(
+      <OverrideForm
+        scheduleId="schedule-1"
+        users={responders}
+        canCreateOverride
+        createOverride={vi.fn()}
+        scheduleTimeZone="Asia/Kathmandu"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add override' }));
+    expect(screen.getByRole('button', { name: /Replace someone/ })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Add extra coverage/ }));
+    expect(screen.queryByText('Responder being replaced')).not.toBeInTheDocument();
+    expect(screen.getByText(/regardless of your browser timezone/)).toBeInTheDocument();
+  });
+
+  it('submits additive coverage without a replacement user', async () => {
+    const createOverride = vi.fn().mockResolvedValue(undefined);
+    render(
+      <OverrideForm
+        scheduleId="schedule-1"
+        users={responders}
+        canCreateOverride
+        createOverride={createOverride}
+        scheduleTimeZone="Asia/Kathmandu"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add override' }));
+    fireEvent.click(screen.getByRole('button', { name: /Add extra coverage/ }));
+    fireEvent.click(screen.getByRole('combobox', { name: 'Select responder' }));
+    fireEvent.click(screen.getByText('Alex Vance'));
+    fireEvent.change(screen.getByLabelText('Starts'), {
+      target: { value: '2026-08-29T15:45' },
+    });
+    fireEvent.change(screen.getByLabelText('Ends'), {
+      target: { value: '2026-08-29T16:45' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add coverage' }));
+
+    await waitFor(() => expect(createOverride).toHaveBeenCalledOnce());
+    const [scheduleId, formData] = createOverride.mock.calls[0] as [string, FormData];
+    expect(scheduleId).toBe('schedule-1');
+    expect(formData.get('userId')).toBe('alex');
+    expect(formData.get('replacesUserId')).toBe('');
+    expect(formData.get('start')).toBe('2026-08-29T15:45');
+  });
+});


### PR DESCRIPTION
## What changed
- Rebuilt schedule detail around task-focused tabs and an immediate on-call hero with the true next effective change.
- Added a Coverage Explorer for 7/14-day and monthly views, with effective and layer detail preserved.
- Reworked overrides into explicit replacement versus extra-coverage workflows, shared cards, correct active/upcoming/completed states, and reachable history pages.
- Reused the searchable responder picker and made override previews schedule-timezone safe.

## Centralization and preserved behavior
Current coverage and next-change presentation consume server-generated canonical blocks. The client timeline no longer reruns final-schedule resolution. All existing timeline/calendar navigation, raw layer visibility, additive/replacement coverage, quick durations, deletion, and read-only behavior remain available.

## Security
Responder directory data loads only for users with a schedule mutation capability. Client capability checks are UX only; every server mutation retains schedule/object relationship validation, audit logging, and domain-safe errors.

## Tests and safety
Added override workflow and timezone submission tests and retained schedule/on-call/escalation regression coverage. This is stacked PR 2/4 and contains one commit.
