### PR TITLE
fix(escalation): fence stale lifecycle state in postgres

### DIFF
--- a/prisma/migrations/20260830181000_enforce_incident_escalation_lifecycle/migration.sql
+++ b/prisma/migrations/20260830181000_enforce_incident_escalation_lifecycle/migration.sql
@@ -1,0 +1,40 @@
+CREATE OR REPLACE FUNCTION "opsknight_enforce_incident_escalation_lifecycle"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Terminal responder lifecycle states must never be resurrected into an
+  -- active escalation generation by a stale worker write.
+  IF NEW."status"::text IN ('ACKNOWLEDGED', 'RESOLVED') THEN
+    NEW."escalationStatus" := 'COMPLETED';
+    NEW."nextEscalationAt" := NULL;
+    NEW."currentEscalationStep" := NULL;
+    NEW."escalationProcessingAt" := NULL;
+    RETURN NEW;
+  END IF;
+
+  -- Muted incidents retain their current step so UNSNOOZE/UNSUPPRESS can use
+  -- the domain lifecycle engine's resume semantics, but no worker lease or due
+  -- timestamp may remain active while the incident is paused.
+  IF NEW."status"::text IN ('SNOOZED', 'SUPPRESSED') THEN
+    NEW."escalationStatus" := 'PAUSED';
+    NEW."nextEscalationAt" := NULL;
+    NEW."escalationProcessingAt" := NULL;
+    RETURN NEW;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "Incident_enforce_escalation_lifecycle" ON "Incident";
+CREATE TRIGGER "Incident_enforce_escalation_lifecycle"
+BEFORE UPDATE OF
+  "status",
+  "escalationStatus",
+  "nextEscalationAt",
+  "currentEscalationStep",
+  "escalationProcessingAt"
+ON "Incident"
+FOR EACH ROW
+EXECUTE FUNCTION "opsknight_enforce_incident_escalation_lifecycle"();

--- a/tests/integration/escalation-lifecycle-invariant.test.ts
+++ b/tests/integration/escalation-lifecycle-invariant.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTestService, resetDatabase, testPrisma } from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+describeIfRealDB('incident escalation lifecycle database invariant', { timeout: 30000 }, () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  async function createIncident(status: 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED') {
+    const service = await createTestService(`Escalation lifecycle ${Math.random()}`);
+    return testPrisma.incident.create({
+      data: {
+        title: `Escalation lifecycle ${status}`,
+        serviceId: service.id,
+        status,
+        urgency: 'HIGH',
+        escalationStatus: status === 'SNOOZED' || status === 'SUPPRESSED' ? 'PAUSED' : 'COMPLETED',
+        currentEscalationStep: status === 'SNOOZED' || status === 'SUPPRESSED' ? 2 : null,
+      },
+    });
+  }
+
+  it.each(['ACKNOWLEDGED', 'RESOLVED'] as const)(
+    'normalizes stale escalation writes after %s',
+    async status => {
+      const incident = await createIncident(status);
+      const staleLease = new Date('2026-08-30T10:00:00.000Z');
+
+      await testPrisma.incident.update({
+        where: { id: incident.id },
+        data: {
+          escalationStatus: 'ESCALATING',
+          currentEscalationStep: 3,
+          nextEscalationAt: new Date('2026-08-30T11:00:00.000Z'),
+          escalationProcessingAt: staleLease,
+        },
+      });
+
+      const stored = await testPrisma.incident.findUnique({ where: { id: incident.id } });
+      expect(stored).toMatchObject({
+        status,
+        escalationStatus: 'COMPLETED',
+        currentEscalationStep: null,
+        nextEscalationAt: null,
+        escalationProcessingAt: null,
+      });
+    }
+  );
+
+  it.each(['SNOOZED', 'SUPPRESSED'] as const)(
+    'keeps %s paused while preserving the resumable step',
+    async status => {
+      const incident = await createIncident(status);
+
+      await testPrisma.incident.update({
+        where: { id: incident.id },
+        data: {
+          escalationStatus: 'ESCALATING',
+          currentEscalationStep: 2,
+          nextEscalationAt: new Date('2026-08-30T11:00:00.000Z'),
+          escalationProcessingAt: new Date('2026-08-30T10:00:00.000Z'),
+        },
+      });
+
+      const stored = await testPrisma.incident.findUnique({ where: { id: incident.id } });
+      expect(stored).toMatchObject({
+        status,
+        escalationStatus: 'PAUSED',
+        currentEscalationStep: 2,
+        nextEscalationAt: null,
+        escalationProcessingAt: null,
+      });
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a PostgreSQL lifecycle invariant that prevents stale escalation workers from resurrecting active escalation state after ACK/RESOLVE/SNOOZE/SUPPRESS
- normalize ACK/RESOLVED incidents to COMPLETED escalation state
- normalize SNOOZED/SUPPRESSED incidents to PAUSED while preserving the resumable step
- clear stale due timestamps and worker leases for all non-OPEN lifecycle states

## Why
The TypeScript worker already has generation fencing on the main path, but several shortcut/error branches can race a lifecycle transition. This adds a defense-in-depth invariant below every adapter and worker so contradictory state cannot be committed even if a future code path misses a generation check.

## Safety
- OPEN and REOPEN behavior is unchanged
- muted incidents retain `currentEscalationStep` for resume semantics
- no notification, authorization, schedule, or #474 public/realtime behavior is changed
- invariant is enforced at the authoritative database boundary

## Tests
Real PostgreSQL regression coverage attempts stale ESCALATING writes after ACKNOWLEDGED, RESOLVED, SNOOZED and SUPPRESSED and verifies the stored state remains lifecycle-correct.

One focused commit.