### PR TITLE
fix: enforce configurable audit and event retention

### DIFF
--- a/docs/v1.5/administration/audit-logs.md
+++ b/docs/v1.5/administration/audit-logs.md
@@ -1,7 +1,7 @@
 ---
 order: 7
 title: Audit Logs
-description: Review the administrative changes recorded by OpsKnight v1.4 and understand the evidence boundary.
+description: Review administrative changes recorded by OpsKnight and understand the evidence boundary.
 ---
 
 # Audit Logs
@@ -14,7 +14,7 @@ The audit log answers a focused question: **who changed supported OpsKnight conf
 2. Under **Insights**, select **Audit Log**.
 3. Read entries from newest to oldest.
 
-The page shows the newest **250** records. v1.4 has no audit search, filtering, pagination, or export. Query or export the PostgreSQL `AuditLog` table through an operator-controlled process if an investigation needs older records.
+The page shows records newest first in pages of 50. Search by actor, action, or entity ID, narrow results by entity type, and move through result pages. **Export CSV** exports the currently visible page. Use an operator-controlled PostgreSQL export for a complete large-range extract.
 
 > **Access boundary:** The Audit Log page (`/audit`) and its settings link are strictly restricted to Administrators (`ADMIN` role only). Users and Responders cannot access this page and will not see it in the sidebar navigation or settings overview. Treat audit metadata as sensitive and restrict application access at the identity or reverse-proxy layer when policy requires tighter separation.
 
@@ -45,7 +45,7 @@ This is an implemented-family summary, not a guarantee that every UI action crea
 ## Investigation workflow
 
 1. Record the incident window and affected user, team, service, or policy.
-2. Capture relevant rows before newer activity pushes them outside the 250-row view.
+2. Search and filter for relevant rows, then preserve the relevant result pages before the retention period expires.
 3. Match actor and entity IDs to current records; names and membership may have changed.
 4. Correlate with application, identity-provider, proxy, and database evidence.
 5. Preserve evidence externally according to your incident-response procedure.
@@ -54,7 +54,9 @@ If an expected row is absent, verify the change completed and its workflow has a
 
 ## Retention and compliance boundary
 
-The **System Logs** retention setting deletes `LogEntry` records; it does **not** delete `AuditLog` records. v1.4 has no configurable audit-retention/export job and does not claim append-only or tamper-evident storage.
+The **Audit & Event History** retention setting controls `AuditLog` and incident-event cleanup, alongside stored application logs. New installations default to one year; existing saved policies are not changed automatically. The 2-, 5-, and 7-year presets retain audit and event history for their stated duration.
+
+OpsKnight has no legal-hold, immutable-store, or tamper-evident audit capability. Do not run destructive cleanup for records subject to a hold; export them to approved, access-controlled storage first.
 
 For high-assurance use, back up PostgreSQL, export audit records to access-controlled immutable storage, define external retention, restrict database access, and validate coverage for each intended control. These records can contribute evidence, but do not by themselves make a deployment compliant.
 

--- a/docs/v1.5/administration/data-retention.md
+++ b/docs/v1.5/administration/data-retention.md
@@ -19,19 +19,21 @@ You need the **ADMIN** role.
 
 Presets only populate the form; they do not run cleanup. **Reset to Defaults** also changes the form without saving it.
 
-| Data set              |  Default | Accepted range | Effect                                                           |
-| --------------------- | -------: | -------------: | ---------------------------------------------------------------- |
-| Resolved incidents    | 730 days |       30–3,650 | Bounds history and selects old resolved incidents for cleanup.   |
-| Unlinked alerts       | 365 days |        7–3,650 | Selects old alerts after retained-incident links are considered. |
-| Stored log entries    |  90 days |          1–365 | Selects PostgreSQL `LogEntry` rows.                              |
-| Metric rollups        | 365 days |       30–3,650 | Bounds historical metric queries and rollup cleanup.             |
-| High-precision window |  90 days |          7–365 | Controls the live-data analytics window, not a separate archive. |
+| Data set              |  Default | Accepted range | Effect                                                                                 |
+| --------------------- | -------: | -------------: | -------------------------------------------------------------------------------------- |
+| Resolved incidents    | 730 days |       30–3,650 | Bounds history and selects eligible old resolved incidents for cleanup.                |
+| Alerts                | 365 days |        7–3,650 | Selects raw alerts older than the alert cutoff.                                        |
+| Audit & event history | 365 days |        1–3,650 | Selects `AuditLog`, `IncidentEvent`, `LogEntry`, and in-app notification records.     |
+| Metric rollups        | 365 days |       30–3,650 | Bounds historical metric queries and rollup cleanup.                                   |
+| Live analytics window |  90 days |          7–365 | Controls the live-data analytics window, not a separate archive.                       |
 
-The server clamps out-of-range values. Internal endpoint users should read back the saved policy because the UI and server minimum for the high-precision window differ.
+The UI and server enforce the same ranges. Requests outside those ranges are rejected rather than silently changed.
 
 ## Preset boundary
 
-Minimal, Standard, Extended, Enterprise, and Compliance presets are convenience templates, not legal advice or certifications. Some labels summarize incident retention while alert and log windows are shorter.
+Minimal, Standard, Extended, Enterprise, and Compliance presets are convenience templates, not legal advice or certifications. Audit and event history is retained for 14 days, 1 year, 2 years, 5 years, and 7 years respectively. The server supports up to 10 years (3,650 days).
+
+New installations and new `SystemSettings` records default Audit & Event History to one year. Existing saved settings are deliberately left unchanged; an administrator must select a preset or save the desired value.
 
 ## Preview and execute cleanup
 
@@ -41,19 +43,19 @@ The settings route uses the signed-in browser session and requires `ADMIN`. It i
 
 ## What cleanup actually removes
 
-| Category      | Selection and action                                                                                                                           |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Incidents     | Deletes only `RESOLVED` incidents whose **creation time** predates the cutoff, after deleting timeline events, notes, and custom-field values. |
-| Linked alerts | Detaches alerts from incidents selected for deletion.                                                                                          |
-| Alerts        | Deletes alerts older than their cutoff only when no longer linked to an incident.                                                              |
-| Logs          | Deletes old PostgreSQL `LogEntry` rows, not audit records or the System Logs memory buffer.                                                    |
-| Metrics       | Deletes metric and SLA rollups older than the metric cutoff.                                                                                   |
+| Category              | Selection and action                                                                                                                                             |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Incidents             | Deletes only eligible `RESOLVED` incidents whose **creation time** predates the cutoff, after deleting dependent timeline events, notes, and custom-field values. |
+| Incident-event safety | An incident is not eligible while it still has an event inside the configured Audit & Event History period.                                                       |
+| Alerts                | Deletes raw alerts older than their alert cutoff.                                                                                                                |
+| Audit & event history | Deletes expired `AuditLog`, `IncidentEvent`, PostgreSQL `LogEntry`, and in-app notification rows in bounded batches.                                             |
+| Metrics               | Deletes metric and SLA rollups older than the metric cutoff.                                                                                                     |
 
