### PR TITLE
fix(postmortem): ensure strictly data-driven 5-whys and contributing factors

### DIFF
--- a/src/components/postmortem/FiveWhysBuilder.test.tsx
+++ b/src/components/postmortem/FiveWhysBuilder.test.tsx
@@ -3,6 +3,14 @@ import { describe, it, expect, vi } from 'vitest';
 import FiveWhysBuilder from './FiveWhysBuilder';
 
 describe('FiveWhysBuilder', () => {
+  it('renders clean empty state in view mode when no steps exist', () => {
+    render(<FiveWhysBuilder initialSteps={[]} isEditable={false} />);
+
+    expect(
+      screen.getByText(/No 5-Whys root cause analysis recorded for this incident/i)
+    ).toBeInTheDocument();
+  });
+
   it('renders step questions and answers in view mode', () => {
     const customSteps = [
       { id: '1', question: 'Why did the API slow down?', answer: 'Database connections spiked.' },
@@ -18,9 +26,9 @@ describe('FiveWhysBuilder', () => {
 
   it('allows adding and editing steps in editable mode', () => {
     const onChange = vi.fn();
-    render(<FiveWhysBuilder isEditable={true} onChange={onChange} />);
+    render(<FiveWhysBuilder initialSteps={[]} isEditable={true} onChange={onChange} />);
 
-    const addButton = screen.getByRole('button', { name: /add why step/i });
+    const addButton = screen.getByRole('button', { name: /add first why step/i });
     expect(addButton).toBeInTheDocument();
     fireEvent.click(addButton);
 

--- a/src/components/postmortem/FiveWhysBuilder.tsx
+++ b/src/components/postmortem/FiveWhysBuilder.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
-import { Plus, Trash2, CheckCircle2, Sparkles } from 'lucide-react';
+import { Plus, Trash2, CheckCircle2, Sparkles, HelpCircle } from 'lucide-react';
 
 export type FiveWhysStep = {
   id: string;
@@ -19,33 +19,13 @@ export type FiveWhysBuilderProps = {
   className?: string;
 };
 
-const DEFAULT_STEPS: FiveWhysStep[] = [
-  {
-    id: 'why-1',
-    question: 'Why did the service fail?',
-    answer: 'The database connection pool was exhausted due to a surge in API traffic.',
-  },
-  {
-    id: 'why-2',
-    question: 'Why was the connection pool exhausted?',
-    answer: 'A newly deployed query had no index, causing connections to stay open 10x longer.',
-  },
-  {
-    id: 'why-3',
-    question: 'Why was the query deployed without an index?',
-    answer: 'The migration was omitted from the automated release pipeline.',
-  },
-];
-
 export default function FiveWhysBuilder({
-  initialSteps = DEFAULT_STEPS,
+  initialSteps = [],
   onChange,
   isEditable = false,
   className,
 }: FiveWhysBuilderProps) {
-  const [steps, setSteps] = useState<FiveWhysStep[]>(
-    initialSteps.length > 0 ? initialSteps : DEFAULT_STEPS
-  );
+  const [steps, setSteps] = useState<FiveWhysStep[]>(initialSteps);
 
   const handleUpdate = (updated: FiveWhysStep[]) => {
     setSteps(updated);
@@ -71,6 +51,45 @@ export default function FiveWhysBuilder({
     const updated = steps.map((step, idx) => (idx === index ? { ...step, [field]: value } : step));
     handleUpdate(updated);
   };
+
+  if (steps.length === 0) {
+    if (isEditable) {
+      return (
+        <div
+          className={cn(
+            'p-4 border border-dashed rounded-lg text-center space-y-3 bg-slate-50/50',
+            className
+          )}
+        >
+          <div className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+            <HelpCircle className="h-4 w-4" />
+            <span>Document the 5-Whys causal chain to uncover the root cause.</span>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleAddStep}
+            className="h-8 text-xs gap-1.5 font-semibold bg-white"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            <span>Add First Why Step</span>
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        className={cn(
+          'p-3 rounded-lg bg-slate-50 border border-slate-200/70 text-xs text-muted-foreground italic',
+          className
+        )}
+      >
+        No 5-Whys root cause analysis recorded for this incident.
+      </div>
+    );
+  }
 
   return (
     <div className={cn('space-y-4', className)}>

--- a/src/components/postmortem/PostmortemDetailView.tsx
+++ b/src/components/postmortem/PostmortemDetailView.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import PostmortemTimeline from './PostmortemTimeline';
 import PostmortemImpactMetrics from './PostmortemImpactMetrics';
-import FiveWhysBuilder from './FiveWhysBuilder';
+import FiveWhysBuilder, { type FiveWhysStep } from './FiveWhysBuilder';
 import ContributingFactorsSelector, { type FactorType } from './ContributingFactorsSelector';
 import DueDateBadge from '@/components/action-items/DueDateBadge';
 import { Badge } from '@/components/ui/shadcn/badge';
@@ -141,16 +141,18 @@ export default function PostmortemDetailView({
     POSTMORTEM_STATUS_CONFIG[postmortem.status as keyof typeof POSTMORTEM_STATUS_CONFIG] ||
     POSTMORTEM_STATUS_CONFIG.DRAFT;
 
-  // Infer contributing factors from rootCause text
+  // Infer contributing factors from incident text only when genuine keywords match
   const getInferredFactors = (): FactorType[] => {
     const factors: FactorType[] = [];
-    const text = (postmortem.rootCause || '').toLowerCase();
+    const text = `${postmortem.rootCause || ''} ${postmortem.summary || ''}`.toLowerCase();
     if (
       text.includes('database') ||
       text.includes('server') ||
       text.includes('cpu') ||
       text.includes('memory') ||
-      text.includes('network')
+      text.includes('network') ||
+      text.includes('redis') ||
+      text.includes('postgres')
     ) {
       factors.push('INFRASTRUCTURE');
     }
@@ -159,7 +161,8 @@ export default function PostmortemDetailView({
       text.includes('null') ||
       text.includes('syntax') ||
       text.includes('release') ||
-      text.includes('deploy')
+      text.includes('deploy') ||
+      text.includes('regression')
     ) {
       factors.push('CODE_DEFECT');
     }
@@ -167,17 +170,50 @@ export default function PostmortemDetailView({
       text.includes('monitoring') ||
       text.includes('alert') ||
       text.includes('metric') ||
-      text.includes('blindspot')
+      text.includes('blindspot') ||
+      text.includes('telemetry')
     ) {
       factors.push('MONITORING_GAP');
     }
-    if (text.includes('runbook') || text.includes('procedure') || text.includes('handoff')) {
+    if (
+      text.includes('runbook') ||
+      text.includes('procedure') ||
+      text.includes('handoff') ||
+      text.includes('documentation')
+    ) {
       factors.push('PROCESS');
     }
-    if (factors.length === 0) {
-      factors.push('INFRASTRUCTURE', 'CODE_DEFECT');
+    if (
+      text.includes('vendor') ||
+      text.includes('third-party') ||
+      text.includes('upstream') ||
+      text.includes('aws outage') ||
+      text.includes('cloudflare')
+    ) {
+      factors.push('VENDOR_DEPENDENCY');
     }
     return factors;
+  };
+
+  // Parse structured 5-whys steps from root cause narrative if present
+  const parseFiveWhys = (): FiveWhysStep[] => {
+    if (!postmortem.rootCause) return [];
+
+    const lines = postmortem.rootCause.split('\n').filter(l => l.trim().length > 0);
+    const whyLines = lines.filter(l => /^(why\s*#?\d*|why:|\d+\.\s*why)/i.test(l.trim()));
+
+    if (whyLines.length > 0) {
+      return whyLines.map((line, idx) => {
+        const parts = line.split(/:\s*|\s*-\s*|\s*➔\s*/);
+        return {
+          id: `why-${idx + 1}`,
+          question: parts[0]?.trim() || `Why #${idx + 1}`,
+          answer: parts.slice(1).join(': ').trim() || '',
+        };
+      });
+    }
+
+    return [];
   };
 
   return (
@@ -376,7 +412,7 @@ export default function PostmortemDetailView({
 
           {/* 5-Whys Diagram */}
           <div className="pt-4 border-t border-slate-100">
-            <FiveWhysBuilder />
+            <FiveWhysBuilder initialSteps={parseFiveWhys()} isEditable={false} />
           </div>
 
           {/* Resolution Description */}


### PR DESCRIPTION
### Summary of Changes

- **Eliminated Fake Default Mock Steps**: Removed hardcoded `DEFAULT_STEPS` (database connection pool mock text) from `FiveWhysBuilder`.
- **Added Clean Empty States**:
  - In view mode: If no 5-Whys analysis has been performed for an incident, cleanly renders *"No 5-Whys root cause analysis recorded for this incident."* instead of displaying fake steps.
  - In edit mode: Starts with a clean canvas and an explicit **"Add First Why Step"** button.
- **Removed Fake Factor Assumptions**: Removed hardcoded `INFRASTRUCTURE` / `CODE_DEFECT` fallbacks in `getInferredFactors()`. Only genuine keyword-matched or explicitly selected tags are displayed; otherwise cleanly displays *"No specific contributing factors tagged."*
- **Updated Unit Tests**: Updated `FiveWhysBuilder.test.tsx` to verify empty state and dynamic step additions.