### PR TITLE
fix: scope team, user, and policy access

### DIFF
--- a/src/app/(app)/policies/[id]/page.tsx
+++ b/src/app/(app)/policies/[id]/page.tsx
@@ -1,5 +1,5 @@
 import prisma from '@/lib/prisma';
-import { getUserPermissions } from '@/lib/rbac';
+import { assertAdmin, getUserPermissions } from '@/lib/rbac';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import StepsList from '@/components/policies/StepsList';
@@ -49,6 +49,11 @@ export default async function PolicyDetailPage({
 }) {
   const { id } = await params;
   const resolvedSearchParams = await searchParams;
+  try {
+    await assertAdmin();
+  } catch {
+    notFound();
+  }
   const errorCode = resolvedSearchParams?.error;
   const defaultTab = resolvedSearchParams?.tab;
 

--- a/src/app/(app)/policies/page.tsx
+++ b/src/app/(app)/policies/page.tsx
@@ -1,5 +1,6 @@
 import prisma from '@/lib/prisma';
-import { getUserPermissions } from '@/lib/rbac';
+import { assertAdmin, getUserPermissions } from '@/lib/rbac';
+import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
 import { ShieldAlert, Server, ArrowRight, HelpCircle, Users, Calendar } from 'lucide-react';
@@ -15,6 +16,11 @@ export default async function PoliciesPage({
 }: {
   searchParams?: Promise<{ error?: string }>;
 }) {
+  try {
+    await assertAdmin();
+  } catch {
+    redirect('/');
+  }
   const [policies, permissions] = await Promise.all([
     prisma.escalationPolicy.findMany({
       include: {

--- a/src/app/(app)/teams/[id]/page.tsx
+++ b/src/app/(app)/teams/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import prisma from '@/lib/prisma';
-import { getUserPermissions } from '@/lib/rbac';
+import { assertCanViewTeam, getUserPermissions } from '@/lib/rbac';
 import {
   addTeamMember,
   assignServicesToTeam,
@@ -53,9 +53,13 @@ type TeamDetailPageProps = {
 export default async function TeamDetailPage({ params, searchParams }: TeamDetailPageProps) {
   const { id } = await params;
   const query = await searchParams;
+  try {
+    await assertCanViewTeam(id);
+  } catch {
+    notFound();
+  }
 
-  const [team, users, allServices, auditLogs, permissions, activeIncidentsCount] =
-    await Promise.all([
+  const [team, permissions, activeIncidentsCount] = await Promise.all([
       prisma.team.findUnique({
         where: { id },
         include: {
@@ -106,50 +110,6 @@ export default async function TeamDetailPage({ params, searchParams }: TeamDetai
           },
         },
       }),
-      prisma.user.findMany({
-        where: { status: 'ACTIVE' },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          status: true,
-          avatarUrl: true,
-          gender: true,
-        },
-        orderBy: { name: 'asc' },
-        take: 100,
-      }),
-      prisma.service.findMany({
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          teamId: true,
-          team: { select: { name: true } },
-        },
-        orderBy: { name: 'asc' },
-      }),
-      prisma.auditLog.findMany({
-        where: {
-          OR: [
-            { entityType: 'TEAM', entityId: id },
-            { entityType: 'TEAM_MEMBER', entityId: { startsWith: `${id}:` } },
-          ],
-        },
-        include: {
-          actor: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              avatarUrl: true,
-              gender: true,
-            },
-          },
-        },
-        orderBy: { createdAt: 'desc' },
-        take: 25,
-      }),
       getUserPermissions(),
       prisma.incident.count({
         where: {
@@ -165,14 +125,65 @@ export default async function TeamDetailPage({ params, searchParams }: TeamDetai
 
   const ownerCount = team.members.filter(m => m.role === 'OWNER').length;
   const isTeamOwner = team.members.some(m => m.userId === permissions.id && m.role === 'OWNER');
-  const canUpdateTeam = permissions.isAdminOrResponder || isTeamOwner;
+  const canUpdateTeam = permissions.isAdmin || isTeamOwner;
   const canDeleteTeam = permissions.isAdmin;
-  const canManageMembers = permissions.isAdminOrResponder || isTeamOwner;
-  const canManageNotifications =
-    permissions.isAdmin ||
-    isTeamOwner ||
-    (permissions.isAdminOrResponder && team.members.some(m => m.userId === permissions.id));
+  const canManageMembers = permissions.isAdmin || isTeamOwner;
+  const canManageNotifications = permissions.isAdmin || isTeamOwner;
   const canAssignOwnerAdmin = permissions.isAdmin || isTeamOwner;
+
+  const [users, allServices, auditLogs] = await Promise.all([
+    canManageMembers
+      ? prisma.user.findMany({
+          where: { status: 'ACTIVE' },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            status: true,
+            avatarUrl: true,
+            gender: true,
+          },
+          orderBy: { name: 'asc' },
+          take: 100,
+        })
+      : Promise.resolve([]),
+    canUpdateTeam
+      ? prisma.service.findMany({
+          where: permissions.isAdmin ? {} : { teamId: null },
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            teamId: true,
+            team: { select: { name: true } },
+          },
+          orderBy: { name: 'asc' },
+        })
+      : Promise.resolve([]),
+    canManageMembers
+      ? prisma.auditLog.findMany({
+          where: {
+            OR: [
+              { entityType: 'TEAM', entityId: id },
+              { entityType: 'TEAM_MEMBER', entityId: { startsWith: `${id}:` } },
+            ],
+          },
+          include: {
+            actor: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                avatarUrl: true,
+                gender: true,
+              },
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+          take: 25,
+        })
+      : Promise.resolve([]),
+  ]);
 
   const existingMemberUserIds = new Set(team.members.map(m => m.userId));
   const availableUsers = users.filter(u => !existingMemberUserIds.has(u.id));

--- a/src/app/(app)/teams/actions.ts
+++ b/src/app/(app)/teams/actions.ts
@@ -510,7 +510,7 @@ export async function designateTeamLead(teamId: string, userId: string | null) {
 }
 
 export async function assignServicesToTeam(teamId: string, serviceIds: string[]) {
-  let currentUser: { id: string } | null = null;
+  let currentUser: { id: string; role: string } | null = null;
   try {
     currentUser = await assertAdminOrTeamOwner(teamId);
   } catch (error) {
@@ -524,6 +524,17 @@ export async function assignServicesToTeam(teamId: string, serviceIds: string[])
 
   if (serviceIds.length === 0) {
     return { error: 'Please select at least one service to assign.' };
+  }
+
+  const services = await prisma.service.findMany({
+    where: { id: { in: serviceIds } },
+    select: { id: true, teamId: true },
+  });
+  if (services.length !== new Set(serviceIds).size) {
+    return { error: 'One or more services could not be found.' };
+  }
+  if (currentUser.role !== 'ADMIN' && services.some(service => service.teamId !== null && service.teamId !== teamId)) {
+    return { error: 'Only administrators can move a service between teams.' };
   }
 
   await prisma.service.updateMany({

--- a/src/app/(app)/teams/page.tsx
+++ b/src/app/(app)/teams/page.tsx
@@ -1,5 +1,5 @@
 import prisma from '@/lib/prisma';
-import { getUserPermissions } from '@/lib/rbac';
+import { getUserPermissions, getViewableTeamWhere } from '@/lib/rbac';
 import { createTeam } from './actions';
 import TeamDirectoryList from '@/components/teams/TeamDirectoryList';
 import TeamStatsCapsule from '@/components/teams/TeamStatsCapsule';
@@ -10,7 +10,9 @@ import { Button } from '@/components/ui/shadcn/button';
 import { Users, Shield, ArrowUpRight, Sparkles, UserCheck } from 'lucide-react';
 
 export default async function TeamsPage() {
+  const teamScope = await getViewableTeamWhere();
   const teams = await prisma.team.findMany({
+    where: teamScope,
     include: {
       teamLead: {
         select: {

--- a/src/app/(app)/users/[id]/page.tsx
+++ b/src/app/(app)/users/[id]/page.tsx
@@ -2,7 +2,7 @@ import prisma from '@/lib/prisma';
 import { notFound, redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
-import { getUserPermissions } from '@/lib/rbac';
+import { getCurrentUser, getUserPermissions } from '@/lib/rbac';
 import { Badge } from '@/components/ui/shadcn/badge';
 import {
   Mail,
@@ -49,6 +49,10 @@ export default async function UserDetailPage({ params, searchParams }: UserDetai
   const session = await getServerSession(await getAuthOptions());
   if (!session?.user?.email) {
     redirect(`/login?callbackUrl=/users/${id}`);
+  }
+  const viewer = await getCurrentUser();
+  if (viewer.role !== 'ADMIN' && viewer.id !== id) {
+    notFound();
   }
 
   const [user, permissions, currentUser] = await Promise.all([

--- a/src/app/(app)/users/page.tsx
+++ b/src/app/(app)/users/page.tsx
@@ -38,6 +38,7 @@ import {
 import { Badge } from '@/components/ui/shadcn/badge';
 import { Users, UserCheck, UserPlus, UserX, ArrowUpDown } from 'lucide-react';
 import { isAppRole } from '@/lib/authorization';
+import { assertAdmin } from '@/lib/rbac';
 
 export const dynamic = 'force-dynamic';
 
@@ -77,6 +78,11 @@ export default async function UsersPage({ searchParams }: UsersPageProps) {
   const session = await getServerSession(await getAuthOptions());
   if (!session) {
     redirect('/login?callbackUrl=/users');
+  }
+  try {
+    await assertAdmin();
+  } catch {
+    redirect('/');
   }
 
   const userCount = await prisma.user.count();

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -114,6 +114,23 @@ export async function assertAdminOrTeamOwner(teamId: string) {
   return user;
 }
 
+export async function getViewableTeamWhere(): Promise<Prisma.TeamWhereInput> {
+  const user = await getCurrentUser();
+  if (hasCapability(user.role as AppRole, CAPABILITIES.SERVICE_READ_ALL)) return {};
+  return { members: { some: { userId: user.id } } };
+}
+
+export async function assertCanViewTeam(teamId: string) {
+  const team = await prisma.team.findFirst({
+    where: { id: teamId, ...(await getViewableTeamWhere()) },
+    select: { id: true },
+  });
+  if (team) return getCurrentUser();
+  throw appError('AUTHORIZATION_DENIED', 'Unauthorized. You do not have permission to view this team.', {
+    teamId,
+  });
+}
+
 export async function assertResponderOrAbove() {
   return assertCapability(
     CAPABILITIES.OPERATIONS_MANAGE,


### PR DESCRIPTION
## Summary
- prevent team owners from moving services out of other teams
- scope team directory and detail pages to team membership
- restrict the user directory to administrators and individual profiles to the user or an administrator
- restrict escalation policy pages to administrators
- avoid loading global user, service, and team-audit data for ordinary team members

## Validation
- `npx tsc --noEmit`
- `git diff --check`
- `npm run build`