### PR TITLE
feat(schedules): streamline rotation workflows

### DIFF
--- a/src/components/LayerCard.tsx
+++ b/src/components/LayerCard.tsx
@@ -25,17 +25,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/shadcn/tooltip';
-import {
-  Trash2,
-  Edit3,
-  Users,
-  Clock,
-  ArrowUp,
-  ArrowDown,
-  Layers,
-  Info,
-  X,
-} from 'lucide-react';
+import { Trash2, Edit3, Users, Clock, ArrowUp, ArrowDown, Layers, Info, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { notify } from '@/lib/toast';
 
@@ -135,7 +125,13 @@ function formatRestrictions(restrictions: LayerRestrictions | null | undefined):
 
     if (isWeekdays) badges.push('Mon-Fri');
     else if (isWeekends) badges.push('Sat-Sun');
-    else if (days.length <= 3) badges.push(days.map(d => getDayName(d)).filter(Boolean).join(', '));
+    else if (days.length <= 3)
+      badges.push(
+        days
+          .map(d => getDayName(d))
+          .filter(Boolean)
+          .join(', ')
+      );
     else badges.push(`${days.length} days`);
   }
 
@@ -298,8 +294,7 @@ export default function LayerCard({
                   </Badge>
                 )}
                 {layer.restrictions &&
-                  (layer.restrictions.daysOfWeek?.length ||
-                    layer.restrictions.startHour != null) &&
+                  (layer.restrictions.daysOfWeek?.length || layer.restrictions.startHour != null) &&
                   formatRestrictions(layer.restrictions).map((badge, index) => (
                     <Badge
                       key={index}
@@ -422,14 +417,6 @@ export default function LayerCard({
                       <span className="text-sm font-medium text-slate-700 truncate">
                         {layerUser.user.name}
                       </span>
-                      {index === 0 && (
-                        <Badge
-                          variant="secondary"
-                          className="h-4 px-1.5 text-[8px] bg-emerald-50 text-emerald-600 border-emerald-100 shrink-0"
-                        >
-                          NEXT
-                        </Badge>
-                      )}
                     </div>
                     {canManageSchedules && (
                       <div className="flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shrink-0">

--- a/src/components/LayerCreateForm.tsx
+++ b/src/components/LayerCreateForm.tsx
@@ -34,6 +34,7 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import LayerTimingFields from '@/components/schedules/LayerTimingFields';
 
 type LayerCreateFormProps = {
   scheduleId: string;
@@ -141,10 +142,6 @@ export default function LayerCreateForm({
     });
   };
 
-  const setQuickDuration = (hours: number) => {
-    setRotationDuration(hours.toString());
-  };
-
   if (!canManageSchedules) return null;
 
   return (
@@ -227,132 +224,15 @@ export default function LayerCreateForm({
             <p className="text-[11px] text-slate-500">Give this rotation a descriptive name</p>
           </div>
 
-          {/* Rotation Length */}
-          <div className="space-y-3">
-            <Label className="flex items-center gap-2">
-              <Repeat className="h-4 w-4 text-slate-500" />
-              Rotation Length
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="h-3.5 w-3.5 text-slate-400 cursor-help" />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-[280px]">
-                    <p>
-                      How often the on-call person changes. After this time, the next person in the
-                      rotation takes over.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </Label>
-            <div className="grid grid-cols-3 gap-2">
-              {[
-                { hours: 12, label: '12 Hours' },
-                { hours: 24, label: 'Daily' },
-                { hours: 168, label: 'Weekly' },
-                { hours: 336, label: '2 Weeks' },
-              ].map(({ hours, label }) => (
-                <Button
-                  key={hours}
-                  type="button"
-                  variant={rotationDuration === hours.toString() ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => setQuickDuration(hours)}
-                  className="text-xs"
-                >
-                  {label}
-                </Button>
-              ))}
-            </div>
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                name="rotationLengthHours"
-                value={rotationDuration}
-                onChange={e => setRotationDuration(e.target.value)}
-                required
-                min="1"
-                disabled={isPending}
-                className="w-24 h-10"
-              />
-              <span className="text-sm text-slate-500">hours</span>
-              <span className="text-xs text-slate-400 ml-auto">{rotationInfo}</span>
-            </div>
-          </div>
-
-          {/* Shift Duration */}
-          <div className="space-y-2">
-            <Label className="flex items-center gap-2">
-              <Clock className="h-4 w-4 text-slate-500" />
-              Shift Duration
-              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                Optional
-              </Badge>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="h-3.5 w-3.5 text-slate-400 cursor-help" />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-[280px]">
-                    <p className="font-medium mb-1">Creates gaps in coverage</p>
-                    <p className="text-slate-400">
-                      Example: 12h shift with 24h rotation = person is on-call for 12 hours, then 12
-                      hours off before next person starts.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </Label>
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                name="shiftLengthHours"
-                value={shiftDuration}
-                onChange={e => setShiftDuration(e.target.value)}
-                min="1"
-                placeholder="Same as rotation"
-                disabled={isPending}
-                className="w-40 h-10"
-              />
-              <span className="text-sm text-slate-500">hours</span>
-            </div>
-          </div>
-
-          {/* Start Date */}
-          <div className="space-y-2">
-            <Label className="flex items-center gap-2">
-              <Calendar className="h-4 w-4 text-slate-500" />
-              Start Date & Time
-            </Label>
-            <input
-              type="datetime-local"
-              name="start"
-              defaultValue={defaultStartDate}
-              required
-              disabled={isPending}
-              className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white px-3 hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20"
-            />
-            <p className="text-[11px] text-slate-500">First rotation starts at this time</p>
-          </div>
-
-          {/* End Date */}
-          <div className="space-y-2">
-            <Label className="flex items-center gap-2">
-              <Calendar className="h-4 w-4 text-slate-500" />
-              End Date
-              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                Optional
-              </Badge>
-            </Label>
-            <input
-              type="datetime-local"
-              name="end"
-              disabled={isPending}
-              className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white px-3 hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20"
-            />
-            <p className="text-[11px] text-slate-500">Leave empty for ongoing rotation</p>
-          </div>
+          <LayerTimingFields
+            rotationDuration={rotationDuration}
+            onRotationDurationChange={setRotationDuration}
+            shiftDuration={shiftDuration}
+            onShiftDurationChange={setShiftDuration}
+            startDefaultValue={defaultStartDate}
+            disabled={isPending}
+            rotationSummary={rotationInfo}
+          />
 
           {/* Restrictions Section */}
           <div className="space-y-4 p-4 rounded-xl bg-purple-50/50 border border-purple-100">

--- a/src/components/LayerEditSheet.tsx
+++ b/src/components/LayerEditSheet.tsx
@@ -12,18 +12,13 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/shadcn/sheet';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/shadcn/tooltip';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
 import { Badge } from '@/components/ui/shadcn/badge';
-import { Loader2, Edit3, Info, Clock, Calendar, Repeat, AlertCircle } from 'lucide-react';
+import { Loader2, Edit3, Clock, Calendar, Repeat, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import LayerTimingFields from '@/components/schedules/LayerTimingFields';
 
 type LayerRestrictions = {
   daysOfWeek?: number[];
@@ -150,10 +145,6 @@ export default function LayerEditSheet({
     });
   };
 
-  const setQuickDuration = (hours: number) => {
-    setRotationDuration(hours.toString());
-  };
-
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-[400px] sm:w-[540px] overflow-y-auto">
@@ -221,109 +212,15 @@ export default function LayerEditSheet({
             />
           </div>
 
-          {/* Rotation Length */}
-          <div className="space-y-3">
-            <Label className="flex items-center gap-2">
-              <Repeat className="h-4 w-4 text-slate-500" />
-              Rotation Length
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="h-3.5 w-3.5 text-slate-400 cursor-help" />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-[280px]">
-                    <p>How often the on-call person changes.</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </Label>
-            <div className="grid grid-cols-4 gap-2">
-              {[
-                { hours: 12, label: '12h' },
-                { hours: 24, label: 'Daily' },
-                { hours: 168, label: 'Weekly' },
-                { hours: 336, label: '2 Weeks' },
-              ].map(({ hours, label }) => (
-                <Button
-                  key={hours}
-                  type="button"
-                  variant={rotationDuration === hours.toString() ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => setQuickDuration(hours)}
-                  className="text-xs"
-                >
-                  {label}
-                </Button>
-              ))}
-            </div>
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                name="rotationLengthHours"
-                value={rotationDuration}
-                onChange={e => setRotationDuration(e.target.value)}
-                required
-                min="1"
-                disabled={isPending}
-                className="w-24 h-10"
-              />
-              <span className="text-sm text-slate-500">hours</span>
-            </div>
-          </div>
-
-          {/* Shift Duration */}
-          <div className="space-y-2">
-            <Label className="flex items-center gap-2">
-              <Clock className="h-4 w-4 text-slate-500" />
-              Shift Duration
-              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                Optional
-              </Badge>
-            </Label>
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                name="shiftLengthHours"
-                value={shiftDuration}
-                onChange={e => setShiftDuration(e.target.value)}
-                min="1"
-                placeholder="Same as rotation"
-                disabled={isPending}
-                className="w-40 h-10"
-              />
-              <span className="text-sm text-slate-500">hours</span>
-            </div>
-          </div>
-
-          {/* Start Date */}
-          <div className="space-y-2">
-            <Label>Start Date & Time</Label>
-            <input
-              type="datetime-local"
-              name="start"
-              defaultValue={formatDateForInput(layer.start, timeZone)}
-              required
-              disabled={isPending}
-              className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white px-3 hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20"
-            />
-          </div>
-
-          {/* End Date */}
-          <div className="space-y-2">
-            <Label className="flex items-center gap-2">
-              End Date
-              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                Optional
-              </Badge>
-            </Label>
-            <input
-              type="datetime-local"
-              name="end"
-              defaultValue={layer.end ? formatDateForInput(layer.end, timeZone) : ''}
-              disabled={isPending}
-              className="w-full h-11 text-sm rounded-lg border-2 border-slate-200 bg-white px-3 hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20"
-            />
-          </div>
+          <LayerTimingFields
+            rotationDuration={rotationDuration}
+            onRotationDurationChange={setRotationDuration}
+            shiftDuration={shiftDuration}
+            onShiftDurationChange={setShiftDuration}
+            startDefaultValue={formatDateForInput(layer.start, timeZone)}
+            endDefaultValue={layer.end ? formatDateForInput(layer.end, timeZone) : ''}
+            disabled={isPending}
+          />
 
           {/* Restrictions Section */}
           <div className="space-y-4 p-4 rounded-xl bg-purple-50/50 border border-purple-100">

--- a/src/components/schedules/LayerTimingFields.tsx
+++ b/src/components/schedules/LayerTimingFields.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { Badge } from '@/components/ui/shadcn/badge';
+import { Button } from '@/components/ui/shadcn/button';
+import { Input } from '@/components/ui/shadcn/input';
+import { Label } from '@/components/ui/shadcn/label';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/shadcn/tooltip';
+import { Calendar, Clock, Info, Repeat } from 'lucide-react';
+
+type LayerTimingFieldsProps = {
+  rotationDuration: string;
+  onRotationDurationChange: (value: string) => void;
+  shiftDuration: string;
+  onShiftDurationChange: (value: string) => void;
+  startDefaultValue: string;
+  endDefaultValue?: string;
+  disabled?: boolean;
+  rotationSummary?: string | null;
+};
+
+const rotationPresets = [
+  { hours: 12, label: '12h' },
+  { hours: 24, label: 'Daily' },
+  { hours: 168, label: 'Weekly' },
+  { hours: 336, label: '2 weeks' },
+];
+
+export default function LayerTimingFields({
+  rotationDuration,
+  onRotationDurationChange,
+  shiftDuration,
+  onShiftDurationChange,
+  startDefaultValue,
+  endDefaultValue = '',
+  disabled = false,
+  rotationSummary,
+}: LayerTimingFieldsProps) {
+  return (
+    <>
+      <div className="space-y-3">
+        <Label className="flex items-center gap-2">
+          <Repeat className="h-4 w-4 text-muted-foreground" />
+          Handoff frequency
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button type="button" aria-label="About handoff frequency">
+                  <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[280px]">
+                How often coverage moves to the next responder in the configured order.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </Label>
+        <div className="grid grid-cols-4 gap-2">
+          {rotationPresets.map(({ hours, label }) => (
+            <Button
+              key={hours}
+              type="button"
+              variant={rotationDuration === hours.toString() ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => onRotationDurationChange(hours.toString())}
+              disabled={disabled}
+              className="text-xs"
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            name="rotationLengthHours"
+            value={rotationDuration}
+            onChange={event => onRotationDurationChange(event.target.value)}
+            required
+            min="1"
+            disabled={disabled}
+            className="h-10 w-24"
+          />
+          <span className="text-sm text-muted-foreground">hours</span>
+          {rotationSummary && (
+            <span className="ml-auto text-xs text-muted-foreground">{rotationSummary}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-muted-foreground" />
+          Coverage duration
+          <Badge variant="secondary" size="xs">
+            Optional
+          </Badge>
+        </Label>
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            name="shiftLengthHours"
+            value={shiftDuration}
+            onChange={event => onShiftDurationChange(event.target.value)}
+            min="1"
+            placeholder="Same as handoff"
+            disabled={disabled}
+            className="h-10 w-40"
+          />
+          <span className="text-sm text-muted-foreground">hours</span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          A shorter duration intentionally creates an uncovered interval before the next handoff.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-muted-foreground" /> Starts
+          </Label>
+          <input
+            type="datetime-local"
+            name="start"
+            defaultValue={startDefaultValue}
+            required
+            disabled={disabled}
+            className="h-10 w-full rounded-md border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-muted-foreground" /> Ends
+            <Badge variant="secondary" size="xs">
+              Optional
+            </Badge>
+          </Label>
+          <input
+            type="datetime-local"
+            name="end"
+            defaultValue={endDefaultValue}
+            disabled={disabled}
+            className="h-10 w-full rounded-md border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tests/components/LayerTimingFields.test.tsx
+++ b/tests/components/LayerTimingFields.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import LayerTimingFields from '@/components/schedules/LayerTimingFields';
+
+describe('LayerTimingFields', () => {
+  it('shares handoff, coverage duration, and date controls across layer workflows', () => {
+    const onRotationDurationChange = vi.fn();
+    const onShiftDurationChange = vi.fn();
+
+    render(
+      <LayerTimingFields
+        rotationDuration="24"
+        onRotationDurationChange={onRotationDurationChange}
+        shiftDuration="12"
+        onShiftDurationChange={onShiftDurationChange}
+        startDefaultValue="2026-08-29T09:00"
+        endDefaultValue="2026-09-29T09:00"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Weekly' }));
+    expect(onRotationDurationChange).toHaveBeenCalledWith('168');
+
+    const numberInputs = screen.getAllByRole('spinbutton');
+    fireEvent.change(numberInputs[1], { target: { value: '8' } });
+    expect(onShiftDurationChange).toHaveBeenCalledWith('8');
+
+    expect(screen.getByDisplayValue('2026-08-29T09:00')).toHaveAttribute('name', 'start');
+    expect(screen.getByDisplayValue('2026-09-29T09:00')).toHaveAttribute('name', 'end');
+  });
+});


### PR DESCRIPTION
## What changed
- Centralized handoff frequency, coverage duration, and timezone-safe layer date controls in one shared form section used by create and edit.
- Clarified rotation configuration and removed the misleading `NEXT` label; numbered responders now communicate order only.
- Preserved responder search, add, reorder, remove, edit, delete, restrictions, optional end dates, and gap-producing shift duration.

## Centralization and preserved behavior
Shared domain controls replace duplicated create/edit markup while workflow submission stays local. No scheduling or mutation semantics changed.

## Security
Existing authoritative layer mutation checks, active-responder validation, ownership validation, transactions, and concurrency protections are unchanged.

## Tests and safety
Added shared timing-field interaction coverage and ran the full relevant schedule/on-call suite. This is stacked PR 3/4 and contains one commit.
