### PR TITLE
fix: harden public integration endpoints

### DIFF
--- a/src/app/api/integrations/azure/route.ts
+++ b/src/app/api/integrations/azure/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest) {
           errors: validation.errors,
           integrationId,
         });
-        // Azure might send non-standard payloads, log but continue
+        return jsonError('Invalid Azure webhook payload', 400, { errors: validation.errors });
       }
 
       // Transform to standard event format

--- a/src/app/api/logs/ingest/route.ts
+++ b/src/app/api/logs/ingest/route.ts
@@ -2,10 +2,20 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIp } from '@/lib/client-ip';
+import {
+  IntegrationBodyTooLargeError,
+  readIntegrationBody,
+} from '@/lib/integrations/request-security';
+import { z } from 'zod';
 
 const MAX_BODY_SIZE = 50 * 1024; // 50KB
 const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
 const RATE_LIMIT_MAX = 30; // 30 logs per minute per IP
+const ClientLogSchema = z.object({
+  level: z.enum(['error', 'warn', 'debug', 'info']).optional(),
+  message: z.string().trim().min(1).max(10_000),
+  context: z.record(z.unknown()).optional(),
+});
 
 export async function POST(req: NextRequest) {
   try {
@@ -20,19 +30,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
     }
 
-    // Body size check
-    const contentLength = Number(req.headers.get('content-length') || 0);
-    if (contentLength > MAX_BODY_SIZE) {
-      return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+    let body: unknown;
+    try {
+      body = JSON.parse(await readIntegrationBody(req, MAX_BODY_SIZE));
+    } catch (error) {
+      if (error instanceof IntegrationBodyTooLargeError) {
+        return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+      }
+      return NextResponse.json({ error: 'Invalid log payload' }, { status: 400 });
     }
 
-    const body = await req.json();
-    const { level, message, context } = body;
+    const parsed = ClientLogSchema.safeParse(body);
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid log payload' }, { status: 400 });
 
-    // Ensure we don't log undefined
-    if (!message) {
-      return NextResponse.json({ error: 'Message is required' }, { status: 400 });
-    }
+    const { level, message, context } = parsed.data;
 
     const logContext = {
       ...context,

--- a/src/app/api/status/subscribe/route.ts
+++ b/src/app/api/status/subscribe/route.ts
@@ -3,6 +3,7 @@ import prisma from '@/lib/prisma';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { logger } from '@/lib/logger';
 import { checkRateLimit } from '@/lib/rate-limit';
+import { getClientIp } from '@/lib/client-ip';
 
 /**
  * Subscribe to Status Page Updates (Public API)
@@ -10,8 +11,7 @@ import { checkRateLimit } from '@/lib/rate-limit';
  */
 export async function POST(req: NextRequest) {
   try {
-    const ipHeader = req.headers.get('x-forwarded-for') || '';
-    const ip = ipHeader.split(',')[0]?.trim() || 'anonymous';
+    const ip = getClientIp(req.headers);
     const rate = await checkRateLimit(`api:status:subscribe:ip:${ip}`, 10, 60_000);
     if (!rate.allowed) {
       const retryAfter = Math.ceil((rate.resetAt - Date.now()) / 1000);
@@ -40,14 +40,17 @@ export async function POST(req: NextRequest) {
       `${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/status-page/subscribe`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        // The canonical endpoint also rate-limits by client address. Forward
+        // the normalized address so this compatibility route does not collapse
+        // every request into one server-side rate-limit bucket.
+        headers: { 'Content-Type': 'application/json', 'x-forwarded-for': ip },
         body: JSON.stringify({ statusPageId, email }),
       }
     );
 
     const data = await response.json();
     return jsonOk(data, response.status);
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger.error('api.status.subscribe.error', {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/lib/integrations/handler.ts
+++ b/src/lib/integrations/handler.ts
@@ -305,7 +305,7 @@ export async function withIntegrationMiddleware(
 
   const integration = await prisma.integration.findUnique({
     where: { id: integrationId },
-    select: { key: true, enabled: true },
+    select: { key: true, enabled: true, type: true },
   });
 
   if (!integration) {
@@ -340,6 +340,30 @@ export async function withIntegrationMiddleware(
         code: 'INTEGRATION_DISABLED',
         userMessage: 'Integration is disabled',
         details: { integrationId },
+      })
+    );
+  }
+
+  // A routing key is scoped to one configured provider. Without this check a
+  // key for one integration could be submitted to a different provider route
+  // and handled with that route's parser and signature policy.
+  if (integration.type !== integrationType) {
+    logger.warn('integration.type_mismatch', {
+      integrationId,
+      expectedType: integrationType,
+      actualType: integration.type,
+    });
+    recordWebhookReceived(
+      integrationType,
+      integrationId,
+      false,
+      performance.now() - startTime,
+      'UNAUTHORIZED'
+    );
+    return jsonError(
+      new AppError({
+        code: 'INTEGRATION_AUTHENTICATION_FAILED',
+        userMessage: LEGACY_INVALID_INPUT_MESSAGE,
       })
     );
   }

--- a/tests/lib/integration-middleware.test.ts
+++ b/tests/lib/integration-middleware.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { findUnique, recordWebhookReceived, checkRateLimit } = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  recordWebhookReceived: vi.fn(),
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: { integration: { findUnique } },
+}));
+
+vi.mock('@/lib/integrations/metrics', () => ({ recordWebhookReceived }));
+vi.mock('@/lib/integrations/rate-limiter', () => ({
+  checkRateLimit,
+  createRateLimitHeaders: vi.fn(() => ({})),
+}));
+
+import { withIntegrationMiddleware } from '@/lib/integrations/handler';
+
+describe('withIntegrationMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkRateLimit.mockResolvedValue({ allowed: true });
+  });
+
+  it('rejects a routing key used with a different provider endpoint', async () => {
+    findUnique.mockResolvedValue({ key: 'routing-key', enabled: true, type: 'NEWRELIC' });
+    const handler = vi.fn();
+    const request = new NextRequest(
+      'http://localhost/api/integrations/azure?integrationId=integration-1',
+      { headers: { 'x-integration-key': 'routing-key' } }
+    );
+
+    const response = await withIntegrationMiddleware(request, 'AZURE', handler);
+
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+    expect(recordWebhookReceived).toHaveBeenCalledWith(
+      'AZURE',
+      'integration-1',
+      false,
+      expect.any(Number),
+      'UNAUTHORIZED'
+    );
+  });
+});

--- a/tests/lib/log-ingest-route.test.ts
+++ b/tests/lib/log-ingest-route.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { checkRateLimit, logger } = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/lib/rate-limit', () => ({ checkRateLimit }));
+vi.mock('@/lib/logger', () => ({ logger }));
+
+import { POST } from '@/app/api/logs/ingest/route';
+
+describe('client log ingestion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkRateLimit.mockResolvedValue({ allowed: true });
+  });
+
+  it('rejects a body that exceeds the enforced streamed size limit', async () => {
+    const request = new NextRequest('http://localhost/api/logs/ingest', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: 'x'.repeat(50 * 1024) }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(413);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('accepts the supported client log payload shape', async () => {
+    const request = new NextRequest('http://localhost/api/logs/ingest', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ level: 'warn', message: 'Request failed', context: { route: '/status' } }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Request failed',
+      expect.objectContaining({ source: 'client', route: '/status' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- bind legacy integration webhook keys to their configured provider type
- reject invalid Azure webhook payloads before event processing
- enforce streamed client-log payload limits and validate the accepted shape
- preserve per-client status subscription throttling through the compatibility route

## Verification
- focused Vitest tests
- ESLint on changed files
- TypeScript check