### PR TITLE
fix: prevent audit page rendering failures

### DIFF
--- a/src/app/(app)/audit/error.tsx
+++ b/src/app/(app)/audit/error.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+import { logger } from '@/lib/logger';
+
+export default function AuditLogError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logger.error('[AuditLog] Render error', {
+      message: error.message,
+      name: error.name,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1600px] justify-center px-4 py-12 md:px-6">
+      <section className="w-full max-w-lg rounded-xl border border-rose-200 bg-rose-50/60 p-6 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-rose-100">
+          <AlertCircle className="h-6 w-6 text-rose-600" aria-hidden="true" />
+        </div>
+        <h1 className="mt-4 text-lg font-semibold text-slate-900">Audit log couldn&apos;t load</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Please try again. If this continues, an administrator can use the error details in System
+          Logs to investigate.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-5 inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+        >
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          Try again
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/audit/page.tsx
+++ b/src/app/(app)/audit/page.tsx
@@ -20,6 +20,7 @@ import { Shield, FileText } from 'lucide-react';
 import { assertAuditorOrAdmin } from '@/lib/rbac';
 import type { Prisma } from '@prisma/client';
 import { parseAuditEntityType } from '@/lib/audit-filters';
+import { logger } from '@/lib/logger';
 
 import TablePaginationFooter from '@/components/ui/TablePaginationFooter';
 import AuditFilters from '@/components/audit/AuditFilters';
@@ -36,6 +37,19 @@ type AuditLogPageProps = {
     page?: string;
   }>;
 };
+
+const auditLogInclude = {
+  actor: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      avatarUrl: true,
+    },
+  },
+} satisfies Prisma.AuditLogInclude;
+
+type AuditLogRow = Prisma.AuditLogGetPayload<{ include: typeof auditLogInclude }>;
 
 export default async function AuditLogPage({ searchParams }: AuditLogPageProps) {
   await assertAuditorOrAdmin();
@@ -75,26 +89,30 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
     ];
   }
 
-  const [logs, totalLogs] = await Promise.all([
-    prisma.auditLog.findMany({
-      where,
-      include: {
-        actor: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatarUrl: true,
-            gender: true,
-          },
-        },
-      },
-      orderBy: { createdAt: 'desc' },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.auditLog.count({ where }),
-  ]);
+  let logs: AuditLogRow[];
+  let totalLogs: number;
+  try {
+    [logs, totalLogs] = await Promise.all([
+      prisma.auditLog.findMany({
+        where,
+        include: auditLogInclude,
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      prisma.auditLog.count({ where }),
+    ]);
+  } catch (error) {
+    logger.error('[AuditLog] Failed to load records', {
+      error,
+      entityType,
+      hasEntityIdFilter: Boolean(entityId),
+      hasActorIdFilter: Boolean(actorId),
+      hasActionFilter: Boolean(action),
+      hasSearchFilter: Boolean(search),
+    });
+    throw error;
+  }
   const totalPages = Math.max(1, Math.ceil(totalLogs / pageSize));
   const pageHref = (targetPage: number) => {
     const params = new URLSearchParams();
@@ -209,7 +227,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
                                 avatarUrl={
                                   log.actor.avatarUrl ||
                                   getDefaultAvatar(
-                                    log.actor.gender,
+                                    undefined,
                                     log.actor.id || log.actor.name || 'user'
                                   )
                                 }


### PR DESCRIPTION
## Summary
- remove the nonessential `User.gender` column from the audit page query, avoiding a production-schema compatibility failure
- add an audit route error boundary so a server-render failure has a clear recovery UI instead of the application-wide React #441 fallback
- log audit-query failures with safe filter metadata for actionable diagnosis

## Verification
- `npx tsc --noEmit`
- targeted ESLint passed
- `npx vitest run tests/lib/audit-filters.test.ts` passed