-Open incidents are not deleted. v1.4 does not copy deleted incidents to cold storage; its archive helper only reports candidates.
+Open incidents are not deleted. OpsKnight does not copy deleted incidents to cold storage; its archive helper only reports candidates.
 
 ### Dry-run limitation
 
-Preview reports incident, alert, and log candidates. It reports zero metrics and events even though execution may delete those records. It is a safety check, not a complete deletion manifest.
+Preview reports incident, alert, stored-log, audit-log, and incident-event candidates. It reports zero metrics and notification candidates. It is a safety check, not a complete deletion manifest.
 
 ## Automatic schedule
 
@@ -64,9 +66,9 @@ The application scheduler runs this cleanup service on its cleanup job. See [Mai
 - **All Time** analytics can be clipped and display a retention notice.
 - Incident deletion removes timeline, notes, and custom-field values.
 - Public status and RSS history cannot show deleted records.
-- Audit records and the per-process System Logs buffer are unaffected.
+- Audit records and incident events are removed when their Audit & Event History period expires; the per-process System Logs buffer is unaffected.
 
-Before reducing a window, identify legal and reporting needs, restore-test a recent backup, export required data, reconcile Preview, notify data owners, observe execution, and verify analytics, status history, storage, and job logs.
+Before reducing a window, identify legal and reporting needs, restore-test a recent backup, export required data, reconcile Preview, notify data owners, observe execution, and verify analytics, status history, storage, and job logs. OpsKnight does not provide a legal hold or immutable archive, so preserve records subject to either requirement outside the cleanup path first.
 
 If cleanup fails, preserve the error and check PostgreSQL health, application logs, and migration activity before retrying.
 

--- a/docs/v1.5/core-concepts/event-logs.md
+++ b/docs/v1.5/core-concepts/event-logs.md
@@ -10,13 +10,13 @@ The **Event Logs** page is a cross-incident view of incident lifecycle events. I
 
 ## Review lifecycle events
 
-Open **Event Logs** from the main navigation (restricted to **Administrators**; hidden from Users and Responders). The page displays the 200 most recent incident events, newest first.
+Open **Event Logs** from the main navigation (restricted to **Administrators**; hidden from Users and Responders). The page displays incident events newest first in pages of 50, so history is not limited to an initial 200-record window.
 
 Each row contains the timestamp in your configured time zone, a short incident identifier and title, the incident's service, and the lifecycle message. Select the incident identifier to open the full incident timeline.
 
 Typical messages appear after an incident is triggered, acknowledged, escalated, reassigned, commented on, reopened, automatically resolved, or manually resolved. Older records may not have a structured event type, so the human-readable message remains important.
 
-The v1.4 Event Logs page does not provide pagination, filters, or export. Use the incident page when you need the complete history for one incident.
+Use the search field to find event messages, incident IDs or titles, and service names. You can also filter by service and move between result pages. **Export CSV** exports the currently visible page; use an operator-controlled database export for a complete large-range extract. Use the incident page when you need the complete timeline for one incident.
 
 ## Send a test event from the UI
 
@@ -47,7 +47,7 @@ The Events API uses the service and `dedup_key` to correlate repeated trigger, a
 | Test returns 404                                | The integration key may have been deleted or may no longer identify a service.                                      |
 | Acknowledge/resolve cannot find the incident    | Reuse the exact deduplication key and integration key from the trigger request.                                     |
 | The incident exists but no off-box page arrived | Check the service policy, current schedule coverage, user preferences, provider settings, and notification history. |
-| An old event is missing                         | The page shows only the 200 most recent incident events. Open the incident for its own timeline.                    |
+| An old event is missing                         | Clear filters and move through result pages. Confirm the configured Audit & Event History retention period has not expired. |
 
 ## Related guides
 

--- a/prisma/migrations/20260830190000_default_operational_history_retention/migration.sql
+++ b/prisma/migrations/20260830190000_default_operational_history_retention/migration.sql
@@ -1,0 +1,5 @@
+-- Keep new installations' audit and incident-event history for one year by default.
+-- Existing tenant settings are deliberately left unchanged: administrators may have
+-- selected a stricter or longer compliance retention period.
+ALTER TABLE "SystemSettings"
+  ALTER COLUMN "logRetentionDays" SET DEFAULT 365;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1263,7 +1263,7 @@ model SystemSettings {
   // Data Retention Policy (days)
   incidentRetentionDays Int @default(730) // 2 years - how long to keep incident data
   alertRetentionDays    Int @default(365) // 1 year - how long to keep alert data
-  logRetentionDays      Int @default(90) // 90 days - how long to keep log entries
+  logRetentionDays      Int @default(365) // 1 year - audit and incident event history
   metricsRetentionDays  Int @default(365) // 1 year - how long to keep metric rollups
   realTimeWindowDays    Int @default(90) // 90 days - real-time queries, older uses rollups
 

--- a/src/app/(app)/audit/page.tsx
+++ b/src/app/(app)/audit/page.tsx
@@ -18,8 +18,8 @@ import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
 import EmptyState from '@/components/ui/EmptyState';
 import { Shield, FileText } from 'lucide-react';
 import { assertAuditorOrAdmin } from '@/lib/rbac';
-import type { AuditEntityType } from '@prisma/client';
-import Link from 'next/link';
+import type { Prisma } from '@prisma/client';
+import { parseAuditEntityType } from '@/lib/audit-filters';
 
 import TablePaginationFooter from '@/components/ui/TablePaginationFooter';
 import AuditFilters from '@/components/audit/AuditFilters';
@@ -41,7 +41,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
   await assertAuditorOrAdmin();
 
   const awaitedParams = await searchParams;
-  const entityType = awaitedParams?.entityType as AuditEntityType | undefined;
+  const entityType = parseAuditEntityType(awaitedParams?.entityType);
   const entityId = awaitedParams?.entityId;
   const actorId = awaitedParams?.actorId;
   const action = awaitedParams?.action;
@@ -56,7 +56,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
     : null;
   const userTimeZone = getUserTimeZone(user ?? undefined);
 
-  const baseWhere: Record<string, unknown> = {
+  const where: Prisma.AuditLogWhereInput = {
     ...(entityType ? { entityType } : {}),
     ...(entityId ? { entityId } : {}),
     ...(actorId ? { actorId } : {}),
@@ -65,7 +65,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
 
   if (search && search.trim()) {
     const q = search.trim();
-    baseWhere.OR = [
+    where.OR = [
       { action: { contains: q, mode: 'insensitive' } },
       { entityId: { contains: q, mode: 'insensitive' } },
       { actorName: { contains: q, mode: 'insensitive' } },
@@ -74,8 +74,6 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
       { actor: { email: { contains: q, mode: 'insensitive' } } },
     ];
   }
-
-  const where = baseWhere;
 
   const [logs, totalLogs] = await Promise.all([
     prisma.auditLog.findMany({

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -1,20 +1,11 @@
 import prisma from '@/lib/prisma';
 import Link from 'next/link';
+import type { Prisma } from '@prisma/client';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
-import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/shadcn/table';
-import { Card } from '@/components/ui/shadcn/card';
+import { getUserTimeZone } from '@/lib/timezone';
 import { Button } from '@/components/ui/shadcn/button';
 import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
-import EmptyState from '@/components/ui/EmptyState';
 import { Activity, Sparkles, Layers, Clock } from 'lucide-react';
 import { assertAdmin } from '@/lib/rbac';
 
@@ -22,8 +13,21 @@ import EventsListTable from '@/components/events/EventsListTable';
 
 export const dynamic = 'force-dynamic';
 
-export default async function EventLogsPage() {
+type EventLogsPageProps = {
+  searchParams?: Promise<{
+    page?: string;
+    search?: string;
+    service?: string;
+  }>;
+};
+
+export default async function EventLogsPage({ searchParams }: EventLogsPageProps) {
   await assertAdmin();
+  const params = await searchParams;
+  const page = Math.max(1, Number.parseInt(params?.page || '1', 10) || 1);
+  const pageSize = 50;
+  const search = params?.search?.trim().slice(0, 200) || undefined;
+  const service = params?.service?.trim().slice(0, 200) || undefined;
   const session = await getServerSession(await getAuthOptions());
   const email = session?.user?.email ?? null;
   const user = email
@@ -31,21 +35,42 @@ export default async function EventLogsPage() {
     : null;
   const userTimeZone = getUserTimeZone(user ?? undefined);
 
-  const events = await prisma.incidentEvent.findMany({
-    include: {
-      incident: {
-        select: {
-          id: true,
-          title: true,
-          service: { select: { name: true } },
+  const filters: Prisma.IncidentEventWhereInput[] = [];
+  if (service) {
+    filters.push({ incident: { service: { name: service } } });
+  }
+  if (search) {
+    filters.push({
+      OR: [
+        { message: { contains: search, mode: 'insensitive' } },
+        { incidentId: { contains: search, mode: 'insensitive' } },
+        { incident: { title: { contains: search, mode: 'insensitive' } } },
+        { incident: { service: { name: { contains: search, mode: 'insensitive' } } } },
+      ],
+    });
+  }
+  const where: Prisma.IncidentEventWhereInput = filters.length > 0 ? { AND: filters } : {};
+
+  const [events, totalEvents, services] = await Promise.all([
+    prisma.incidentEvent.findMany({
+      where,
+      include: {
+        incident: {
+          select: {
+            id: true,
+            title: true,
+            service: { select: { name: true } },
+          },
         },
       },
-    },
-    orderBy: { createdAt: 'desc' },
-    take: 200,
-  });
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.incidentEvent.count({ where }),
+    prisma.service.findMany({ select: { name: true }, orderBy: { name: 'asc' } }),
+  ]);
 
-  const totalEvents = events.length;
   const uniqueIncidents = new Set(events.map(e => e.incident.id)).size;
   const uniqueServices = new Set(events.map(e => e.incident.service.name)).size;
   return (
@@ -79,32 +104,40 @@ export default async function EventLogsPage() {
         }
         stats={[
           {
-            label: 'Retained Events',
+            label: 'Matching Events',
             value: totalEvents,
             icon: <Activity className="h-3.5 w-3.5" />,
           },
           {
-            label: 'Incidents Touched',
+            label: 'Incidents on Page',
             value: uniqueIncidents,
             icon: <Layers className="h-3.5 w-3.5 text-rose-200" />,
             valueClassName: uniqueIncidents > 0 ? 'text-rose-200' : undefined,
           },
           {
-            label: 'Services Active',
+            label: 'Services on Page',
             value: uniqueServices,
             icon: <Layers className="h-3.5 w-3.5 text-blue-200" />,
             valueClassName: uniqueServices > 0 ? 'text-blue-200' : undefined,
           },
           {
-            label: 'Window',
-            value: 'Recent 200',
+            label: 'Page',
+            value: `${page} of ${Math.max(1, Math.ceil(totalEvents / pageSize))}`,
             icon: <Clock className="h-3.5 w-3.5 text-amber-200" />,
           },
         ]}
       />
 
-      {/* Events List Table with Search, Filter & CSV Export */}
-      <EventsListTable initialEvents={events} userTimeZone={userTimeZone} />
+      <EventsListTable
+        initialEvents={events}
+        userTimeZone={userTimeZone}
+        currentSearch={search}
+        currentService={service}
+        serviceNames={services.map(item => item.name)}
+        page={page}
+        totalCount={totalEvents}
+        pageSize={pageSize}
+      />
     </main>
   );
 }

--- a/src/app/api/settings/retention/route.ts
+++ b/src/app/api/settings/retention/route.ts
@@ -14,11 +14,11 @@ import { z } from 'zod';
 
 const RetentionUpdateSchema = z
   .object({
-    incidentRetentionDays: z.number().int().min(1).max(3650).optional(),
-    alertRetentionDays: z.number().int().min(1).max(3650).optional(),
+    incidentRetentionDays: z.number().int().min(30).max(3650).optional(),
+    alertRetentionDays: z.number().int().min(7).max(3650).optional(),
     logRetentionDays: z.number().int().min(1).max(3650).optional(),
-    metricsRetentionDays: z.number().int().min(1).max(3650).optional(),
-    realTimeWindowDays: z.number().int().min(1).max(365).optional(),
+    metricsRetentionDays: z.number().int().min(30).max(3650).optional(),
+    realTimeWindowDays: z.number().int().min(7).max(365).optional(),
   })
   .refine(data => Object.keys(data).length > 0, { message: 'No valid fields provided' });
 
@@ -60,7 +60,7 @@ export async function GET() {
           name: 'Standard (1 year)',
           incidentRetentionDays: 365,
           alertRetentionDays: 180,
-          logRetentionDays: 30,
+          logRetentionDays: 365,
           metricsRetentionDays: 365,
           realTimeWindowDays: 60,
         },
@@ -68,7 +68,7 @@ export async function GET() {
           name: 'Extended (2 years)',
           incidentRetentionDays: 730,
           alertRetentionDays: 365,
-          logRetentionDays: 90,
+          logRetentionDays: 730,
           metricsRetentionDays: 730,
           realTimeWindowDays: 90,
         },
@@ -76,7 +76,7 @@ export async function GET() {
           name: 'Enterprise (5 years)',
           incidentRetentionDays: 1825,
           alertRetentionDays: 730,
-          logRetentionDays: 180,
+          logRetentionDays: 1825,
           metricsRetentionDays: 1825,
           realTimeWindowDays: 90,
         },
@@ -84,7 +84,7 @@ export async function GET() {
           name: 'Compliance (7 years)',
           incidentRetentionDays: 2555,
           alertRetentionDays: 1825,
-          logRetentionDays: 365,
+          logRetentionDays: 2555,
           metricsRetentionDays: 2555,
           realTimeWindowDays: 90,
         },

--- a/src/components/audit/AuditFilters.tsx
+++ b/src/components/audit/AuditFilters.tsx
@@ -14,6 +14,7 @@ import SearchFilterBar from '@/components/ui/SearchFilterBar';
 import LivePulseBadge from '@/components/ui/LivePulseBadge';
 import { exportToCsv } from '@/lib/export-csv';
 import { Download } from 'lucide-react';
+import { AUDIT_ENTITY_TYPES } from '@/lib/audit-filters';
 
 export type AuditFiltersProps = {
   currentEntityType?: string;
@@ -31,17 +32,6 @@ export type AuditFiltersProps = {
     details?: unknown;
   }>;
 };
-
-const ENTITY_TYPES = [
-  'USER',
-  'TEAM',
-  'SERVICE',
-  'ESCALATION_POLICY',
-  'SCHEDULE',
-  'INTEGRATION',
-  'SETTING',
-  'CUSTOM_FIELD',
-];
 
 export default function AuditFilters({
   currentEntityType = 'ALL',
@@ -103,6 +93,7 @@ export default function AuditFilters({
       searchValue={currentSearch}
       onSearchChange={val => updateParam('search', val)}
       searchPlaceholder="Search actor, action, or entity ID..."
+      searchDebounceMs={300}
       hasActiveFilters={hasActiveFilters}
       onResetFilters={handleReset}
       filters={
@@ -115,7 +106,7 @@ export default function AuditFilters({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="ALL">All Entity Types</SelectItem>
-            {ENTITY_TYPES.map(type => (
+            {AUDIT_ENTITY_TYPES.map(type => (
               <SelectItem key={type} value={type}>
                 {type.replace(/_/g, ' ')}
               </SelectItem>

--- a/src/components/events/EventsListTable.tsx
+++ b/src/components/events/EventsListTable.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useTransition } from 'react';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { formatDateTime } from '@/lib/timezone';
 import {
   Table,
@@ -43,49 +44,41 @@ export type EventItem = {
 export type EventsListTableProps = {
   initialEvents: EventItem[];
   userTimeZone: string;
+  currentSearch?: string;
+  currentService?: string;
+  serviceNames: string[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
 };
 
-export default function EventsListTable({ initialEvents, userTimeZone }: EventsListTableProps) {
-  const [search, setSearch] = useState('');
-  const [selectedService, setSelectedService] = useState('ALL');
-  const [page, setPage] = useState(1);
-  const pageSize = 25;
+export default function EventsListTable({
+  initialEvents,
+  userTimeZone,
+  currentSearch = '',
+  currentService = '',
+  serviceNames,
+  page,
+  pageSize,
+  totalCount,
+}: EventsListTableProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
 
-  const services = useMemo(() => {
-    const set = new Set<string>();
-    initialEvents.forEach(e => {
-      if (e.incident?.service?.name) {
-        set.add(e.incident.service.name);
-      }
-    });
-    return Array.from(set).sort();
-  }, [initialEvents]);
+  const updateParam = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (!value || value === 'ALL') params.delete(key);
+    else params.set(key, value);
+    params.delete('page');
+    startTransition(() => router.push(`/events?${params.toString()}`));
+  };
 
-  const filteredEvents = useMemo(() => {
-    let result = initialEvents;
-
-    if (selectedService !== 'ALL') {
-      result = result.filter(e => e.incident?.service?.name === selectedService);
-    }
-
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      result = result.filter(
-        e =>
-          e.message.toLowerCase().includes(q) ||
-          e.incident?.title.toLowerCase().includes(q) ||
-          e.incident?.service?.name.toLowerCase().includes(q) ||
-          e.incident?.id.toLowerCase().includes(q)
-      );
-    }
-
-    return result;
-  }, [initialEvents, selectedService, search]);
-
-  const paginatedEvents = useMemo(() => {
-    const start = (page - 1) * pageSize;
-    return filteredEvents.slice(start, start + pageSize);
-  }, [filteredEvents, page, pageSize]);
+  const pageHref = (targetPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('page', String(targetPage));
+    return `/events?${params.toString()}`;
+  };
 
   const handleExportCsv = () => {
     exportToCsv(
@@ -98,45 +91,38 @@ export default function EventsListTable({ initialEvents, userTimeZone }: EventsL
         { header: 'Service', accessor: row => row.incident?.service?.name ?? '' },
         { header: 'Message', accessor: 'message' },
       ],
-      filteredEvents
+      initialEvents
     );
   };
 
-  const hasActiveFilters = Boolean(search) || selectedService !== 'ALL';
+  const hasActiveFilters = Boolean(currentSearch) || Boolean(currentService);
 
   const handleResetFilters = () => {
-    setSearch('');
-    setSelectedService('ALL');
-    setPage(1);
+    startTransition(() => router.push('/events'));
   };
 
   return (
     <div className="space-y-4">
       {/* Search & Filter Toolbar */}
       <SearchFilterBar
-        searchValue={search}
-        onSearchChange={val => {
-          setSearch(val);
-          setPage(1);
-        }}
+        searchValue={currentSearch}
+        onSearchChange={val => updateParam('search', val)}
         searchPlaceholder="Search event messages, incidents, services..."
+        searchDebounceMs={300}
         hasActiveFilters={hasActiveFilters}
         onResetFilters={handleResetFilters}
         filters={
-          services.length > 0 ? (
+          serviceNames.length > 0 ? (
             <Select
-              value={selectedService}
-              onValueChange={val => {
-                setSelectedService(val);
-                setPage(1);
-              }}
+              value={currentService || 'ALL'}
+              onValueChange={val => updateParam('service', val)}
             >
               <SelectTrigger className="h-9 w-[160px] bg-slate-50/60 text-xs">
                 <SelectValue placeholder="All Services" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="ALL">All Services</SelectItem>
-                {services.map(svc => (
+                {serviceNames.map(svc => (
                   <SelectItem key={svc} value={svc}>
                     {svc}
                   </SelectItem>
@@ -152,7 +138,7 @@ export default function EventsListTable({ initialEvents, userTimeZone }: EventsL
               variant="outline"
               size="sm"
               onClick={handleExportCsv}
-              disabled={filteredEvents.length === 0}
+              disabled={initialEvents.length === 0}
               className="h-9 gap-1.5 text-xs shadow-sm hover:bg-slate-100"
             >
               <Download className="h-3.5 w-3.5 text-muted-foreground" />
@@ -164,7 +150,7 @@ export default function EventsListTable({ initialEvents, userTimeZone }: EventsL
 
       {/* Events Card & Table */}
       <Card className="bg-white overflow-hidden shadow-sm">
-        {filteredEvents.length === 0 ? (
+        {initialEvents.length === 0 ? (
           <div className="p-6">
             <EmptyState
               icon={<Activity className="h-6 w-6 text-muted-foreground/60" />}
@@ -208,7 +194,7 @@ export default function EventsListTable({ initialEvents, userTimeZone }: EventsL
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {paginatedEvents.map(event => (
+                  {initialEvents.map(event => (
                     <TableRow
                       key={event.id}
                       className="border-b border-slate-100 hover:bg-slate-50/70 transition-colors"
@@ -250,8 +236,8 @@ export default function EventsListTable({ initialEvents, userTimeZone }: EventsL
             <TablePaginationFooter
               page={page}
               pageSize={pageSize}
-              totalCount={filteredEvents.length}
-              onPageChange={newPage => setPage(newPage)}
+              totalCount={totalCount}
+              pageHref={pageHref}
             />
           </>
         )}

--- a/src/components/settings/RetentionPolicySettings.tsx
+++ b/src/components/settings/RetentionPolicySettings.tsx
@@ -11,7 +11,6 @@ import {
   Card,
   CardHeader,
   CardTitle,
-  CardDescription,
   CardContent,
 } from '@/components/ui/shadcn/card';
 import { Badge } from '@/components/ui/shadcn/badge';
@@ -60,6 +59,7 @@ interface CleanupResult {
   logs: number;
   metrics: number;
   events: number;
+  auditLogs: number;
   executionTimeMs: number;
   dryRun: boolean;
 }
@@ -67,7 +67,7 @@ interface CleanupResult {
 const DEFAULT_POLICY: RetentionPolicy = {
   incidentRetentionDays: 730,
   alertRetentionDays: 365,
-  logRetentionDays: 90,
+  logRetentionDays: 365,
   metricsRetentionDays: 365,
   realTimeWindowDays: 90,
 };
@@ -124,24 +124,24 @@ export default function RetentionPolicySettings() {
     const errors: Partial<Record<keyof RetentionPolicy, string>> = {};
     let isValid = true;
 
-    if (currentPolicy.incidentRetentionDays < 30) {
-      errors.incidentRetentionDays = 'Must be at least 30 days';
+    if (currentPolicy.incidentRetentionDays < 30 || currentPolicy.incidentRetentionDays > 3650) {
+      errors.incidentRetentionDays = 'Must be between 30 days and 10 years';
       isValid = false;
     }
-    if (currentPolicy.alertRetentionDays < 7) {
-      errors.alertRetentionDays = 'Must be at least 7 days';
+    if (currentPolicy.alertRetentionDays < 7 || currentPolicy.alertRetentionDays > 3650) {
+      errors.alertRetentionDays = 'Must be between 7 days and 10 years';
       isValid = false;
     }
-    if (currentPolicy.logRetentionDays < 1) {
-      errors.logRetentionDays = 'Must be at least 1 day';
+    if (currentPolicy.logRetentionDays < 1 || currentPolicy.logRetentionDays > 3650) {
+      errors.logRetentionDays = 'Must be between 1 day and 10 years';
       isValid = false;
     }
-    if (currentPolicy.metricsRetentionDays < 30) {
-      errors.metricsRetentionDays = 'Must be at least 30 days';
+    if (currentPolicy.metricsRetentionDays < 30 || currentPolicy.metricsRetentionDays > 3650) {
+      errors.metricsRetentionDays = 'Must be between 30 days and 10 years';
       isValid = false;
     }
-    if (currentPolicy.realTimeWindowDays < 1) {
-      errors.realTimeWindowDays = 'Must be at least 1 day';
+    if (currentPolicy.realTimeWindowDays < 7 || currentPolicy.realTimeWindowDays > 365) {
+      errors.realTimeWindowDays = 'Must be between 7 days and 1 year';
       isValid = false;
     }
 
@@ -249,10 +249,12 @@ export default function RetentionPolicySettings() {
   };
 
   const handleInputChange = (field: keyof RetentionPolicy, value: string) => {
-    const num = parseInt(value);
+    const num = Number.parseInt(value, 10);
     if (!policy) return;
 
     // Clear error for this field when user types
+    // `field` is a compile-time `keyof RetentionPolicy`, not request input.
+    // eslint-disable-next-line security/detect-object-injection
     if (validationErrors[field]) {
       setValidationErrors(prev => ({ ...prev, [field]: undefined }));
       if (Object.keys(validationErrors).length <= 1) setGeneralError(null);
@@ -381,6 +383,7 @@ export default function RetentionPolicySettings() {
                   value={policy.incidentRetentionDays}
                   onChange={v => handleInputChange('incidentRetentionDays', v)}
                   min={30}
+                  max={3650}
                   error={validationErrors.incidentRetentionDays}
                 />
 
@@ -390,15 +393,17 @@ export default function RetentionPolicySettings() {
                   value={policy.alertRetentionDays}
                   onChange={v => handleInputChange('alertRetentionDays', v)}
                   min={7}
+                  max={3650}
                   error={validationErrors.alertRetentionDays}
                 />
 
                 <RetentionFieldRow
-                  label="System Logs"
-                  description="Audit trails and debug events."
+                  label="Audit & Event History"
+                  description="Audit trails and incident events. One year is the default."
                   value={policy.logRetentionDays}
                   onChange={v => handleInputChange('logRetentionDays', v)}
                   min={1}
+                  max={3650}
                   error={validationErrors.logRetentionDays}
                 />
 
@@ -408,15 +413,17 @@ export default function RetentionPolicySettings() {
                   value={policy.metricsRetentionDays}
                   onChange={v => handleInputChange('metricsRetentionDays', v)}
                   min={30}
+                  max={3650}
                   error={validationErrors.metricsRetentionDays}
                 />
 
                 <RetentionFieldRow
-                  label="High-Precision Metrics"
-                  description="Raw, real-time metric data points."
+                  label="Live Analytics Window"
+                  description="Uses direct incident and alert data; older eligible ranges use rollups."
                   value={policy.realTimeWindowDays}
                   onChange={v => handleInputChange('realTimeWindowDays', v)}
-                  min={1}
+                  min={7}
+                  max={365}
                   error={validationErrors.realTimeWindowDays}
                 />
               </>
@@ -476,10 +483,12 @@ export default function RetentionPolicySettings() {
                     </Badge>
                   </h5>
                 </div>
-                <div className="flex gap-8 text-sm">
+                <div className="flex flex-wrap gap-8 text-sm">
                   <StatItem label="Incidents" value={cleanupResult.incidents} />
                   <StatItem label="Alerts" value={cleanupResult.alerts} />
                   <StatItem label="Logs" value={cleanupResult.logs} />
+                  <StatItem label="Audit logs" value={cleanupResult.auditLogs} />
+                  <StatItem label="Events" value={cleanupResult.events} />
                   <StatItem label="Metrics" value={cleanupResult.metrics} />
                 </div>
                 {cleanupResult.dryRun && (
@@ -555,6 +564,7 @@ function RetentionFieldRow({
   value,
   onChange,
   min,
+  max,
   error,
 }: {
   label: string;
@@ -562,6 +572,7 @@ function RetentionFieldRow({
   value: number | string;
   onChange: (val: string) => void;
   min?: number;
+  max?: number;
   error?: string;
 }) {
   return (
@@ -580,6 +591,7 @@ function RetentionFieldRow({
         <Input
           type="number"
           min={min}
+          max={max}
           value={value}
           onChange={e => onChange(e.target.value)}
           className={`w-24 rounded-r-none border-r-0 ${error ? 'border-destructive focus-visible:ring-destructive' : ''}`}

--- a/src/components/ui/SearchFilterBar.tsx
+++ b/src/components/ui/SearchFilterBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/shadcn/input';
 import { Button } from '@/components/ui/shadcn/button';
@@ -14,6 +14,8 @@ export type SearchFilterBarProps = {
   actions?: ReactNode;
   hasActiveFilters?: boolean;
   onResetFilters?: () => void;
+  /** Debounce server-backed searches to avoid a database request for every keystroke. */
+  searchDebounceMs?: number;
   className?: string;
 };
 
@@ -25,8 +27,38 @@ export default function SearchFilterBar({
   actions,
   hasActiveFilters = false,
   onResetFilters,
+  searchDebounceMs = 0,
   className,
 }: SearchFilterBarProps) {
+  const [draftSearch, setDraftSearch] = useState(searchValue);
+  const skipNextDebounce = useRef(false);
+
+  useEffect(() => {
+    setDraftSearch(searchValue);
+  }, [searchValue]);
+
+  useEffect(() => {
+    if (!onSearchChange || searchDebounceMs <= 0 || draftSearch === searchValue) return;
+    if (skipNextDebounce.current) {
+      skipNextDebounce.current = false;
+      return;
+    }
+
+    const timer = window.setTimeout(() => onSearchChange(draftSearch), searchDebounceMs);
+    return () => window.clearTimeout(timer);
+  }, [draftSearch, onSearchChange, searchDebounceMs, searchValue]);
+
+  const handleSearchChange = (value: string) => {
+    setDraftSearch(value);
+    if (searchDebounceMs <= 0) onSearchChange?.(value);
+  };
+
+  const clearSearch = () => {
+    setDraftSearch('');
+    skipNextDebounce.current = true;
+    onSearchChange?.('');
+  };
+
   return (
     <div
       className={cn(
@@ -38,18 +70,18 @@ export default function SearchFilterBar({
       <div className="flex flex-1 flex-col gap-2.5 sm:flex-row sm:items-center">
         {onSearchChange && (
           <div className="relative flex-1 min-w-[200px] max-w-md">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="text"
               placeholder={searchPlaceholder}
-              value={searchValue}
-              onChange={e => onSearchChange(e.target.value)}
-              className="h-9 pl-9 pr-8 text-xs sm:text-sm bg-slate-50/60 focus:bg-white transition-colors"
+              value={draftSearch}
+              onChange={e => handleSearchChange(e.target.value)}
+              className="h-9 !pl-10 !pr-8 text-xs sm:text-sm bg-slate-50/60 focus:bg-white transition-colors"
             />
-            {searchValue && (
+            {draftSearch && (
               <button
                 type="button"
-                onClick={() => onSearchChange('')}
+                onClick={clearSearch}
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground p-0.5 rounded"
                 aria-label="Clear search"
               >

--- a/src/lib/audit-filters.ts
+++ b/src/lib/audit-filters.ts
@@ -1,0 +1,23 @@
+import type { AuditEntityType } from '@prisma/client';
+
+export const AUDIT_ENTITY_TYPES = [
+  'USER',
+  'TEAM',
+  'TEAM_MEMBER',
+  'SERVICE',
+  'ESCALATION_POLICY',
+  'API_KEY',
+  'SSO_CONFIG',
+  'SCHEDULE',
+  'CUSTOM_FIELD',
+  'STATUS_PAGE',
+  'SYSTEM_CONFIG',
+] as const satisfies readonly AuditEntityType[];
+
+function isAuditEntityType(value: string): value is AuditEntityType {
+  return (AUDIT_ENTITY_TYPES as readonly string[]).includes(value);
+}
+
+export function parseAuditEntityType(value?: string): AuditEntityType | undefined {
+  return value && isAuditEntityType(value) ? value : undefined;
+}

--- a/src/lib/data-cleanup.ts
+++ b/src/lib/data-cleanup.ts
@@ -19,6 +19,7 @@ export interface CleanupResult {
   logs: number;
   metrics: number;
   events: number;
+  auditLogs: number;
   inAppNotifications: number;
   slaPerformanceLogs: number;
   executionTimeMs: number;
@@ -54,22 +55,30 @@ export async function performDataCleanup(dryRun: boolean = false): Promise<Clean
   const metricsCutoff = new Date(now);
   metricsCutoff.setDate(metricsCutoff.getDate() - policy.metricsRetentionDays);
 
+  // Incident events are deleted with their parent incident. Do not let a
+  // shorter incident-retention period silently remove event history that is
+  // still inside the separately configured audit/event retention period.
+  const resolvedIncidentCleanupWhere = {
+    createdAt: { lt: incidentCutoff },
+    status: 'RESOLVED' as const,
+    events: { none: { createdAt: { gte: logCutoff } } },
+  };
+
   let incidentCount = 0;
   let alertCount = 0;
   let logCount = 0;
   let metricsCount = 0;
   let eventCount = 0;
+  let auditLogCount = 0;
   let inAppNotificationCount = 0;
   let slaPerformanceLogCount = 0;
 
   try {
     // 1. Count what would be deleted
-    const [incidentsToDelete, alertsToDelete, logsToDelete] = await Promise.all([
+    const [incidentsToDelete, alertsToDelete, logsToDelete, eventsToDelete, auditLogsToDelete] =
+      await Promise.all([
       prisma.incident.count({
-        where: {
-          createdAt: { lt: incidentCutoff },
-          status: 'RESOLVED', // Only delete resolved incidents
-        },
+        where: resolvedIncidentCleanupWhere,
       }),
       prisma.alert.count({
         where: { createdAt: { lt: alertCutoff } },
@@ -77,12 +86,16 @@ export async function performDataCleanup(dryRun: boolean = false): Promise<Clean
       prisma.logEntry.count({
         where: { timestamp: { lt: logCutoff } },
       }),
+      prisma.incidentEvent.count({ where: { createdAt: { lt: logCutoff } } }),
+      prisma.auditLog.count({ where: { createdAt: { lt: logCutoff } } }),
     ]);
 
     logger.info('[DataCleanup] Records to cleanup', {
       incidents: incidentsToDelete,
       alerts: alertsToDelete,
       logs: logsToDelete,
+      events: eventsToDelete,
+      auditLogs: auditLogsToDelete,
       cutoffs: {
         incident: incidentCutoff.toISOString(),
         alert: alertCutoff.toISOString(),
@@ -96,7 +109,8 @@ export async function performDataCleanup(dryRun: boolean = false): Promise<Clean
         alerts: alertsToDelete,
         logs: logsToDelete,
         metrics: 0,
-        events: 0,
+        events: eventsToDelete,
+        auditLogs: auditLogsToDelete,
         inAppNotifications: 0,
         slaPerformanceLogs: 0,
         executionTimeMs: Date.now() - startTime,
@@ -109,7 +123,7 @@ export async function performDataCleanup(dryRun: boolean = false): Promise<Clean
     const BATCH_SIZE = 500;
     while (true) {
       const incidentIds = await prisma.incident.findMany({
-        where: { createdAt: { lt: incidentCutoff }, status: 'RESOLVED' },
+        where: resolvedIncidentCleanupWhere,
         select: { id: true },
         orderBy: { id: 'asc' },
         take: BATCH_SIZE,
@@ -179,6 +193,26 @@ export async function performDataCleanup(dryRun: boolean = false): Promise<Clean
         }),
       ids => prisma.alert.deleteMany({ where: { id: { in: ids } } })
     );
+    eventCount += await deleteInBatches(
+      () =>
+        prisma.incidentEvent.findMany({
+          where: { createdAt: { lt: logCutoff } },
+          select: { id: true },
+          orderBy: { id: 'asc' },
+          take: BATCH_SIZE,
+        }),
+      ids => prisma.incidentEvent.deleteMany({ where: { id: { in: ids } } })
+    );
+    auditLogCount = await deleteInBatches(
+      () =>
+        prisma.auditLog.findMany({
+          where: { createdAt: { lt: logCutoff } },
+          select: { id: true },
+          orderBy: { id: 'asc' },
+          take: BATCH_SIZE,
+        }),
+      ids => prisma.auditLog.deleteMany({ where: { id: { in: ids } } })
+    );
     logCount = await deleteInBatches(
       () =>
         prisma.logEntry.findMany({
@@ -218,6 +252,7 @@ export async function performDataCleanup(dryRun: boolean = false): Promise<Clean
     logger.info('[DataCleanup] Cleanup completed', {
       incidents: incidentCount,
       events: eventCount,
+      auditLogs: auditLogCount,
       alerts: alertCount,
       logs: logCount,
       metrics: metricsCount,
@@ -232,6 +267,7 @@ export async function performDataCleanup(dryRun: boolean = false): Promise<Clean
       logs: logCount,
       metrics: metricsCount,
       events: eventCount,
+      auditLogs: auditLogCount,
       inAppNotifications: inAppNotificationCount,
       slaPerformanceLogs: slaPerformanceLogCount,
       executionTimeMs,

--- a/src/lib/retention-policy.ts
+++ b/src/lib/retention-policy.ts
@@ -16,7 +16,7 @@ import {
  * Settings:
  * - incidentRetentionDays: How long to keep incident data (default: 730 = 2 years)
  * - alertRetentionDays: How long to keep alert data (default: 365 = 1 year)
- * - logRetentionDays: How long to keep log entries (default: 90 days)
+ * - logRetentionDays: How long to keep audit and event history (default: 365 days)
  * - metricsRetentionDays: How long to keep metric rollups (default: 365 = 1 year)
  * - realTimeWindowDays: Use real-time queries for this period, rollups for older (default: 90 days)
  */
@@ -39,7 +39,7 @@ export interface RetentionPolicy {
 const DEFAULT_POLICY: RetentionPolicy = {
   incidentRetentionDays: 730, // 2 years
   alertRetentionDays: 365, // 1 year
-  logRetentionDays: 90, // 90 days
+  logRetentionDays: 365, // 1 year for event and audit history
   metricsRetentionDays: 365, // 1 year
   realTimeWindowDays: 90, // 90 days for real-time, older uses rollups
   businessHoursTimeZone: 'UTC',
@@ -193,7 +193,7 @@ export async function updateRetentionPolicy(
     validated.alertRetentionDays = Math.max(7, Math.min(3650, policy.alertRetentionDays)); // 7 days to 10 years
   }
   if (policy.logRetentionDays !== undefined) {
-    validated.logRetentionDays = Math.max(1, Math.min(365, policy.logRetentionDays)); // 1 day to 1 year
+    validated.logRetentionDays = Math.max(1, Math.min(3650, policy.logRetentionDays)); // 1 day to 10 years
   }
   if (policy.metricsRetentionDays !== undefined) {
     validated.metricsRetentionDays = Math.max(30, Math.min(3650, policy.metricsRetentionDays)); // 30 days to 10 years

--- a/tests/lib/audit-filters.test.ts
+++ b/tests/lib/audit-filters.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { AUDIT_ENTITY_TYPES, parseAuditEntityType } from '@/lib/audit-filters';
+
+describe('audit entity filters', () => {
+  it('accepts only entity types that Prisma can query', () => {
+    expect(parseAuditEntityType('SYSTEM_CONFIG')).toBe('SYSTEM_CONFIG');
+    expect(parseAuditEntityType('TEAM_MEMBER')).toBe('TEAM_MEMBER');
+    expect(AUDIT_ENTITY_TYPES).toContain('SCHEDULE');
+  });
+
+  it('ignores invalid URL values instead of passing them to Prisma', () => {
+    expect(parseAuditEntityType('INTEGRATION')).toBeUndefined();
+    expect(parseAuditEntityType('SETTING')).toBeUndefined();
+    expect(parseAuditEntityType('not-an-enum')).toBeUndefined();
+    expect(parseAuditEntityType()).toBeUndefined();
+  });
+});

--- a/tests/lib/data-cleanup.test.ts
+++ b/tests/lib/data-cleanup.test.ts
@@ -20,6 +20,13 @@ const mockPrisma = {
     deleteMany: vi.fn(),
   },
   incidentEvent: {
+    count: vi.fn(),
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  auditLog: {
+    count: vi.fn(),
+    findMany: vi.fn(),
     deleteMany: vi.fn(),
   },
   incidentNote: {
@@ -67,6 +74,8 @@ describe('Data Cleanup Service', () => {
     mockPrisma.incident.count.mockResolvedValue(5);
     mockPrisma.alert.count.mockResolvedValue(10);
     mockPrisma.logEntry.count.mockResolvedValue(20);
+    mockPrisma.incidentEvent.count.mockResolvedValue(0);
+    mockPrisma.auditLog.count.mockResolvedValue(0);
   });
 
   it('should respect dryRun flag and NOT delete data', async () => {
@@ -76,11 +85,21 @@ describe('Data Cleanup Service', () => {
     expect(result.incidents).toBe(5);
     expect(result.alerts).toBe(10);
     expect(result.logs).toBe(20);
+    expect(result.events).toBe(0);
+    expect(result.auditLogs).toBe(0);
+
+    expect(mockPrisma.incident.count).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        status: 'RESOLVED',
+        events: expect.objectContaining({ none: expect.any(Object) }),
+      }),
+    });
 
     // Verify delete was NOT called
     expect(mockPrisma.incident.deleteMany).not.toHaveBeenCalled();
     expect(mockPrisma.alert.deleteMany).not.toHaveBeenCalled();
     expect(mockPrisma.logEntry.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.auditLog.deleteMany).not.toHaveBeenCalled();
   });
 
   it('should delete data when dryRun is false', async () => {
@@ -97,6 +116,9 @@ describe('Data Cleanup Service', () => {
     mockPrisma.alert.deleteMany.mockResolvedValue({ count: 1 });
     mockPrisma.logEntry.findMany.mockResolvedValueOnce([{ id: 'log-1' }]).mockResolvedValueOnce([]);
     mockPrisma.logEntry.deleteMany.mockResolvedValue({ count: 1 });
+    mockPrisma.incidentEvent.findMany.mockResolvedValue([]);
+    mockPrisma.auditLog.findMany.mockResolvedValueOnce([{ id: 'audit-1' }]).mockResolvedValueOnce([]);
+    mockPrisma.auditLog.deleteMany.mockResolvedValue({ count: 1 });
     mockPrisma.inAppNotification.findMany.mockResolvedValue([]);
     mockPrisma.sLAPerformanceLog.findMany.mockResolvedValue([]);
 
@@ -106,11 +128,13 @@ describe('Data Cleanup Service', () => {
     expect(result.incidents).toBe(2);
     expect(result.events).toBe(10);
     expect(result.logs).toBe(1);
+    expect(result.auditLogs).toBe(1);
 
     // Verify delete WAS called
     expect(mockPrisma.incident.deleteMany).toHaveBeenCalled();
     expect(mockPrisma.alert.deleteMany).toHaveBeenCalled();
     expect(mockPrisma.logEntry.deleteMany).toHaveBeenCalled();
+    expect(mockPrisma.auditLog.deleteMany).toHaveBeenCalled();
     const slaCutoff = mockPrisma.sLAPerformanceLog.findMany.mock.calls[0][0].where.timestamp.lt;
     expect(Date.now() - slaCutoff.getTime()).toBeGreaterThan(360 * 24 * 60 * 60 * 1000);
   });


### PR DESCRIPTION
## Summary
- replace the 200-row event-log cap with paginated, server-side filtering
- apply configured retention to audit logs and incident events using bounded cleanup batches
- default new settings to one year while preserving existing tenant choices
- align retention presets, UI/API validation, and v1.5 documentation
- protect events still inside the configured event-retention period from incident cleanup

## Verification
- `npx tsc --noEmit`
- 27 focused Vitest tests passed
- Prisma schema validation passed
- v1.5 documentation link and capability checks passed

## Note
The full suite requires a configured PostgreSQL URL for its advisory-lock integration test; it passes against the configured local PostgreSQL instance.