### PR TITLE
fix: make audit log rendering resilient

### DIFF
--- a/src/app/(app)/audit/error.tsx
+++ b/src/app/(app)/audit/error.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+import { logger } from '@/lib/logger';
+
+export default function AuditLogError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logger.error('[AuditLog] Render error', {
+      message: error.message,
+      name: error.name,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1600px] justify-center px-4 py-12 md:px-6">
+      <section className="w-full max-w-lg rounded-xl border border-rose-200 bg-rose-50/60 p-6 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-rose-100">
+          <AlertCircle className="h-6 w-6 text-rose-600" aria-hidden="true" />
+        </div>
+        <h1 className="mt-4 text-lg font-semibold text-slate-900">Audit log couldn&apos;t load</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Please try again. If this continues, an administrator can use the error details in System
+          Logs to investigate.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-5 inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+        >
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          Try again
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/audit/page.tsx
+++ b/src/app/(app)/audit/page.tsx
@@ -1,6 +1,4 @@
 import prisma from '@/lib/prisma';
-import { getServerSession } from 'next-auth';
-import { getAuthOptions } from '@/lib/auth';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { DirectUserAvatar } from '@/components/UserAvatar';
 import { getDefaultAvatar } from '@/lib/avatar';
@@ -51,8 +49,25 @@ const auditLogInclude = {
 
 type AuditLogRow = Prisma.AuditLogGetPayload<{ include: typeof auditLogInclude }>;
 
+type AuditLogView = Omit<AuditLogRow, 'createdAt' | 'details'> & {
+  createdAt: string;
+  details: string;
+};
+
+function serializeAuditDetails(details: Prisma.JsonValue | null): string {
+  if (details === null) return '-';
+
+  try {
+    return JSON.stringify(details);
+  } catch (error) {
+    // A malformed historical value should not make the audit log unavailable.
+    logger.warn('[AuditLog] Could not serialize record details', { error });
+    return '[Details unavailable]';
+  }
+}
+
 export default async function AuditLogPage({ searchParams }: AuditLogPageProps) {
-  await assertAuditorOrAdmin();
+  const currentUser = await assertAuditorOrAdmin();
 
   const awaitedParams = await searchParams;
   const entityType = parseAuditEntityType(awaitedParams?.entityType);
@@ -63,12 +78,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
   const page = Math.max(1, Number.parseInt(awaitedParams?.page || '1', 10) || 1);
   const pageSize = 50;
 
-  const session = await getServerSession(await getAuthOptions());
-  const email = session?.user?.email ?? null;
-  const user = email
-    ? await prisma.user.findUnique({ where: { email }, select: { timeZone: true } })
-    : null;
-  const userTimeZone = getUserTimeZone(user ?? undefined);
+  const userTimeZone = getUserTimeZone(currentUser);
 
   const where: Prisma.AuditLogWhereInput = {
     ...(entityType ? { entityType } : {}),
@@ -113,6 +123,11 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
     });
     throw error;
   }
+  const viewLogs: AuditLogView[] = logs.map(log => ({
+    ...log,
+    createdAt: log.createdAt.toISOString(),
+    details: serializeAuditDetails(log.details),
+  }));
   const totalPages = Math.max(1, Math.ceil(totalLogs / pageSize));
   const pageHref = (targetPage: number) => {
     const params = new URLSearchParams();
@@ -150,7 +165,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
           },
           {
             label: 'Page Entries',
-            value: logs.length,
+            value: viewLogs.length,
             icon: <FileText className="h-3.5 w-3.5 text-blue-200" />,
           },
           {
@@ -167,12 +182,12 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
           currentEntityType={entityType}
           currentAction={action}
           currentSearch={search}
-          logsData={logs}
+          logsData={viewLogs}
         />
 
         {/* Audit Table */}
         <Card className="bg-white overflow-hidden shadow-sm">
-          {logs.length === 0 ? (
+          {viewLogs.length === 0 ? (
             <div className="p-6">
               <EmptyState
                 icon={<Shield className="h-6 w-6 text-muted-foreground/60" />}
@@ -212,7 +227,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {logs.map(log => (
+                    {viewLogs.map(log => (
                       <TableRow
                         key={log.id}
                         className="border-b border-slate-100 hover:bg-slate-50/70 transition-colors"
@@ -261,7 +276,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
                           </div>
                         </TableCell>
                         <TableCell className="p-4 text-xs font-mono text-muted-foreground max-w-xs truncate">
-                          {log.details ? JSON.stringify(log.details) : '-'}
+                          {log.details}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/src/app/(app)/audit/page.tsx
+++ b/src/app/(app)/audit/page.tsx
@@ -20,6 +20,7 @@ import { Shield, FileText } from 'lucide-react';
 import { assertAuditorOrAdmin } from '@/lib/rbac';
 import type { Prisma } from '@prisma/client';
 import { parseAuditEntityType } from '@/lib/audit-filters';
+import { logger } from '@/lib/logger';
 
 import TablePaginationFooter from '@/components/ui/TablePaginationFooter';
 import AuditFilters from '@/components/audit/AuditFilters';
@@ -36,6 +37,19 @@ type AuditLogPageProps = {
     page?: string;
   }>;
 };
+
+const auditLogInclude = {
+  actor: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      avatarUrl: true,
+    },
+  },
+} satisfies Prisma.AuditLogInclude;
+
+type AuditLogRow = Prisma.AuditLogGetPayload<{ include: typeof auditLogInclude }>;
 
 export default async function AuditLogPage({ searchParams }: AuditLogPageProps) {
   await assertAuditorOrAdmin();
@@ -75,26 +89,30 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
     ];
   }
 
-  const [logs, totalLogs] = await Promise.all([
-    prisma.auditLog.findMany({
-      where,
-      include: {
-        actor: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatarUrl: true,
-            gender: true,
-          },
-        },
-      },
-      orderBy: { createdAt: 'desc' },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
-    prisma.auditLog.count({ where }),
-  ]);
+  let logs: AuditLogRow[];
+  let totalLogs: number;
+  try {
+    [logs, totalLogs] = await Promise.all([
+      prisma.auditLog.findMany({
+        where,
+        include: auditLogInclude,
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      prisma.auditLog.count({ where }),
+    ]);
+  } catch (error) {
+    logger.error('[AuditLog] Failed to load records', {
+      error,
+      entityType,
+      hasEntityIdFilter: Boolean(entityId),
+      hasActorIdFilter: Boolean(actorId),
+      hasActionFilter: Boolean(action),
+      hasSearchFilter: Boolean(search),
+    });
+    throw error;
+  }
   const totalPages = Math.max(1, Math.ceil(totalLogs / pageSize));
   const pageHref = (targetPage: number) => {
     const params = new URLSearchParams();
@@ -209,7 +227,7 @@ export default async function AuditLogPage({ searchParams }: AuditLogPageProps) 
                                 avatarUrl={
                                   log.actor.avatarUrl ||
                                   getDefaultAvatar(
-                                    log.actor.gender,
+                                    undefined,
                                     log.actor.id || log.actor.name || 'user'
                                   )
                                 }

--- a/src/components/audit/AuditFilters.tsx
+++ b/src/components/audit/AuditFilters.tsx
@@ -29,7 +29,7 @@ export type AuditFiltersProps = {
     actorName: string | null;
     actorEmail: string | null;
     actor?: { name: string | null; email: string | null } | null;
-    details?: unknown;
+    details?: string;
   }>;
 };
 
@@ -81,7 +81,7 @@ export default function AuditFilters({
         { header: 'Entity ID', accessor: row => row.entityId || '-' },
         {
           header: 'Details',
-          accessor: row => (row.details ? JSON.stringify(row.details) : ''),
+          accessor: row => (row.details === '-' ? '' : row.details || ''),
         },
       ],
       logsData


### PR DESCRIPTION
## Summary
- reuse the authorized user data instead of repeating the audit page session and user lookup
- normalize audit records to safe display values before rendering or sending them to the client
- ensure malformed historical audit metadata cannot take down the audit page or break CSV export

## Verification
- `npx tsc --noEmit`
- `npx eslint src/app/(app)/audit/page.tsx src/components/audit/AuditFilters.tsx`
- `npx vitest run tests/lib/audit-filters.test.ts`