### PR TITLE
fix(teams): allow JsonValue details in TeamActivityTimeline

### DIFF
--- a/src/components/teams/TeamActivityTimeline.tsx
+++ b/src/components/teams/TeamActivityTimeline.tsx
@@ -18,7 +18,7 @@ type AuditLogItem = {
   action: string;
   actorName?: string | null;
   actorEmail?: string | null;
-  details?: Record<string, unknown> | string | null;
+  details?: unknown;
   createdAt: Date | string;
   actor?: {
     id: string;


### PR DESCRIPTION
### 🐛 Bug Fix Summary

#### Problem
The recent CI runs on `main` failed in the **Tests (lint + unit)** typecheck step and **Docker Image build** Next.js compilation step with:
```
src/app/(app)/teams/[id]/page.tsx(329,33): error TS2322: Type '({ actor: ... } & { action: string; ... })[]' is not assignable to type 'AuditLogItem[]'.
  Types of property 'details' are incompatible.
    Type 'JsonValue' is not assignable to type 'string | Record<string, unknown> | null | undefined'.
```

#### Root Cause
Prisma's `auditLog.details` field is typed as `Prisma.JsonValue` (which includes numbers, booleans, and arrays), whereas `AuditLogItem.details` in `TeamActivityTimeline.tsx` was constrained to `Record<string, unknown> | string | null`.

#### Fix
- Updated `AuditLogItem.details` in `src/components/teams/TeamActivityTimeline.tsx` to `unknown` so any JSON structure from Prisma is accepted.
- Runtime guards inside `TeamActivityTimeline` already safely parse and handle object, string, and primitive values.
- Verified full TypeScript compilation (`npx tsc --noEmit`), test suite (1,579 unit/integration tests passed), and Next.js production build (`next build --webpack`).