### PR TITLE
fix(status): make public delivery target-idempotent

### DIFF
--- a/src/lib/status-page-delivery.ts
+++ b/src/lib/status-page-delivery.ts
@@ -1,0 +1,159 @@
+import { createHash } from 'node:crypto';
+import prisma from '@/lib/prisma';
+
+export type StatusDeliveryTarget = 'SUBSCRIBER_EMAIL' | 'STATUS_WEBHOOK';
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function statusDeliveryMarkerId(
+  target: StatusDeliveryTarget,
+  deliveryKey: string,
+  targetId: string
+): string {
+  return `status-delivery:${hash(`${target}\u001f${deliveryKey}\u001f${targetId}`)}`;
+}
+
+export async function isStatusDeliveryComplete(markerId: string): Promise<boolean> {
+  const marker = await prisma.backgroundJob.findUnique({
+    where: { id: markerId },
+    select: { status: true },
+  });
+  return marker?.status === 'COMPLETED';
+}
+
+export async function markStatusDeliveryComplete(input: {
+  markerId: string;
+  target: StatusDeliveryTarget;
+  deliveryKey: string;
+  targetId: string;
+}): Promise<void> {
+  const now = new Date();
+  await prisma.backgroundJob.upsert({
+    where: { id: input.markerId },
+    update: {
+      status: 'COMPLETED',
+      completedAt: now,
+      failedAt: null,
+      error: null,
+      payload: {
+        task: 'STATUS_DELIVERY_MARKER',
+        target: input.target,
+        deliveryKey: input.deliveryKey,
+        targetId: input.targetId,
+      },
+    },
+    create: {
+      id: input.markerId,
+      type: 'SCHEDULED_TASK',
+      status: 'COMPLETED',
+      scheduledAt: now,
+      completedAt: now,
+      maxAttempts: 1,
+      payload: {
+        task: 'STATUS_DELIVERY_MARKER',
+        target: input.target,
+        deliveryKey: input.deliveryKey,
+        targetId: input.targetId,
+      },
+    },
+  });
+}
+
+export function incidentSubscriberDeliveryKey(
+  incident: {
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    acknowledgedAt?: Date | null;
+    resolvedAt?: Date | null;
+  },
+  eventType: string,
+  explicitKey?: string
+): string {
+  if (explicitKey) return explicitKey;
+
+  const lifecycleInstant =
+    eventType === 'triggered'
+      ? incident.createdAt
+      : eventType === 'acknowledged'
+        ? incident.acknowledgedAt
+        : eventType === 'resolved'
+          ? incident.resolvedAt
+          : incident.updatedAt;
+
+  return `${incident.id}:${eventType}:${(lifecycleInstant ?? incident.updatedAt).toISOString()}`;
+}
+
+export function statusWebhookDeliveryKey(
+  event: string,
+  data: Record<string, unknown>,
+  explicitKey?: string
+): string {
+  if (explicitKey) return explicitKey;
+
+  const id = typeof data.id === 'string' ? data.id : 'unknown';
+  const lifecycleInstant =
+    event === 'incident.created'
+      ? data.createdAt
+      : event === 'incident.acknowledged'
+        ? data.acknowledgedAt
+        : event === 'incident.resolved'
+          ? data.resolvedAt
+          : undefined;
+
+  if (typeof lifecycleInstant === 'string' && lifecycleInstant) {
+    return `${id}:${event}:${lifecycleInstant}`;
+  }
+
+  return `${id}:${event}:${hash(JSON.stringify(data))}`;
+}
+
+export function statusWebhookDeliveryId(deliveryKey: string, webhookId: string): string {
+  return hash(`status-webhook\u001f${deliveryKey}\u001f${webhookId}`);
+}
+
+export function buildSubscriberIncidentPresentation<
+  T extends {
+    title: string;
+    description?: string | null;
+    service?: { name?: string | null } | null;
+  },
+>(
+  page: {
+    showIncidentDetails: boolean;
+    showIncidentTitles: boolean;
+    showIncidentDescriptions: boolean;
+    showAffectedServices: boolean;
+    showIncidentTimestamps: boolean;
+  },
+  incident: T
+): {
+  incident: T;
+  showAffectedService: boolean;
+  showDescription: boolean;
+  showTimestamp: boolean;
+} {
+  const showDetails = page.showIncidentDetails;
+  const showTitle = showDetails && page.showIncidentTitles;
+  const showDescription = showDetails && page.showIncidentDescriptions;
+  const showAffectedService = showDetails && page.showAffectedServices;
+
+  return {
+    incident: {
+      ...incident,
+      title: showTitle ? incident.title : 'Incident Update',
+      description: showDescription ? incident.description : null,
+      service: incident.service
+        ? {
+            ...incident.service,
+            name: showAffectedService ? incident.service.name : 'Service',
+          }
+        : incident.service,
+    },
+    showAffectedService,
+    showDescription,
+    showTimestamp: showDetails && page.showIncidentTimestamps,
+  };
+}

