### PR TITLE
fix(ui): unify DetailHeroBanner across escalation policies and users pages

### DIFF
--- a/src/app/(app)/policies/[id]/page.tsx
+++ b/src/app/(app)/policies/[id]/page.tsx
@@ -34,6 +34,8 @@ import {
   ChevronRight,
   Plus,
   ExternalLink,
+  Layers,
+  Clock,
 } from 'lucide-react';
 import { Input } from '@/components/ui/shadcn/input';
 import { Textarea } from '@/components/ui/shadcn/textarea';
@@ -344,14 +346,17 @@ export default async function PolicyDetailPage({
           {
             label: 'Steps',
             value: policy.steps.length,
+            icon: <Layers className="h-3.5 w-3.5" />,
           },
           {
             label: 'Services',
             value: services.length,
+            icon: <Server className="h-3.5 w-3.5" />,
           },
           {
             label: 'Cycle Time',
             value: `~${totalDuration}m`,
+            icon: <Clock className="h-3.5 w-3.5" />,
           },
         ]}
         alert={

--- a/src/app/(app)/policies/page.tsx
+++ b/src/app/(app)/policies/page.tsx
@@ -3,7 +3,8 @@ import { assertAdmin, getUserPermissions } from '@/lib/rbac';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
-import { ShieldAlert, Server, ArrowRight, HelpCircle, Users, Calendar } from 'lucide-react';
+import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
+import { ShieldAlert, Server, Layers, HelpCircle, ArrowRight, Calendar, Users } from 'lucide-react';
 import PolicyCreateForm from '@/components/policies/PolicyCreateForm';
 import PolicyDirectoryList from '@/components/policies/PolicyDirectoryList';
 import { createPolicyAction } from './actions';
@@ -71,68 +72,48 @@ export default async function PoliciesPage({
   }));
 
   return (
-    <div className="w-full px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-6 space-y-6">
-      {/* Centralized Hero Header with 3-Stat Capsule */}
-      <div className="bg-gradient-to-r from-primary via-primary/95 to-primary/80 text-white rounded-2xl p-6 sm:p-7 shadow-lg relative overflow-hidden">
-        <div className="absolute -right-12 -bottom-12 w-64 h-64 rounded-full bg-white/5 pointer-events-none blur-2xl" />
-        <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-6 relative z-10">
-          <div className="space-y-1.5 max-w-2xl">
-            <div className="flex items-center gap-2">
-              <span className="px-2.5 py-0.5 rounded-full text-[11px] font-semibold bg-white/15 text-white/90 backdrop-blur-xs border border-white/20">
-                Incident Response Routing
-              </span>
+    <div className="mx-auto w-full max-w-[1600px] space-y-6 px-4 py-6 md:px-6 md:py-8">
+      {/* Centralized Hero Header */}
+      <DetailHeroBanner
+        tag="Incident Response Routing"
+        title="Escalation Policies"
+        icon={
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary-foreground/15 text-primary-foreground ring-1 ring-inset ring-primary-foreground/20">
+            <ShieldAlert className="h-6 w-6" aria-hidden="true" />
+          </div>
+        }
+        subtitle={
+          <p className="text-xs text-primary-foreground/85 leading-relaxed">
+            Define multi-tier responder routing, failover delays, and notification cadences when
+            critical incidents occur across your services.
+          </p>
+        }
+        stats={[
+          {
+            label: 'Total Policies',
+            value: totalPolicies,
+            icon: <ShieldAlert className="h-3.5 w-3.5" />,
+          },
+          {
+            label: 'In Use',
+            value: inUsePoliciesCount,
+            icon: <Server className="h-3.5 w-3.5 text-emerald-200" />,
+            valueClassName: inUsePoliciesCount > 0 ? 'text-emerald-200' : undefined,
+          },
+          {
+            label: 'Total Steps',
+            value: totalStepsCount,
+            icon: <Layers className="h-3.5 w-3.5" />,
+          },
+        ]}
+        alert={
+          errorCode === 'duplicate-policy' ? (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-xs font-medium">
+              An escalation policy with this name already exists. Please choose a unique name.
             </div>
-            <h1 className="text-2xl sm:text-3xl font-black tracking-tight flex items-center gap-2.5 text-white">
-              <ShieldAlert className="h-7 w-7 sm:h-8 sm:w-8 shrink-0 text-white/90" />
-              Escalation Policies
-            </h1>
-            <p className="text-xs sm:text-sm text-white/80 leading-relaxed">
-              Define multi-tier responder routing, failover delays, and notification cadences when
-              critical incidents occur across your services.
-            </p>
-          </div>
-
-          {/* 3-Stat Capsule */}
-          <div className="grid grid-cols-3 gap-2.5 sm:gap-3.5 w-full lg:w-auto shrink-0">
-            <Card className="bg-white/10 border-white/20 backdrop-blur-md text-white shadow-xs">
-              <CardContent className="p-3 sm:p-4 text-center">
-                <div className="text-xl sm:text-2xl font-black tracking-tight">{totalPolicies}</div>
-                <div className="text-[10px] sm:text-xs text-white/75 font-medium mt-0.5">
-                  Total Policies
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="bg-white/10 border-white/20 backdrop-blur-md text-white shadow-xs">
-              <CardContent className="p-3 sm:p-4 text-center">
-                <div className="text-xl sm:text-2xl font-black tracking-tight text-emerald-200">
-                  {inUsePoliciesCount}
-                </div>
-                <div className="text-[10px] sm:text-xs text-white/75 font-medium mt-0.5">
-                  In Use (Services)
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="bg-white/10 border-white/20 backdrop-blur-md text-white shadow-xs">
-              <CardContent className="p-3 sm:p-4 text-center">
-                <div className="text-xl sm:text-2xl font-black tracking-tight text-blue-200">
-                  {totalStepsCount}
-                </div>
-                <div className="text-[10px] sm:text-xs text-white/75 font-medium mt-0.5">
-                  Total Steps
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </div>
-
-      {errorCode === 'duplicate-policy' && (
-        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-xs font-medium">
-          An escalation policy with this name already exists. Please choose a unique name.
-        </div>
-      )}
+          ) : undefined
+        }
+      />
 
       {/* Interactive Dashed Expander Create Policy Form */}
       {canManagePolicies && (

--- a/src/app/(app)/users/page.tsx
+++ b/src/app/(app)/users/page.tsx
@@ -36,6 +36,7 @@ import {
   SelectValue,
 } from '@/components/ui/shadcn/select';
 import { Badge } from '@/components/ui/shadcn/badge';
+import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
 import { Users, UserCheck, UserPlus, UserX, ArrowUpDown } from 'lucide-react';
 import { isAppRole } from '@/lib/authorization';
 import { assertAdmin } from '@/lib/rbac';
@@ -102,14 +103,20 @@ export default async function UsersPage({ searchParams }: UsersPageProps) {
         : {},
       statusFilter ? { status: statusFilter as UserStatus } : {},
       roleFilter ? { role: roleFilter as Role } : {},
-      teamFilter ? { teamMemberships: { some: { teamId: teamFilter } } } : {},
-    ].filter(Boolean),
+      teamFilter
+        ? {
+            teamMemberships: {
+              some: {
+                teamId: teamFilter,
+              },
+            },
+          }
+        : {},
+    ],
   };
 
-  const auditLogWhere = {
-    entityType: {
-      in: ['USER', 'TEAM', 'TEAM_MEMBER'] as AuditEntityType[],
-    },
+  const auditLogWhere: Prisma.AuditLogWhereInput = {
+    entityType: 'USER' as AuditEntityType,
   };
 
   const [users, totalCount, auditLogs, auditLogTotal, teams] = await Promise.all([
@@ -226,71 +233,48 @@ export default async function UsersPage({ searchParams }: UsersPageProps) {
   }
 
   return (
-    <div className="w-full px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-6 space-y-6">
+    <div className="mx-auto w-full max-w-[1600px] space-y-6 px-4 py-6 md:px-6 md:py-8">
       {/* Centralized Hero Header with 4-Stat Capsule */}
-      <div className="bg-gradient-to-r from-primary via-primary/95 to-primary/80 text-white rounded-2xl p-6 sm:p-7 shadow-lg relative overflow-hidden">
-        <div className="absolute -right-12 -bottom-12 w-64 h-64 rounded-full bg-white/5 pointer-events-none blur-2xl" />
-        <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-6 relative z-10">
-          <div className="space-y-1.5 max-w-2xl">
-            <div className="flex items-center gap-2">
-              <span className="px-2.5 py-0.5 rounded-full text-[11px] font-semibold bg-white/15 text-white/90 backdrop-blur-xs border border-white/20">
-                Team & Member Access
-              </span>
-            </div>
-            <h1 className="text-2xl sm:text-3xl font-black tracking-tight flex items-center gap-2.5 text-white">
-              <Users className="h-7 w-7 sm:h-8 sm:w-8 shrink-0 text-white/90" />
-              Users & Responders
-            </h1>
-            <p className="text-xs sm:text-sm text-white/80 leading-relaxed">
-              Manage organization members, assign operational roles, configure paging channels, and
-              oversee on-call responder access.
-            </p>
+      <DetailHeroBanner
+        tag="Team & Member Access"
+        title="Users & Responders"
+        icon={
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary-foreground/15 text-primary-foreground ring-1 ring-inset ring-primary-foreground/20">
+            <Users className="h-6 w-6" aria-hidden="true" />
           </div>
-
-          {/* 4-Stat Capsule */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5 sm:gap-3.5 w-full lg:w-auto shrink-0">
-            <Card className="bg-white/10 border-white/20 backdrop-blur-md text-white shadow-xs">
-              <CardContent className="p-3 sm:p-4 text-center">
-                <div className="text-xl sm:text-2xl font-black tracking-tight">{stats.total}</div>
-                <div className="text-[10px] sm:text-xs text-white/75 font-medium mt-0.5">Total</div>
-              </CardContent>
-            </Card>
-
-            <Card className="bg-white/10 border-white/20 backdrop-blur-md text-white shadow-xs">
-              <CardContent className="p-3 sm:p-4 text-center">
-                <div className="text-xl sm:text-2xl font-black tracking-tight text-emerald-200">
-                  {stats.active}
-                </div>
-                <div className="text-[10px] sm:text-xs text-white/75 font-medium mt-0.5">
-                  Active
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="bg-white/10 border-white/20 backdrop-blur-md text-white shadow-xs">
-              <CardContent className="p-3 sm:p-4 text-center">
-                <div className="text-xl sm:text-2xl font-black tracking-tight text-amber-200">
-                  {stats.invited}
-                </div>
-                <div className="text-[10px] sm:text-xs text-white/75 font-medium mt-0.5">
-                  Invited
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="bg-white/10 border-white/20 backdrop-blur-md text-white shadow-xs">
-              <CardContent className="p-3 sm:p-4 text-center">
-                <div className="text-xl sm:text-2xl font-black tracking-tight text-slate-200">
-                  {stats.disabled}
-                </div>
-                <div className="text-[10px] sm:text-xs text-white/75 font-medium mt-0.5">
-                  Disabled
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </div>
+        }
+        subtitle={
+          <p className="text-xs text-primary-foreground/85 leading-relaxed">
+            Manage organization members, assign operational roles, configure paging channels, and
+            oversee on-call responder access.
+          </p>
+        }
+        stats={[
+          {
+            label: 'Total Users',
+            value: stats.total,
+            icon: <Users className="h-3.5 w-3.5" />,
+          },
+          {
+            label: 'Active',
+            value: stats.active,
+            icon: <UserCheck className="h-3.5 w-3.5 text-emerald-200" />,
+            valueClassName: stats.active > 0 ? 'text-emerald-200' : undefined,
+          },
+          {
+            label: 'Invited',
+            value: stats.invited,
+            icon: <UserPlus className="h-3.5 w-3.5 text-amber-200" />,
+            valueClassName: stats.invited > 0 ? 'text-amber-200' : undefined,
+          },
+          {
+            label: 'Disabled',
+            value: stats.disabled,
+            icon: <UserX className="h-3.5 w-3.5 text-rose-200" />,
+            valueClassName: stats.disabled > 0 ? 'text-rose-200' : undefined,
+          },
+        ]}
+      />
 
       <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 md:gap-6">
         {/* Main Content */}

--- a/src/components/ui/DetailHeroBanner.tsx
+++ b/src/components/ui/DetailHeroBanner.tsx
@@ -97,9 +97,10 @@ export default function DetailHeroBanner({
               <div
                 className={cn(
                   'grid gap-1.5 rounded-lg border border-primary-foreground/20 bg-primary-foreground/10 p-1.5 backdrop-blur-sm',
-                  stats.length === 2 && 'grid-cols-2 lg:min-w-[200px]',
-                  stats.length === 3 && 'grid-cols-3 lg:min-w-[300px]',
-                  stats.length >= 4 && 'grid-cols-4 lg:min-w-[360px]'
+                  stats.length === 1 && 'grid-cols-1 min-w-[120px]',
+                  stats.length === 2 && 'grid-cols-2 min-w-[200px]',
+                  stats.length === 3 && 'grid-cols-3 min-w-[280px]',
+                  stats.length >= 4 && 'grid-cols-2 sm:grid-cols-4 min-w-[240px] sm:min-w-[360px]'
                 )}
               >
                 {stats.map((stat, idx) => (
@@ -107,7 +108,11 @@ export default function DetailHeroBanner({
                     key={stat.label || idx}
                     className={cn(
                       'min-w-0 rounded-md px-2.5 py-1.5 text-center',
-                      idx > 0 && 'border-l border-primary-foreground/20',
+                      idx > 0 && stats.length <= 3 && 'border-l border-primary-foreground/20',
+                      idx > 0 && stats.length >= 4 && 'sm:border-l sm:border-primary-foreground/20',
+                      idx % 2 === 1 &&
+                        stats.length >= 4 &&
+                        'border-l border-primary-foreground/20 sm:border-l',
                       stat.className
                     )}
                   >


### PR DESCRIPTION
## Summary
- Replaced custom ad-hoc gradient banner cards on `/policies` and `/users` with the centralized, glassmorphic `DetailHeroBanner` component.
- Standardized page container padding to `mx-auto w-full max-w-[1600px] space-y-6 px-4 py-6 md:px-6 md:py-8`.
- Enhanced `DetailHeroBanner` stat capsule to provide a clean responsive 2x2 grid wrap with dividers on mobile viewports for 4-stat layouts (`grid-cols-2 sm:grid-cols-4`).
- Added icons (`Layers`, `Server`, `Clock`) to `/policies/[id]` hero stats for design consistency across directory and detail views.

## Verification
- `npx tsc --noEmit` passed with 0 errors.
- Vitest test suite passed with 226/226 suites (1,596 unit tests).
- Production webpack build succeeded (`next build --webpack`).