### PR TITLE
fix: harden scoped access and outbound URL validation

### DIFF
--- a/src/app/(app)/services/[id]/webhooks/actions.ts
+++ b/src/app/(app)/services/[id]/webhooks/actions.ts
@@ -64,15 +64,24 @@ export async function createWebhookIntegration(serviceId: string, formData: Form
 
 export async function updateWebhookIntegration(
   integrationId: string,
-  serviceId: string,
+  _serviceId: string,
   formData: FormData
 ) {
+  // Always authorize against the integration's persisted service. The route
+  // parameter is client-controlled and must not determine access.
+  const existing = await prisma.webhookIntegration.findUnique({
+    where: { id: integrationId },
+    select: { serviceId: true, secret: true },
+  });
+  if (!existing) throw new Error('Webhook integration not found');
+
   let currentUser: { id: string } | null = null;
   try {
-    currentUser = await assertCanModifyService(serviceId);
+    currentUser = await assertCanModifyService(existing.serviceId);
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
+  const ownedServiceId = existing.serviceId;
 
   const name = formData.get('name') as string;
   const type = formData.get('type') as string;
@@ -85,11 +94,6 @@ export async function updateWebhookIntegration(
     throw new Error('Name, type, and URL are required');
   }
   await assertSafeOutboundUrl(url);
-
-  // Get existing webhook to preserve secret if not provided
-  const existing = await prisma.webhookIntegration.findUnique({
-    where: { id: integrationId },
-  });
 
   let normalizedName = name;
   try {
@@ -109,7 +113,7 @@ export async function updateWebhookIntegration(
       name: normalizedName,
       type,
       url,
-      secret: secret ? await encrypt(secret) : existing?.secret || null,
+      secret: secret ? await encrypt(secret) : existing.secret || null,
       channel: channel || null,
       enabled,
     },
@@ -118,20 +122,26 @@ export async function updateWebhookIntegration(
   await logAudit({
     action: 'webhook.integration.updated',
     entityType: 'SERVICE',
-    entityId: serviceId,
+    entityId: ownedServiceId,
     actorId: currentUser.id,
     details: { integrationId, name: normalizedName, type },
   });
 
-  revalidatePath(`/services/${serviceId}/settings`);
-  revalidatePath(`/services/${serviceId}/webhooks`);
-  redirect(`/services/${serviceId}/settings?saved=1`);
+  revalidatePath(`/services/${ownedServiceId}/settings`);
+  revalidatePath(`/services/${ownedServiceId}/webhooks`);
+  redirect(`/services/${ownedServiceId}/settings?saved=1`);
 }
 
-export async function deleteWebhookIntegration(integrationId: string, serviceId: string) {
+export async function deleteWebhookIntegration(integrationId: string, _serviceId: string) {
+  const existing = await prisma.webhookIntegration.findUnique({
+    where: { id: integrationId },
+    select: { serviceId: true },
+  });
+  if (!existing) throw new Error('Webhook integration not found');
+
   let currentUser: { id: string } | null = null;
   try {
-    currentUser = await assertCanModifyService(serviceId);
+    currentUser = await assertCanModifyService(existing.serviceId);
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Unauthorized');
   }
@@ -143,10 +153,10 @@ export async function deleteWebhookIntegration(integrationId: string, serviceId:
   await logAudit({
     action: 'webhook.integration.deleted',
     entityType: 'SERVICE',
-    entityId: serviceId,
+    entityId: existing.serviceId,
     actorId: currentUser.id,
     details: { integrationId },
   });
 
-  revalidatePath(`/services/${serviceId}/settings`);
+  revalidatePath(`/services/${existing.serviceId}/settings`);
 }

--- a/src/app/(app)/services/[id]/webhooks/actions.ts
+++ b/src/app/(app)/services/[id]/webhooks/actions.ts
@@ -102,7 +102,7 @@ export async function updateWebhookIntegration(
     });
   } catch (error) {
     if (error instanceof UniqueNameConflictError) {
-      redirect(`/services/${serviceId}/webhooks/${integrationId}/edit?error=duplicate-webhook`);
+      redirect(`/services/${ownedServiceId}/webhooks/${integrationId}/edit?error=duplicate-webhook`);
     }
     throw error;
   }

--- a/src/app/api/dashboards/[id]/route.ts
+++ b/src/app/api/dashboards/[id]/route.ts
@@ -4,6 +4,8 @@ import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { logger } from '@/lib/logger';
 
+const dashboardVisibilities = new Set(['PRIVATE', 'TEAM', 'PUBLIC']);
+
 export const dynamic = 'force-dynamic';
 
 /**
@@ -79,7 +81,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
     const user = await prisma.user.findUnique({
       where: { email: session.user.email },
-      select: { id: true },
+      select: { id: true, teamMemberships: { select: { teamId: true } } },
     });
 
     if (!user) {
@@ -89,7 +91,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     // Check ownership
     const existing = await prisma.dashboard.findUnique({
       where: { id },
-      select: { userId: true },
+      select: { userId: true, visibility: true, teamId: true },
     });
 
     if (!existing) {
@@ -105,6 +107,19 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
     const body = await request.json();
     const { name, description, layout, config, visibility, teamId, widgets } = body;
+    const effectiveVisibility = visibility ?? existing.visibility;
+    const effectiveTeamId = teamId ?? existing.teamId;
+    if (!dashboardVisibilities.has(effectiveVisibility)) {
+      return NextResponse.json({ error: 'Invalid dashboard visibility' }, { status: 400 });
+    }
+    const teamIds = new Set(user.teamMemberships.map(membership => membership.teamId));
+    if (effectiveVisibility === 'TEAM') {
+      if (typeof effectiveTeamId !== 'string' || !teamIds.has(effectiveTeamId)) {
+        return NextResponse.json({ error: 'Team dashboard access denied' }, { status: 403 });
+      }
+    } else if (teamId !== undefined) {
+      return NextResponse.json({ error: 'Only team dashboards can specify a team' }, { status: 400 });
+    }
 
     // Transaction: Update dashboard and replace widgets
     const dashboard = await prisma.$transaction(async tx => {
@@ -122,7 +137,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
           ...(layout !== undefined && { layout }),
           ...(config !== undefined && { config }),
           ...(visibility !== undefined && { visibility }),
-          ...(teamId !== undefined && { teamId: visibility === 'TEAM' ? teamId : null }),
+          ...(visibility !== undefined && {
+            teamId: effectiveVisibility === 'TEAM' ? effectiveTeamId : null,
+          }),
+          ...(visibility === undefined && teamId !== undefined && { teamId: effectiveTeamId }),
           ...(widgets &&
             Array.isArray(widgets) && {
               widgets: {

--- a/src/app/api/dashboards/route.ts
+++ b/src/app/api/dashboards/route.ts
@@ -4,6 +4,8 @@ import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { logger } from '@/lib/logger';
 
+const dashboardVisibilities = new Set(['PRIVATE', 'TEAM', 'PUBLIC']);
+
 export const dynamic = 'force-dynamic';
 
 /**
@@ -102,7 +104,7 @@ export async function POST(request: NextRequest) {
 
     const user = await prisma.user.findUnique({
       where: { email: session.user.email },
-      select: { id: true },
+      select: { id: true, teamMemberships: { select: { teamId: true } } },
     });
 
     if (!user) {
@@ -112,8 +114,15 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { name, description, templateId, visibility = 'PRIVATE', teamId, widgets = [] } = body;
 
-    if (!name || typeof name !== 'string') {
-      return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+    if (!name || typeof name !== 'string' || !dashboardVisibilities.has(visibility)) {
+      return NextResponse.json({ error: 'Invalid dashboard configuration' }, { status: 400 });
+    }
+    const teamIds = new Set(user.teamMemberships.map(membership => membership.teamId));
+    if (
+      (visibility === 'TEAM' && (typeof teamId !== 'string' || !teamIds.has(teamId))) ||
+      (visibility !== 'TEAM' && teamId !== undefined && teamId !== null)
+    ) {
+      return NextResponse.json({ error: 'Invalid team dashboard configuration' }, { status: 403 });
     }
 
     // If creating from template, clone the template's widgets
@@ -123,15 +132,20 @@ export async function POST(request: NextRequest) {
         where: { id: templateId },
         include: { widgets: true },
       });
-      if (template) {
-        widgetsToCreate = template.widgets.map(w => ({
-          widgetType: w.widgetType,
-          metricKey: w.metricKey,
-          title: w.title,
-          position: w.position,
-          config: w.config,
-        }));
-      }
+      if (!template) return NextResponse.json({ error: 'Template not found' }, { status: 404 });
+      const canReadTemplate =
+        template.isTemplate ||
+        template.visibility === 'PUBLIC' ||
+        template.userId === user.id ||
+        (template.teamId !== null && teamIds.has(template.teamId));
+      if (!canReadTemplate) return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+      widgetsToCreate = template.widgets.map(w => ({
+        widgetType: w.widgetType,
+        metricKey: w.metricKey,
+        title: w.title,
+        position: w.position,
+        config: w.config,
+      }));
     }
 
     const dashboard = await prisma.dashboard.create({

--- a/src/app/api/integrations/health/route.ts
+++ b/src/app/api/integrations/health/route.ts
@@ -16,6 +16,7 @@ import {
 import { getRateLimitStatus } from '@/lib/integrations/rate-limiter';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
+import { assertCanViewService } from '@/lib/rbac';
 
 export async function GET(req: NextRequest) {
   try {
@@ -47,6 +48,12 @@ export async function GET(req: NextRequest) {
 
       if (!integration) {
         return jsonError('Integration not found', 404);
+      }
+
+      try {
+        await assertCanViewService(integration.service.id);
+      } catch {
+        return jsonError('Forbidden', 403);
       }
 
       const metrics = getMetricsByIntegration(integrationId);
@@ -112,13 +119,19 @@ export async function POST(req: NextRequest) {
       select: {
         id: true,
         type: true,
-        key: true,
+        serviceId: true,
         enabled: true,
       },
     });
 
     if (!integration) {
       return jsonError('Integration not found', 404);
+    }
+
+    try {
+      await assertCanViewService(integration.serviceId);
+    } catch {
+      return jsonError('Forbidden', 403);
     }
 
     // Parse test payload

--- a/src/app/api/sla-definitions/[id]/route.ts
+++ b/src/app/api/sla-definitions/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { getServerSession } from 'next-auth';
-import { getAuthOptions } from '@/lib/auth';
-import { assertAdmin } from '@/lib/rbac';
+import { assertAdmin, getCurrentUser } from '@/lib/rbac';
 import { z } from 'zod';
 import { logger } from '@/lib/logger';
+import { resolveUserActor } from '@/lib/authorization-actors';
+import { serviceReadWhere } from '@/lib/authorization-filters';
 
 const updateSchema = z.object({
   name: z.string().min(1).max(100).optional(),
@@ -13,15 +13,17 @@ const updateSchema = z.object({
 });
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(await getAuthOptions());
-  if (!session?.user) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  const actor = await resolveUserActor(user.id);
+  if (!actor) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { id } = await params;
 
-  const definition = await prisma.sLADefinition.findUnique({
-    where: { id },
+  const definition = await prisma.sLADefinition.findFirst({
+    where: { id, service: serviceReadWhere(actor) },
     include: {
       service: { select: { id: true, name: true } },
       snapshots: {

--- a/src/app/api/sla-definitions/route.ts
+++ b/src/app/api/sla-definitions/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { getServerSession } from 'next-auth';
-import { getAuthOptions } from '@/lib/auth';
-import { assertAdmin } from '@/lib/rbac';
+import { assertAdmin, getCurrentUser } from '@/lib/rbac';
 import { z } from 'zod';
 import { logger } from '@/lib/logger';
+import { resolveUserActor } from '@/lib/authorization-actors';
+import { serviceReadWhere } from '@/lib/authorization-filters';
 
 const createSchema = z.object({
   serviceId: z.string().min(1),
@@ -15,15 +15,21 @@ const createSchema = z.object({
 });
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(await getAuthOptions());
-  if (!session?.user) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  const actor = await resolveUserActor(user.id);
+  if (!actor) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { searchParams } = new URL(request.url);
   const serviceId = searchParams.get('serviceId');
 
-  const where = serviceId ? { serviceId, activeTo: null } : { activeTo: null };
+  const where = {
+    ...(serviceId ? { serviceId } : {}),
+    activeTo: null,
+    service: serviceReadWhere(actor),
+  };
 
   const definitions = await prisma.sLADefinition.findMany({
     where,

--- a/src/lib/network-security.ts
+++ b/src/lib/network-security.ts
@@ -43,23 +43,35 @@ export function isPrivateIp(ip: string): boolean {
 
   // IPv6 checks
   if (ip.includes(':')) {
+    const ipv6Parts = expandIpv6(ip);
+    if (!ipv6Parts) return true;
+
+    const firstHextet = ipv6Parts[0];
+    const isIpv4Embedded =
+      ipv6Parts.slice(0, 5).every(part => part === 0) &&
+      (ipv6Parts[5] === 0 || ipv6Parts[5] === 0xffff);
+    if (isIpv4Embedded) {
+      const ipv4 = `${ipv6Parts[6] >> 8}.${ipv6Parts[6] & 0xff}.${ipv6Parts[7] >> 8}.${ipv6Parts[7] & 0xff}`;
+      return isPrivateIp(ipv4);
+    }
+
     // Loopback
     if (lowerIp === '::1') return true;
     // Link-local (fe80::/10)
-    if (lowerIp.startsWith('fe80:')) return true;
+    if (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) return true;
     // Unique Local Addresses (fc00::/7 includes fd00::/8)
-    if (lowerIp.startsWith('fc') || lowerIp.startsWith('fd')) return true;
-    // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
-    if (lowerIp.startsWith('::ffff:')) {
-      const ipv4Part = ip.slice(7); // Extract IPv4 part
-      return isPrivateIp(ipv4Part);
-    }
+    if ((firstHextet & 0xfe00) === 0xfc00) return true;
     // Site-local (deprecated but still blocked) fec0::/10
-    if (lowerIp.startsWith('fec')) return true;
-    // Unspecified address and IPv4-compatible encodings.
-    if (lowerIp === '::' || lowerIp.startsWith('::ffff:0:')) return true;
+    if (firstHextet >= 0xfec0 && firstHextet <= 0xfeff) return true;
+    // Unspecified address.
+    if (lowerIp === '::') return true;
     // Documentation and multicast ranges.
-    if (lowerIp.startsWith('2001:db8:') || lowerIp.startsWith('ff')) return true;
+    if (
+      (firstHextet === 0x2001 && ipv6Parts[1] === 0x0db8) ||
+      (firstHextet & 0xff00) === 0xff00
+    ) {
+      return true;
+    }
     return false;
   }
 
@@ -112,6 +124,25 @@ export function isPrivateIp(ip: string): boolean {
   if (parts[0] >= 240) return true;
 
   return false;
+}
+
+function expandIpv6(ip: string): number[] | null {
+  const [address] = ip.split('%');
+  if (!address || address.includes('.')) return null;
+
+  const halves = address.split('::');
+  if (halves.length > 2) return null;
+  const parseHalf = (half: string) =>
+    half
+      ? half.split(':').map(part => (/^[0-9a-f]{1,4}$/i.test(part) ? parseInt(part, 16) : NaN))
+      : [];
+  const head = parseHalf(halves[0]);
+  const tail = parseHalf(halves[1] ?? '');
+  if ([...head, ...tail].some(Number.isNaN)) return null;
+
+  if (halves.length === 1) return head.length === 8 ? head : null;
+  const omitted = 8 - head.length - tail.length;
+  return omitted >= 1 ? [...head, ...Array(omitted).fill(0), ...tail] : null;
 }
 
 export async function assertSafeOutboundUrl(

--- a/tests/lib/network-security.test.ts
+++ b/tests/lib/network-security.test.ts
@@ -31,6 +31,9 @@ describe('outbound URL security', () => {
 
   it('blocks reserved IPv6 ranges', () => {
     expect(isPrivateIp('::')).toBe(true);
+    expect(isPrivateIp('::ffff:7f00:1')).toBe(true);
+    expect(isPrivateIp('::7f00:1')).toBe(true);
+    expect(isPrivateIp('fe90::1')).toBe(true);
     expect(isPrivateIp('2001:db8::1')).toBe(true);
     expect(isPrivateIp('ff02::1')).toBe(true);
     expect(isPrivateIp('2606:4700:4700::1111')).toBe(false);


### PR DESCRIPTION
## Summary
- authorize webhook mutations using each integration’s persisted service owner
- enforce service visibility for integration health and SLA reads
- prevent private-dashboard template cloning and arbitrary team sharing
- close IPv6-encoded internal-address bypasses in outbound URL validation

## Validation
- `npx tsc --noEmit`
- `npx vitest run tests/lib/network-security.test.ts`
- `git diff --check`