--- a/src/lib/status-page-notifications.ts
+++ b/src/lib/status-page-notifications.ts
@@ -5,6 +5,13 @@ import { logger } from '@/lib/logger';
 import { getBaseUrl } from '@/lib/env-validation';
 import { getStatusPageLogoUrl, getStatusPagePublicUrl } from '@/lib/status-page-url';
 import {
+  buildSubscriberIncidentPresentation,
+  incidentSubscriberDeliveryKey,
+  isStatusDeliveryComplete,
+  markStatusDeliveryComplete,
+  statusDeliveryMarkerId,
+} from '@/lib/status-page-delivery';
+import {
   EmailContainer,
   EmailContent,
   SubscriberEmailHeader,
@@ -27,7 +34,8 @@ export async function notifyStatusPageSubscribers(
     | 'triggered'
     | 'acknowledged'
     | 'snoozed'
-    | 'suppressed'
+    | 'suppressed',
+  deliveryKey?: string
 ): Promise<{ success: boolean; sent: number; failed: number; skipped?: boolean }> {
   let totalSent = 0;
   let totalFailed = 0;
@@ -51,6 +59,8 @@ export async function notifyStatusPageSubscribers(
       );
       return { success: true, sent: 0, failed: 0, skipped: true };
     }
+
+    const effectiveDeliveryKey = incidentSubscriberDeliveryKey(incident, eventType, deliveryKey);
 
     // 2. Find all status pages that include this service
     const statusPages = await prisma.statusPage.findMany({
@@ -96,15 +106,12 @@ export async function notifyStatusPageSubscribers(
 
     // 4. Send notifications for each status page
     for (const page of pagesWithSubscribers) {
-      // Get email config from pre-fetched map
       const emailConfig = emailConfigMap.get(page.id);
       if (!emailConfig?.enabled) {
         logger.warn(`Email not configured for status page ${page.name} (${page.id})`);
         continue;
       }
 
-      // Prepare email content
-      // Prepare email content
       const displayName = (page as any).organizationName || page.name; // eslint-disable-line @typescript-eslint/no-explicit-any
       const branding =
         page.branding && typeof page.branding === 'object' && !Array.isArray(page.branding)
@@ -118,17 +125,22 @@ export async function notifyStatusPageSubscribers(
           : rawLogoUrl;
       const brandLogoUrl = resolveBrandLogoUrl(logoUrl, statusPageUrl);
       const safeBrandLogoUrl = brandLogoUrl ? escapeHtml(brandLogoUrl) : undefined;
-      const subject = formatSubject(displayName, incident.title, eventType);
+      const presentation = buildSubscriberIncidentPresentation(page, incident);
+      const subject = formatSubject(displayName, presentation.incident.title, eventType);
       const html = formatEmailBody(
         displayName,
-        incident,
+        presentation.incident,
         eventType,
         statusPageUrl,
         page.contactUrl,
-        safeBrandLogoUrl
+        safeBrandLogoUrl,
+        {
+          showAffectedService: presentation.showAffectedService,
+          showDescription: presentation.showDescription,
+          showTimestamp: presentation.showTimestamp,
+        }
       );
 
-      // Send to all subscribers
       logger.info(
         `Sending notifications to ${page.subscriptions.length} subscribers for page ${page.name}`
       );
@@ -140,8 +152,17 @@ export async function notifyStatusPageSubscribers(
       for (let i = 0; i < page.subscriptions.length; i += BATCH_SIZE) {
         const batch = page.subscriptions.slice(i, i + BATCH_SIZE);
         const results = await Promise.allSettled(
-          batch.map(sub =>
-            sendEmail(
+          batch.map(async sub => {
+            const markerId = statusDeliveryMarkerId(
+              'SUBSCRIBER_EMAIL',
+              effectiveDeliveryKey,
+              sub.id
+            );
+            if (await isStatusDeliveryComplete(markerId)) {
+              return { success: true, skipped: true };
+            }
+
+            const result = await sendEmail(
               {
                 to: sub.email,
                 subject,
@@ -154,11 +175,24 @@ export async function notifyStatusPageSubscribers(
                 source: `status-page-${page.id}`,
                 ...emailConfig,
               }
-            )
-          )
+            );
+
+            if (result.success) {
+              await markStatusDeliveryComplete({
+                markerId,
+                target: 'SUBSCRIBER_EMAIL',
+                deliveryKey: effectiveDeliveryKey,
+                targetId: sub.id,
+              });
+            }
+
+            return { success: result.success, skipped: false };
+          })
         );
 
-        sent += results.filter(r => r.status === 'fulfilled' && r.value.success).length;
+        sent += results.filter(
+          r => r.status === 'fulfilled' && r.value.success && !r.value.skipped
+        ).length;
         failed += results.filter(
           r => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.success)
         ).length;
@@ -235,7 +269,12 @@ function formatEmailBody(
   eventType: string,
   statusPageUrl: string,
   contactUrl?: string | null,
-  logoUrl?: string
+  logoUrl?: string,
+  privacy: {
+    showAffectedService: boolean;
+    showDescription: boolean;
+    showTimestamp: boolean;
+  } = { showAffectedService: true, showDescription: true, showTimestamp: true }
 ): string {
   const statusMap: Record<
     string,
@@ -258,13 +297,12 @@ function formatEmailBody(
   const safeServiceName = escapeHtml(incident.service?.name || 'Service');
   const safeDescription = incident.description
     ? escapeHtml(incident.description)
-    : 'No additional details provided.';
+    : 'Additional incident details are not published.';
   const safeStatusPageUrl = escapeHtml(statusPageUrl);
   const supportUrl = normalizeSupportUrl(contactUrl);
   const safeSupportUrl = supportUrl ? escapeHtml(supportUrl) : '';
   const safeStatusLabel = escapeHtml(statusInfo.label);
 
-  // Build the email content using components
   const headerGradients: Record<string, string> = {
     success: 'linear-gradient(135deg, #166534 0%, #16a34a 45%, #22c55e 100%)',
     warning: 'linear-gradient(135deg, #92400e 0%, #d97706 50%, #f59e0b 100%)',
@@ -296,8 +334,9 @@ function formatEmailBody(
     brandName: safePageName,
   });
 
-  // Main content body
-  let contentBody = `
+  let contentBody = '';
+  if (privacy.showAffectedService) {
+    contentBody += `
         <div style="margin-bottom: 24px;">
             <p style="font-size: 16px; color: #4b5563; margin-bottom: 8px; font-weight: 500;">
                 Affecting Service:
@@ -305,22 +344,27 @@ function formatEmailBody(
             <h2 style="font-size: 20px; color: #1f2937; margin: 0; font-weight: 700;">
                 ${safeServiceName}
             </h2>
-        </div>
+        </div>`;
+  }
 
+  contentBody += `
         <div style="background: #f9fafb; border-radius: 12px; padding: 24px; border: 1px solid #e5e7eb; margin-bottom: 32px;">
             <h3 style="font-size: 14px; text-transform: uppercase; color: #6b7280; margin: 0 0 12px 0; letter-spacing: 0.05em; font-weight: 600;">
                 Update Details
             </h3>
             <p style="font-size: 16px; line-height: 1.6; color: #374151; margin: 0; white-space: pre-wrap;">
-                ${safeDescription}
+                ${privacy.showDescription ? safeDescription : 'Additional incident details are not published.'}
             </p>
-            <p style="font-size: 14px; color: #9ca3af; margin-top: 16px; font-style: italic;">
+            ${
+              privacy.showTimestamp
+                ? `<p style="font-size: 14px; color: #9ca3af; margin-top: 16px; font-style: italic;">
                 Posted on ${new Date().toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}
-            </p>
+            </p>`
+                : ''
+            }
         </div>
     `;
 
-  // Add CTA Button
   const buttonTheme = buttonThemes[statusInfo.badge] || buttonThemes.info;
   contentBody += EmailButton('View Status Page', safeStatusPageUrl, {
     buttonBackground: buttonTheme.background,
@@ -340,8 +384,6 @@ function formatEmailBody(
   }
 
   const body = EmailContent(contentBody);
-
-  // We need to inject the unsubscribe URL at send time, so we keep the placeholder
   const footer = SubscriberEmailFooter('{{unsubscribe_url}}', safePageName);
 
   return EmailContainer(header + body + footer);
@@ -395,7 +437,6 @@ export async function notifyStatusPageSubscribersAnnouncement(
     }
 
     // 4. Prepare email content
-    // 4. Prepare email content
     const displayName = (page as any).organizationName || page.name; // eslint-disable-line @typescript-eslint/no-explicit-any
     const branding =
       page.branding && typeof page.branding === 'object' && !Array.isArray(page.branding)
@@ -413,7 +454,6 @@ export async function notifyStatusPageSubscribersAnnouncement(
     const safeAnnouncementTitle = escapeHtml(announcement.title || 'Announcement');
     const safeAnnouncementMessage = escapeHtml(announcement.message || '');
 
-    // Define theme based on announcement type
     const themes: Record<
       string,
       { label: string; color: string; bg: string; borderColor: string }
@@ -435,8 +475,6 @@ export async function notifyStatusPageSubscribersAnnouncement(
 
     let html = '';
 
-    // Build the email content using components
-    // We pass the theme label (e.g., "Maintenance") as the badge text
     const announcementHeader = SubscriberEmailHeader(
       safeDisplayName,
       escapeHtml(theme.label),
@@ -457,7 +495,6 @@ export async function notifyStatusPageSubscribersAnnouncement(
       }
     );
 
-    // Main content body with themed styles
     const contentBody = `
             <div style="background: ${theme.bg}; border-radius: 12px; padding: 24px; border: 1px solid ${theme.borderColor}; margin-bottom: 32px;">
                 <h3 style="font-size: 14px; text-transform: uppercase; color: ${theme.color}; margin: 0 0 12px 0; letter-spacing: 0.05em; font-weight: 700;">
@@ -494,7 +531,6 @@ export async function notifyStatusPageSubscribersAnnouncement(
 
     html = EmailContainer(announcementHeader + body + footer);
 
-    // 5. Send to all subscribers
     logger.info(
       `Sending announcement notifications to ${page.subscriptions.length} subscribers for page ${page.name}`
     );

--- a/src/lib/status-page-webhooks.ts
+++ b/src/lib/status-page-webhooks.ts
@@ -8,20 +8,39 @@ import crypto from 'crypto';
 import { decryptStoredSecret } from './encryption';
 import { retry } from './retry';
 import { CircuitBreakers } from './circuit-breaker';
+import {
+  isStatusDeliveryComplete,
+  markStatusDeliveryComplete,
+  statusDeliveryMarkerId,
+  statusWebhookDeliveryId,
+  statusWebhookDeliveryKey,
+} from './status-page-delivery';
 
 export interface WebhookPayload {
   event: string;
   timestamp: string;
-  data: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  data: unknown;
+}
+
+function asWebhookRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return { value };
 }
 
 /**
- * Deliver webhook payload to a URL
+ * Deliver webhook payload to a URL.
+ *
+ * The caller may provide a semantic delivery ID. Keeping this identifier stable
+ * across durable retries lets receivers implement exactly-once effects even
+ * though HTTP itself remains at-least-once.
  */
 export async function deliverWebhook(
   url: string,
   secret: string,
-  payload: WebhookPayload
+  payload: WebhookPayload,
+  deliveryId: string = crypto.randomUUID()
 ): Promise<boolean> {
   try {
     // SSRF Protection: Validate webhook URL before making request
@@ -39,13 +58,14 @@ export async function deliverWebhook(
       .createHmac('sha256', secret)
       .update(`${signatureTimestamp}.${payloadString}`)
       .digest('hex');
-    const deliveryId = crypto.randomUUID();
 
     const cb = CircuitBreakers.webhook(url);
 
     const retryResult = await retry(
       async () => {
         const response = await cb.execute(async () => {
+          // Revalidate on every network attempt to defend against DNS rebinding
+          // and configuration changes between retries.
           await assertSafeOutboundUrl(url);
           const res = await fetch(url, {
             method: 'POST',
@@ -88,6 +108,7 @@ export async function deliverWebhook(
     if (!retryResult.success || !retryResult.data) {
       logger.warn('api.status_page.webhook.delivery_failed', {
         url,
+        deliveryId,
         error:
           retryResult.error instanceof Error
             ? retryResult.error.message
@@ -108,13 +129,15 @@ export async function deliverWebhook(
 
     logger.warn('api.status_page.webhook.delivery_failed_status', {
       url,
+      deliveryId,
       status: response.status,
       statusText: response.statusText,
     });
     return false;
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger.error('api.status_page.webhook.delivery_error', {
       url,
+      deliveryId,
       error: error instanceof Error ? error.message : String(error),
     });
     return false;
@@ -146,7 +169,7 @@ export async function getStatusPagesForService(serviceId: string): Promise<strin
     return statusPageServices
       .filter(sps => sps.statusPage.enabled && sps.statusPage.showIncidents)
       .map(sps => sps.statusPageId);
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger.error('api.status_page.get_status_pages_for_service_error', {
       serviceId,
       error: error instanceof Error ? error.message : String(error),
@@ -156,12 +179,17 @@ export async function getStatusPagesForService(serviceId: string): Promise<strin
 }
 
 /**
- * Trigger webhooks for a status page event
+ * Trigger webhooks for a status page event.
+ *
+ * Delivery completion is persisted per webhook target. If a durable parent job
+ * is retried after partial success, already-completed targets are skipped and
+ * only failed targets are attempted again.
  */
 export async function triggerStatusPageWebhooks(
   statusPageId: string,
   event: string,
-  data: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  data: unknown,
+  deliveryKey?: string
 ): Promise<{ attempted: number; failed: number }> {
   try {
     const allWebhooks = await prisma.statusPageWebhook.findMany({
@@ -181,6 +209,11 @@ export async function triggerStatusPageWebhooks(
       return { attempted: 0, failed: 0 };
     }
 
+    const effectiveDeliveryKey = statusWebhookDeliveryKey(
+      event,
+      asWebhookRecord(data),
+      deliveryKey
+    );
     const payload: WebhookPayload = {
       event,
       timestamp: new Date().toISOString(),
@@ -189,26 +222,60 @@ export async function triggerStatusPageWebhooks(
 
     // Deliver to webhooks in concurrency-controlled batches
     const BATCH_SIZE = 25;
+    let attempted = 0;
     let failed = 0;
     for (let i = 0; i < webhooks.length; i += BATCH_SIZE) {
       const batch = webhooks.slice(i, i + BATCH_SIZE);
       const results = await Promise.allSettled(
-        batch.map(async webhook =>
-          deliverWebhook(webhook.url, await decryptStoredSecret(webhook.secret), payload)
-        )
+        batch.map(async webhook => {
+          const markerId = statusDeliveryMarkerId(
+            'STATUS_WEBHOOK',
+            effectiveDeliveryKey,
+            webhook.id
+          );
+          if (await isStatusDeliveryComplete(markerId)) {
+            return { attempted: false, success: true };
+          }
+
+          const stableDeliveryId = statusWebhookDeliveryId(effectiveDeliveryKey, webhook.id);
+          const success = await deliverWebhook(
+            webhook.url,
+            await decryptStoredSecret(webhook.secret),
+            payload,
+            stableDeliveryId
+          );
+
+          if (success) {
+            await markStatusDeliveryComplete({
+              markerId,
+              target: 'STATUS_WEBHOOK',
+              deliveryKey: effectiveDeliveryKey,
+              targetId: webhook.id,
+            });
+          }
+
+          return { attempted: true, success };
+        })
       );
+
+      attempted += results.filter(
+        result => result.status === 'fulfilled' && result.value.attempted
+      ).length;
       failed += results.filter(
-        result => result.status === 'rejected' || (result.status === 'fulfilled' && !result.value)
+        result => result.status === 'rejected' || (result.status === 'fulfilled' && !result.value.success)
       ).length;
     }
 
     logger.info('api.status_page.webhooks.triggered', {
       statusPageId,
       event,
+      deliveryKey: effectiveDeliveryKey,
       webhookCount: webhooks.length,
+      attempted,
+      failed,
     });
-    return { attempted: webhooks.length, failed };
-  } catch (error: any) {
+    return { attempted, failed };
+  } catch (error: unknown) {
     logger.error('api.status_page.webhooks.trigger_error', {
       statusPageId,
       event,
@@ -225,18 +292,21 @@ export async function triggerStatusPageWebhooks(
 export async function triggerWebhooksForService(
   serviceId: string,
   event: string,
-  incidentData: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  incidentData: unknown,
+  deliveryKey?: string
 ): Promise<{ attempted: number; failed: number; skipped?: boolean }> {
   try {
+    const incidentRecord = asWebhookRecord(incidentData);
+
     // Incident visibility is security-sensitive: load it from the database
     // instead of trusting an optional caller-supplied payload field.
-    if (incidentData?.id) {
+    if (typeof incidentRecord.id === 'string' && incidentRecord.id) {
       const inc = await prisma.incident.findUnique({
-        where: { id: incidentData.id },
+        where: { id: incidentRecord.id },
         select: { visibility: true },
       });
       if (!inc || inc.visibility !== 'PUBLIC') return { attempted: 0, failed: 0, skipped: true };
-    } else if (incidentData?.visibility !== 'PUBLIC') {
+    } else if (incidentRecord.visibility !== 'PUBLIC') {
       return { attempted: 0, failed: 0, skipped: true };
     }
 
@@ -251,7 +321,7 @@ export async function triggerWebhooksForService(
     // Trigger webhooks for all associated status pages in parallel
     const results = await Promise.allSettled(
       statusPageIds.map(statusPageId =>
-        triggerStatusPageWebhooks(statusPageId, event, incidentData)
+        triggerStatusPageWebhooks(statusPageId, event, incidentData, deliveryKey)
       )
     );
     return results.reduce(
@@ -265,7 +335,7 @@ export async function triggerWebhooksForService(
       },
       { attempted: 0, failed: 0 }
     );
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger.error('api.status_page.webhook.trigger_for_service_fatal_error', {
       serviceId,
       event,

--- a/tests/lib/status-page-delivery.test.ts
+++ b/tests/lib/status-page-delivery.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSubscriberIncidentPresentation,
+  incidentSubscriberDeliveryKey,
+  statusWebhookDeliveryId,
+  statusWebhookDeliveryKey,
+} from '@/lib/status-page-delivery';
+
+const incident = {
+  id: 'incident-1',
+  title: 'Database credentials exposed',
+  description: 'Sensitive diagnostic details',
+  service: { name: 'Payments Primary' },
+  createdAt: new Date('2026-08-30T10:00:00.000Z'),
+  updatedAt: new Date('2026-08-30T10:15:00.000Z'),
+  acknowledgedAt: new Date('2026-08-30T10:05:00.000Z'),
+  resolvedAt: new Date('2026-08-30T10:20:00.000Z'),
+};
+
+describe('status page delivery semantics', () => {
+  it('redacts subscriber incident fields according to the public page privacy contract', () => {
+    const presentation = buildSubscriberIncidentPresentation(
+      {
+        showIncidentDetails: true,
+        showIncidentTitles: false,
+        showIncidentDescriptions: false,
+        showAffectedServices: false,
+        showIncidentTimestamps: false,
+      },
+      incident
+    );
+
+    expect(presentation.incident.title).toBe('Incident Update');
+    expect(presentation.incident.description).toBeNull();
+    expect(presentation.incident.service?.name).toBe('Service');
+    expect(presentation).toMatchObject({
+      showAffectedService: false,
+      showDescription: false,
+      showTimestamp: false,
+    });
+  });
+
+  it('treats showIncidentDetails=false as the master privacy gate', () => {
+    const presentation = buildSubscriberIncidentPresentation(
+      {
+        showIncidentDetails: false,
+        showIncidentTitles: true,
+        showIncidentDescriptions: true,
+        showAffectedServices: true,
+        showIncidentTimestamps: true,
+      },
+      incident
+    );
+
+    expect(presentation.incident).toMatchObject({
+      title: 'Incident Update',
+      description: null,
+      service: { name: 'Service' },
+    });
+    expect(presentation.showTimestamp).toBe(false);
+  });
+
+  it('preserves published incident fields when every privacy switch permits them', () => {
+    const presentation = buildSubscriberIncidentPresentation(
+      {
+        showIncidentDetails: true,
+        showIncidentTitles: true,
+        showIncidentDescriptions: true,
+        showAffectedServices: true,
+        showIncidentTimestamps: true,
+      },
+      incident
+    );
+
+    expect(presentation.incident).toMatchObject({
+      title: incident.title,
+      description: incident.description,
+      service: { name: incident.service.name },
+    });
+    expect(presentation.showTimestamp).toBe(true);
+  });
+
+  it('uses lifecycle timestamps as stable semantic delivery keys', () => {
+    expect(incidentSubscriberDeliveryKey(incident, 'acknowledged')).toBe(
+      'incident-1:acknowledged:2026-08-30T10:05:00.000Z'
+    );
+
+    const first = statusWebhookDeliveryKey('incident.resolved', {
+      id: incident.id,
+      title: 'old title',
+      resolvedAt: incident.resolvedAt.toISOString(),
+    });
+    const retry = statusWebhookDeliveryKey('incident.resolved', {
+      id: incident.id,
+      title: 'newly fetched title',
+      resolvedAt: incident.resolvedAt.toISOString(),
+    });
+    expect(retry).toBe(first);
+  });
+
+  it('derives stable target-specific webhook delivery ids', () => {
+    const key = 'incident-1:incident.resolved:2026-08-30T10:20:00.000Z';
+    const first = statusWebhookDeliveryId(key, 'webhook-a');
+    expect(statusWebhookDeliveryId(key, 'webhook-a')).toBe(first);
+    expect(statusWebhookDeliveryId(key, 'webhook-b')).not.toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary
- persist per-subscriber and per-webhook completion markers so durable retries only re-attempt failed targets
- derive stable semantic webhook delivery IDs across parent-job retries
- keep existing SSRF validation, redirect blocking, timeout and circuit-breaker protections
- apply status-page incident title, description, affected-service and timestamp privacy switches to subscriber email content
- use `showIncidentDetails` as the master detail privacy gate

## Why
A single failed subscriber or webhook previously caused the parent job to retry the whole fan-out, potentially re-emailing or re-posting to targets that had already succeeded. Subscriber email formatting also exposed incident fields independently of the public page privacy switches.

## Reliability / security
- delivery remains at-least-once at the transport layer, with stable target delivery IDs for consumer dedupe
- successful targets are durably skipped on retry
- hidden public incident fields are redacted before subject/body formatting
- status webhook visibility checks and network-security protections remain unchanged
- this does not modify #474 or its public API/realtime boundary work

## Tests
Adds focused regression coverage for:
- title/description/service/timestamp privacy projection
- `showIncidentDetails` master gating
- stable lifecycle delivery keys
- stable target-specific webhook delivery IDs

One focused commit.