### PR TITLE
feat(notifications): centralize durable delivery control plane

### DIFF
--- a/prisma/migrations/20260831090000_generalize_notification_control_plane/migration.sql
+++ b/prisma/migrations/20260831090000_generalize_notification_control_plane/migration.sql
@@ -47,7 +47,10 @@ ALTER TABLE "Notification"
     ("recipientId" IS NOT NULL AND "recipientHash" IS NOT NULL)
   ),
   ADD CONSTRAINT "Notification_generic_payload_check" CHECK (
-    "category" = 'INCIDENT' OR "payloadEncrypted" IS NOT NULL
+    "category" = 'INCIDENT' OR
+    "payloadEncrypted" IS NOT NULL OR
+    "status" IN ('SENT', 'DELIVERED', 'SKIPPED') OR
+    ("status" = 'FAILED' AND "attempts" >= "maxAttempts")
   );
 
 CREATE UNIQUE INDEX "Notification_deliveryKey_key" ON "Notification"("deliveryKey");

--- a/prisma/migrations/20260831090000_generalize_notification_control_plane/migration.sql
+++ b/prisma/migrations/20260831090000_generalize_notification_control_plane/migration.sql
@@ -1,0 +1,88 @@
+-- Generalize the durable notification ledger without changing the existing
+-- user-specific incident history contract. Existing rows retain INCIDENT/USER
+-- defaults; new system deliveries can target external recipients safely.
+CREATE TYPE "NotificationCategory" AS ENUM (
+  'INCIDENT',
+  'SECURITY',
+  'STATUS_PAGE',
+  'SLA',
+  'ADMINISTRATION',
+  'SYSTEM'
+);
+
+CREATE TYPE "NotificationRecipientType" AS ENUM (
+  'USER',
+  'EMAIL',
+  'PHONE',
+  'SUBSCRIBER',
+  'SLACK_CHANNEL',
+  'WEBHOOK'
+);
+
+ALTER TABLE "Notification"
+  ALTER COLUMN "incidentId" DROP NOT NULL,
+  ALTER COLUMN "userId" DROP NOT NULL,
+  ADD COLUMN "category" "NotificationCategory" NOT NULL DEFAULT 'INCIDENT',
+  ADD COLUMN "recipientType" "NotificationRecipientType" NOT NULL DEFAULT 'USER',
+  ADD COLUMN "recipientId" TEXT,
+  ADD COLUMN "recipientDisplay" TEXT,
+  ADD COLUMN "recipientHash" TEXT,
+  ADD COLUMN "templateKey" TEXT,
+  ADD COLUMN "sourceType" TEXT,
+  ADD COLUMN "sourceId" TEXT,
+  ADD COLUMN "deliveryKey" TEXT,
+  ADD COLUMN "payloadEncrypted" TEXT,
+  ADD COLUMN "priority" INTEGER NOT NULL DEFAULT 5,
+  ADD COLUMN "scheduledAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN "lastAttemptAt" TIMESTAMP(3),
+  ADD COLUMN "maxAttempts" INTEGER NOT NULL DEFAULT 3,
+  ADD COLUMN "expiresAt" TIMESTAMP(3);
+
+ALTER TABLE "Notification"
+  ADD CONSTRAINT "Notification_priority_check" CHECK ("priority" BETWEEN 0 AND 9),
+  ADD CONSTRAINT "Notification_maxAttempts_check" CHECK ("maxAttempts" BETWEEN 1 AND 20),
+  ADD CONSTRAINT "Notification_target_check" CHECK (
+    "userId" IS NOT NULL OR
+    ("recipientId" IS NOT NULL AND "recipientHash" IS NOT NULL)
+  ),
+  ADD CONSTRAINT "Notification_generic_payload_check" CHECK (
+    "category" = 'INCIDENT' OR "payloadEncrypted" IS NOT NULL
+  );
+
+CREATE UNIQUE INDEX "Notification_deliveryKey_key" ON "Notification"("deliveryKey");
+CREATE INDEX "idx_notification_delivery_due"
+  ON "Notification"("status", "nextAttemptAt", "priority", "createdAt");
+CREATE INDEX "idx_notification_category_created"
+  ON "Notification"("category", "createdAt");
+CREATE INDEX "idx_notification_recipient_created"
+  ON "Notification"("recipientHash", "createdAt");
+CREATE INDEX "idx_notification_source_created"
+  ON "Notification"("sourceType", "sourceId", "createdAt");
+CREATE INDEX "idx_notification_created_cursor"
+  ON "Notification"("createdAt", "id");
+
+CREATE TABLE "NotificationDeliveryAttempt" (
+  "id" TEXT NOT NULL,
+  "notificationId" TEXT NOT NULL,
+  "ordinal" INTEGER NOT NULL,
+  "outcome" TEXT NOT NULL,
+  "provider" TEXT,
+  "providerMessageId" TEXT,
+  "errorCode" TEXT,
+  "errorMessage" TEXT,
+  "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "finishedAt" TIMESTAMP(3),
+  "latencyMs" INTEGER,
+  CONSTRAINT "NotificationDeliveryAttempt_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "NotificationDeliveryAttempt_notificationId_fkey"
+    FOREIGN KEY ("notificationId") REFERENCES "Notification"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "NotificationDeliveryAttempt_notificationId_ordinal_key"
+  ON "NotificationDeliveryAttempt"("notificationId", "ordinal");
+CREATE INDEX "NotificationDeliveryAttempt_notificationId_startedAt_idx"
+  ON "NotificationDeliveryAttempt"("notificationId", "startedAt");
+CREATE INDEX "NotificationDeliveryAttempt_outcome_startedAt_idx"
+  ON "NotificationDeliveryAttempt"("outcome", "startedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,24 @@ enum NotificationChannel {
   WHATSAPP
 }
 
+enum NotificationCategory {
+  INCIDENT
+  SECURITY
+  STATUS_PAGE
+  SLA
+  ADMINISTRATION
+  SYSTEM
+}
+
+enum NotificationRecipientType {
+  USER
+  EMAIL
+  PHONE
+  SUBSCRIBER
+  SLACK_CHANNEL
+  WEBHOOK
+}
+
 enum InAppNotificationType {
   INCIDENT
   SCHEDULE
@@ -847,23 +865,40 @@ model OnCallShift {
 
 // Notification model for contact attempts
 model Notification {
-  id                String              @id @default(cuid())
-  incidentId        String
-  userId            String
+  id                String                    @id @default(cuid())
+  incidentId        String?
+  userId            String?
   channel           NotificationChannel
-  status            NotificationStatus  @default(PENDING)
+  status            NotificationStatus        @default(PENDING)
   message           String?
-  eventType         String              @default("triggered")
+  eventType         String                    @default("triggered")
+  category          NotificationCategory      @default(INCIDENT)
+  recipientType     NotificationRecipientType @default(USER)
+  recipientId       String?
+  recipientDisplay  String?
+  recipientHash     String?
+  templateKey       String?
+  sourceType        String?
+  sourceId          String?
+  deliveryKey       String?                   @unique
+  payloadEncrypted  String?
+  priority          Int                       @default(5)
+  scheduledAt       DateTime                  @default(now())
+  nextAttemptAt     DateTime                  @default(now())
+  lastAttemptAt     DateTime?
+  maxAttempts       Int                       @default(3)
+  expiresAt         DateTime?
   sentAt            DateTime?
   deliveredAt       DateTime?
   failedAt          DateTime?
   errorMsg          String?
-  providerMessageId String?             @unique
-  attempts          Int                 @default(0) // Retry attempt count
-  createdAt         DateTime            @default(now())
+  providerMessageId String?                   @unique
+  attempts          Int                       @default(0) // Retry attempt count
+  createdAt         DateTime                  @default(now())
 
-  incident Incident @relation(fields: [incidentId], references: [id])
-  user     User     @relation(fields: [userId], references: [id])
+  incident         Incident?                     @relation(fields: [incidentId], references: [id])
+  user             User?                         @relation(fields: [userId], references: [id])
+  deliveryAttempts NotificationDeliveryAttempt[]
 
   @@index([incidentId]) // For querying notifications by incident
   @@index([userId]) // For querying notifications by user
@@ -873,6 +908,31 @@ model Notification {
   @@index([userId, status, createdAt]) // For user's pending notification queries
   @@index([incidentId, channel], name: "idx_notification_incident_channel") // For channel fallback detection per incident
   @@index([incidentId, userId, status], name: "idx_notification_incident_user_status") // For per-incident per-user dedup checks
+  @@index([status, nextAttemptAt, priority, createdAt], name: "idx_notification_delivery_due")
+  @@index([category, createdAt], name: "idx_notification_category_created")
+  @@index([recipientHash, createdAt], name: "idx_notification_recipient_created")
+  @@index([sourceType, sourceId, createdAt], name: "idx_notification_source_created")
+  @@index([createdAt, id], name: "idx_notification_created_cursor")
+}
+
+model NotificationDeliveryAttempt {
+  id                String    @id @default(cuid())
+  notificationId    String
+  ordinal           Int
+  outcome           String
+  provider          String?
+  providerMessageId String?
+  errorCode         String?
+  errorMessage      String?
+  startedAt         DateTime  @default(now())
+  finishedAt        DateTime?
+  latencyMs         Int?
+
+  notification Notification @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+
+  @@unique([notificationId, ordinal])
+  @@index([notificationId, startedAt])
+  @@index([outcome, startedAt])
 }
 
 model InAppNotification {

--- a/src/app/(app)/settings/custom-fields/page.tsx
+++ b/src/app/(app)/settings/custom-fields/page.tsx
@@ -29,6 +29,13 @@ export default async function CustomFieldsPage() {
       },
     },
   })
+  const serializedCustomFields = customFields.map(field => ({
+    ...field,
+    options:
+      Array.isArray(field.options) && field.options.every(value => typeof value === 'string')
+        ? field.options
+        : null,
+  }))
 
   return (
     <div className="space-y-6">
@@ -43,7 +50,7 @@ export default async function CustomFieldsPage() {
         title="Custom Field Builder"
         description="Create, edit, and manage structured incident metadata"
       >
-        <CustomFieldsConfig customFields={customFields} />
+        <CustomFieldsConfig customFields={serializedCustomFields} />
       </SettingsSection>
     </div>
   )

--- a/src/app/(app)/settings/notifications/operations/page.tsx
+++ b/src/app/(app)/settings/notifications/operations/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation';
+import SettingsPage from '@/components/settings/SettingsPage';
+import SettingsSectionCard from '@/components/settings/SettingsSectionCard';
+import NotificationOperations from '@/components/settings/NotificationOperations';
+import { getCurrentUser } from '@/lib/rbac';
+
+export default async function NotificationOperationsPage() {
+  let user: Awaited<ReturnType<typeof getCurrentUser>>;
+  try {
+    user = await getCurrentUser();
+  } catch {
+    redirect('/login');
+  }
+
+  if (user.role !== 'ADMIN' && user.role !== 'AUDITOR') {
+    redirect('/settings');
+  }
+
+  return (
+    <SettingsPage
+      currentPageId="notification-operations"
+      backHref="/settings"
+      title="Notification Operations"
+      description="Workspace-wide delivery health and recovery for every centralized channel."
+    >
+      <SettingsSectionCard
+        title="Delivery control plane"
+        description="Recipients are masked, provider errors are redacted, and encrypted message payloads are never exposed."
+      >
+        <NotificationOperations canRetry={user.role === 'ADMIN'} />
+      </SettingsSectionCard>
+    </SettingsPage>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -8,8 +8,6 @@ import {
   CardDescription,
   CardContent,
 } from '@/components/ui/shadcn/card';
-import { Input } from '@/components/ui/shadcn/input';
-import { Badge } from '@/components/ui/shadcn/badge';
 import {
   User,
   Settings,
@@ -17,19 +15,19 @@ import {
   Building2,
   Puzzle,
   Bell,
-  Search,
   ArrowRight,
   Lock,
+  type LucideIcon,
 } from 'lucide-react';
 
-const sectionIcons: Record<string, any> = {
+const sectionIcons: Record<string, LucideIcon> = {
   account: User,
   workspace: Building2,
   integrations: Puzzle,
   advanced: Settings,
 };
 
-const itemIcons: Record<string, any> = {
+const itemIcons: Record<string, LucideIcon> = {
   profile: User,
   preferences: Settings,
   security: Shield,
@@ -43,8 +41,13 @@ import '@/styles/pages/settings.css';
 export default async function SettingsOverviewPage() {
   const permissions = await getUserPermissions();
 
-  const canAccess = (item: { requiresAdmin?: boolean; requiresResponder?: boolean }) => {
+  const canAccess = (item: {
+    requiresAdmin?: boolean;
+    requiresAdminOrAuditor?: boolean;
+    requiresResponder?: boolean;
+  }) => {
     if (item.requiresAdmin && !permissions.isAdmin) return false;
+    if (item.requiresAdminOrAuditor && !permissions.isAdmin && !permissions.isAuditor) return false;
     if (item.requiresResponder && !permissions.isResponderOrAbove) return false;
     return true;
   };

--- a/src/app/(app)/users/actions.ts
+++ b/src/app/(app)/users/actions.ts
@@ -13,6 +13,7 @@ import { getServerSession } from 'next-auth';
 import type { Role } from '@prisma/client';
 
 async function sendInviteEmailIfConfigured(data: {
+  userId: string;
   email: string;
   name: string;
   inviteUrl: string;
@@ -26,24 +27,36 @@ async function sendInviteEmailIfConfigured(data: {
       return false;
     }
 
-    const { sendEmail } = await import('@/lib/email');
     const { getUserInviteEmailTemplate } = await import('@/lib/user-invite-email-template');
+    const { enqueueCentralNotification } = await import('@/lib/notification-control-plane');
     const template = getUserInviteEmailTemplate({
       userName: data.name,
       inviteUrl: data.inviteUrl,
       invitedBy: data.invitedBy,
     });
 
-    const result = await sendEmail(
-      {
+    const result = await enqueueCentralNotification({
+      category: 'ADMINISTRATION',
+      channel: 'EMAIL',
+      recipientType: 'USER',
+      recipientId: data.userId,
+      recipientAddress: data.email,
+      userId: data.userId,
+      templateKey: 'user-invitation',
+      sourceType: 'USER_INVITATION',
+      sourceId: data.userId,
+      eventKey: data.inviteUrl,
+      displayMessage: 'Workspace invitation',
+      priority: 2,
+      payload: {
+        kind: 'EMAIL',
         to: data.email,
         subject: template.subject,
         html: template.html,
         text: template.text,
       },
-      emailConfig
-    );
-    return result.success;
+    });
+    return result.delivered === true;
   } catch (error) {
     logger.warn('Failed to send invite email', {
       component: 'users-actions',
@@ -234,9 +247,7 @@ export async function addUser(
     }
 
     let inviteUrl = '';
-    let user: any = null; // Typing as any to avoid Prisma type verbosity in this snippet, or infer it.
-
-    user = await prisma.$transaction(async tx => {
+    const user = await prisma.$transaction(async tx => {
       const newUser = await tx.user.create({
         data: {
           name,
@@ -284,6 +295,7 @@ export async function addUser(
     revalidatePath('/audit');
 
     const emailSent = await sendInviteEmailIfConfigured({
+      userId: user.id,
       email,
       name,
       inviteUrl,
@@ -529,6 +541,7 @@ export async function generateInvite(
   revalidatePath('/audit');
 
   const emailSent = await sendInviteEmailIfConfigured({
+    userId: user.id,
     email: user.email,
     name: user.name || user.email,
     inviteUrl,

--- a/src/app/api/admin/notifications/operations/[id]/retry/route.ts
+++ b/src/app/api/admin/notifications/operations/[id]/retry/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from 'next/server';
+import { getCurrentUser } from '@/lib/rbac';
+import { requeueCentralNotification } from '@/lib/notification-control-plane';
+import { emitAuditEvent } from '@/lib/audit';
+import { logger } from '@/lib/logger';
+import { jsonError, jsonOk } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  let user: Awaited<ReturnType<typeof getCurrentUser>>;
+  try {
+    user = await getCurrentUser();
+  } catch {
+    return jsonError('Authentication required', 401);
+  }
+  if (user.role !== 'ADMIN') {
+    return jsonError('Administrator access required', 403);
+  }
+  const origin = request.headers.get('origin');
+  if (origin !== request.nextUrl.origin) {
+    return jsonError('Invalid request origin', 403);
+  }
+
+  const { id } = await context.params;
+  if (!/^notification_[A-Za-z0-9_-]{1,64}$/.test(id)) {
+    return jsonError('Invalid notification ID', 400);
+  }
+
+  try {
+    const requeued = await requeueCentralNotification(id);
+    if (!requeued) {
+      return jsonError('Notification is not eligible for another delivery attempt', 409);
+    }
+    await emitAuditEvent({
+      action: 'NOTIFICATION_DELIVERY_REQUEUED',
+      source: 'UI',
+      actor: { type: 'USER', id: user.id, email: user.email, name: user.name },
+      target: { type: 'SYSTEM_CONFIG', id },
+      metadata: { notificationId: id },
+    });
+    return jsonOk({ requeued: true }, 200, { 'Cache-Control': 'no-store' });
+  } catch (error) {
+    logger.error('api.admin.notifications.retry.failed', {
+      actorId: user.id,
+      notificationId: id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return jsonError('Unable to requeue notification', 500);
+  }
+}

--- a/src/app/api/admin/notifications/operations/route.ts
+++ b/src/app/api/admin/notifications/operations/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server';
+import type { NotificationCategory, NotificationChannel, NotificationStatus } from '@prisma/client';
+import { getCurrentUser } from '@/lib/rbac';
+import {
+  getNotificationOperations,
+  OPERATIONS_CATEGORIES,
+  OPERATIONS_CHANNELS,
+  OPERATIONS_STATUSES,
+} from '@/lib/notification-operations';
+import { logger } from '@/lib/logger';
+import { jsonError, jsonOk } from '@/lib/api-response';
+
+export const dynamic = 'force-dynamic';
+
+function allowed<T extends string>(value: string | null, values: readonly T[]): T | undefined {
+  return value && values.includes(value as T) ? (value as T) : undefined;
+}
+
+function dateParam(value: string | null): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : undefined;
+}
+
+export async function GET(request: NextRequest) {
+  let user: Awaited<ReturnType<typeof getCurrentUser>>;
+  try {
+    user = await getCurrentUser();
+  } catch {
+    return jsonError('Authentication required', 401);
+  }
+  if (user.role !== 'ADMIN' && user.role !== 'AUDITOR') {
+    return jsonError('Admin or Auditor access required', 403);
+  }
+
+  const params = request.nextUrl.searchParams;
+  const limit = Number.parseInt(params.get('limit') || '50', 10);
+  const from = dateParam(params.get('from'));
+  const to = dateParam(params.get('to'));
+  const channel = allowed<NotificationChannel>(params.get('channel'), OPERATIONS_CHANNELS);
+  const status = allowed<NotificationStatus>(params.get('status'), OPERATIONS_STATUSES);
+  const category = allowed<NotificationCategory>(params.get('category'), OPERATIONS_CATEGORIES);
+  if (
+    (params.has('channel') && !channel) ||
+    (params.has('status') && !status) ||
+    (params.has('category') && !category)
+  ) {
+    return jsonError('Invalid notification operations filter', 400);
+  }
+  if ((params.has('from') && !from) || (params.has('to') && !to)) {
+    return jsonError('Invalid date filter', 400);
+  }
+  if (from && to && from > to) {
+    return jsonError('The start date must be before the end date', 400);
+  }
+  if (from && Date.now() - from.getTime() > 90 * 24 * 60 * 60 * 1000) {
+    return jsonError('Operations queries are limited to 90 days', 400);
+  }
+
+  try {
+    const result = await getNotificationOperations({
+      channel,
+      status,
+      category,
+      query: params.get('q') || undefined,
+      cursor: params.get('cursor') || undefined,
+      limit: Number.isFinite(limit) ? limit : 50,
+      from,
+      to,
+    });
+    return jsonOk(result, 200, { 'Cache-Control': 'private, no-store', Vary: 'Cookie' });
+  } catch (error) {
+    logger.error('api.admin.notifications.operations.failed', {
+      actorId: user.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return jsonError('Unable to load notification operations', 500);
+  }
+}

--- a/src/app/api/notifications/test-push/route.ts
+++ b/src/app/api/notifications/test-push/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { getAuthOptions } from '@/lib/auth';
 import { AppError, isAppError } from '@/lib/errors';
@@ -5,7 +6,7 @@ import { logger } from '@/lib/logger';
 import { getPushConfig } from '@/lib/notification-providers';
 import prisma from '@/lib/prisma';
 import { notificationProviderUnavailable } from '@/lib/provider-errors';
-import { sendPush } from '@/lib/push';
+import { enqueueCentralNotification } from '@/lib/notification-control-plane';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getServerSession } from 'next-auth';
 
@@ -72,18 +73,35 @@ export async function POST() {
       );
     }
 
-    const result = await sendPush({
+    const result = await enqueueCentralNotification({
+      category: 'SYSTEM',
+      channel: 'PUSH',
+      recipientType: 'USER',
+      recipientId: user.id,
+      recipientAddress: user.id,
       userId: user.id,
-      title: '🔔 OpsKnight Test Push',
-      body: `Hey ${user.name || 'there'}! Your push notifications are working perfectly. ✅`,
-      data: {
-        url: '/m/notifications',
-        type: 'test',
+      templateKey: 'test-push',
+      sourceType: 'USER',
+      sourceId: user.id,
+      // Each rate-limited user action is intentionally a distinct delivery request.
+      eventKey: `manual-test:${crypto.randomUUID()}`,
+      displayMessage: 'Test push notification',
+      priority: 2,
+      expiresAt: new Date(Date.now() + 10 * 60_000),
+      payload: {
+        kind: 'PUSH',
+        userId: user.id,
+        title: '🔔 OpsKnight Test Push',
+        body: `Hey ${user.name || 'there'}! Your push notifications are working perfectly. ✅`,
+        data: {
+          url: '/m/notifications',
+          type: 'test',
+        },
+        badge: 1,
       },
-      badge: 1,
     });
 
-    if (!result.success) {
+    if (!result.delivered) {
       const remainingDevices = await prisma.userDevice.count({
         where: { userId: user.id, platform: 'web' },
       });

--- a/src/app/api/status-page/subscribe/route.ts
+++ b/src/app/api/status-page/subscribe/route.ts
@@ -4,7 +4,6 @@ import { jsonError, jsonOk } from '@/lib/api-response';
 import { AppError, isAppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 import { randomBytes } from 'crypto';
-import { sendEmail } from '@/lib/email';
 import { getVerificationEmailTemplate } from '@/lib/status-page-email-templates';
 import { getBaseUrl } from '@/lib/env-validation';
 import { checkRateLimit } from '@/lib/rate-limit';
@@ -130,6 +129,11 @@ export async function POST(req: NextRequest) {
       });
     }
 
+    const subscription = await prisma.statusPageSubscription.findUniqueOrThrow({
+      where: { statusPageId_email: { statusPageId, email: normalizedEmail } },
+      select: { id: true },
+    });
+
     try {
       const { getStatusPageEmailConfig } = await import('@/lib/notification-providers');
       const emailConfig = await getStatusPageEmailConfig(statusPageId);
@@ -165,20 +169,35 @@ export async function POST(req: NextRequest) {
           logoUrl,
         });
 
-        await sendEmail(
-          {
+        const { enqueueCentralNotification } = await import('@/lib/notification-control-plane');
+        const delivery = await enqueueCentralNotification({
+          category: 'STATUS_PAGE',
+          channel: 'EMAIL',
+          recipientType: 'SUBSCRIBER',
+          recipientId: subscription.id,
+          recipientAddress: normalizedEmail,
+          templateKey: 'status-page-verification',
+          sourceType: 'STATUS_PAGE_SUBSCRIPTION',
+          sourceId: subscription.id,
+          eventKey: verificationToken,
+          displayMessage: `Verify subscription to ${statusPage.name}`,
+          priority: 2,
+          payload: {
+            kind: 'EMAIL',
             to: normalizedEmail,
             subject: emailTemplate.subject,
             html: emailTemplate.html,
             text: emailTemplate.text,
+            providerScope: { statusPageId },
           },
-          emailConfig
-        );
+        });
 
-        logger.info('api.status_page.subscription.verification_email_sent', {
+        logger.info('api.status_page.subscription.verification_email_enqueued', {
           statusPageId,
           email: normalizedEmail,
           provider: emailConfig.provider,
+          notificationId: delivery.id,
+          delivered: delivery.delivered === true,
         });
       }
     } catch (emailError) {

--- a/src/app/api/status-page/webhooks/test/route.ts
+++ b/src/app/api/status-page/webhooks/test/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest } from 'next/server';
+import crypto from 'crypto';
 import prisma from '@/lib/prisma';
 import { assertAdmin } from '@/lib/rbac';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { logger } from '@/lib/logger';
-import { deliverWebhook } from '@/lib/status-page-webhooks';
 import { decryptStoredSecret } from '@/lib/encryption';
+import { enqueueCentralNotification } from '@/lib/notification-control-plane';
 
 /**
  * Test webhook endpoint
@@ -28,7 +29,7 @@ export async function POST(req: NextRequest) {
 
     // Get webhook if specific webhookId provided, otherwise test all webhooks for status page
     const webhooks = webhookId
-      ? [await prisma.statusPageWebhook.findUnique({ where: { id: webhookId } })]
+      ? [await prisma.statusPageWebhook.findFirst({ where: { id: webhookId, statusPageId } })]
       : await prisma.statusPageWebhook.findMany({
           where: { statusPageId, enabled: true },
         });
@@ -65,12 +66,29 @@ export async function POST(req: NextRequest) {
           timestamp: new Date().toISOString(),
           data: testPayload,
         };
-        const ok = await deliverWebhook(
-          webhook!.url,
-          await decryptStoredSecret(webhook!.secret),
-          payload
-        );
-        if (!ok) throw new Error(`Failed delivery to ${webhook!.url}`);
+        const deliveryId = crypto.randomUUID();
+        const result = await enqueueCentralNotification({
+          category: 'STATUS_PAGE',
+          channel: 'WEBHOOK',
+          recipientType: 'WEBHOOK',
+          recipientId: webhook!.id,
+          recipientAddress: webhook!.url,
+          templateKey: 'status-page-webhook-test',
+          sourceType: 'STATUS_PAGE_WEBHOOK',
+          sourceId: webhook!.id,
+          eventKey: `manual-test:${deliveryId}`,
+          displayMessage: 'Status-page webhook test',
+          priority: 2,
+          expiresAt: new Date(Date.now() + 10 * 60_000),
+          payload: {
+            kind: 'STATUS_PAGE_WEBHOOK',
+            url: webhook!.url,
+            secret: await decryptStoredSecret(webhook!.secret),
+            payload,
+            deliveryId,
+          },
+        });
+        if (!result.delivered) throw new Error(`Failed delivery to ${webhook!.url}`);
         return { webhookId: webhook!.id, url: webhook!.url, success: true };
       })
     );
@@ -97,7 +115,7 @@ export async function POST(req: NextRequest) {
       },
       200
     );
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger.error('api.status_page.webhook.test_error', {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/components/settings/NotificationOperations.tsx
+++ b/src/components/settings/NotificationOperations.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  ShieldCheck,
+} from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/shadcn/alert';
+import { Badge } from '@/components/ui/shadcn/badge';
+import { Button } from '@/components/ui/shadcn/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
+import { Input } from '@/components/ui/shadcn/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/shadcn/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/shadcn/table';
+import { logger } from '@/lib/logger';
+
+const CHANNELS = ['EMAIL', 'SMS', 'PUSH', 'SLACK', 'WEBHOOK', 'WHATSAPP'] as const;
+const STATUSES = ['PENDING', 'SENT', 'DELIVERED', 'FAILED', 'SKIPPED'] as const;
+const CATEGORIES = [
+  'INCIDENT',
+  'SECURITY',
+  'STATUS_PAGE',
+  'SLA',
+  'ADMINISTRATION',
+  'SYSTEM',
+] as const;
+
+type Operation = {
+  id: string;
+  channel: string;
+  status: string;
+  category: string;
+  recipientDisplay: string | null;
+  templateKey: string | null;
+  sourceType: string | null;
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAt: string;
+  sentAt: string | null;
+  failedAt: string | null;
+  errorMsg: string | null;
+  createdAt: string;
+  incident: { id: string; title: string } | null;
+  lastAttempt: { outcome: string; latencyMs: number; startedAt: string } | null;
+};
+
+type OperationsResponse = {
+  notifications: Operation[];
+  stats: {
+    byStatus: Record<string, number>;
+    byCategory: Record<string, number>;
+  };
+  pagination: { nextCursor: string | null; hasMore: boolean };
+};
+
+type Props = { canRetry: boolean };
+
+function statusVariant(status: string): 'success' | 'warning' | 'danger' | 'outline' {
+  if (status === 'SENT' || status === 'DELIVERED') return 'success';
+  if (status === 'PENDING') return 'warning';
+  if (status === 'FAILED') return 'danger';
+  return 'outline';
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) return '—';
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+export default function NotificationOperations({ canRetry }: Props) {
+  const [rows, setRows] = useState<Operation[]>([]);
+  const [stats, setStats] = useState<Record<string, number>>({});
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+  const [channel, setChannel] = useState('all');
+  const [status, setStatus] = useState('all');
+  const [category, setCategory] = useState('all');
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const requestSequence = useRef(0);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedQuery(query.trim()), 350);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
+  const fetchOperations = useCallback(
+    async (nextCursor?: string) => {
+      const sequence = ++requestSequence.current;
+      if (nextCursor) setLoadingMore(true);
+      else setLoading(true);
+      setError('');
+      const params = new URLSearchParams({ limit: '50' });
+      if (channel !== 'all') params.set('channel', channel);
+      if (status !== 'all') params.set('status', status);
+      if (category !== 'all') params.set('category', category);
+      if (debouncedQuery) params.set('q', debouncedQuery);
+      if (from) params.set('from', new Date(`${from}T00:00:00`).toISOString());
+      if (to) params.set('to', new Date(`${to}T23:59:59.999`).toISOString());
+      if (nextCursor) params.set('cursor', nextCursor);
+
+      try {
+        const response = await fetch(`/api/admin/notifications/operations?${params}`, {
+          cache: 'no-store',
+        });
+        const body = (await response.json()) as OperationsResponse & { error?: string };
+        if (!response.ok) throw new Error(body.error || 'Unable to load delivery operations');
+        if (sequence !== requestSequence.current) return;
+        setRows(current => (nextCursor ? [...current, ...body.notifications] : body.notifications));
+        setStats(body.stats.byStatus);
+        setCursor(body.pagination.nextCursor);
+        setHasMore(body.pagination.hasMore);
+      } catch (caught) {
+        if (sequence !== requestSequence.current) return;
+        const message =
+          caught instanceof Error ? caught.message : 'Unable to load delivery operations';
+        setError(message);
+        logger.error('settings.notification_operations.load_failed', { error: message });
+      } finally {
+        if (sequence === requestSequence.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
+      }
+    },
+    [category, channel, debouncedQuery, from, status, to]
+  );
+
+  useEffect(() => {
+    void fetchOperations();
+  }, [fetchOperations]);
+
+  const retry = async (id: string) => {
+    setRetryingId(id);
+    setError('');
+    try {
+      const response = await fetch(`/api/admin/notifications/operations/${id}/retry`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const body = (await response.json()) as { error?: string };
+      if (!response.ok) throw new Error(body.error || 'Unable to requeue notification');
+      await fetchOperations();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Unable to requeue notification');
+    } finally {
+      setRetryingId(null);
+    }
+  };
+
+  const total = Object.values(stats).reduce((sum, value) => sum + value, 0);
+  const delivered = (stats.SENT || 0) + (stats.DELIVERED || 0);
+
+  return (
+    <div className="space-y-5">
+      <Alert>
+        <ShieldCheck className="h-4 w-4" />
+        <AlertTitle>{canRetry ? 'Administrator control' : 'Auditor read-only access'}</AlertTitle>
+        <AlertDescription>
+          This workspace view contains delivery metadata only. Message bodies and destination
+          secrets remain encrypted at rest and are never returned by the operations API.
+        </AlertDescription>
+      </Alert>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {(
+          [
+            ['Total', total, Activity, 'text-foreground'],
+            ['Delivered', delivered, CheckCircle2, 'text-emerald-600'],
+            ['Pending', stats.PENDING || 0, Clock3, 'text-amber-600'],
+            ['Failed', stats.FAILED || 0, AlertTriangle, 'text-red-600'],
+          ] as const
+        ).map(([label, value, Icon, color]) => (
+          <Card key={String(label)}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">{String(label)}</CardTitle>
+              <Icon className={`h-4 w-4 ${color}`} />
+            </CardHeader>
+            <CardContent className={`text-2xl font-bold ${color}`}>{String(value)}</CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+        <div className="relative xl:col-span-2">
+          <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+          <Input
+            aria-label="Search delivery operations"
+            className="pl-9"
+            placeholder="Search source, incident, or masked recipient"
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+          />
+        </div>
+        <Select value={channel} onValueChange={setChannel}>
+          <SelectTrigger aria-label="Filter by channel">
+            <SelectValue placeholder="Channel" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All channels</SelectItem>
+            {CHANNELS.map(value => (
+              <SelectItem key={value} value={value}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={status} onValueChange={setStatus}>
+          <SelectTrigger aria-label="Filter by status">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            {STATUSES.map(value => (
+              <SelectItem key={value} value={value}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={category} onValueChange={setCategory}>
+          <SelectTrigger aria-label="Filter by category">
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All categories</SelectItem>
+            {CATEGORIES.map(value => (
+              <SelectItem key={value} value={value}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button variant="outline" onClick={() => void fetchOperations()} disabled={loading}>
+          <RefreshCw className={loading ? 'animate-spin' : ''} /> Refresh
+        </Button>
+        <Input
+          aria-label="From date"
+          type="date"
+          value={from}
+          onChange={event => setFrom(event.target.value)}
+        />
+        <Input
+          aria-label="To date"
+          type="date"
+          value={to}
+          onChange={event => setTo(event.target.value)}
+        />
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Delivery operations unavailable</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Status</TableHead>
+              <TableHead>Delivery</TableHead>
+              <TableHead>Recipient</TableHead>
+              <TableHead>Source</TableHead>
+              <TableHead>Attempts</TableHead>
+              <TableHead>Created</TableHead>
+              {canRetry && <TableHead className="text-right">Action</TableHead>}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={canRetry ? 7 : 6} className="h-28 text-center">
+                  <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+                  <span className="sr-only">Loading notification operations</span>
+                </TableCell>
+              </TableRow>
+            ) : rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={canRetry ? 7 : 6}
+                  className="h-28 text-center text-muted-foreground"
+                >
+                  No deliveries match these filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map(row => (
+                <TableRow key={row.id}>
+                  <TableCell>
+                    <Badge variant={statusVariant(row.status)} size="xs">
+                      {row.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="font-medium">{row.channel}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {row.category} · {row.templateKey || 'unspecified'}
+                    </div>
+                    {row.errorMsg && (
+                      <div className="mt-1 max-w-72 text-xs text-destructive" title={row.errorMsg}>
+                        {row.errorMsg}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {row.recipientDisplay || 'Legacy recipient'}
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      className="max-w-56 truncate text-sm"
+                      title={row.incident?.title || row.sourceType || undefined}
+                    >
+                      {row.incident?.title || row.sourceType || '—'}
+                    </div>
+                    <div className="max-w-56 truncate text-xs text-muted-foreground">
+                      {row.sourceType}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <span className="tabular-nums">
+                      {row.attempts}/{row.maxAttempts}
+                    </span>
+                    {row.lastAttempt && (
+                      <div className="text-xs text-muted-foreground">
+                        {row.lastAttempt.latencyMs} ms
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-xs">
+                    {formatTimestamp(row.createdAt)}
+                    {row.status === 'PENDING' && (
+                      <div className="text-muted-foreground">
+                        Next: {formatTimestamp(row.nextAttemptAt)}
+                      </div>
+                    )}
+                  </TableCell>
+                  {canRetry && (
+                    <TableCell className="text-right">
+                      {row.status === 'FAILED' && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={retryingId === row.id}
+                          onClick={() => void retry(row.id)}
+                        >
+                          {retryingId === row.id ? (
+                            <Loader2 className="animate-spin" />
+                          ) : (
+                            <RotateCcw />
+                          )}{' '}
+                          Retry
+                        </Button>
+                      )}
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {hasMore && cursor && (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            disabled={loadingMore}
+            onClick={() => void fetchOperations(cursor)}
+          >
+            {loadingMore && <Loader2 className="animate-spin" />}Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -31,6 +31,7 @@ export default async function SettingsPage({
         <SettingsPageHeader
           currentPageId={currentPageId}
           isAdmin={permissions.isAdmin}
+          isAuditor={permissions.isAuditor}
           isResponderOrAbove={permissions.isResponderOrAbove}
         />
       )}

--- a/src/components/settings/SettingsPageHeader.tsx
+++ b/src/components/settings/SettingsPageHeader.tsx
@@ -9,155 +9,161 @@ import { SETTINGS_NAV_SECTIONS, type SettingsNavItem } from './navConfig';
 import { Badge } from '@/components/ui/shadcn/badge';
 
 type Props = {
-    currentPageId: string;
-    isAdmin?: boolean;
-    isResponderOrAbove?: boolean;
+  currentPageId: string;
+  isAdmin?: boolean;
+  isAuditor?: boolean;
+  isResponderOrAbove?: boolean;
 };
 
-export default function SettingsPageHeader({ currentPageId, isAdmin = false, isResponderOrAbove = false }: Props) {
-    const [isOpen, setIsOpen] = useState(false);
-    const [searchQuery, setSearchQuery] = useState('');
-    const dropdownRef = useRef<HTMLDivElement>(null);
-    const router = useRouter();
+export default function SettingsPageHeader({
+  currentPageId,
+  isAdmin = false,
+  isAuditor = false,
+  isResponderOrAbove = false,
+}: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
 
-    // Find current page info
-    const currentPage = SETTINGS_NAV_SECTIONS
-        .flatMap(section => section.items)
-        .find(item => item.id === currentPageId);
+  // Find current page info
+  const currentPage = SETTINGS_NAV_SECTIONS.flatMap(section => section.items).find(
+    item => item.id === currentPageId
+  );
 
-    // Close dropdown when clicking outside
-    useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-                setIsOpen(false);
-                setSearchQuery('');
-            }
-        };
-
-        if (isOpen) {
-            document.addEventListener('mousedown', handleClickOutside);
-        }
-
-        return () => {
-            document.removeEventListener('mousedown', handleClickOutside);
-        };
-    }, [isOpen]);
-
-    // Filter items based on search
-    const filterItems = (items: SettingsNavItem[]) => {
-        if (!searchQuery) return items;
-
-        const query = searchQuery.toLowerCase();
-        return items.filter(item =>
-            item.label.toLowerCase().includes(query) ||
-            item.description.toLowerCase().includes(query) ||
-            item.keywords?.some(k => k.toLowerCase().includes(query))
-        );
-    };
-
-    // Check if item is accessible
-    const canAccess = (item: SettingsNavItem) => {
-        if (item.requiresAdmin && !isAdmin) return false;
-        if (item.requiresResponder && !isResponderOrAbove) return false;
-        return true;
-    };
-
-    const handleNavigate = (href: string) => {
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
         setSearchQuery('');
-        router.push(href);
+      }
     };
 
-    return (
-        <div className="settings-page-header settings-page-header-switcher">
-            <div className="settings-page-header-nav">
-                <div className="settings-breadcrumb">
-                    <span className="settings-breadcrumb-home">Settings</span>
-                    <span className="settings-breadcrumb-separator">›</span>
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
 
-                    <div className="settings-dropdown" ref={dropdownRef}>
-                        <button
-                            className="settings-dropdown-trigger"
-                            onClick={() => setIsOpen(!isOpen)}
-                            aria-expanded={isOpen}
-                            aria-haspopup="true"
-                        >
-                            <span>{currentPage?.label || 'Settings'}</span>
-                            <ChevronDown size={16} className={isOpen ? 'rotate-180' : ''} />
-                        </button>
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
 
-                        {isOpen && (
-                            <div className="settings-dropdown-menu">
-                                {/* Search */}
-                                <div className="settings-dropdown-search">
-                                    <Search size={16} />
-                                    <input
-                                        type="text"
-                                        placeholder="Jump to setting..."
-                                        value={searchQuery}
-                                        onChange={(e) => setSearchQuery(e.target.value)}
-                                        autoFocus
-                                    />
-                                </div>
+  // Filter items based on search
+  const filterItems = (items: SettingsNavItem[]) => {
+    if (!searchQuery) return items;
 
-                                {/* Navigation items grouped by section */}
-                                <div className="settings-dropdown-content">
-                                    {SETTINGS_NAV_SECTIONS
-                                        .filter(section => section.id !== 'overview')
-                                        .map(section => {
-                                            const filteredItems = filterItems(section.items);
-                                            if (filteredItems.length === 0) return null;
-
-                                            return (
-                                                <div key={section.id} className="settings-dropdown-section">
-                                                    <div className="settings-dropdown-section-label">
-                                                        {section.label}
-                                                    </div>
-                                                    {filteredItems.map(item => {
-                                                        const isDisabled = !canAccess(item);
-                                                        const isActive = item.id === currentPageId;
-
-                                                        if (isDisabled) {
-                                                            return (
-                                                                <div
-                                                                    key={item.id}
-                                                                    className="settings-dropdown-item disabled"
-                                                                    title="Insufficient permissions"
-                                                                >
-                                                                    <span className="settings-dropdown-item-label">
-                                                                        {item.label}
-                                                                    </span>
-                                                                    <Badge variant="neutral" size="xs">
-                                                                        {item.requiresAdmin ? 'Admin' : 'Responder+'}
-                                                                    </Badge>
-                                                                </div>
-                                                            );
-                                                        }
-
-                                                        return (
-                                                            <button
-                                                                key={item.id}
-                                                                className={`settings-dropdown-item ${isActive ? 'active' : ''}`}
-                                                                onClick={() => handleNavigate(item.href)}
-                                                            >
-                                                                <span className="settings-dropdown-item-label">
-                                                                    {item.label}
-                                                                </span>
-                                                                {isActive && (
-                                                                    <span className="settings-dropdown-item-check">✓</span>
-                                                                )}
-                                                            </button>
-                                                        );
-                                                    })}
-                                                </div>
-                                            );
-                                        })}
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                </div>
-            </div>
-        </div>
+    const query = searchQuery.toLowerCase();
+    return items.filter(
+      item =>
+        item.label.toLowerCase().includes(query) ||
+        item.description.toLowerCase().includes(query) ||
+        item.keywords?.some(k => k.toLowerCase().includes(query))
     );
+  };
+
+  // Check if item is accessible
+  const canAccess = (item: SettingsNavItem) => {
+    if (item.requiresAdmin && !isAdmin) return false;
+    if (item.requiresAdminOrAuditor && !isAdmin && !isAuditor) return false;
+    if (item.requiresResponder && !isResponderOrAbove) return false;
+    return true;
+  };
+
+  const handleNavigate = (href: string) => {
+    setIsOpen(false);
+    setSearchQuery('');
+    router.push(href);
+  };
+
+  return (
+    <div className="settings-page-header settings-page-header-switcher">
+      <div className="settings-page-header-nav">
+        <div className="settings-breadcrumb">
+          <span className="settings-breadcrumb-home">Settings</span>
+          <span className="settings-breadcrumb-separator">›</span>
+
+          <div className="settings-dropdown" ref={dropdownRef}>
+            <button
+              className="settings-dropdown-trigger"
+              onClick={() => setIsOpen(!isOpen)}
+              aria-expanded={isOpen}
+              aria-haspopup="true"
+            >
+              <span>{currentPage?.label || 'Settings'}</span>
+              <ChevronDown size={16} className={isOpen ? 'rotate-180' : ''} />
+            </button>
+
+            {isOpen && (
+              <div className="settings-dropdown-menu">
+                {/* Search */}
+                <div className="settings-dropdown-search">
+                  <Search size={16} />
+                  <input
+                    type="text"
+                    placeholder="Jump to setting..."
+                    value={searchQuery}
+                    onChange={e => setSearchQuery(e.target.value)}
+                    autoFocus
+                  />
+                </div>
+
+                {/* Navigation items grouped by section */}
+                <div className="settings-dropdown-content">
+                  {SETTINGS_NAV_SECTIONS.filter(section => section.id !== 'overview').map(
+                    section => {
+                      const filteredItems = filterItems(section.items);
+                      if (filteredItems.length === 0) return null;
+
+                      return (
+                        <div key={section.id} className="settings-dropdown-section">
+                          <div className="settings-dropdown-section-label">{section.label}</div>
+                          {filteredItems.map(item => {
+                            const isDisabled = !canAccess(item);
+                            const isActive = item.id === currentPageId;
+
+                            if (isDisabled) {
+                              return (
+                                <div
+                                  key={item.id}
+                                  className="settings-dropdown-item disabled"
+                                  title="Insufficient permissions"
+                                >
+                                  <span className="settings-dropdown-item-label">{item.label}</span>
+                                  <Badge variant="neutral" size="xs">
+                                    {item.requiresAdmin
+                                      ? 'Admin'
+                                      : item.requiresAdminOrAuditor
+                                        ? 'Admin/Auditor'
+                                        : 'Responder+'}
+                                  </Badge>
+                                </div>
+                              );
+                            }
+
+                            return (
+                              <button
+                                key={item.id}
+                                className={`settings-dropdown-item ${isActive ? 'active' : ''}`}
+                                onClick={() => handleNavigate(item.href)}
+                              >
+                                <span className="settings-dropdown-item-label">{item.label}</span>
+                                {isActive && (
+                                  <span className="settings-dropdown-item-check">✓</span>
+                                )}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      );
+                    }
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/settings/layout/SettingsNav.tsx
+++ b/src/components/settings/layout/SettingsNav.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils';
 
 type Props = {
   isAdmin?: boolean;
+  isAuditor?: boolean;
   isResponderOrAbove?: boolean;
   variant?: 'sidebar' | 'drawer';
   onNavigate?: () => void;
@@ -50,14 +51,20 @@ const iconMap: Record<string, React.ComponentType<{ size?: number; className?: s
 
 export default function SettingsNav({
   isAdmin = false,
+  isAuditor = false,
   isResponderOrAbove = false,
   variant = 'sidebar',
   onNavigate,
 }: Props) {
   const pathname = usePathname();
 
-  const isItemDisabled = (item: { requiresAdmin?: boolean; requiresResponder?: boolean }) => {
+  const isItemDisabled = (item: {
+    requiresAdmin?: boolean;
+    requiresAdminOrAuditor?: boolean;
+    requiresResponder?: boolean;
+  }) => {
     if (item.requiresAdmin && !isAdmin) return true;
+    if (item.requiresAdminOrAuditor && !isAdmin && !isAuditor) return true;
     if (item.requiresResponder && !isResponderOrAbove) return true;
     return false;
   };

--- a/src/components/settings/navConfig.ts
+++ b/src/components/settings/navConfig.ts
@@ -6,6 +6,7 @@ export type SettingsNavItem = {
   icon: string;
   keywords?: string[];
   requiresAdmin?: boolean;
+  requiresAdminOrAuditor?: boolean;
   requiresResponder?: boolean;
 };
 
@@ -118,6 +119,15 @@ export const SETTINGS_NAV_SECTIONS: SettingsNavSection[] = [
         icon: 'bell',
         requiresAdmin: true,
         keywords: ['twilio', 'push', 'sms'],
+      },
+      {
+        id: 'notification-operations',
+        label: 'Notification Operations',
+        description: 'Workspace delivery health, failures, and retries',
+        href: '/settings/notifications/operations',
+        icon: 'activity',
+        requiresAdminOrAuditor: true,
+        keywords: ['delivery', 'operations', 'failures', 'retries', 'dead letter'],
       },
       {
         id: 'audit-logs',

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -7,7 +7,8 @@
 
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { getSlackBotToken, sendSlackMessageToChannel } from '@/lib/slack';
+import { getSlackBotToken } from '@/lib/slack';
+import { enqueueCentralNotification } from '@/lib/notification-control-plane';
 import { getBaseUrl } from '@/lib/env-validation';
 import { retryFetch } from '@/lib/retry';
 
@@ -430,21 +431,35 @@ export async function createIncidentWarRoom(
     const warRoomUrl = generateBridgeUrl(incidentId, videoBridge, customUrl);
 
     // Post Incident Command Card to the channel
-    await sendSlackMessageToChannel(
-      channelId,
-      {
-        id: incident.id,
-        title: incident.title,
-        status: incident.status,
-        urgency: incident.urgency,
-        serviceName: incident.service.name,
-        assigneeName: incident.assignee?.name,
+    await enqueueCentralNotification({
+      category: 'INCIDENT',
+      channel: 'SLACK',
+      recipientType: 'SLACK_CHANNEL',
+      recipientAddress: channelId,
+      incidentId: incident.id,
+      templateKey: 'chatops-war-room-command-card',
+      sourceType: 'INCIDENT',
+      sourceId: incident.id,
+      eventKey: `war-room:${channelId}:command-card`,
+      displayMessage: `War-room command card for ${incident.title}`,
+      priority: 1,
+      payload: {
+        kind: 'SLACK_CHANNEL',
+        channel: channelId,
+        incident: {
+          id: incident.id,
+          title: incident.title,
+          status: incident.status,
+          urgency: incident.urgency,
+          serviceName: incident.service.name,
+          assigneeName: incident.assignee?.name,
+        },
+        eventType: 'triggered',
+        includeInteractiveButtons: true,
+        serviceId: incident.serviceId,
+        additionalMessage: warRoomUrl ? `📹 Video Bridge: ${warRoomUrl}` : undefined,
       },
-      'triggered',
-      true,
-      incident.serviceId,
-      warRoomUrl ? `📹 Video Bridge: ${warRoomUrl}` : undefined
-    ).catch(err => logger.warn('[ChatOps] Failed to post command card', { error: err }));
+    }).catch(err => logger.warn('[ChatOps] Failed to queue command card', { error: err }));
 
     // Post War-Room Welcome & Feature Hints Card
     await postWarRoomWelcomeCard(channelId, incident.title, botToken).catch(err =>

--- a/src/lib/cron-scheduler.ts
+++ b/src/lib/cron-scheduler.ts
@@ -2,6 +2,10 @@ import { processPendingEscalations } from './escalation';
 import { processPendingJobs, cleanupOldJobs } from './jobs/queue';
 import { logger } from './logger';
 import { getNextNotificationRetryAt, retryFailedNotifications } from './notification-retry';
+import {
+  getNextCentralNotificationAt,
+  processCentralNotificationQueue,
+} from './notification-control-plane';
 import { processAutoUnsnoozeInternal } from '@/lib/unsnooze';
 import { cleanupUserTokens } from '@/lib/user-tokens';
 import { cleanupExpiredRateLimits } from '@/lib/rate-limit';
@@ -189,56 +193,64 @@ async function updateState(data: {
 async function getNextScheduledTime(): Promise<Date> {
   try {
     const prisma = (await import('./prisma')).default;
-    const [nextIncident, nextJob, nextSlaBreach, nextSnooze, nextNotificationRetry] =
-      await Promise.all([
-        prisma.incident.findFirst({
-          where: {
-            escalationStatus: 'ESCALATING',
-            nextEscalationAt: { not: null },
-          },
-          orderBy: { nextEscalationAt: 'asc' },
-          select: { nextEscalationAt: true },
-        }),
-        prisma.backgroundJob.findFirst({
-          where: { status: 'PENDING' },
-          orderBy: { scheduledAt: 'asc' },
-          select: { scheduledAt: true },
-        }),
-        prisma.incident.findFirst({
-          where: {
-            status: { in: activeIncidentStatuses() },
-            service: { serviceNotifyOnSlaBreach: true },
-          },
-          orderBy: { createdAt: 'asc' },
-          select: {
-            createdAt: true,
-            acknowledgedAt: true,
-            priority: true,
-            service: {
-              select: {
-                targetAckMinutes: true,
-                targetResolveMinutes: true,
-                serviceNotifyOnSlaBreach: true,
-              },
+    const [
+      nextIncident,
+      nextJob,
+      nextSlaBreach,
+      nextSnooze,
+      nextNotificationRetry,
+      nextCentralNotification,
+    ] = await Promise.all([
+      prisma.incident.findFirst({
+        where: {
+          escalationStatus: 'ESCALATING',
+          nextEscalationAt: { not: null },
+        },
+        orderBy: { nextEscalationAt: 'asc' },
+        select: { nextEscalationAt: true },
+      }),
+      prisma.backgroundJob.findFirst({
+        where: { status: 'PENDING' },
+        orderBy: { scheduledAt: 'asc' },
+        select: { scheduledAt: true },
+      }),
+      prisma.incident.findFirst({
+        where: {
+          status: { in: activeIncidentStatuses() },
+          service: { serviceNotifyOnSlaBreach: true },
+        },
+        orderBy: { createdAt: 'asc' },
+        select: {
+          createdAt: true,
+          acknowledgedAt: true,
+          priority: true,
+          service: {
+            select: {
+              targetAckMinutes: true,
+              targetResolveMinutes: true,
+              serviceNotifyOnSlaBreach: true,
             },
           },
-        }),
-        prisma.incident.findFirst({
-          where: {
-            status: 'SNOOZED',
-            snoozedUntil: { not: null },
-          },
-          orderBy: { snoozedUntil: 'asc' },
-          select: { snoozedUntil: true },
-        }),
-        getNextNotificationRetryAt(),
-      ]);
+        },
+      }),
+      prisma.incident.findFirst({
+        where: {
+          status: 'SNOOZED',
+          snoozedUntil: { not: null },
+        },
+        orderBy: { snoozedUntil: 'asc' },
+        select: { snoozedUntil: true },
+      }),
+      getNextNotificationRetryAt(),
+      getNextCentralNotificationAt(),
+    ]);
 
     const times: (number | null)[] = [
       nextIncident?.nextEscalationAt ? new Date(nextIncident.nextEscalationAt).getTime() : null,
       nextJob?.scheduledAt ? new Date(nextJob.scheduledAt).getTime() : null,
       nextSnooze?.snoozedUntil ? new Date(nextSnooze.snoozedUntil).getTime() : null,
       nextNotificationRetry?.getTime() ?? null,
+      nextCentralNotification?.getTime() ?? null,
     ];
 
     // Add SLA breach check time (proportional warning before ack/resolve target)
@@ -360,17 +372,25 @@ async function runOnce() {
     // Group 2: Secondary tasks (can run in parallel)
     const { processShiftRotations, processUpcomingShiftReminders } =
       await import('./oncall-handoff');
-    const [retryResult, autoUnsnoozeResult, breachResult, handoffResult, reminderCount] =
-      await Promise.all([
-        retryFailedNotifications(),
-        processAutoUnsnoozeInternal(),
-        checkSLABreaches(),
-        processShiftRotations(new Date()),
-        processUpcomingShiftReminders(new Date(), 60),
-      ]);
+    const [
+      retryResult,
+      centralNotificationResult,
+      autoUnsnoozeResult,
+      breachResult,
+      handoffResult,
+      reminderCount,
+    ] = await Promise.all([
+      retryFailedNotifications(),
+      processCentralNotificationQueue(),
+      processAutoUnsnoozeInternal(),
+      checkSLABreaches(),
+      processShiftRotations(new Date()),
+      processUpcomingShiftReminders(new Date(), 60),
+    ]);
 
     logger.info('[Cron] Secondary tasks processed', {
       retries: retryResult,
+      centralNotifications: centralNotificationResult,
       autoUnsnooze: autoUnsnoozeResult,
       slaBreaches: {
         activeIncidents: breachResult.activeIncidentCount,

--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -5,6 +5,7 @@ import { buildScheduleBlocks, getFinalScheduleBlocks } from './oncall';
 import { logger } from './logger';
 import { ESCALATION_LOCK_TIMEOUT_MS } from './config';
 import { startOfDayInTimeZone, startOfNextDayInTimeZone } from './timezone';
+import type { NotificationChannel } from './notifications';
 // import { formatDateTime } from './timezone'; // Unused
 
 export interface EscalationExecutionResult {
@@ -657,11 +658,12 @@ export async function executeEscalation(
     return { escalated: false, reason: 'No users to notify' };
   }
 
-  // Send notifications to all resolved users. Recipient preferences are the
-  // source of truth for channel fan-out; escalation routing chooses who, not
-  // which of their explicitly enabled channels should be suppressed.
+  // Use escalation-step channels when configured, intersected with each
+  // recipient's enabled channels by sendUserNotification.
   const { sendUserNotification } = await import('./user-notifications');
   const notificationsSent = [];
+  const escalationChannels: NotificationChannel[] | undefined =
+    step.notificationChannels.length > 0 ? step.notificationChannels : undefined;
 
   for (const userId of targetUserIds) {
     try {
@@ -678,7 +680,7 @@ export async function executeEscalation(
         return supersededEscalationResult();
       }
       const message = `[OpsKnight] Incident: ${incident.title}${currentStepIndex > 0 ? ` (Escalation Level ${currentStepIndex + 1})` : ''}`;
-      const result = await sendUserNotification(incidentId, userId, message);
+      const result = await sendUserNotification(incidentId, userId, message, escalationChannels);
       notificationsSent.push({ userId, result });
     } catch (err) {
       logger.error('Failed to send escalation notification to user', {

--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -1,8 +1,6 @@
 import { Prisma } from '@prisma/client';
 import prisma from './prisma';
 import { runSerializableTransaction } from './db-utils';
-// import { sendNotification, NotificationChannel } from './notifications'; // Unused
-import type { NotificationChannel } from './notifications';
 import { buildScheduleBlocks, getFinalScheduleBlocks } from './oncall';
 import { logger } from './logger';
 import { ESCALATION_LOCK_TIMEOUT_MS } from './config';
@@ -659,12 +657,11 @@ export async function executeEscalation(
     return { escalated: false, reason: 'No users to notify' };
   }
 
-  // Send notifications to all resolved users
-  // Use escalation step channels if specified, otherwise use user preferences
+  // Send notifications to all resolved users. Recipient preferences are the
+  // source of truth for channel fan-out; escalation routing chooses who, not
+  // which of their explicitly enabled channels should be suppressed.
   const { sendUserNotification } = await import('./user-notifications');
   const notificationsSent = [];
-  const escalationChannels: NotificationChannel[] | undefined =
-    step.notificationChannels.length > 0 ? step.notificationChannels : undefined;
 
   for (const userId of targetUserIds) {
     try {
@@ -681,7 +678,7 @@ export async function executeEscalation(
         return supersededEscalationResult();
       }
       const message = `[OpsKnight] Incident: ${incident.title}${currentStepIndex > 0 ? ` (Escalation Level ${currentStepIndex + 1})` : ''}`;
-      const result = await sendUserNotification(incidentId, userId, message, escalationChannels);
+      const result = await sendUserNotification(incidentId, userId, message);
       notificationsSent.push({ userId, result });
     } catch (err) {
       logger.error('Failed to send escalation notification to user', {

--- a/src/lib/event-side-effects.ts
+++ b/src/lib/event-side-effects.ts
@@ -1,6 +1,5 @@
 import prisma from './prisma';
 import { executeEscalation } from './notifications';
-import { notifySlackForIncident } from './slack';
 import { logger } from './logger';
 import type { EventSideEffectPayload, LifecycleSideEffectContext } from './event-outbox';
 import {
@@ -357,8 +356,10 @@ export async function processEventSideEffect(payload: EventSideEffectPayload): P
       return;
     case 'RESOLVE_SLACK':
       requireDelivery(
-        await notifySlackForIncident(payload.incidentId, 'resolved'),
-        'Slack resolve'
+        await import('./service-notifications').then(module =>
+          module.sendServiceNotifications(payload.incidentId, 'resolved')
+        ),
+        'service resolve notification'
       );
       return;
     case 'RESOLVE_WAR_ROOM_ARCHIVE':
@@ -366,8 +367,10 @@ export async function processEventSideEffect(payload: EventSideEffectPayload): P
       return;
     case 'ACK_SLACK':
       requireDelivery(
-        await notifySlackForIncident(payload.incidentId, 'acknowledged'),
-        'Slack acknowledge'
+        await import('./service-notifications').then(module =>
+          module.sendServiceNotifications(payload.incidentId, 'acknowledged')
+        ),
+        'service acknowledge notification'
       );
       return;
     case 'LIFECYCLE_USER_NOTIFICATION': {

--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -1,0 +1,776 @@
+import 'server-only';
+
+import crypto from 'crypto';
+import {
+  Prisma,
+  type NotificationCategory,
+  type NotificationChannel,
+  type NotificationRecipientType,
+} from '@prisma/client';
+import prisma from './prisma';
+import { CircuitBreakerError, CircuitBreakers } from './circuit-breaker';
+import { decrypt, encrypt, getEncryptionKey } from './encryption';
+import { acquireProviderAdmission, type ProviderAdmissionScope } from './provider-admission';
+import { notificationRetryDelayMs, NOTIFICATION_RETRY_POLICY } from './notification-delivery';
+
+const MAX_ENCRYPTED_PAYLOAD_BYTES = 768 * 1024;
+const MAX_ERROR_LENGTH = 1_000;
+// This lease exceeds every adapter timeout. Reclaiming an active provider call can
+// produce a duplicate on channels that do not support provider-side idempotency.
+const CLAIM_TIMEOUT_MS = 10 * 60_000;
+const SYSTEM_NOTIFICATION_BATCH_SIZE = 100;
+const SYSTEM_NOTIFICATION_CONCURRENCY = 10;
+
+type IncidentPresentation = {
+  id: string;
+  title: string;
+  status: string;
+  urgency: string;
+  serviceName: string;
+  assigneeName?: string;
+};
+
+export type CentralNotificationPayload =
+  | {
+      kind: 'EMAIL';
+      to: string;
+      subject: string;
+      html: string;
+      text?: string;
+      providerScope?: { statusPageId: string };
+    }
+  | { kind: 'SMS'; to: string; message: string }
+  | { kind: 'WHATSAPP'; to: string; message: string; from?: string }
+  | {
+      kind: 'PUSH';
+      userId: string;
+      title: string;
+      body: string;
+      data?: Record<string, unknown>;
+      badge?: number;
+    }
+  | {
+      kind: 'SLACK_CHANNEL';
+      channel: string;
+      incident: IncidentPresentation;
+      eventType: 'triggered' | 'acknowledged' | 'resolved';
+      includeInteractiveButtons?: boolean;
+      serviceId?: string;
+      additionalMessage?: string;
+    }
+  | {
+      kind: 'SLACK_WEBHOOK';
+      incident: IncidentPresentation;
+      eventType: 'triggered' | 'acknowledged' | 'resolved';
+      webhookUrl?: string;
+      additionalMessage?: string;
+    }
+  | {
+      kind: 'WEBHOOK';
+      url: string;
+      payload: Record<string, unknown>;
+      headers?: Record<string, string>;
+      secret?: string;
+      method?: 'POST' | 'PUT' | 'PATCH';
+      timeout?: number;
+    }
+  | {
+      kind: 'STATUS_PAGE_WEBHOOK';
+      url: string;
+      secret: string;
+      payload: { event: string; timestamp: string; data: unknown };
+      deliveryId: string;
+    };
+
+export type CentralNotificationInput = {
+  category: NotificationCategory;
+  channel: NotificationChannel;
+  recipientType: NotificationRecipientType;
+  recipientId?: string;
+  recipientAddress: string;
+  userId?: string;
+  incidentId?: string;
+  templateKey: string;
+  sourceType: string;
+  sourceId: string;
+  eventKey: string;
+  displayMessage: string;
+  payload: CentralNotificationPayload;
+  priority?: number;
+  scheduledAt?: Date;
+  expiresAt?: Date;
+  maxAttempts?: number;
+};
+
+type NotificationStore = Pick<Prisma.TransactionClient, 'notification'>;
+
+type DeliveryResult = {
+  success: boolean;
+  error?: string;
+  providerMessageId?: string;
+};
+
+function normalizedRecipient(channel: NotificationChannel, recipient: string): string {
+  const value = recipient.trim();
+  if (channel === 'EMAIL') return value.toLowerCase();
+  if (channel === 'SMS' || channel === 'WHATSAPP') return value.replace(/[\s().-]/g, '');
+  return value;
+}
+
+export function maskedNotificationRecipient(
+  channel: NotificationChannel,
+  recipient: string
+): string {
+  const value = normalizedRecipient(channel, recipient);
+  if (channel === 'EMAIL') {
+    const separator = value.lastIndexOf('@');
+    if (separator <= 0) return '***';
+    const local = value.slice(0, separator);
+    return `${local.slice(0, 1)}***@${value.slice(separator + 1)}`;
+  }
+  if (channel === 'SMS' || channel === 'WHATSAPP') {
+    return value.length > 4 ? `***${value.slice(-4)}` : '***';
+  }
+  if (channel === 'WEBHOOK') {
+    try {
+      return new URL(value).origin;
+    } catch {
+      return 'Webhook endpoint';
+    }
+  }
+  return value.length > 24 ? `${value.slice(0, 21)}...` : value;
+}
+
+function recipientDigest(channel: NotificationChannel, recipient: string): string {
+  const key = getEncryptionKey();
+  if (!key) throw new Error('Notification encryption is not configured');
+  return crypto
+    .createHmac('sha256', Buffer.from(key, 'hex'))
+    .update(`${channel}\u001f${normalizedRecipient(channel, recipient)}`)
+    .digest('hex');
+}
+
+function stableDigest(...parts: string[]): string {
+  return crypto.createHash('sha256').update(parts.join('\u001f')).digest('hex');
+}
+
+function intentId(deliveryKey: string): string {
+  return `notification_${deliveryKey.slice(0, 31)}`;
+}
+
+function channelForPayload(payload: CentralNotificationPayload): NotificationChannel {
+  if (payload.kind === 'SLACK_CHANNEL' || payload.kind === 'SLACK_WEBHOOK') return 'SLACK';
+  if (payload.kind === 'STATUS_PAGE_WEBHOOK') return 'WEBHOOK';
+  return payload.kind;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isCentralNotificationPayload(value: unknown): value is CentralNotificationPayload {
+  if (!isRecord(value)) return false;
+  switch (value.kind) {
+    case 'EMAIL':
+      return hasText(value.to) && hasText(value.subject) && hasText(value.html);
+    case 'SMS':
+    case 'WHATSAPP':
+      return hasText(value.to) && hasText(value.message);
+    case 'PUSH':
+      return hasText(value.userId) && hasText(value.title) && hasText(value.body);
+    case 'SLACK_CHANNEL':
+      return hasText(value.channel) && isRecord(value.incident) && hasText(value.incident.id);
+    case 'SLACK_WEBHOOK':
+      return isRecord(value.incident) && hasText(value.incident.id);
+    case 'WEBHOOK':
+      return hasText(value.url) && isRecord(value.payload);
+    case 'STATUS_PAGE_WEBHOOK':
+      return (
+        hasText(value.url) &&
+        hasText(value.secret) &&
+        hasText(value.deliveryId) &&
+        isRecord(value.payload) &&
+        hasText(value.payload.event) &&
+        hasText(value.payload.timestamp)
+      );
+    default:
+      return false;
+  }
+}
+
+function assertValidInput(input: CentralNotificationInput): void {
+  if (!isCentralNotificationPayload(input.payload)) {
+    throw new Error('Notification payload is incomplete or unsupported');
+  }
+  if (channelForPayload(input.payload) !== input.channel) {
+    throw new Error('Notification payload does not match the selected channel');
+  }
+  if (!input.templateKey.trim() || !input.sourceType.trim() || !input.sourceId.trim()) {
+    throw new Error('Notification template and source identity are required');
+  }
+  if (!input.eventKey.trim()) throw new Error('A stable notification event key is required');
+  if (input.expiresAt && input.scheduledAt && input.expiresAt <= input.scheduledAt) {
+    throw new Error('Notification expiry must be later than its scheduled time');
+  }
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as { code?: string }).code === 'P2002'
+  );
+}
+
+export async function createCentralNotificationIntent(
+  input: CentralNotificationInput,
+  store: NotificationStore = prisma
+): Promise<{ id: string; created: boolean }> {
+  assertValidInput(input);
+  const recipientHash = recipientDigest(input.channel, input.recipientAddress);
+  const deliveryKey = stableDigest(
+    input.category,
+    input.channel,
+    recipientHash,
+    input.templateKey,
+    input.sourceType,
+    input.sourceId,
+    input.eventKey
+  );
+  const serializedPayload = JSON.stringify(input.payload);
+  if (Buffer.byteLength(serializedPayload, 'utf8') > MAX_ENCRYPTED_PAYLOAD_BYTES) {
+    throw new Error('Notification payload exceeds the durable delivery limit');
+  }
+  const payloadEncrypted = await encrypt(serializedPayload);
+  const scheduledAt = input.scheduledAt ?? new Date();
+  const maxAttempts = Math.min(
+    Math.max(input.maxAttempts ?? NOTIFICATION_RETRY_POLICY.maxAttempts, 1),
+    20
+  );
+  const priority = Math.min(Math.max(input.priority ?? 5, 0), 9);
+  const id = intentId(deliveryKey);
+
+  try {
+    await store.notification.create({
+      data: {
+        id,
+        incidentId: input.incidentId,
+        userId: input.userId,
+        channel: input.channel,
+        status: 'PENDING',
+        message: input.displayMessage.slice(0, 2_000),
+        eventType: input.templateKey,
+        category: input.category,
+        recipientType: input.recipientType,
+        recipientId: input.recipientId || recipientHash,
+        recipientDisplay: maskedNotificationRecipient(input.channel, input.recipientAddress),
+        recipientHash,
+        templateKey: input.templateKey,
+        sourceType: input.sourceType,
+        sourceId: input.sourceId,
+        deliveryKey,
+        payloadEncrypted,
+        priority,
+        scheduledAt,
+        nextAttemptAt: scheduledAt,
+        maxAttempts,
+        expiresAt: input.expiresAt,
+      },
+      select: { id: true },
+    });
+    return { id, created: true };
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const existing = await store.notification.findUnique({
+      where: { deliveryKey },
+      select: { id: true },
+    });
+    if (!existing) throw error;
+    return { id: existing.id, created: false };
+  }
+}
+
+export async function enqueueCentralNotification(
+  input: CentralNotificationInput,
+  options: { dispatchImmediately?: boolean } = {}
+): Promise<{ id: string; created: boolean; delivered?: boolean; error?: string }> {
+  const intent = await createCentralNotificationIntent(input);
+  if (!intent.created || options.dispatchImmediately === false) return intent;
+  const result = await deliverCentralNotification(intent.id);
+  return { ...intent, delivered: result.success, error: result.error };
+}
+
+function payloadProviderKey(payload: CentralNotificationPayload): string {
+  if (payload.kind === 'EMAIL' && payload.providerScope?.statusPageId) {
+    return `status-page:${payload.providerScope.statusPageId}`;
+  }
+  if (payload.kind === 'WEBHOOK' || payload.kind === 'STATUS_PAGE_WEBHOOK') {
+    try {
+      return new URL(payload.url).origin;
+    } catch {
+      return 'invalid-webhook';
+    }
+  }
+  if (payload.kind === 'SLACK_CHANNEL') return `channel:${payload.channel}`;
+  if (payload.kind === 'SLACK_WEBHOOK' && payload.webhookUrl) {
+    try {
+      return new URL(payload.webhookUrl).origin;
+    } catch {
+      return 'invalid-slack-webhook';
+    }
+  }
+  return 'default';
+}
+
+async function providerAdmission(payload: CentralNotificationPayload) {
+  const channel = channelForPayload(payload);
+  if (channel === 'SLACK') return { allowed: true } as const;
+  return acquireProviderAdmission(channel as ProviderAdmissionScope, payloadProviderKey(payload));
+}
+
+async function dispatchPayload(
+  payload: CentralNotificationPayload,
+  notificationId: string
+): Promise<DeliveryResult> {
+  switch (payload.kind) {
+    case 'EMAIL': {
+      const { sendEmail } = await import('./email');
+      const config = payload.providerScope?.statusPageId
+        ? await import('./notification-providers').then(module =>
+            module.getStatusPageEmailConfig(payload.providerScope!.statusPageId)
+          )
+        : undefined;
+      return CircuitBreakers.email().execute(() =>
+        sendEmail(
+          {
+            to: payload.to,
+            subject: payload.subject,
+            html: payload.html,
+            text: payload.text,
+            idempotencyKey: notificationId,
+          },
+          config
+        )
+      );
+    }
+    case 'SMS': {
+      const { sendSMS } = await import('./sms');
+      return CircuitBreakers.sms().execute(async () => {
+        const result = await sendSMS({ to: payload.to, message: payload.message });
+        return { ...result, providerMessageId: result.messageSid };
+      });
+    }
+    case 'WHATSAPP': {
+      const { sendWhatsApp } = await import('./whatsapp');
+      return CircuitBreakers.whatsapp().execute(async () => {
+        const result = await sendWhatsApp(payload.to, payload.message, payload.from);
+        return { ...result, providerMessageId: result.messageSid };
+      });
+    }
+    case 'PUSH': {
+      const { sendPush } = await import('./push');
+      return CircuitBreakers.push().execute(() =>
+        sendPush({
+          userId: payload.userId,
+          title: payload.title,
+          body: payload.body,
+          data: payload.data,
+          badge: payload.badge,
+          deliveryKey: notificationId,
+        })
+      );
+    }
+    case 'SLACK_CHANNEL': {
+      const { sendSlackMessageToChannel } = await import('./slack');
+      return CircuitBreakers.slack().execute(() =>
+        sendSlackMessageToChannel(
+          payload.channel,
+          payload.incident,
+          payload.eventType,
+          payload.includeInteractiveButtons ?? true,
+          payload.serviceId,
+          payload.additionalMessage
+        )
+      );
+    }
+    case 'SLACK_WEBHOOK': {
+      const { sendSlackNotification } = await import('./slack');
+      return CircuitBreakers.slack().execute(() =>
+        sendSlackNotification(
+          payload.eventType,
+          payload.incident,
+          payload.additionalMessage,
+          payload.webhookUrl
+        )
+      );
+    }
+    case 'WEBHOOK': {
+      const { sendWebhook } = await import('./webhooks');
+      return CircuitBreakers.webhook(payload.url).execute(() =>
+        sendWebhook({
+          url: payload.url,
+          payload: payload.payload,
+          headers: payload.headers,
+          secret: payload.secret,
+          method: payload.method,
+          timeout: payload.timeout,
+        })
+      );
+    }
+    case 'STATUS_PAGE_WEBHOOK': {
+      const { deliverWebhook } = await import('./status-page-webhooks');
+      const success = await CircuitBreakers.webhook(payload.url).execute(() =>
+        deliverWebhook(payload.url, payload.secret, payload.payload, payload.deliveryId)
+      );
+      return success
+        ? { success: true, providerMessageId: payload.deliveryId }
+        : { success: false, error: 'Status-page webhook delivery failed' };
+    }
+  }
+}
+
+function safeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/[\r\n\t]+/g, ' ').slice(0, MAX_ERROR_LENGTH);
+}
+
+function isPermanentProviderError(message: string): boolean {
+  return /not configured|not found|invalid|restricted|no phone|no device|no web subscription|unsupported|unknown provider/i.test(
+    message
+  );
+}
+
+async function finishAttempt(input: {
+  notificationId: string;
+  ordinal: number;
+  outcome: string;
+  startedAt: Date;
+  providerMessageId?: string;
+  errorMessage?: string;
+}) {
+  const finishedAt = new Date();
+  await prisma.notificationDeliveryAttempt.create({
+    data: {
+      notificationId: input.notificationId,
+      ordinal: input.ordinal,
+      outcome: input.outcome,
+      providerMessageId: input.providerMessageId,
+      errorMessage: input.errorMessage,
+      startedAt: input.startedAt,
+      finishedAt,
+      latencyMs: Math.max(0, finishedAt.getTime() - input.startedAt.getTime()),
+    },
+  });
+}
+
+export async function deliverCentralNotification(
+  notificationId: string
+): Promise<{ success: boolean; claimed: boolean; error?: string }> {
+  const now = new Date();
+  const candidate = await prisma.notification.findUnique({
+    where: { id: notificationId },
+    select: {
+      id: true,
+      status: true,
+      category: true,
+      attempts: true,
+      maxAttempts: true,
+      nextAttemptAt: true,
+      scheduledAt: true,
+      lastAttemptAt: true,
+      expiresAt: true,
+      payloadEncrypted: true,
+    },
+  });
+  if (!candidate || !candidate.payloadEncrypted) {
+    return { success: false, claimed: false, error: 'Central notification not found' };
+  }
+  if (candidate.status !== 'PENDING' && candidate.status !== 'FAILED') {
+    return { success: false, claimed: false };
+  }
+  if (candidate.expiresAt && candidate.expiresAt <= now) {
+    await prisma.notification.updateMany({
+      where: { id: candidate.id, status: { in: ['PENDING', 'FAILED'] } },
+      data: { status: 'SKIPPED', errorMsg: 'Notification expired before delivery.' },
+    });
+    return { success: true, claimed: true };
+  }
+  if (
+    candidate.attempts >= candidate.maxAttempts ||
+    candidate.scheduledAt > now ||
+    candidate.nextAttemptAt > now
+  ) {
+    return { success: false, claimed: false };
+  }
+  const staleClaimBefore = new Date(now.getTime() - CLAIM_TIMEOUT_MS);
+  const claim = await prisma.notification.updateMany({
+    where: {
+      id: candidate.id,
+      status: candidate.status,
+      attempts: candidate.attempts,
+      scheduledAt: { lte: now },
+      nextAttemptAt: { lte: now },
+      OR: [{ lastAttemptAt: null }, { lastAttemptAt: { lt: staleClaimBefore } }],
+    },
+    data: { status: 'PENDING', lastAttemptAt: now, errorMsg: null },
+  });
+  if (claim.count === 0) return { success: false, claimed: false };
+
+  if (!candidate.payloadEncrypted) {
+    await prisma.notification.updateMany({
+      where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+      data: {
+        status: 'FAILED',
+        attempts: candidate.maxAttempts,
+        failedAt: new Date(),
+        errorMsg: 'Encrypted delivery payload is missing.',
+      },
+    });
+    return { success: false, claimed: true, error: 'Encrypted delivery payload is missing' };
+  }
+
+  let payload: CentralNotificationPayload;
+  try {
+    const decoded: unknown = JSON.parse(await decrypt(candidate.payloadEncrypted));
+    if (!isCentralNotificationPayload(decoded)) throw new Error('Unknown notification payload');
+    payload = decoded;
+  } catch (error) {
+    const errorMessage = safeError(error);
+    await prisma.notification.updateMany({
+      where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+      data: {
+        status: 'FAILED',
+        attempts: candidate.maxAttempts,
+        failedAt: new Date(),
+        errorMsg: `Unable to decrypt delivery payload: ${errorMessage}`,
+      },
+    });
+    return { success: false, claimed: true, error: errorMessage };
+  }
+
+  const admission = await providerAdmission(payload);
+  if (!admission.allowed) {
+    await prisma.notification.updateMany({
+      where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+      data: {
+        status: 'FAILED',
+        failedAt: now,
+        lastAttemptAt: null,
+        nextAttemptAt: admission.retryAt,
+        errorMsg: `Provider admission deferred until ${admission.retryAt.toISOString()}`,
+      },
+    });
+    return { success: false, claimed: true };
+  }
+
+  const ordinal = candidate.attempts + 1;
+  const attemptClaim = await prisma.notification.updateMany({
+    where: {
+      id: candidate.id,
+      status: 'PENDING',
+      lastAttemptAt: now,
+      attempts: candidate.attempts,
+    },
+    data: { attempts: { increment: 1 } },
+  });
+  if (attemptClaim.count === 0) return { success: false, claimed: false };
+  const startedAt = new Date();
+
+  try {
+    const result = await dispatchPayload(payload, candidate.id);
+    if (result.success) {
+      const committed = await prisma.notification.updateMany({
+        where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+        data: {
+          status: 'SENT',
+          sentAt: new Date(),
+          failedAt: null,
+          errorMsg: null,
+          providerMessageId: result.providerMessageId,
+        },
+      });
+      await finishAttempt({
+        notificationId: candidate.id,
+        ordinal,
+        outcome: committed.count > 0 ? 'ACCEPTED' : 'SUPERSEDED',
+        startedAt,
+        providerMessageId: result.providerMessageId,
+      });
+      return { success: true, claimed: true };
+    }
+
+    const errorMessage = safeError(result.error || 'Provider delivery failed');
+    const permanent = isPermanentProviderError(errorMessage);
+    const exhausted = ordinal >= candidate.maxAttempts;
+    await prisma.notification.updateMany({
+      where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+      data: {
+        status: 'FAILED',
+        failedAt: new Date(),
+        errorMsg: errorMessage,
+        nextAttemptAt:
+          permanent || exhausted
+            ? candidate.nextAttemptAt
+            : new Date(Date.now() + notificationRetryDelayMs(ordinal)),
+        attempts: permanent ? candidate.maxAttempts : ordinal,
+        lastAttemptAt: null,
+      },
+    });
+    await finishAttempt({
+      notificationId: candidate.id,
+      ordinal,
+      outcome: permanent || exhausted ? 'PERMANENT_FAILURE' : 'RETRYABLE_FAILURE',
+      startedAt,
+      errorMessage,
+    });
+    return { success: false, claimed: true, error: errorMessage };
+  } catch (error) {
+    const circuitOpen = error instanceof CircuitBreakerError;
+    const errorMessage = safeError(error);
+    const exhausted = ordinal >= candidate.maxAttempts;
+    await prisma.notification.updateMany({
+      where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+      data: {
+        status: 'FAILED',
+        failedAt: new Date(),
+        errorMsg: errorMessage,
+        nextAttemptAt: exhausted
+          ? candidate.nextAttemptAt
+          : new Date(Date.now() + notificationRetryDelayMs(ordinal)),
+        attempts: ordinal,
+        lastAttemptAt: null,
+      },
+    });
+    await finishAttempt({
+      notificationId: candidate.id,
+      ordinal,
+      outcome: circuitOpen ? 'CIRCUIT_OPEN' : exhausted ? 'PERMANENT_FAILURE' : 'RETRYABLE_FAILURE',
+      startedAt,
+      errorMessage,
+    });
+    return { success: false, claimed: true, error: errorMessage };
+  }
+}
+
+export async function processCentralNotificationQueue(): Promise<{
+  processed: number;
+  succeeded: number;
+  failed: number;
+}> {
+  const now = new Date();
+  const staleClaimBefore = new Date(now.getTime() - CLAIM_TIMEOUT_MS);
+  const candidates = await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT "id"
+    FROM "Notification"
+    WHERE "payloadEncrypted" IS NOT NULL
+      AND "attempts" < "maxAttempts"
+      AND "scheduledAt" <= ${now}
+      AND "nextAttemptAt" <= ${now}
+      AND ("expiresAt" IS NULL OR "expiresAt" > ${now})
+      AND (
+        "status" = 'FAILED'::"NotificationStatus"
+        OR (
+          "status" = 'PENDING'::"NotificationStatus"
+          AND ("lastAttemptAt" IS NULL OR "lastAttemptAt" < ${staleClaimBefore})
+        )
+      )
+    ORDER BY "priority" ASC, "nextAttemptAt" ASC, "createdAt" ASC
+    LIMIT ${SYSTEM_NOTIFICATION_BATCH_SIZE}
+  `);
+
+  let succeeded = 0;
+  let failed = 0;
+  for (let index = 0; index < candidates.length; index += SYSTEM_NOTIFICATION_CONCURRENCY) {
+    const batch = candidates.slice(index, index + SYSTEM_NOTIFICATION_CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(item => deliverCentralNotification(item.id))
+    );
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value.claimed && result.value.success)
+        succeeded++;
+      else if (
+        result.status === 'rejected' ||
+        (result.status === 'fulfilled' && result.value.claimed)
+      )
+        failed++;
+    }
+  }
+  return { processed: succeeded + failed, succeeded, failed };
+}
+
+/** Earliest durable control-plane deadline used by the adaptive scheduler. */
+export async function getNextCentralNotificationAt(now: Date = new Date()): Promise<Date | null> {
+  const rows = await prisma.$queryRaw<Array<{ nextAttemptAt: Date }>>(Prisma.sql`
+    SELECT "nextAttemptAt"
+    FROM "Notification"
+    WHERE "payloadEncrypted" IS NOT NULL
+      AND "attempts" < "maxAttempts"
+      AND "status" IN ('PENDING'::"NotificationStatus", 'FAILED'::"NotificationStatus")
+      AND ("expiresAt" IS NULL OR "expiresAt" > ${now})
+    ORDER BY "nextAttemptAt" ASC
+    LIMIT 1
+  `);
+  return rows[0]?.nextAttemptAt ?? null;
+}
+
+export async function requeueCentralNotification(notificationId: string): Promise<boolean> {
+  const notification = await prisma.notification.findFirst({
+    where: {
+      id: notificationId,
+      payloadEncrypted: { not: null },
+      status: 'FAILED',
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    },
+    select: { attempts: true, maxAttempts: true },
+  });
+  if (!notification || notification.attempts >= 20) return false;
+  const maxAttempts = Math.min(20, Math.max(notification.maxAttempts, notification.attempts + 1));
+  const updated = await prisma.notification.updateMany({
+    where: {
+      id: notificationId,
+      payloadEncrypted: { not: null },
+      status: 'FAILED',
+      attempts: notification.attempts,
+      maxAttempts: notification.maxAttempts,
+    },
+    data: {
+      status: 'PENDING',
+      maxAttempts,
+      failedAt: null,
+      errorMsg: null,
+      lastAttemptAt: null,
+      nextAttemptAt: new Date(),
+    },
+  });
+  return updated.count > 0;
+}
+
+export async function cancelCentralNotification(
+  notificationId: string,
+  reason: string
+): Promise<boolean> {
+  const updated = await prisma.notification.updateMany({
+    where: {
+      id: notificationId,
+      payloadEncrypted: { not: null },
+      status: { in: ['PENDING', 'FAILED'] },
+    },
+    data: {
+      status: 'SKIPPED',
+      errorMsg: reason.slice(0, MAX_ERROR_LENGTH),
+      lastAttemptAt: null,
+    },
+  });
+  return updated.count > 0;
+}
+
+export const CENTRAL_NOTIFICATION_LIMITS = Object.freeze({
+  batchSize: SYSTEM_NOTIFICATION_BATCH_SIZE,
+  concurrency: SYSTEM_NOTIFICATION_CONCURRENCY,
+  claimTimeoutMs: CLAIM_TIMEOUT_MS,
+});

--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -492,9 +492,7 @@ async function cleanupExpiredSecurityNotifications(now: Date): Promise<number> {
 }
 
 function isPermanentProviderError(message: string): boolean {
-  return /not configured|not found|invalid|restricted|no phone|no device|no web subscription|unsupported|unknown provider/i.test(
-    message
-  );
+  return /not configured|no (?:enabled email|SMS) provider configured|no Slack webhook URL configured|notifications? (?:are )?(?:disabled|not enabled)|package not installed|configuration incomplete|unsupported provider|unknown provider|invalid phone number format|phone number .* not verified|phone number must include an international country code|no (?:phone number|device|web subscription)|official Slack host|webhook URL is required|invalid or restricted Webhook URL/i.test(message);
 }
 
 async function finishAttempt(input: {
@@ -614,8 +612,8 @@ export async function deliverCentralNotification(
     await prisma.notification.updateMany({
       where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
       data: {
-        status: 'FAILED',
-        failedAt: now,
+        status: 'PENDING',
+        failedAt: null,
         lastAttemptAt: null,
         nextAttemptAt: admission.retryAt,
         errorMsg: `Provider admission deferred until ${admission.retryAt.toISOString()}`,
@@ -669,6 +667,18 @@ export async function deliverCentralNotification(
     if (providerRetryAt) {
       const identity = providerAdmissionIdentity(payload);
       await deferProviderAdmission(identity.scope, identity.providerKey, providerRetryAt);
+      await prisma.notification.updateMany({
+        where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+        data: {
+          status: 'PENDING',
+          attempts: candidate.attempts,
+          failedAt: null,
+          lastAttemptAt: null,
+          nextAttemptAt: providerRetryAt,
+          errorMsg: `Provider rate-limited delivery until ${providerRetryAt.toISOString()}`,
+        },
+      });
+      return { success: false, claimed: true, error: errorMessage };
     }
     const permanent = isPermanentProviderError(errorMessage);
     const exhausted = ordinal >= candidate.maxAttempts;
@@ -691,11 +701,7 @@ export async function deliverCentralNotification(
     await finishAttempt({
       notificationId: candidate.id,
       ordinal,
-      outcome: providerRateLimited
-        ? 'RATE_LIMITED'
-        : permanent || exhausted
-          ? 'PERMANENT_FAILURE'
-          : 'RETRYABLE_FAILURE',
+      outcome: permanent || exhausted ? 'PERMANENT_FAILURE' : 'RETRYABLE_FAILURE',
       startedAt,
       errorMessage,
     });
@@ -704,6 +710,21 @@ export async function deliverCentralNotification(
     const circuitOpen = error instanceof CircuitBreakerError;
     const errorMessage = safeError(error);
     const exhausted = ordinal >= candidate.maxAttempts;
+    if (circuitOpen) {
+      const retryAt = new Date(Date.now() + notificationRetryDelayMs(Math.max(1, ordinal)));
+      await prisma.notification.updateMany({
+        where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
+        data: {
+          status: 'PENDING',
+          attempts: candidate.attempts,
+          failedAt: null,
+          errorMsg: errorMessage,
+          nextAttemptAt: retryAt,
+          lastAttemptAt: null,
+        },
+      });
+      return { success: false, claimed: true, error: errorMessage };
+    }
     await prisma.notification.updateMany({
       where: { id: candidate.id, status: 'PENDING', lastAttemptAt: now },
       data: {
@@ -721,7 +742,7 @@ export async function deliverCentralNotification(
     await finishAttempt({
       notificationId: candidate.id,
       ordinal,
-      outcome: circuitOpen ? 'CIRCUIT_OPEN' : exhausted ? 'PERMANENT_FAILURE' : 'RETRYABLE_FAILURE',
+      outcome: exhausted ? 'PERMANENT_FAILURE' : 'RETRYABLE_FAILURE',
       startedAt,
       errorMessage,
     });

--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -10,7 +10,11 @@ import {
 import prisma from './prisma';
 import { CircuitBreakerError, CircuitBreakers } from './circuit-breaker';
 import { decrypt, encrypt, getEncryptionKey } from './encryption';
-import { acquireProviderAdmission, type ProviderAdmissionScope } from './provider-admission';
+import {
+  acquireProviderAdmission,
+  deferProviderAdmission,
+  type ProviderAdmissionScope,
+} from './provider-admission';
 import { notificationRetryDelayMs, NOTIFICATION_RETRY_POLICY } from './notification-delivery';
 
 const MAX_ENCRYPTED_PAYLOAD_BYTES = 768 * 1024;
@@ -20,6 +24,7 @@ const MAX_ERROR_LENGTH = 1_000;
 const CLAIM_TIMEOUT_MS = 10 * 60_000;
 const SYSTEM_NOTIFICATION_BATCH_SIZE = 100;
 const SYSTEM_NOTIFICATION_CONCURRENCY = 10;
+const SECURITY_PAYLOAD_CLEANUP_BATCH_SIZE = 100;
 
 type IncidentPresentation = {
   id: string;
@@ -108,6 +113,8 @@ type DeliveryResult = {
   success: boolean;
   error?: string;
   providerMessageId?: string;
+  statusCode?: number;
+  retryAfterMs?: number;
 };
 
 function normalizedRecipient(channel: NotificationChannel, recipient: string): string {
@@ -329,8 +336,14 @@ function payloadProviderKey(payload: CentralNotificationPayload): string {
 
 async function providerAdmission(payload: CentralNotificationPayload) {
   const channel = channelForPayload(payload);
-  if (channel === 'SLACK') return { allowed: true } as const;
   return acquireProviderAdmission(channel as ProviderAdmissionScope, payloadProviderKey(payload));
+}
+
+function providerAdmissionIdentity(payload: CentralNotificationPayload) {
+  return {
+    scope: channelForPayload(payload) as ProviderAdmissionScope,
+    providerKey: payloadProviderKey(payload),
+  };
 }
 
 async function dispatchPayload(
@@ -394,7 +407,8 @@ async function dispatchPayload(
           payload.eventType,
           payload.includeInteractiveButtons ?? true,
           payload.serviceId,
-          payload.additionalMessage
+          payload.additionalMessage,
+          { maxAttempts: 1 }
         )
       );
     }
@@ -405,7 +419,8 @@ async function dispatchPayload(
           payload.eventType,
           payload.incident,
           payload.additionalMessage,
-          payload.webhookUrl
+          payload.webhookUrl,
+          { maxAttempts: 1 }
         )
       );
     }
@@ -419,17 +434,25 @@ async function dispatchPayload(
           secret: payload.secret,
           method: payload.method,
           timeout: payload.timeout,
+          maxAttempts: 1,
         })
       );
     }
     case 'STATUS_PAGE_WEBHOOK': {
       const { deliverWebhook } = await import('./status-page-webhooks');
-      const success = await CircuitBreakers.webhook(payload.url).execute(() =>
-        deliverWebhook(payload.url, payload.secret, payload.payload, payload.deliveryId)
+      const result = await CircuitBreakers.webhook(payload.url).execute(() =>
+        deliverWebhook(payload.url, payload.secret, payload.payload, payload.deliveryId, {
+          maxAttempts: 1,
+        })
       );
-      return success
+      return result.success
         ? { success: true, providerMessageId: payload.deliveryId }
-        : { success: false, error: 'Status-page webhook delivery failed' };
+        : {
+            success: false,
+            error: result.error || 'Status-page webhook delivery failed',
+            statusCode: result.statusCode,
+            retryAfterMs: result.retryAfterMs,
+          };
     }
   }
 }
@@ -441,6 +464,31 @@ function safeError(error: unknown): string {
 
 function terminalPayload(category: NotificationCategory): { payloadEncrypted: null } | object {
   return category === 'SECURITY' ? { payloadEncrypted: null } : {};
+}
+
+async function cleanupExpiredSecurityNotifications(now: Date): Promise<number> {
+  const expired = await prisma.notification.findMany({
+    where: {
+      category: 'SECURITY',
+      payloadEncrypted: { not: null },
+      expiresAt: { lte: now },
+      status: { in: ['PENDING', 'FAILED'] },
+    },
+    orderBy: { expiresAt: 'asc' },
+    take: SECURITY_PAYLOAD_CLEANUP_BATCH_SIZE,
+    select: { id: true },
+  });
+  if (expired.length === 0) return 0;
+  const result = await prisma.notification.updateMany({
+    where: { id: { in: expired.map(item => item.id) } },
+    data: {
+      status: 'SKIPPED',
+      payloadEncrypted: null,
+      lastAttemptAt: null,
+      errorMsg: 'Security notification expired before delivery.',
+    },
+  });
+  return result.count;
 }
 
 function isPermanentProviderError(message: string): boolean {
@@ -614,6 +662,14 @@ export async function deliverCentralNotification(
     }
 
     const errorMessage = safeError(result.error || 'Provider delivery failed');
+    const providerRateLimited = result.statusCode === 429;
+    const providerRetryAt = providerRateLimited
+      ? new Date(Date.now() + Math.max(result.retryAfterMs ?? 60_000, 1_000))
+      : null;
+    if (providerRetryAt) {
+      const identity = providerAdmissionIdentity(payload);
+      await deferProviderAdmission(identity.scope, identity.providerKey, providerRetryAt);
+    }
     const permanent = isPermanentProviderError(errorMessage);
     const exhausted = ordinal >= candidate.maxAttempts;
     await prisma.notification.updateMany({
@@ -623,9 +679,10 @@ export async function deliverCentralNotification(
         failedAt: new Date(),
         errorMsg: errorMessage,
         nextAttemptAt:
-          permanent || exhausted
+          providerRetryAt ??
+          (permanent || exhausted
             ? candidate.nextAttemptAt
-            : new Date(Date.now() + notificationRetryDelayMs(ordinal)),
+            : new Date(Date.now() + notificationRetryDelayMs(ordinal))),
         attempts: permanent ? candidate.maxAttempts : ordinal,
         lastAttemptAt: null,
         ...(permanent || exhausted ? terminalPayload(candidate.category) : {}),
@@ -634,7 +691,11 @@ export async function deliverCentralNotification(
     await finishAttempt({
       notificationId: candidate.id,
       ordinal,
-      outcome: permanent || exhausted ? 'PERMANENT_FAILURE' : 'RETRYABLE_FAILURE',
+      outcome: providerRateLimited
+        ? 'RATE_LIMITED'
+        : permanent || exhausted
+          ? 'PERMANENT_FAILURE'
+          : 'RETRYABLE_FAILURE',
       startedAt,
       errorMessage,
     });
@@ -674,6 +735,7 @@ export async function processCentralNotificationQueue(): Promise<{
   failed: number;
 }> {
   const now = new Date();
+  await cleanupExpiredSecurityNotifications(now);
   const staleClaimBefore = new Date(now.getTime() - CLAIM_TIMEOUT_MS);
   const candidates = await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
     SELECT "id"
@@ -716,6 +778,17 @@ export async function processCentralNotificationQueue(): Promise<{
 
 /** Earliest durable control-plane deadline used by the adaptive scheduler. */
 export async function getNextCentralNotificationAt(now: Date = new Date()): Promise<Date | null> {
+  const expiredSecurityNotification = await prisma.notification.findFirst({
+    where: {
+      category: 'SECURITY',
+      payloadEncrypted: { not: null },
+      expiresAt: { lte: now },
+      status: { in: ['PENDING', 'FAILED'] },
+    },
+    select: { id: true },
+  });
+  if (expiredSecurityNotification) return now;
+
   const rows = await prisma.$queryRaw<Array<{ nextEligibleAt: Date }>>(Prisma.sql`
     SELECT GREATEST(
       "scheduledAt",

--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -439,6 +439,10 @@ function safeError(error: unknown): string {
   return message.replace(/[\r\n\t]+/g, ' ').slice(0, MAX_ERROR_LENGTH);
 }
 
+function terminalPayload(category: NotificationCategory): { payloadEncrypted: null } | object {
+  return category === 'SECURITY' ? { payloadEncrypted: null } : {};
+}
+
 function isPermanentProviderError(message: string): boolean {
   return /not configured|not found|invalid|restricted|no phone|no device|no web subscription|unsupported|unknown provider/i.test(
     message
@@ -496,7 +500,11 @@ export async function deliverCentralNotification(
   if (candidate.expiresAt && candidate.expiresAt <= now) {
     await prisma.notification.updateMany({
       where: { id: candidate.id, status: { in: ['PENDING', 'FAILED'] } },
-      data: { status: 'SKIPPED', errorMsg: 'Notification expired before delivery.' },
+      data: {
+        status: 'SKIPPED',
+        errorMsg: 'Notification expired before delivery.',
+        ...terminalPayload(candidate.category),
+      },
     });
     return { success: true, claimed: true };
   }
@@ -592,6 +600,7 @@ export async function deliverCentralNotification(
           failedAt: null,
           errorMsg: null,
           providerMessageId: result.providerMessageId,
+          ...terminalPayload(candidate.category),
         },
       });
       await finishAttempt({
@@ -619,6 +628,7 @@ export async function deliverCentralNotification(
             : new Date(Date.now() + notificationRetryDelayMs(ordinal)),
         attempts: permanent ? candidate.maxAttempts : ordinal,
         lastAttemptAt: null,
+        ...(permanent || exhausted ? terminalPayload(candidate.category) : {}),
       },
     });
     await finishAttempt({
@@ -644,6 +654,7 @@ export async function deliverCentralNotification(
           : new Date(Date.now() + notificationRetryDelayMs(ordinal)),
         attempts: ordinal,
         lastAttemptAt: null,
+        ...(exhausted ? terminalPayload(candidate.category) : {}),
       },
     });
     await finishAttempt({
@@ -705,17 +716,25 @@ export async function processCentralNotificationQueue(): Promise<{
 
 /** Earliest durable control-plane deadline used by the adaptive scheduler. */
 export async function getNextCentralNotificationAt(now: Date = new Date()): Promise<Date | null> {
-  const rows = await prisma.$queryRaw<Array<{ nextAttemptAt: Date }>>(Prisma.sql`
-    SELECT "nextAttemptAt"
+  const rows = await prisma.$queryRaw<Array<{ nextEligibleAt: Date }>>(Prisma.sql`
+    SELECT GREATEST(
+      "scheduledAt",
+      "nextAttemptAt",
+      CASE
+        WHEN "status" = 'PENDING'::"NotificationStatus" AND "lastAttemptAt" IS NOT NULL
+          THEN "lastAttemptAt" + (${CLAIM_TIMEOUT_MS} * INTERVAL '1 millisecond')
+        ELSE "nextAttemptAt"
+      END
+    ) AS "nextEligibleAt"
     FROM "Notification"
     WHERE "payloadEncrypted" IS NOT NULL
       AND "attempts" < "maxAttempts"
       AND "status" IN ('PENDING'::"NotificationStatus", 'FAILED'::"NotificationStatus")
       AND ("expiresAt" IS NULL OR "expiresAt" > ${now})
-    ORDER BY "nextAttemptAt" ASC
+    ORDER BY "nextEligibleAt" ASC
     LIMIT 1
   `);
-  return rows[0]?.nextAttemptAt ?? null;
+  return rows[0]?.nextEligibleAt ?? null;
 }
 
 export async function requeueCentralNotification(notificationId: string): Promise<boolean> {
@@ -764,6 +783,7 @@ export async function cancelCentralNotification(
       status: 'SKIPPED',
       errorMsg: reason.slice(0, MAX_ERROR_LENGTH),
       lastAttemptAt: null,
+      payloadEncrypted: null,
     },
   });
   return updated.count > 0;

--- a/src/lib/notification-operations.ts
+++ b/src/lib/notification-operations.ts
@@ -1,0 +1,198 @@
+import 'server-only';
+
+import type {
+  NotificationCategory,
+  NotificationChannel,
+  NotificationStatus,
+  Prisma,
+} from '@prisma/client';
+import prisma from './prisma';
+
+export const OPERATIONS_CHANNELS = [
+  'EMAIL',
+  'SMS',
+  'PUSH',
+  'SLACK',
+  'WEBHOOK',
+  'WHATSAPP',
+] as const satisfies readonly NotificationChannel[];
+export const OPERATIONS_STATUSES = [
+  'PENDING',
+  'SENT',
+  'DELIVERED',
+  'FAILED',
+  'SKIPPED',
+] as const satisfies readonly NotificationStatus[];
+export const OPERATIONS_CATEGORIES = [
+  'INCIDENT',
+  'SECURITY',
+  'STATUS_PAGE',
+  'SLA',
+  'ADMINISTRATION',
+  'SYSTEM',
+] as const satisfies readonly NotificationCategory[];
+
+type Cursor = { createdAt: string; id: string };
+
+export type NotificationOperationsFilters = {
+  channel?: NotificationChannel;
+  status?: NotificationStatus;
+  category?: NotificationCategory;
+  query?: string;
+  from?: Date;
+  to?: Date;
+  cursor?: string;
+  limit?: number;
+};
+
+function encodeCursor(cursor: Cursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeCursor(value: string | undefined): { createdAt: Date; id: string } | null {
+  if (!value || value.length > 512) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Partial<Cursor>;
+    const createdAt = new Date(parsed.createdAt || '');
+    if (
+      !parsed.id ||
+      parsed.id.length > 191 ||
+      !/^[A-Za-z0-9_-]+$/.test(parsed.id) ||
+      !Number.isFinite(createdAt.getTime())
+    ) {
+      return null;
+    }
+    return { createdAt, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+export function redactNotificationError(value: string | null): string | null {
+  if (!value) return null;
+  return value
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted email]')
+    .replace(/https?:\/\/[^\s]+/gi, '[redacted url]')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, 'Bearer [redacted]')
+    .replace(/\+\d[\d ().-]{6,}\d/g, '[redacted phone]')
+    .replace(/(token|secret|authorization|api[-_ ]?key)\s*[:=]\s*\S+/gi, '$1=[redacted]')
+    .slice(0, 1_000);
+}
+
+export async function getNotificationOperations(
+  filters: NotificationOperationsFilters,
+  now: Date = new Date()
+) {
+  const limit = Math.min(Math.max(filters.limit ?? 50, 1), 100);
+  const defaultFrom = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const cursor = decodeCursor(filters.cursor);
+  const query = filters.query?.trim().slice(0, 120);
+  const baseWhere: Prisma.NotificationWhereInput = {
+    ...(filters.channel ? { channel: filters.channel } : {}),
+    ...(filters.status ? { status: filters.status } : {}),
+    ...(filters.category ? { category: filters.category } : {}),
+    createdAt: {
+      gte: filters.from ?? defaultFrom,
+      ...(filters.to ? { lte: filters.to } : {}),
+    },
+    ...(query
+      ? {
+          OR: [
+            { message: { contains: query, mode: 'insensitive' } },
+            { recipientDisplay: { contains: query, mode: 'insensitive' } },
+            { sourceType: { contains: query, mode: 'insensitive' } },
+            { sourceId: { contains: query, mode: 'insensitive' } },
+            { incident: { title: { contains: query, mode: 'insensitive' } } },
+          ],
+        }
+      : {}),
+  };
+  const where: Prisma.NotificationWhereInput = {
+    ...baseWhere,
+    ...(cursor
+      ? {
+          AND: [
+            {
+              OR: [
+                { createdAt: { lt: cursor.createdAt } },
+                { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+              ],
+            },
+          ],
+        }
+      : {}),
+  };
+
+  const [rows, statusGroups, categoryGroups] = await Promise.all([
+    prisma.notification.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      select: {
+        id: true,
+        channel: true,
+        status: true,
+        category: true,
+        recipientType: true,
+        recipientDisplay: true,
+        templateKey: true,
+        sourceType: true,
+        attempts: true,
+        maxAttempts: true,
+        priority: true,
+        scheduledAt: true,
+        nextAttemptAt: true,
+        sentAt: true,
+        deliveredAt: true,
+        failedAt: true,
+        errorMsg: true,
+        createdAt: true,
+        incident: { select: { id: true, title: true } },
+        deliveryAttempts: {
+          orderBy: { ordinal: 'desc' },
+          take: 1,
+          select: { outcome: true, latencyMs: true, startedAt: true },
+        },
+      },
+    }),
+    prisma.notification.groupBy({ by: ['status'], where: baseWhere, _count: { _all: true } }),
+    prisma.notification.groupBy({ by: ['category'], where: baseWhere, _count: { _all: true } }),
+  ]);
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page.at(-1);
+  const nextCursor =
+    hasMore && last ? encodeCursor({ createdAt: last.createdAt.toISOString(), id: last.id }) : null;
+  const byStatus = Object.fromEntries(OPERATIONS_STATUSES.map(status => [status, 0]));
+  for (const group of statusGroups) byStatus[group.status] = group._count._all;
+  const byCategory = Object.fromEntries(OPERATIONS_CATEGORIES.map(category => [category, 0]));
+  for (const group of categoryGroups) byCategory[group.category] = group._count._all;
+
+  return {
+    notifications: page.map(row => ({
+      ...row,
+      errorMsg: redactNotificationError(row.errorMsg),
+      payloadEncrypted: undefined,
+      createdAt: row.createdAt.toISOString(),
+      scheduledAt: row.scheduledAt.toISOString(),
+      nextAttemptAt: row.nextAttemptAt.toISOString(),
+      sentAt: row.sentAt?.toISOString() ?? null,
+      deliveredAt: row.deliveredAt?.toISOString() ?? null,
+      failedAt: row.failedAt?.toISOString() ?? null,
+      lastAttempt: row.deliveryAttempts[0]
+        ? {
+            ...row.deliveryAttempts[0],
+            startedAt: row.deliveryAttempts[0].startedAt.toISOString(),
+          }
+        : null,
+      deliveryAttempts: undefined,
+    })),
+    stats: { byStatus, byCategory },
+    pagination: { limit, nextCursor, hasMore },
+    range: {
+      from: (filters.from ?? defaultFrom).toISOString(),
+      to: filters.to?.toISOString() ?? null,
+    },
+  };
+}

--- a/src/lib/notification-retry.ts
+++ b/src/lib/notification-retry.ts
@@ -16,6 +16,8 @@ export async function retryFailedNotifications(): Promise<{
 }> {
   await prisma.notification.updateMany({
     where: {
+      category: 'INCIDENT',
+      payloadEncrypted: null,
       status: 'PENDING',
       createdAt: { lt: new Date(Date.now() - NOTIFICATION_RETRY_POLICY.pendingTimeoutMs) },
       attempts: { lt: NOTIFICATION_RETRY_POLICY.maxAttempts },
@@ -30,7 +32,11 @@ export async function retryFailedNotifications(): Promise<{
   const now = Date.now();
   const failedNotifications = await prisma.notification.findMany({
     where: {
+      category: 'INCIDENT',
+      payloadEncrypted: null,
       status: 'FAILED',
+      incidentId: { not: null },
+      userId: { not: null },
       OR: Array.from({ length: NOTIFICATION_RETRY_POLICY.maxAttempts }, (_, attempts) => ({
         attempts,
         failedAt: { lte: new Date(now - notificationRetryDelayMs(attempts)) },
@@ -72,6 +78,9 @@ export async function retryFailedNotifications(): Promise<{
 
           let result;
           try {
+            if (!notification.incidentId || !notification.userId) {
+              throw new Error('Incident notification target is incomplete');
+            }
             result = await dispatchNotificationAttempt({
               notificationId: notification.id,
               incidentId: notification.incidentId,
@@ -184,6 +193,8 @@ export async function getNextNotificationRetryAt(): Promise<Date | null> {
   const [pending, ...failedByAttempt] = await Promise.all([
     prisma.notification.findFirst({
       where: {
+        category: 'INCIDENT',
+        payloadEncrypted: null,
         status: 'PENDING',
         attempts: { lt: NOTIFICATION_RETRY_POLICY.maxAttempts },
       },
@@ -192,7 +203,13 @@ export async function getNextNotificationRetryAt(): Promise<Date | null> {
     }),
     ...attempts.map(attempt =>
       prisma.notification.findFirst({
-        where: { status: 'FAILED', attempts: attempt, failedAt: { not: null } },
+        where: {
+          category: 'INCIDENT',
+          payloadEncrypted: null,
+          status: 'FAILED',
+          attempts: attempt,
+          failedAt: { not: null },
+        },
         orderBy: { failedAt: 'asc' },
         select: { failedAt: true },
       })
@@ -219,10 +236,19 @@ export async function getNotificationRetryStats(): Promise<{
   failedRecent: number;
 }> {
   const [pending, failed, failedRecent] = await Promise.all([
-    prisma.notification.count({ where: { status: 'PENDING' } }),
-    prisma.notification.count({ where: { status: 'FAILED' } }),
     prisma.notification.count({
-      where: { status: 'FAILED', failedAt: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) } },
+      where: { category: 'INCIDENT', payloadEncrypted: null, status: 'PENDING' },
+    }),
+    prisma.notification.count({
+      where: { category: 'INCIDENT', payloadEncrypted: null, status: 'FAILED' },
+    }),
+    prisma.notification.count({
+      where: {
+        category: 'INCIDENT',
+        payloadEncrypted: null,
+        status: 'FAILED',
+        failedAt: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) },
+      },
     }),
   ]);
   return { pending, failed, failedRecent };

--- a/src/lib/password-reset.ts
+++ b/src/lib/password-reset.ts
@@ -82,14 +82,15 @@ export async function initiatePasswordReset(
     const resetLink = `${appUrl}/reset-password?token=${token}`;
 
     let notificationSent = false;
+    let emailIntentId: string | null = null;
 
     // Try email first
     const emailConfig = await getEmailConfig();
     if (emailConfig?.enabled) {
       try {
-        const { sendEmail } = await import('@/lib/email');
         const { getPasswordResetEmailTemplate } =
           await import('@/lib/password-reset-email-template');
+        const { enqueueCentralNotification } = await import('@/lib/notification-control-plane');
 
         const emailTemplate = getPasswordResetEmailTemplate({
           userName: user.name || 'User',
@@ -97,13 +98,30 @@ export async function initiatePasswordReset(
           expiryMinutes: 60,
         });
 
-        await sendEmail({
-          to: user.email,
-          subject: emailTemplate.subject,
-          text: emailTemplate.text,
-          html: emailTemplate.html,
+        const delivery = await enqueueCentralNotification({
+          category: 'SECURITY',
+          channel: 'EMAIL',
+          recipientType: 'USER',
+          recipientId: user.id,
+          recipientAddress: user.email,
+          userId: user.id,
+          templateKey: 'password-reset',
+          sourceType: 'USER',
+          sourceId: user.id,
+          eventKey: tokenHash,
+          displayMessage: 'Password reset instructions',
+          expiresAt: expires,
+          priority: 0,
+          payload: {
+            kind: 'EMAIL',
+            to: user.email,
+            subject: emailTemplate.subject,
+            text: emailTemplate.text,
+            html: emailTemplate.html,
+          },
         });
-        notificationSent = true;
+        emailIntentId = delivery.id;
+        notificationSent = delivery.delivered === true;
       } catch (e) {
         const err = e as Error;
         logger.warn('[PasswordReset] Email sending failed, will try SMS fallback', {
@@ -118,12 +136,35 @@ export async function initiatePasswordReset(
       const smsConfig = await getSMSConfig();
       if (smsConfig?.enabled) {
         try {
-          const { sendSMS } = await import('@/lib/sms');
-          await sendSMS({
-            to: user.phoneNumber,
-            message: `Reset your password: ${resetLink}`,
+          const { enqueueCentralNotification } = await import('@/lib/notification-control-plane');
+          const delivery = await enqueueCentralNotification({
+            category: 'SECURITY',
+            channel: 'SMS',
+            recipientType: 'USER',
+            recipientId: user.id,
+            recipientAddress: user.phoneNumber,
+            userId: user.id,
+            templateKey: 'password-reset-sms',
+            sourceType: 'USER',
+            sourceId: user.id,
+            eventKey: tokenHash,
+            displayMessage: 'Password reset instructions',
+            expiresAt: expires,
+            priority: 0,
+            payload: {
+              kind: 'SMS',
+              to: user.phoneNumber,
+              message: `Reset your password: ${resetLink}`,
+            },
           });
-          notificationSent = true;
+          notificationSent = delivery.delivered === true;
+          if (notificationSent && emailIntentId) {
+            const { cancelCentralNotification } = await import('@/lib/notification-control-plane');
+            await cancelCentralNotification(
+              emailIntentId,
+              'Superseded by successful SMS fallback.'
+            );
+          }
         } catch (_error) {
           logger.warn('[PasswordReset] SMS sending failed', {
             component: 'password-reset',

--- a/src/lib/provider-admission.ts
+++ b/src/lib/provider-admission.ts
@@ -16,6 +16,23 @@ const DEFAULT_LIMITS: Record<ProviderAdmissionScope, { limit: number; windowMs: 
   WEBHOOK: { limit: 20, windowMs: 1_000 },
 };
 
+function providerLimit(scope: ProviderAdmissionScope): { limit: number; windowMs: number } {
+  switch (scope) {
+    case 'EMAIL':
+      return DEFAULT_LIMITS.EMAIL;
+    case 'SMS':
+      return DEFAULT_LIMITS.SMS;
+    case 'WHATSAPP':
+      return DEFAULT_LIMITS.WHATSAPP;
+    case 'PUSH':
+      return DEFAULT_LIMITS.PUSH;
+    case 'SLACK':
+      return DEFAULT_LIMITS.SLACK;
+    case 'WEBHOOK':
+      return DEFAULT_LIMITS.WEBHOOK;
+  }
+}
+
 function bucketKey(scope: ProviderAdmissionScope, providerKey: string): string {
   return `provider:${scope.toLowerCase()}:${providerKey}`.slice(0, 240);
 }
@@ -29,7 +46,7 @@ export async function acquireProviderAdmission(
   providerKey: string,
   now: Date = new Date()
 ): Promise<ProviderAdmissionResult> {
-  const config = DEFAULT_LIMITS[scope];
+  const config = providerLimit(scope);
   const key = bucketKey(scope, providerKey);
 
   return prisma.$transaction(
@@ -62,7 +79,7 @@ export async function deferProviderAdmission(
   providerKey: string,
   retryAt: Date
 ): Promise<void> {
-  const config = DEFAULT_LIMITS[scope];
+  const config = providerLimit(scope);
   const key = bucketKey(scope, providerKey);
   await prisma.$executeRaw(Prisma.sql`
     INSERT INTO "RateLimit" ("key", "count", "expiresAt")

--- a/src/lib/provider-admission.ts
+++ b/src/lib/provider-admission.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import prisma from './prisma';
 
-export type ProviderAdmissionScope = 'EMAIL' | 'SMS' | 'WHATSAPP' | 'PUSH' | 'WEBHOOK';
+export type ProviderAdmissionScope = 'EMAIL' | 'SMS' | 'WHATSAPP' | 'PUSH' | 'SLACK' | 'WEBHOOK';
 
 export type ProviderAdmissionResult =
   | { allowed: true }
@@ -12,6 +12,7 @@ const DEFAULT_LIMITS: Record<ProviderAdmissionScope, { limit: number; windowMs: 
   SMS: { limit: 20, windowMs: 1_000 },
   WHATSAPP: { limit: 50, windowMs: 1_000 },
   PUSH: { limit: 100, windowMs: 1_000 },
+  SLACK: { limit: 1, windowMs: 1_000 },
   WEBHOOK: { limit: 20, windowMs: 1_000 },
 };
 
@@ -53,4 +54,21 @@ export async function acquireProviderAdmission(
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
   );
+}
+
+/** Persist a provider-supplied cooldown (for example HTTP Retry-After) across replicas. */
+export async function deferProviderAdmission(
+  scope: ProviderAdmissionScope,
+  providerKey: string,
+  retryAt: Date
+): Promise<void> {
+  const config = DEFAULT_LIMITS[scope];
+  const key = bucketKey(scope, providerKey);
+  await prisma.$executeRaw(Prisma.sql`
+    INSERT INTO "RateLimit" ("key", "count", "expiresAt")
+    VALUES (${key}, ${config.limit}, ${retryAt})
+    ON CONFLICT ("key") DO UPDATE SET
+      "count" = GREATEST("RateLimit"."count", EXCLUDED."count"),
+      "expiresAt" = GREATEST("RateLimit"."expiresAt", EXCLUDED."expiresAt")
+  `);
 }

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -172,6 +172,7 @@ export async function retryFetch(
     // Check if response status is retryable
     if (!response.ok && isRetryableHttpError(response.status)) {
       const retryAfter = response.headers?.get ? response.headers.get('Retry-After') : null;
+      let retryAfterMs: number | undefined;
       if (response.status === 429 && retryAfter) {
         let waitMs = 0;
         const seconds = parseInt(retryAfter, 10);
@@ -185,10 +186,19 @@ export async function retryFetch(
           }
         }
         if (waitMs > 0) {
-          await sleep(Math.min(waitMs, 60000));
+          retryAfterMs = waitMs;
+          if ((retryOptions?.maxAttempts ?? DEFAULT_OPTIONS.maxAttempts) > 1) {
+            await sleep(Math.min(waitMs, 60000));
+          }
         }
       }
-      const err = new Error(`HTTP ${response.status}: ${response.statusText || 'Error'}`) as any;
+      const err = new Error(`HTTP ${response.status}: ${response.statusText || 'Error'}`) as Error & {
+        statusCode?: number;
+        retryAfterHandled?: boolean;
+        retryAfterMs?: number;
+      };
+      err.statusCode = response.status;
+      err.retryAfterMs = retryAfterMs;
       if (response.status === 429 && retryAfter) {
         err.retryAfterHandled = true;
       }

--- a/src/lib/service-notifications.ts
+++ b/src/lib/service-notifications.ts
@@ -1,9 +1,9 @@
 /** Service notification dispatcher with target-level durable idempotency. */
 import prisma from './prisma';
-import { notifySlackForIncident, sendSlackMessageToChannel } from './slack';
-import { sendIncidentWebhook } from './webhooks';
 import { logger } from './logger';
-import { deliveryMarkerId, isDeliveryComplete, markDeliveryComplete } from './delivery-idempotency';
+import { enqueueCentralNotification } from './notification-control-plane';
+import { formatWebhookPayloadByType, generateIncidentWebhookPayload } from './webhooks';
+import { getBaseUrl } from './env-validation';
 
 export type ServiceNotificationEventType = 'triggered' | 'acknowledged' | 'resolved' | 'updated';
 
@@ -28,22 +28,15 @@ function serviceDeliveryKey(
   return `${incident.id}:${eventType}:${at.toISOString()}`;
 }
 
-async function once(
-  deliveryKey: string,
-  targetId: string,
-  deliver: () => Promise<{ success: boolean; error?: string }>
-): Promise<{ success: boolean; skipped?: boolean; error?: string }> {
-  const markerId = deliveryMarkerId('service-notification', deliveryKey, targetId);
-  if (await isDeliveryComplete(markerId)) return { success: true, skipped: true };
-  const result = await deliver();
-  if (result.success)
-    await markDeliveryComplete({
-      markerId,
-      namespace: 'service-notification',
-      deliveryKey,
-      targetId,
-    });
-  return result;
+async function persistIntent(
+  deliver: () => Promise<void>
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await deliver();
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 export async function sendServiceNotifications(
@@ -100,41 +93,79 @@ export async function sendServiceNotifications(
       : serviceDeliveryKey(incident, eventType);
     const serviceChannels = service.serviceNotificationChannels || [];
     const errors: string[] = [];
+    const incidentPresentation = {
+      id: incident.id,
+      title: incident.title,
+      status: incident.status,
+      urgency: incident.urgency,
+      serviceName: service.name,
+      assigneeName: incident.assignee?.name || undefined,
+    };
+    const webhookIncident = {
+      id: incident.id,
+      title: incident.title,
+      description: incident.description,
+      status: incident.status,
+      urgency: incident.urgency,
+      service: { id: service.id, name: service.name },
+      assignee: incident.assignee,
+      createdAt: incident.createdAt,
+      acknowledgedAt: incident.acknowledgedAt,
+      resolvedAt: incident.resolvedAt,
+    };
 
     if (serviceChannels.includes('SLACK')) {
       if (service.slackChannel && eventType !== 'updated') {
-        const result = await once(deliveryKey, `slack-channel:${service.id}`, async () => {
-          const response = await sendSlackMessageToChannel(
-            service.slackChannel!,
-            {
-              id: incident.id,
-              title: incident.title,
-              status: incident.status,
-              urgency: incident.urgency,
-              serviceName: service.name,
-              assigneeName: incident.assignee?.name,
+        const result = await persistIntent(async () => {
+          await enqueueCentralNotification({
+            category: 'INCIDENT',
+            channel: 'SLACK',
+            recipientType: 'SLACK_CHANNEL',
+            recipientId: service.id,
+            recipientAddress: service.slackChannel!,
+            incidentId,
+            templateKey: `service-slack-${eventType}`,
+            sourceType: 'SERVICE_INCIDENT',
+            sourceId: `${service.id}:${incidentId}`,
+            eventKey: deliveryKey,
+            displayMessage: `${eventType}: ${incident.title}`,
+            priority: incident.urgency === 'HIGH' ? 1 : 3,
+            payload: {
+              kind: 'SLACK_CHANNEL',
+              channel: service.slackChannel!,
+              incident: incidentPresentation,
+              eventType,
+              includeInteractiveButtons: true,
+              serviceId: incident.serviceId,
             },
-            eventType,
-            true,
-            incident.serviceId
-          );
-          return { success: response.success, error: response.error };
+          });
         });
         if (!result.success)
           errors.push(`Slack channel notification failed: ${result.error || 'Unknown error'}`);
       }
 
       if (service.slackWebhookUrl && eventType !== 'updated') {
-        const result = await once(deliveryKey, `slack-webhook:${service.id}`, async () => {
-          try {
-            const response = await notifySlackForIncident(incidentId, eventType);
-            return { success: response.success, error: response.error };
-          } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-            };
-          }
+        const result = await persistIntent(async () => {
+          await enqueueCentralNotification({
+            category: 'INCIDENT',
+            channel: 'SLACK',
+            recipientType: 'WEBHOOK',
+            recipientId: service.id,
+            recipientAddress: service.slackWebhookUrl!,
+            incidentId,
+            templateKey: `service-slack-webhook-${eventType}`,
+            sourceType: 'SERVICE_INCIDENT',
+            sourceId: `${service.id}:${incidentId}`,
+            eventKey: deliveryKey,
+            displayMessage: `${eventType}: ${incident.title}`,
+            priority: incident.urgency === 'HIGH' ? 1 : 3,
+            payload: {
+              kind: 'SLACK_WEBHOOK',
+              incident: incidentPresentation,
+              eventType,
+              webhookUrl: service.slackWebhookUrl!,
+            },
+          });
         });
         if (!result.success)
           errors.push(`Slack webhook notification failed: ${result.error || 'Unknown error'}`);
@@ -144,23 +175,34 @@ export async function sendServiceNotifications(
     if (serviceChannels.includes('WEBHOOK')) {
       const results = await Promise.all(
         service.webhookIntegrations.map(async webhook => {
-          const result = await once(deliveryKey, `webhook:${webhook.id}`, async () => {
-            try {
-              const { decryptStoredSecret } = await import('./encryption');
-              return await sendIncidentWebhook(
-                webhook.url,
-                incidentId,
-                eventType,
-                webhook.secret ? await decryptStoredSecret(webhook.secret) : undefined,
-                webhook.type,
-                webhook.channel || undefined
-              );
-            } catch (error) {
-              return {
-                success: false,
-                error: error instanceof Error ? error.message : String(error),
-              };
-            }
+          const result = await persistIntent(async () => {
+            const { decryptStoredSecret } = await import('./encryption');
+            await enqueueCentralNotification({
+              category: 'INCIDENT',
+              channel: 'WEBHOOK',
+              recipientType: 'WEBHOOK',
+              recipientId: webhook.id,
+              recipientAddress: webhook.url,
+              incidentId,
+              templateKey: `service-webhook-${eventType}`,
+              sourceType: 'WEBHOOK_INTEGRATION',
+              sourceId: webhook.id,
+              eventKey: deliveryKey,
+              displayMessage: `${eventType}: ${incident.title}`,
+              priority: incident.urgency === 'HIGH' ? 1 : 3,
+              payload: {
+                kind: 'WEBHOOK',
+                url: webhook.url,
+                payload: formatWebhookPayloadByType(
+                  webhook.type,
+                  webhookIncident,
+                  eventType,
+                  getBaseUrl(),
+                  webhook.channel || undefined
+                ),
+                secret: webhook.secret ? await decryptStoredSecret(webhook.secret) : undefined,
+              },
+            });
           });
           return { webhookId: webhook.id, ...result };
         })
@@ -171,8 +213,26 @@ export async function sendServiceNotifications(
     }
 
     if (service.webhookUrl && !serviceChannels.includes('WEBHOOK')) {
-      const result = await once(deliveryKey, `legacy-webhook:${service.id}`, () =>
-        sendIncidentWebhook(service.webhookUrl!, incidentId, eventType)
+      const result = await persistIntent(() =>
+        enqueueCentralNotification({
+          category: 'INCIDENT',
+          channel: 'WEBHOOK',
+          recipientType: 'WEBHOOK',
+          recipientId: service.id,
+          recipientAddress: service.webhookUrl!,
+          incidentId,
+          templateKey: `legacy-service-webhook-${eventType}`,
+          sourceType: 'SERVICE_INCIDENT',
+          sourceId: `${service.id}:${incidentId}`,
+          eventKey: deliveryKey,
+          displayMessage: `${eventType}: ${incident.title}`,
+          priority: incident.urgency === 'HIGH' ? 1 : 3,
+          payload: {
+            kind: 'WEBHOOK',
+            url: service.webhookUrl!,
+            payload: generateIncidentWebhookPayload(webhookIncident, eventType),
+          },
+        }).then(() => undefined)
       );
       if (!result.success) errors.push(`Legacy webhook failed: ${result.error || 'Unknown error'}`);
     }

--- a/src/lib/sla-breach-monitor.ts
+++ b/src/lib/sla-breach-monitor.ts
@@ -4,6 +4,9 @@ import { WebhookIntegration } from '@prisma/client';
 import { getPrioritySLATarget } from './sla-priority';
 import { escapeHtml } from './email-components';
 import { activeIncidentStatuses } from './incident-status';
+import { enqueueCentralNotification } from './notification-control-plane';
+import { formatWebhookPayloadByType } from './webhooks';
+import { getBaseUrl } from './env-validation';
 
 /**
  * SLA Breach Monitor - Proactive Breach Detection
@@ -364,124 +367,101 @@ async function notifyBreachWarning(
     service: warning.serviceName,
     message: plainText,
   });
+  const eventKey = `${warning.breachType}:${isBreached ? 'breached' : 'warning'}:${warning.targetMinutes}`;
+  const incidentPresentation = {
+    id: warning.incidentId,
+    title: warning.title,
+    status: warning.status,
+    urgency: warning.urgency,
+    serviceName: warning.serviceName,
+    assigneeName: warning.assigneeName,
+  };
 
   // 1. Send Slack notification if enabled
   if (config.notifySlack) {
-    const { sendSlackNotification, sendSlackMessageToChannel } = await import('./slack');
     const channels = warning.serviceNotificationChannels || [];
     const hasSlackEnabled = channels.length === 0 || channels.includes('SLACK');
 
     if (hasSlackEnabled) {
-      let sent = false;
-
-      // Try OAuth Channel First
-      if (warning.slackChannel) {
-        try {
-          const result = await sendSlackMessageToChannel(
-            warning.slackChannel,
-            {
-              id: warning.incidentId,
-              title: warning.title,
-              status: warning.status,
-              urgency: warning.urgency,
-              serviceName: warning.serviceName,
-              assigneeName: warning.assigneeName,
+      await enqueueCentralNotification({
+        category: 'SLA',
+        channel: 'SLACK',
+        recipientType: warning.slackChannel ? 'SLACK_CHANNEL' : 'WEBHOOK',
+        recipientId: warning.serviceId,
+        recipientAddress: warning.slackChannel || warning.slackWebhookUrl || 'global-slack-webhook',
+        incidentId: warning.incidentId,
+        templateKey: `sla-${warning.breachType}-${isBreached ? 'breached' : 'warning'}`,
+        sourceType: 'INCIDENT_SLA',
+        sourceId: warning.incidentId,
+        eventKey,
+        displayMessage: plainText,
+        priority: isBreached ? 0 : 1,
+        payload: warning.slackChannel
+          ? {
+              kind: 'SLACK_CHANNEL',
+              channel: warning.slackChannel,
+              incident: incidentPresentation,
+              eventType: 'triggered',
+              includeInteractiveButtons: true,
+              serviceId: warning.serviceId,
+              additionalMessage: message,
+            }
+          : {
+              kind: 'SLACK_WEBHOOK',
+              incident: incidentPresentation,
+              eventType: 'triggered',
+              webhookUrl: warning.slackWebhookUrl || undefined,
+              additionalMessage: message,
             },
-            'triggered',
-            true,
-            warning.serviceId
-          );
-
-          if (result.success) {
-            sent = true;
-            logger.info('[SLA Breach Monitor] Slack notification sent via OAuth channel', {
-              warning,
-            });
-          }
-        } catch (err) {
-          logger.warn('[SLA Breach Monitor] OAuth Slack error, trying webhook fallback', { err });
-        }
-      }
-
-      // Fallback to Service Webhook
-      if (!sent && warning.slackWebhookUrl) {
-        try {
-          await sendSlackNotification(
-            'triggered',
-            {
-              id: warning.incidentId,
-              title: warning.title,
-              status: warning.status,
-              urgency: warning.urgency,
-              serviceName: warning.serviceName,
-              assigneeName: warning.assigneeName,
-            },
-            message,
-            warning.slackWebhookUrl
-          );
-          sent = true;
-          logger.info('[SLA Breach Monitor] Slack notification sent via Service Webhook', {
-            warning,
-          });
-        } catch (error) {
-          logger.error('[SLA Breach Monitor] Failed to send Slack webhook notification', { error });
-        }
-      }
-
-      // Last resort: Global webhook
-      if (!sent && !warning.slackChannel && !warning.slackWebhookUrl) {
-        try {
-          await sendSlackNotification(
-            'triggered',
-            {
-              id: warning.incidentId,
-              title: warning.title,
-              status: warning.status,
-              urgency: warning.urgency,
-              serviceName: warning.serviceName,
-              assigneeName: warning.assigneeName,
-            },
-            message
-          );
-          logger.info('[SLA Breach Monitor] Slack notification sent via Global Webhook', {
-            warning,
-          });
-        } catch (error) {
-          logger.error('[SLA Breach Monitor] Failed to send Global Slack notification', { error });
-        }
-      }
+      });
     }
   }
 
   // 2. Send Webhook notifications if enabled
   if (config.notifyWebhook && warning.serviceNotificationChannels?.includes('WEBHOOK')) {
     try {
-      const { sendIncidentWebhook } = await import('./webhooks');
       const webhooks = warning.webhookIntegrations || [];
 
       for (const webhook of webhooks) {
         try {
           const { decryptStoredSecret } = await import('./encryption');
-          const result = await sendIncidentWebhook(
-            webhook.url,
-            warning.incidentId,
-            isBreached ? 'triggered' : 'warning',
-            webhook.secret ? await decryptStoredSecret(webhook.secret) : undefined,
-            webhook.type,
-            webhook.channel || undefined
-          );
-
-          if (result.success) {
-            logger.info('[SLA Breach Monitor] Webhook notification sent', {
-              webhookId: webhook.id,
-              type: webhook.type,
-            });
-          } else {
-            logger.warn('[SLA Breach Monitor] Webhook notification failed', {
-              webhookId: webhook.id,
-              error: result.error,
-            });
-          }
+          await enqueueCentralNotification({
+            category: 'SLA',
+            channel: 'WEBHOOK',
+            recipientType: 'WEBHOOK',
+            recipientId: webhook.id,
+            recipientAddress: webhook.url,
+            incidentId: warning.incidentId,
+            templateKey: `sla-webhook-${warning.breachType}-${isBreached ? 'breached' : 'warning'}`,
+            sourceType: 'WEBHOOK_INTEGRATION',
+            sourceId: webhook.id,
+            eventKey,
+            displayMessage: plainText,
+            priority: isBreached ? 0 : 1,
+            payload: {
+              kind: 'WEBHOOK',
+              url: webhook.url,
+              payload: formatWebhookPayloadByType(
+                webhook.type,
+                {
+                  id: warning.incidentId,
+                  title: warning.title,
+                  status: warning.status,
+                  urgency: warning.urgency,
+                  service: { id: warning.serviceId, name: warning.serviceName },
+                  createdAt: warning.createdAt,
+                },
+                isBreached ? 'triggered' : 'warning',
+                getBaseUrl(),
+                webhook.channel || undefined
+              ),
+              secret: webhook.secret ? await decryptStoredSecret(webhook.secret) : undefined,
+            },
+          });
+          logger.info('[SLA Breach Monitor] Webhook notification enqueued', {
+            webhookId: webhook.id,
+            type: webhook.type,
+          });
         } catch (error) {
           logger.error('[SLA Breach Monitor] Error sending webhook notification', {
             webhookId: webhook.id,
@@ -500,19 +480,16 @@ async function notifyBreachWarning(
       const alertEmail = config.alertEmail || process.env.SLA_ALERT_EMAIL;
 
       if (alertEmail) {
-        const { sendEmail } = await import('./email');
         const safeServiceName = escapeHtml(warning.serviceName);
         const safeTitle = escapeHtml(warning.title);
         const safeUrgency = escapeHtml(warning.urgency);
         const baseUrl = (process.env.NEXTAUTH_URL || '').replace(/\/+$/, '');
         const incidentUrl = `${baseUrl}/incidents/${encodeURIComponent(warning.incidentId)}`;
 
-        await sendEmail({
-          to: alertEmail,
-          subject: isBreached
-            ? `[SLA BREACHED] ${warning.serviceName}: ${warning.title}`
-            : `[SLA WARNING] ${warning.serviceName}: ${warning.title}`,
-          html: `
+        const subject = isBreached
+          ? `[SLA BREACHED] ${warning.serviceName}: ${warning.title}`
+          : `[SLA WARNING] ${warning.serviceName}: ${warning.title}`;
+        const html = `
                           <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 0; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);">
                               <div style="background-color: ${isBreached ? '#fee2e2' : '#fef3c7'}; padding: 20px; text-align: center; border-bottom: 1px solid ${isBreached ? '#fecaca' : '#fde68a'};">
                                   <h1 style="color: ${isBreached ? '#991b1b' : '#92400e'}; margin: 0; font-size: 24px; font-weight: 800;">${breachEmoji} SLA ${breachTypeUpper} ${breachAction}</h1>
@@ -557,11 +534,23 @@ async function notifyBreachWarning(
                                   OpsKnight SLA Monitor • ${new Date().toUTCString()}
                               </div>
                           </div>
-                      `,
-          text: plainText,
+                      `;
+        await enqueueCentralNotification({
+          category: 'SLA',
+          channel: 'EMAIL',
+          recipientType: 'EMAIL',
+          recipientAddress: alertEmail,
+          incidentId: warning.incidentId,
+          templateKey: `sla-email-${warning.breachType}-${isBreached ? 'breached' : 'warning'}`,
+          sourceType: 'INCIDENT_SLA',
+          sourceId: warning.incidentId,
+          eventKey,
+          displayMessage: plainText,
+          priority: isBreached ? 0 : 1,
+          payload: { kind: 'EMAIL', to: alertEmail, subject, html, text: plainText },
         });
 
-        logger.info('[SLA Breach Monitor] Email notification sent', { to: alertEmail });
+        logger.info('[SLA Breach Monitor] Email notification enqueued', { to: alertEmail });
       } else {
         logger.debug('[SLA Breach Monitor] Email skipped (SLA_ALERT_EMAIL not set)');
       }

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -95,8 +95,9 @@ export async function sendSlackNotification(
   eventType: SlackEventType,
   incident: IncidentDetails,
   additionalMessage?: string,
-  webhookUrl?: string | null
-): Promise<{ success: boolean; error?: string }> {
+  webhookUrl?: string | null,
+  options: { maxAttempts?: number } = {}
+): Promise<{ success: boolean; error?: string; statusCode?: number; retryAfterMs?: number }> {
   const targetUrl = webhookUrl || SLACK_WEBHOOK_URL;
 
   if (!targetUrl) {
@@ -139,7 +140,7 @@ export async function sendSlackNotification(
         redirect: 'manual',
       },
       {
-        maxAttempts: 3,
+        maxAttempts: options.maxAttempts ?? 3,
         initialDelayMs: 1000,
         retryableErrors: error => {
           // Only retry on network errors or 5xx server errors
@@ -185,13 +186,18 @@ export async function sendSlackNotification(
     );
     return { success: true };
   } catch (error: unknown) {
-    const err = error as { message?: string };
+    const err = error as { message?: string; statusCode?: number; retryAfterMs?: number };
     logger.error('[Slack] Webhook error after retries', {
       component: 'slack',
       error: err.message,
       incident: incident.id,
     });
-    return { success: false, error: err.message || 'Slack webhook error' };
+    return {
+      success: false,
+      error: err.message || 'Slack webhook error',
+      statusCode: err.statusCode,
+      retryAfterMs: err.retryAfterMs,
+    };
   }
 }
 
@@ -423,15 +429,16 @@ export async function sendSlackMessageToChannel(
   eventType: SlackEventType,
   includeInteractiveButtons: boolean = true,
   serviceId?: string,
-  additionalMessage?: string
-): Promise<{ success: boolean; error?: string }> {
+  additionalMessage?: string,
+  options: { maxAttempts?: number } = {}
+): Promise<{ success: boolean; error?: string; statusCode?: number; retryAfterMs?: number }> {
   // Get bot token (from OAuth integration or env fallback)
   const botToken = await getSlackBotToken(serviceId);
 
   if (!botToken) {
     logger.warn('[Slack] No bot token configured, falling back to webhook');
     // Fallback to webhook if API token not available
-    return sendSlackNotification(eventType, incident, additionalMessage, undefined);
+    return sendSlackNotification(eventType, incident, additionalMessage, undefined, options);
   }
 
   const color = getStatusColor(eventType);
@@ -470,7 +477,7 @@ export async function sendSlackMessageToChannel(
         body: JSON.stringify(payload),
       },
       {
-        maxAttempts: 3,
+        maxAttempts: options.maxAttempts ?? 3,
         initialDelayMs: 1000,
         retryableErrors: error => {
           if (error instanceof Error) {
@@ -499,9 +506,14 @@ export async function sendSlackMessageToChannel(
     );
     return { success: true };
   } catch (error: unknown) {
-    const err = error as { message?: string };
+    const err = error as { message?: string; statusCode?: number; retryAfterMs?: number };
     logger.error('[Slack] API error', { error: err.message, channel });
-    return { success: false, error: err.message || 'Slack API error' };
+    return {
+      success: false,
+      error: err.message || 'Slack API error',
+      statusCode: err.statusCode,
+      retryAfterMs: err.retryAfterMs,
+    };
   }
 }
 

--- a/src/lib/status-page-notifications.ts
+++ b/src/lib/status-page-notifications.ts
@@ -1,15 +1,12 @@
 import prisma from '@/lib/prisma';
-import { sendEmail } from '@/lib/email';
 import { getStatusPageEmailConfig } from '@/lib/notification-providers';
+import { enqueueCentralNotification } from '@/lib/notification-control-plane';
 import { logger } from '@/lib/logger';
 import { getBaseUrl } from '@/lib/env-validation';
 import { getStatusPageLogoUrl, getStatusPagePublicUrl } from '@/lib/status-page-url';
 import {
   buildSubscriberIncidentPresentation,
   incidentSubscriberDeliveryKey,
-  isStatusDeliveryComplete,
-  markStatusDeliveryComplete,
-  statusDeliveryMarkerId,
 } from '@/lib/status-page-delivery';
 import {
   EmailContainer,
@@ -153,40 +150,31 @@ export async function notifyStatusPageSubscribers(
         const batch = page.subscriptions.slice(i, i + BATCH_SIZE);
         const results = await Promise.allSettled(
           batch.map(async sub => {
-            const markerId = statusDeliveryMarkerId(
-              'SUBSCRIBER_EMAIL',
-              effectiveDeliveryKey,
-              sub.id
-            );
-            if (await isStatusDeliveryComplete(markerId)) {
-              return { success: true, skipped: true };
-            }
-
-            const result = await sendEmail(
-              {
+            const intent = await enqueueCentralNotification({
+              category: 'STATUS_PAGE',
+              channel: 'EMAIL',
+              recipientType: 'SUBSCRIBER',
+              recipientId: sub.id,
+              recipientAddress: sub.email,
+              incidentId,
+              templateKey: `status-page-incident-${eventType}`,
+              sourceType: 'STATUS_PAGE_INCIDENT',
+              sourceId: `${page.id}:${incidentId}`,
+              eventKey: effectiveDeliveryKey,
+              displayMessage: subject,
+              priority: eventType === 'resolved' ? 3 : 1,
+              payload: {
+                kind: 'EMAIL',
                 to: sub.email,
                 subject,
                 html: html.replaceAll(
                   '{{unsubscribe_url}}',
                   `${appBaseUrl}/status/unsubscribe/${sub.token}`
                 ),
+                providerScope: { statusPageId: page.id },
               },
-              {
-                source: `status-page-${page.id}`,
-                ...emailConfig,
-              }
-            );
-
-            if (result.success) {
-              await markStatusDeliveryComplete({
-                markerId,
-                target: 'SUBSCRIBER_EMAIL',
-                deliveryKey: effectiveDeliveryKey,
-                targetId: sub.id,
-              });
-            }
-
-            return { success: result.success, skipped: false };
+            });
+            return { success: true, skipped: !intent.created };
           })
         );
 
@@ -542,22 +530,32 @@ export async function notifyStatusPageSubscribersAnnouncement(
     for (let i = 0; i < page.subscriptions.length; i += BATCH_SIZE) {
       const batch = page.subscriptions.slice(i, i + BATCH_SIZE);
       const results = await Promise.allSettled(
-        batch.map(sub =>
-          sendEmail(
-            {
+        batch.map(async sub => {
+          const intent = await enqueueCentralNotification({
+            category: 'STATUS_PAGE',
+            channel: 'EMAIL',
+            recipientType: 'SUBSCRIBER',
+            recipientId: sub.id,
+            recipientAddress: sub.email,
+            templateKey: 'status-page-announcement',
+            sourceType: 'STATUS_PAGE_ANNOUNCEMENT',
+            sourceId: announcement.id,
+            eventKey: announcement.updatedAt.toISOString(),
+            displayMessage: subject,
+            priority: announcement.type === 'INCIDENT' ? 1 : 4,
+            payload: {
+              kind: 'EMAIL',
               to: sub.email,
               subject,
               html: html.replaceAll(
                 '{{unsubscribe_url}}',
                 `${appBaseUrl}/status/unsubscribe/${sub.token}`
               ),
+              providerScope: { statusPageId: page.id },
             },
-            {
-              source: `status-page-${page.id}`,
-              ...emailConfig,
-            }
-          )
-        )
+          });
+          return { success: true, skipped: !intent.created };
+        })
       );
 
       sent += results.filter(r => r.status === 'fulfilled' && r.value.success).length;

--- a/src/lib/status-page-webhooks.ts
+++ b/src/lib/status-page-webhooks.ts
@@ -17,6 +17,22 @@ export interface WebhookPayload {
   data: unknown;
 }
 
+export type StatusPageWebhookDeliveryResult = {
+  success: boolean;
+  statusCode?: number;
+  retryAfterMs?: number;
+  error?: string;
+};
+
+function retryAfterMs(response: Response): number | undefined {
+  const value = response.headers.get('Retry-After');
+  if (!value) return undefined;
+  const seconds = Number.parseInt(value, 10);
+  if (Number.isFinite(seconds) && seconds > 0) return seconds * 1_000;
+  const deadline = new Date(value).getTime();
+  return Number.isFinite(deadline) ? Math.max(1_000, deadline - Date.now()) : undefined;
+}
+
 function asWebhookRecord(value: unknown): Record<string, unknown> {
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
     return value as Record<string, unknown>;
@@ -35,8 +51,9 @@ export async function deliverWebhook(
   url: string,
   secret: string,
   payload: WebhookPayload,
-  deliveryId: string = crypto.randomUUID()
-): Promise<boolean> {
+  deliveryId: string = crypto.randomUUID(),
+  options: { maxAttempts?: number } = {}
+): Promise<StatusPageWebhookDeliveryResult> {
   try {
     // SSRF Protection: Validate webhook URL before making request
     const { assertSafeOutboundUrl } = await import('./network-security');
@@ -44,7 +61,7 @@ export async function deliverWebhook(
       await assertSafeOutboundUrl(url);
     } catch {
       logger.warn('api.status_page.webhook.blocked_ssrf', { url });
-      return false;
+      return { success: false, error: 'Invalid or restricted webhook URL' };
     }
 
     const payloadString = JSON.stringify(payload);
@@ -78,7 +95,13 @@ export async function deliverWebhook(
           });
 
           if (!res.ok && (res.status >= 500 || res.status === 429)) {
-            throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+            const error = new Error(`HTTP ${res.status}: ${res.statusText}`) as Error & {
+              statusCode?: number;
+              retryAfterMs?: number;
+            };
+            error.statusCode = res.status;
+            error.retryAfterMs = retryAfterMs(res);
+            throw error;
           }
 
           return res;
@@ -87,7 +110,7 @@ export async function deliverWebhook(
         return response;
       },
       {
-        maxAttempts: 3,
+        maxAttempts: options.maxAttempts ?? 3,
         initialDelayMs: 1000,
         retryableErrors: error => {
           if (error instanceof Error) {
@@ -109,7 +132,15 @@ export async function deliverWebhook(
             ? retryResult.error.message
             : String(retryResult.error),
       });
-      return false;
+      const error = retryResult.error as
+        | (Error & { statusCode?: number; retryAfterMs?: number })
+        | undefined;
+      return {
+        success: false,
+        error: error?.message || 'Status-page webhook delivery failed',
+        statusCode: error?.statusCode,
+        retryAfterMs: error?.retryAfterMs,
+      };
     }
 
     const response = retryResult.data;
@@ -119,7 +150,7 @@ export async function deliverWebhook(
         where: { url },
         data: { lastTriggeredAt: new Date() },
       });
-      return true;
+      return { success: true, statusCode: response.status };
     }
 
     logger.warn('api.status_page.webhook.delivery_failed_status', {
@@ -128,14 +159,22 @@ export async function deliverWebhook(
       status: response.status,
       statusText: response.statusText,
     });
-    return false;
+    return {
+      success: false,
+      statusCode: response.status,
+      retryAfterMs: retryAfterMs(response),
+      error: `HTTP ${response.status}: ${response.statusText}`,
+    };
   } catch (error: unknown) {
     logger.error('api.status_page.webhook.delivery_error', {
       url,
       deliveryId,
       error: error instanceof Error ? error.message : String(error),
     });
-    return false;
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 

--- a/src/lib/status-page-webhooks.ts
+++ b/src/lib/status-page-webhooks.ts
@@ -8,13 +8,8 @@ import crypto from 'crypto';
 import { decryptStoredSecret } from './encryption';
 import { retry } from './retry';
 import { CircuitBreakers } from './circuit-breaker';
-import {
-  isStatusDeliveryComplete,
-  markStatusDeliveryComplete,
-  statusDeliveryMarkerId,
-  statusWebhookDeliveryId,
-  statusWebhookDeliveryKey,
-} from './status-page-delivery';
+import { statusWebhookDeliveryId, statusWebhookDeliveryKey } from './status-page-delivery';
+import { enqueueCentralNotification } from './notification-control-plane';
 
 export interface WebhookPayload {
   event: string;
@@ -228,33 +223,29 @@ export async function triggerStatusPageWebhooks(
       const batch = webhooks.slice(i, i + BATCH_SIZE);
       const results = await Promise.allSettled(
         batch.map(async webhook => {
-          const markerId = statusDeliveryMarkerId(
-            'STATUS_WEBHOOK',
-            effectiveDeliveryKey,
-            webhook.id
-          );
-          if (await isStatusDeliveryComplete(markerId)) {
-            return { attempted: false, success: true };
-          }
-
           const stableDeliveryId = statusWebhookDeliveryId(effectiveDeliveryKey, webhook.id);
-          const success = await deliverWebhook(
-            webhook.url,
-            await decryptStoredSecret(webhook.secret),
-            payload,
-            stableDeliveryId
-          );
+          await enqueueCentralNotification({
+            category: 'STATUS_PAGE',
+            channel: 'WEBHOOK',
+            recipientType: 'WEBHOOK',
+            recipientId: webhook.id,
+            recipientAddress: webhook.url,
+            templateKey: `status-page-webhook-${event}`,
+            sourceType: 'STATUS_PAGE_WEBHOOK',
+            sourceId: webhook.id,
+            eventKey: effectiveDeliveryKey,
+            displayMessage: `Status-page webhook: ${event}`,
+            priority: 3,
+            payload: {
+              kind: 'STATUS_PAGE_WEBHOOK',
+              url: webhook.url,
+              secret: await decryptStoredSecret(webhook.secret),
+              payload,
+              deliveryId: stableDeliveryId,
+            },
+          });
 
-          if (success) {
-            await markStatusDeliveryComplete({
-              markerId,
-              target: 'STATUS_WEBHOOK',
-              deliveryKey: effectiveDeliveryKey,
-              targetId: webhook.id,
-            });
-          }
-
-          return { attempted: true, success };
+          return { attempted: true, success: true };
         })
       );
 
@@ -262,7 +253,8 @@ export async function triggerStatusPageWebhooks(
         result => result.status === 'fulfilled' && result.value.attempted
       ).length;
       failed += results.filter(
-        result => result.status === 'rejected' || (result.status === 'fulfilled' && !result.value.success)
+        result =>
+          result.status === 'rejected' || (result.status === 'fulfilled' && !result.value.success)
       ).length;
     }
 

--- a/src/lib/user-notifications.ts
+++ b/src/lib/user-notifications.ts
@@ -176,6 +176,7 @@ export async function sendUserNotification(
   incidentId: string,
   userId: string,
   message: string,
+  escalationChannels?: NotificationChannel[],
   options: {
     createInApp?: boolean;
     eventType?: NotificationEventType;
@@ -250,10 +251,13 @@ export async function sendUserNotification(
     }
   }
 
-  // User preferences are authoritative. Each enabled and configured channel is
-  // an independent durable intent; an escalation step must never narrow this
-  // list and silently suppress a channel the recipient explicitly enabled.
   let channels = userChannels;
+  if (escalationChannels && escalationChannels.length > 0) {
+    const selected = escalationChannels.filter(channel => userChannels.includes(channel));
+    // Preserve the existing fallback for legacy policies whose configured
+    // channels are unavailable for this recipient.
+    channels = selected.length > 0 ? selected : userChannels;
+  }
 
   if (channels.length === 0) {
     return {

--- a/src/lib/user-notifications.ts
+++ b/src/lib/user-notifications.ts
@@ -176,7 +176,6 @@ export async function sendUserNotification(
   incidentId: string,
   userId: string,
   message: string,
-  escalationChannels?: NotificationChannel[],
   options: {
     createInApp?: boolean;
     eventType?: NotificationEventType;
@@ -251,11 +250,10 @@ export async function sendUserNotification(
     }
   }
 
+  // User preferences are authoritative. Each enabled and configured channel is
+  // an independent durable intent; an escalation step must never narrow this
+  // list and silently suppress a channel the recipient explicitly enabled.
   let channels = userChannels;
-  if (escalationChannels && escalationChannels.length > 0) {
-    const selected = escalationChannels.filter(channel => userChannels.includes(channel));
-    channels = selected.length > 0 ? selected : userChannels;
-  }
 
   if (channels.length === 0) {
     return {
@@ -321,7 +319,9 @@ async function previouslyEngagedResponderIds(incidentId: string): Promise<string
     },
     select: { userId: true },
   });
-  return [...new Set(rows.map(row => row.userId))];
+  return [
+    ...new Set(rows.map(row => row.userId).filter((userId): userId is string => Boolean(userId))),
+  ];
 }
 
 /** Personal lifecycle fan-out. Service integrations are deliberately separate. */

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -24,6 +24,7 @@ export type WebhookOptions = {
   secret?: string; // For HMAC signature
   method?: 'POST' | 'PUT' | 'PATCH';
   timeout?: number; // Timeout in milliseconds
+  maxAttempts?: number;
 };
 
 export type WebhookResult = {
@@ -31,6 +32,7 @@ export type WebhookResult = {
   error?: string;
   statusCode?: number;
   responseBody?: string;
+  retryAfterMs?: number;
 };
 
 /**
@@ -52,6 +54,7 @@ export async function sendWebhook(options: WebhookOptions): Promise<WebhookResul
       secret,
       method = 'POST',
       timeout = 10000, // 10 seconds default
+      maxAttempts = 3,
     } = options;
 
     if (!url) {
@@ -109,7 +112,17 @@ export async function sendWebhook(options: WebhookOptions): Promise<WebhookResul
               });
 
               if (!response.ok && isRetryableHttpError(response.status)) {
-                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                const retryAfter = response.headers.get('Retry-After');
+                const retryAfterSeconds = retryAfter ? Number.parseInt(retryAfter, 10) : NaN;
+                const error = new Error(`HTTP ${response.status}: ${response.statusText}`) as Error & {
+                  statusCode?: number;
+                  retryAfterMs?: number;
+                };
+                error.statusCode = response.status;
+                if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+                  error.retryAfterMs = retryAfterSeconds * 1_000;
+                }
+                throw error;
               }
 
               return response;
@@ -121,7 +134,7 @@ export async function sendWebhook(options: WebhookOptions): Promise<WebhookResul
           }
         },
         {
-          maxAttempts: 3,
+          maxAttempts,
           initialDelayMs: 1000,
           retryableErrors: error => {
             if (error instanceof Error) {
@@ -189,7 +202,12 @@ export async function sendWebhook(options: WebhookOptions): Promise<WebhookResul
     }
   } catch (error: any) {
     logger.error('Webhook send error', { component: 'webhooks', error, url: options.url });
-    return { success: false, error: error.message };
+    return {
+      success: false,
+      error: error.message,
+      statusCode: error.statusCode,
+      retryAfterMs: error.retryAfterMs,
+    };
   }
 }
 

--- a/tests/api/notification-operations.test.ts
+++ b/tests/api/notification-operations.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/admin/notifications/operations/route';
+import { POST } from '@/app/api/admin/notifications/operations/[id]/retry/route';
+import { getCurrentUser } from '@/lib/rbac';
+import { getNotificationOperations } from '@/lib/notification-operations';
+import { requeueCentralNotification } from '@/lib/notification-control-plane';
+
+vi.mock('@/lib/rbac', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('@/lib/notification-operations', () => ({
+  OPERATIONS_CHANNELS: ['EMAIL', 'SMS', 'PUSH', 'SLACK', 'WEBHOOK', 'WHATSAPP'],
+  OPERATIONS_STATUSES: ['PENDING', 'SENT', 'DELIVERED', 'FAILED', 'SKIPPED'],
+  OPERATIONS_CATEGORIES: ['INCIDENT', 'SECURITY', 'STATUS_PAGE', 'SLA', 'ADMINISTRATION', 'SYSTEM'],
+  getNotificationOperations: vi.fn(),
+}));
+vi.mock('@/lib/notification-control-plane', () => ({
+  requeueCentralNotification: vi.fn(),
+}));
+vi.mock('@/lib/audit', () => ({ emitAuditEvent: vi.fn() }));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const admin = { id: 'admin-1', role: 'ADMIN', email: 'admin@example.com', name: 'Admin' };
+const auditor = { ...admin, id: 'auditor-1', role: 'AUDITOR' };
+const responder = { ...admin, id: 'responder-1', role: 'RESPONDER' };
+
+describe('notification operations authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getNotificationOperations).mockResolvedValue({
+      notifications: [],
+      stats: { byStatus: {}, byCategory: {} },
+      pagination: { limit: 50, nextCursor: null, hasMore: false },
+      range: { from: new Date().toISOString(), to: null },
+    });
+  });
+
+  it('allows auditors to inspect workspace delivery metadata', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(auditor as never);
+    const response = await GET(
+      new NextRequest('https://example.com/api/admin/notifications/operations?status=FAILED')
+    );
+    expect(response.status).toBe(200);
+    expect(getNotificationOperations).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'FAILED' })
+    );
+    expect(response.headers.get('cache-control')).toBe('private, no-store');
+  });
+
+  it('denies the workspace console to ordinary responders', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(responder as never);
+    const response = await GET(
+      new NextRequest('https://example.com/api/admin/notifications/operations')
+    );
+    expect(response.status).toBe(403);
+    expect(getNotificationOperations).not.toHaveBeenCalled();
+  });
+
+  it('rejects unbounded history scans beyond the 90-day operations window', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(admin as never);
+    const response = await GET(
+      new NextRequest(
+        'https://example.com/api/admin/notifications/operations?from=2020-01-01T00:00:00.000Z'
+      )
+    );
+    expect(response.status).toBe(400);
+    expect(getNotificationOperations).not.toHaveBeenCalled();
+  });
+
+  it('keeps retry mutation administrator-only', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(auditor as never);
+    const response = await POST(
+      new NextRequest(
+        'https://example.com/api/admin/notifications/operations/notification_abc/retry',
+        {
+          method: 'POST',
+        }
+      ),
+      { params: Promise.resolve({ id: 'notification_abc' }) }
+    );
+    expect(response.status).toBe(403);
+    expect(requeueCentralNotification).not.toHaveBeenCalled();
+  });
+
+  it('atomically requeues an eligible delivery for an administrator', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(admin as never);
+    vi.mocked(requeueCentralNotification).mockResolvedValue(true);
+    const response = await POST(
+      new NextRequest(
+        'https://example.com/api/admin/notifications/operations/notification_abc/retry',
+        {
+          method: 'POST',
+          headers: { origin: 'https://example.com' },
+        }
+      ),
+      { params: Promise.resolve({ id: 'notification_abc' }) }
+    );
+    expect(response.status).toBe(200);
+    expect(requeueCentralNotification).toHaveBeenCalledWith('notification_abc');
+  });
+});

--- a/tests/api/notifications-test-push.test.ts
+++ b/tests/api/notifications-test-push.test.ts
@@ -3,7 +3,7 @@ import { POST } from '@/app/api/notifications/test-push/route';
 import prisma from '@/lib/prisma';
 import { getPushConfig } from '@/lib/notification-providers';
 import { getServerSession } from 'next-auth';
-import { sendPush } from '@/lib/push';
+import { enqueueCentralNotification } from '@/lib/notification-control-plane';
 
 vi.mock('next-auth', () => ({
   getServerSession: vi.fn(),
@@ -33,8 +33,8 @@ vi.mock('@/lib/notification-providers', () => ({
   getPushConfig: vi.fn(),
 }));
 
-vi.mock('@/lib/push', () => ({
-  sendPush: vi.fn(),
+vi.mock('@/lib/notification-control-plane', () => ({
+  enqueueCentralNotification: vi.fn(),
 }));
 
 function mockCurrentUser() {
@@ -54,6 +54,11 @@ describe('API Route - Notifications Test Push', () => {
       vapidPrivateKey: 'private-key',
     });
     vi.mocked(prisma.userDevice.count).mockResolvedValue(1);
+    vi.mocked(enqueueCentralNotification).mockResolvedValue({
+      id: 'notification_test',
+      created: true,
+      delivered: true,
+    });
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -88,7 +93,7 @@ describe('API Route - Notifications Test Push', () => {
     expect(res.status).toBe(400);
     expect(body.code).toBe('VALIDATION_FAILED');
     expect(body.retryable).toBe(false);
-    expect(sendPush).not.toHaveBeenCalled();
+    expect(enqueueCentralNotification).not.toHaveBeenCalled();
   });
 
   it('returns non-retryable validation when no web subscription exists', async () => {
@@ -102,14 +107,18 @@ describe('API Route - Notifications Test Push', () => {
     expect(res.status).toBe(400);
     expect(body.code).toBe('VALIDATION_FAILED');
     expect(body.retryable).toBe(false);
-    expect(sendPush).not.toHaveBeenCalled();
+    expect(enqueueCentralNotification).not.toHaveBeenCalled();
   });
 
   it('returns retryable provider unavailable when delivery fails but subscription remains', async () => {
     vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
     mockCurrentUser();
     vi.mocked(prisma.userDevice.count).mockResolvedValue(1);
-    vi.mocked(sendPush).mockResolvedValue({ success: false, error: 'provider unavailable' });
+    vi.mocked(enqueueCentralNotification).mockResolvedValue({
+      id: 'notification_test',
+      created: true,
+      delivered: false,
+    });
 
     const res = await POST();
     const body = await res.json();
@@ -122,10 +131,12 @@ describe('API Route - Notifications Test Push', () => {
   it('returns non-retryable validation when a failed send removes the expired subscription', async () => {
     vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
     mockCurrentUser();
-    vi.mocked(prisma.userDevice.count)
-      .mockResolvedValueOnce(1)
-      .mockResolvedValueOnce(0);
-    vi.mocked(sendPush).mockResolvedValue({ success: false, error: 'subscription expired' });
+    vi.mocked(prisma.userDevice.count).mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+    vi.mocked(enqueueCentralNotification).mockResolvedValue({
+      id: 'notification_test',
+      created: true,
+      delivered: false,
+    });
 
     const res = await POST();
     const body = await res.json();
@@ -138,10 +149,11 @@ describe('API Route - Notifications Test Push', () => {
   it('returns 200 when push succeeds', async () => {
     vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
     mockCurrentUser();
-    vi.mocked(sendPush).mockResolvedValue({ success: true });
-
     const res = await POST();
 
     expect(res.status).toBe(200);
+    expect(enqueueCentralNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'SYSTEM', channel: 'PUSH', userId: 'user-1' })
+    );
   });
 });

--- a/tests/architecture/notification-control-plane-contract.test.ts
+++ b/tests/architecture/notification-control-plane-contract.test.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const DIRECT_PROVIDER_MODULES = new Set(['email', 'sms', 'push', 'whatsapp', 'slack', 'webhooks']);
+const ALLOWED_PROVIDER_SENDERS = new Set([
+  'src/lib/notification-control-plane.ts',
+  'src/lib/notification-delivery.ts',
+  'src/lib/incident-push-delivery.ts',
+]);
+
+function providerModule(specifier: string): string | null {
+  const match = specifier.match(/(?:^@\/lib\/|^\.\/)(email|sms|push|whatsapp|slack|webhooks)$/);
+  return match?.[1] || null;
+}
+
+describe('notification control-plane architecture', () => {
+  it('prevents new production senders from importing provider adapters directly', () => {
+    const root = process.cwd();
+    const violations: string[] = [];
+    for (const absolute of ts.sys.readDirectory(path.join(root, 'src'), ['.ts', '.tsx'])) {
+      const relative = path.relative(root, absolute).split(path.sep).join('/');
+      const sourceText = ts.sys.readFile(absolute);
+      if (!sourceText) continue;
+      if (ALLOWED_PROVIDER_SENDERS.has(relative)) continue;
+      const source = ts.createSourceFile(absolute, sourceText, ts.ScriptTarget.Latest, true);
+      source.forEachChild(node => {
+        if (!ts.isImportDeclaration(node) || !ts.isStringLiteral(node.moduleSpecifier)) return;
+        const provider = providerModule(node.moduleSpecifier.text);
+        if (!provider || !DIRECT_PROVIDER_MODULES.has(provider)) return;
+        const importedNames =
+          node.importClause?.namedBindings && ts.isNamedImports(node.importClause.namedBindings)
+            ? node.importClause.namedBindings.elements.map(element => element.name.text)
+            : [];
+        if (importedNames.some(name => /^(?:send|notify)/.test(name))) {
+          violations.push(`${relative}: ${provider}`);
+        }
+      });
+      if (
+        /\{\s*(?:send|notify)[A-Za-z0-9_]*\s*\}\s*=\s*await\s+import\(['"](?:@\/lib\/|\.\/)(?:email|sms|push|whatsapp|slack|webhooks)['"]\)/.test(
+          sourceText
+        )
+      )
+        violations.push(`${relative}: dynamic provider sender`);
+    }
+    expect(
+      violations,
+      `Outbound producers must create durable notification intents.\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('keeps the personal history endpoint separate from the workspace operations endpoint', () => {
+    const personal = ts.sys.readFile(
+      path.join(process.cwd(), 'src/app/api/notifications/history/route.ts')
+    );
+    const operations = ts.sys.readFile(
+      path.join(process.cwd(), 'src/app/api/admin/notifications/operations/route.ts')
+    );
+    expect(personal).toMatch(/userId\s*:\s*user\.id/);
+    expect(operations).toContain("user.role !== 'ADMIN' && user.role !== 'AUDITOR'");
+  });
+});

--- a/tests/architecture/notification-control-plane-contract.test.ts
+++ b/tests/architecture/notification-control-plane-contract.test.ts
@@ -59,4 +59,25 @@ describe('notification control-plane architecture', () => {
     expect(personal).toMatch(/userId\s*:\s*user\.id/);
     expect(operations).toContain("user.role !== 'ADMIN' && user.role !== 'AUDITOR'");
   });
+
+  it('allows sensitive ciphertext to be removed from terminal notification rows', () => {
+    const migration = ts.sys.readFile(
+      path.join(
+        process.cwd(),
+        'prisma/migrations/20260831090000_generalize_notification_control_plane/migration.sql'
+      )
+    );
+    expect(migration).toContain('"status" IN (\'SENT\', \'DELIVERED\', \'SKIPPED\')');
+    expect(migration).toContain('"attempts" >= "maxAttempts"');
+  });
+
+  it('keeps durable attempts as the sole retry and admission owner', () => {
+    const controlPlane = ts.sys.readFile(
+      path.join(process.cwd(), 'src/lib/notification-control-plane.ts')
+    );
+    const admission = ts.sys.readFile(path.join(process.cwd(), 'src/lib/provider-admission.ts'));
+    expect(controlPlane).not.toContain("if (channel === 'SLACK') return { allowed: true }");
+    expect(controlPlane?.match(/maxAttempts: 1/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(admission).toContain("'SLACK'");
+  });
 });

--- a/tests/integration/notification-control-plane.test.ts
+++ b/tests/integration/notification-control-plane.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  createCentralNotificationIntent,
+  requeueCentralNotification,
+} from '@/lib/notification-control-plane';
+import { resetDatabase, testPrisma } from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+describeIfRealDB('notification control-plane database guarantees', { timeout: 30_000 }, () => {
+  beforeEach(async () => {
+    process.env.ENCRYPTION_KEY = '0123456789abcdef'.repeat(4);
+    await resetDatabase();
+  });
+
+  it('materializes exactly one intent under concurrent producer retries', async () => {
+    const input = {
+      category: 'SECURITY' as const,
+      channel: 'EMAIL' as const,
+      recipientType: 'EMAIL' as const,
+      recipientAddress: 'recipient@example.com',
+      templateKey: 'security-alert',
+      sourceType: 'SECURITY_EVENT',
+      sourceId: 'event-1',
+      eventKey: 'generation-1',
+      displayMessage: 'Security alert',
+      payload: {
+        kind: 'EMAIL' as const,
+        to: 'recipient@example.com',
+        subject: 'Security alert',
+        html: '<p>secret body</p>',
+      },
+    };
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => createCentralNotificationIntent(input))
+    );
+
+    expect(results.filter(result => result.created)).toHaveLength(1);
+    expect(new Set(results.map(result => result.id)).size).toBe(1);
+    const rows = await testPrisma.notification.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.recipientDisplay).toBe('r***@example.com');
+    expect(rows[0]?.payloadEncrypted).not.toContain('recipient@example.com');
+    expect(rows[0]?.payloadEncrypted).not.toContain('secret body');
+  });
+
+  it('allows only one administrator to requeue the same failed generation', async () => {
+    const created = await createCentralNotificationIntent({
+      category: 'SYSTEM',
+      channel: 'PUSH',
+      recipientType: 'USER',
+      recipientId: 'user-1',
+      recipientAddress: 'user-1',
+      templateKey: 'system-alert',
+      sourceType: 'SYSTEM',
+      sourceId: 'system-1',
+      eventKey: 'generation-1',
+      displayMessage: 'System alert',
+      payload: { kind: 'PUSH', userId: 'user-1', title: 'Alert', body: 'Body' },
+    });
+    await testPrisma.notification.update({
+      where: { id: created.id },
+      data: { status: 'FAILED', attempts: 3, maxAttempts: 3 },
+    });
+
+    const results = await Promise.all([
+      requeueCentralNotification(created.id),
+      requeueCentralNotification(created.id),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    await expect(
+      testPrisma.notification.findUniqueOrThrow({ where: { id: created.id } })
+    ).resolves.toMatchObject({ status: 'PENDING', attempts: 3, maxAttempts: 4 });
+  });
+});

--- a/tests/integration/notification-flow.test.ts
+++ b/tests/integration/notification-flow.test.ts
@@ -95,7 +95,6 @@ describeIfRealDB('Notification Flow Integration Tests (Real DB)', () => {
     const incident = await createTestIncident('Test Incident', service.id);
 
     // 2. Send Service Notifications
-    // 2. Send Service Notifications
     const serviceResult = await sendServiceNotifications(incident.id, 'triggered');
     expect(serviceResult.success).toBe(true);
 
@@ -121,9 +120,10 @@ describeIfRealDB('Notification Flow Integration Tests (Real DB)', () => {
       where: { incidentId: incident.id },
     });
 
-    expect(notifications.length).toBeGreaterThan(0);
-    expect(notifications[0].userId).toBe(user.id);
-    expect(notifications.some(n => n.channel === 'EMAIL')).toBe(true);
+    const escalationNotification = notifications.find(
+      notification => notification.channel === 'EMAIL' && notification.userId === user.id
+    );
+    expect(escalationNotification).toBeDefined();
   });
 
   it('should handle team escalation (Real DB)', async () => {

--- a/tests/lib/incident-notification-outcomes.test.ts
+++ b/tests/lib/incident-notification-outcomes.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   incidentFindUnique: vi.fn(),
   userFindMany: vi.fn(),
+  userFindUnique: vi.fn(),
   notificationFindMany: vi.fn(),
   createInAppNotifications: vi.fn(),
   sendNotification: vi.fn(),
@@ -13,7 +14,7 @@ vi.mock('@/lib/prisma', () => ({
   __esModule: true,
   default: {
     incident: { findUnique: mocks.incidentFindUnique },
-    user: { findMany: mocks.userFindMany },
+    user: { findMany: mocks.userFindMany, findUnique: mocks.userFindUnique },
     notification: { findMany: mocks.notificationFindMany },
   },
 }));
@@ -29,7 +30,7 @@ vi.mock('@/lib/quiet-hours', () => ({
   filterChannelsForQuietHours: mocks.filterChannelsForQuietHours,
 }));
 vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), error: vi.fn() } }));
-import { sendIncidentNotifications } from '@/lib/user-notifications';
+import { sendIncidentNotifications, sendUserNotification } from '@/lib/user-notifications';
 const now = new Date('2026-08-30T12:00:00.000Z');
 const incident = {
   id: 'inc-1',
@@ -71,6 +72,7 @@ describe('incident notification fan-out', () => {
     vi.clearAllMocks();
     mocks.incidentFindUnique.mockResolvedValue(incident);
     mocks.userFindMany.mockResolvedValue([recipient]);
+    mocks.userFindUnique.mockResolvedValue({ ...recipient, status: 'ACTIVE' });
     mocks.notificationFindMany.mockResolvedValue([]);
     mocks.createInAppNotifications.mockResolvedValue(undefined);
     mocks.isChannelAvailable.mockResolvedValue(true);
@@ -109,6 +111,32 @@ describe('incident notification fan-out', () => {
     expect(mocks.sendNotification.mock.calls.map(call => call[2])).toEqual(
       expect.arrayContaining(['PUSH', 'SMS', 'WHATSAPP', 'EMAIL'])
     );
+  });
+  it('uses all user-enabled channels for escalation delivery', async () => {
+    mocks.incidentFindUnique.mockResolvedValue({ ...incident, status: 'OPEN', urgency: 'HIGH' });
+    mocks.userFindUnique.mockResolvedValue({
+      ...recipient,
+      status: 'ACTIVE',
+      pushNotificationsEnabled: true,
+      smsNotificationsEnabled: true,
+      whatsappNotificationsEnabled: false,
+      emailNotificationsEnabled: true,
+      phoneNumber: '+15555550100',
+    });
+    mocks.sendNotification.mockResolvedValue({
+      success: true,
+      outcome: 'DELIVERED',
+      notificationId: 'intent-1',
+    });
+
+    const result = await sendUserNotification('inc-1', 'user-1', 'Escalation alert');
+
+    expect(result).toMatchObject({ success: true, disposition: 'DELIVERED' });
+    expect(mocks.sendNotification.mock.calls.map(call => call[2])).toEqual([
+      'PUSH',
+      'SMS',
+      'EMAIL',
+    ]);
   });
   it('contains a provider outage to the persisted channel intent instead of retrying the parent', async () => {
     mocks.userFindMany.mockResolvedValue([{ ...recipient, pushNotificationsEnabled: true }]);

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -7,6 +7,8 @@ import {
   processCentralNotificationQueue,
 } from '@/lib/notification-control-plane';
 import prisma from '@/lib/prisma';
+import { CircuitBreakerError } from '@/lib/circuit-breaker';
+import { acquireProviderAdmission } from '@/lib/provider-admission';
 
 const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(),
@@ -73,6 +75,7 @@ const input = {
 describe('central notification control plane', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(acquireProviderAdmission).mockResolvedValue({ allowed: true });
     vi.mocked(prisma.notification.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.notification.findMany).mockResolvedValue([]);
     vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
@@ -159,6 +162,70 @@ describe('central notification control plane', () => {
     const sql = query.strings?.join('?') ?? '';
     expect(sql).toContain('lastAttemptAt');
     expect(sql).toContain('nextEligibleAt');
+  });
+
+  it('keeps admission deferrals pending without consuming delivery attempts', async () => {
+    const due = new Date(Date.now() - 60_000);
+    vi.mocked(prisma.notification.findUnique).mockResolvedValue({
+      id: 'notification_deferred',
+      status: 'PENDING',
+      category: 'SECURITY',
+      attempts: 0,
+      maxAttempts: 5,
+      nextAttemptAt: due,
+      scheduledAt: due,
+      lastAttemptAt: null,
+      expiresAt: null,
+      payloadEncrypted: `encrypted:${JSON.stringify(input.payload)}`,
+    } as never);
+    const retryAt = new Date(Date.now() + 30_000);
+    vi.mocked(acquireProviderAdmission).mockResolvedValue({
+      allowed: false,
+      retryAt,
+      reason: 'RATE_LIMITED',
+    });
+    vi.mocked(prisma.notification.updateMany).mockResolvedValue({ count: 1 } as never);
+
+    await deliverCentralNotification('notification_deferred');
+
+    expect(prisma.notification.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'PENDING',
+          failedAt: null,
+          lastAttemptAt: null,
+          nextAttemptAt: retryAt,
+        }),
+      })
+    );
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not consume retry budget when the provider circuit is already open', async () => {
+    const due = new Date(Date.now() - 60_000);
+    vi.mocked(prisma.notification.findUnique).mockResolvedValue({
+      id: 'notification_circuit_open',
+      status: 'PENDING',
+      category: 'SECURITY',
+      attempts: 1,
+      maxAttempts: 5,
+      nextAttemptAt: due,
+      scheduledAt: due,
+      lastAttemptAt: null,
+      expiresAt: null,
+      payloadEncrypted: `encrypted:${JSON.stringify(input.payload)}`,
+    } as never);
+    vi.mocked(prisma.notification.updateMany).mockResolvedValue({ count: 1 } as never);
+    mocks.sendEmail.mockRejectedValue(new CircuitBreakerError('Email circuit is open', 'email'));
+
+    await deliverCentralNotification('notification_circuit_open');
+
+    expect(prisma.notification.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'PENDING', attempts: 1, failedAt: null }),
+      })
+    );
+    expect(prisma.notificationDeliveryAttempt.create).not.toHaveBeenCalled();
   });
 
   it('scrubs expired security payloads in a bounded queue cleanup pass', async () => {

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -4,6 +4,7 @@ import {
   deliverCentralNotification,
   getNextCentralNotificationAt,
   maskedNotificationRecipient,
+  processCentralNotificationQueue,
 } from '@/lib/notification-control-plane';
 import prisma from '@/lib/prisma';
 
@@ -17,6 +18,8 @@ vi.mock('@/lib/prisma', () => ({
   default: {
     notification: {
       create: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
       findUnique: vi.fn(),
       updateMany: vi.fn(),
     },
@@ -32,6 +35,7 @@ vi.mock('@/lib/encryption', () => ({
 vi.mock('@/lib/email', () => ({ sendEmail: mocks.sendEmail }));
 vi.mock('@/lib/provider-admission', () => ({
   acquireProviderAdmission: vi.fn().mockResolvedValue({ allowed: true }),
+  deferProviderAdmission: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@/lib/circuit-breaker', () => ({
   CircuitBreakerError: class CircuitBreakerError extends Error {},
@@ -69,6 +73,9 @@ const input = {
 describe('central notification control plane', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.notification.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.notification.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
   });
 
   it('stores only encrypted payloads and masked recipients', async () => {
@@ -152,6 +159,27 @@ describe('central notification control plane', () => {
     const sql = query.strings?.join('?') ?? '';
     expect(sql).toContain('lastAttemptAt');
     expect(sql).toContain('nextEligibleAt');
+  });
+
+  it('scrubs expired security payloads in a bounded queue cleanup pass', async () => {
+    vi.mocked(prisma.notification.findMany).mockResolvedValue([
+      { id: 'notification_expired' },
+    ] as never);
+    vi.mocked(prisma.notification.updateMany).mockResolvedValue({ count: 1 } as never);
+
+    await expect(processCentralNotificationQueue()).resolves.toEqual({
+      processed: 0,
+      succeeded: 0,
+      failed: 0,
+    });
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 100 })
+    );
+    expect(prisma.notification.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'SKIPPED', payloadEncrypted: null }),
+      })
+    );
   });
 
   it('never redelivers an already terminal notification', async () => {

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createCentralNotificationIntent,
   deliverCentralNotification,
+  getNextCentralNotificationAt,
   maskedNotificationRecipient,
 } from '@/lib/notification-control-plane';
 import prisma from '@/lib/prisma';
@@ -135,6 +136,22 @@ describe('central notification control plane', () => {
 
     expect(results.filter(result => result.claimed)).toHaveLength(1);
     expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    expect(prisma.notification.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'SENT', payloadEncrypted: null }),
+      })
+    );
+  });
+
+  it('uses lease expiry as the next scheduler deadline for active claims', async () => {
+    const leaseExpiry = new Date(Date.now() + 9 * 60_000);
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ nextEligibleAt: leaseExpiry }] as never);
+
+    await expect(getNextCentralNotificationAt()).resolves.toEqual(leaseExpiry);
+    const query = vi.mocked(prisma.$queryRaw).mock.calls[0]?.[0] as { strings?: string[] };
+    const sql = query.strings?.join('?') ?? '';
+    expect(sql).toContain('lastAttemptAt');
+    expect(sql).toContain('nextEligibleAt');
   });
 
   it('never redelivers an already terminal notification', async () => {

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createCentralNotificationIntent,
+  deliverCentralNotification,
+  maskedNotificationRecipient,
+} from '@/lib/notification-control-plane';
+import prisma from '@/lib/prisma';
+
+const mocks = vi.hoisted(() => ({
+  sendEmail: vi.fn(),
+  encrypt: vi.fn(async (value: string) => `encrypted:${value}`),
+  decrypt: vi.fn(async (value: string) => value.replace(/^encrypted:/, '')),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    notification: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    notificationDeliveryAttempt: { create: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+}));
+vi.mock('@/lib/encryption', () => ({
+  encrypt: mocks.encrypt,
+  decrypt: mocks.decrypt,
+  getEncryptionKey: vi.fn(() => '11'.repeat(32)),
+}));
+vi.mock('@/lib/email', () => ({ sendEmail: mocks.sendEmail }));
+vi.mock('@/lib/provider-admission', () => ({
+  acquireProviderAdmission: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+vi.mock('@/lib/circuit-breaker', () => ({
+  CircuitBreakerError: class CircuitBreakerError extends Error {},
+  CircuitBreakers: {
+    email: () => ({ execute: (operation: () => unknown) => operation() }),
+    sms: () => ({ execute: (operation: () => unknown) => operation() }),
+    whatsapp: () => ({ execute: (operation: () => unknown) => operation() }),
+    push: () => ({ execute: (operation: () => unknown) => operation() }),
+    slack: () => ({ execute: (operation: () => unknown) => operation() }),
+    webhook: () => ({ execute: (operation: () => unknown) => operation() }),
+  },
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const input = {
+  category: 'SECURITY' as const,
+  channel: 'EMAIL' as const,
+  recipientType: 'EMAIL' as const,
+  recipientAddress: 'Person@Example.com',
+  templateKey: 'password-reset',
+  sourceType: 'USER',
+  sourceId: 'user-1',
+  eventKey: 'reset-request-1',
+  displayMessage: 'Password reset',
+  payload: {
+    kind: 'EMAIL' as const,
+    to: 'Person@Example.com',
+    subject: 'Reset password',
+    html: '<p>Reset</p>',
+  },
+};
+
+describe('central notification control plane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stores only encrypted payloads and masked recipients', async () => {
+    vi.mocked(prisma.notification.create).mockResolvedValue({ id: 'notification_one' } as never);
+
+    const result = await createCentralNotificationIntent(input);
+
+    expect(result.created).toBe(true);
+    expect(mocks.encrypt).toHaveBeenCalledWith(JSON.stringify(input.payload));
+    expect(prisma.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          recipientDisplay: 'p***@example.com',
+          payloadEncrypted: expect.stringMatching(/^encrypted:/),
+          deliveryKey: expect.stringMatching(/^[a-f0-9]{64}$/),
+        }),
+      })
+    );
+  });
+
+  it('returns the durable existing intent when concurrent creation loses the unique race', async () => {
+    vi.mocked(prisma.notification.create).mockRejectedValue({ code: 'P2002' });
+    vi.mocked(prisma.notification.findUnique).mockResolvedValue({
+      id: 'notification_existing',
+    } as never);
+
+    await expect(createCentralNotificationIntent(input)).resolves.toEqual({
+      id: 'notification_existing',
+      created: false,
+    });
+  });
+
+  it('uses one atomic claim when two workers race for the same delivery', async () => {
+    const due = new Date(Date.now() - 60_000);
+    vi.mocked(prisma.notification.findUnique).mockResolvedValue({
+      id: 'notification_race',
+      status: 'PENDING',
+      category: 'SECURITY',
+      attempts: 0,
+      maxAttempts: 5,
+      nextAttemptAt: due,
+      scheduledAt: due,
+      lastAttemptAt: null,
+      expiresAt: null,
+      payloadEncrypted: `encrypted:${JSON.stringify(input.payload)}`,
+    } as never);
+    let claimed = false;
+    vi.mocked(prisma.notification.updateMany).mockImplementation((async (
+      args: Parameters<typeof prisma.notification.updateMany>[0]
+    ) => {
+      const data = args.data as Record<string, unknown>;
+      if ('lastAttemptAt' in data && !('attempts' in data)) {
+        if (claimed) return { count: 0 };
+        claimed = true;
+      }
+      return { count: 1 };
+    }) as never);
+    vi.mocked(prisma.notificationDeliveryAttempt.create).mockResolvedValue({} as never);
+    mocks.sendEmail.mockResolvedValue({ success: true, providerMessageId: 'provider-1' });
+
+    const results = await Promise.all([
+      deliverCentralNotification('notification_race'),
+      deliverCentralNotification('notification_race'),
+    ]);
+
+    expect(results.filter(result => result.claimed)).toHaveLength(1);
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('never redelivers an already terminal notification', async () => {
+    vi.mocked(prisma.notification.findUnique).mockResolvedValue({
+      id: 'notification_sent',
+      status: 'SENT',
+      payloadEncrypted: 'encrypted:{}',
+    } as never);
+
+    await expect(deliverCentralNotification('notification_sent')).resolves.toEqual({
+      success: false,
+      claimed: false,
+    });
+    expect(prisma.notification.updateMany).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('masks every externally-addressed channel without exposing a full address', () => {
+    expect(maskedNotificationRecipient('EMAIL', 'alice@example.com')).toBe('a***@example.com');
+    expect(maskedNotificationRecipient('SMS', '+1 (555) 123-9876')).toBe('***9876');
+    expect(maskedNotificationRecipient('WEBHOOK', 'https://hooks.example.com/secret/token')).toBe(
+      'https://hooks.example.com'
+    );
+  });
+});

--- a/tests/lib/notification-operations.test.ts
+++ b/tests/lib/notification-operations.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getNotificationOperations, redactNotificationError } from '@/lib/notification-operations';
+import prisma from '@/lib/prisma';
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    notification: {
+      findMany: vi.fn(),
+      groupBy: vi.fn(),
+    },
+  },
+}));
+
+describe('notification operations query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.notification.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.notification.groupBy).mockResolvedValue([] as never);
+  });
+
+  it('redacts destinations and credentials from provider errors', () => {
+    expect(
+      redactNotificationError(
+        'Failed alice@example.com at https://hooks.example.com/private token=super-secret'
+      )
+    ).toBe('Failed [redacted email] at [redacted url] token=[redacted]');
+  });
+
+  it('uses keyset pagination only for rows, not aggregate health totals', async () => {
+    const cursor = Buffer.from(
+      JSON.stringify({ createdAt: '2026-08-31T00:00:00.000Z', id: 'notification_abc' })
+    ).toString('base64url');
+
+    await getNotificationOperations({ cursor, status: 'FAILED', limit: 50 });
+
+    const rowArgs = vi.mocked(prisma.notification.findMany).mock.calls[0]![0]!;
+    const statusArgs = vi.mocked(prisma.notification.groupBy).mock.calls[0]![0]!;
+    const rowWhere = rowArgs.where;
+    const statusWhere = statusArgs.where;
+    expect(rowWhere).toHaveProperty('AND');
+    expect(statusWhere).not.toHaveProperty('AND');
+    expect(statusWhere).toMatchObject({ status: 'FAILED' });
+  });
+
+  it('caps page size to protect the operations database path', async () => {
+    await getNotificationOperations({ limit: 10_000 });
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 101 })
+    );
+  });
+});

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -23,9 +23,12 @@ import {
 } from '@/lib/webhooks';
 import { sendIncidentWhatsApp } from '@/lib/whatsapp';
 import { getUserNotificationChannels, sendIncidentNotifications } from '@/lib/user-notifications';
-import * as slack from '@/lib/slack';
 import * as notificationProviders from '@/lib/notification-providers';
 import * as sms from '@/lib/sms';
+import { enqueueCentralNotification } from '@/lib/notification-control-plane';
+vi.mock('@/lib/notification-control-plane', () => ({
+  enqueueCentralNotification: vi.fn(),
+}));
 vi.mock('@/lib/prisma', () => ({
   __esModule: true,
   default: {
@@ -64,6 +67,11 @@ describe('Notification System Tests', () => {
     vi.mocked(prisma.notification.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.backgroundJob.findUnique).mockResolvedValue(null as never);
     vi.mocked(prisma.backgroundJob.upsert).mockResolvedValue({} as never);
+    vi.mocked(enqueueCentralNotification).mockResolvedValue({
+      id: 'notification_test',
+      created: true,
+      delivered: true,
+    });
   });
 
   describe('Service Notification Isolation', () => {
@@ -101,13 +109,12 @@ describe('Notification System Tests', () => {
 
       vi.mocked(prisma.notification.create).mockResolvedValue({ id: 'notif-1' } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-      const slackSpy = vi.spyOn(slack, 'notifySlackForIncident');
-      slackSpy.mockResolvedValue({ success: true });
-
       const result = await sendServiceNotifications(incidentId, 'triggered');
 
       expect(result.success).toBe(true);
-      expect(slackSpy).toHaveBeenCalled();
+      expect(enqueueCentralNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'SLACK', incidentId })
+      );
     });
   });
 
@@ -296,7 +303,9 @@ describe('Notification System Tests', () => {
     });
 
     it('should page the higher-priority layer when layers overlap', async () => {
-      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(scheduleWithLayers(0, 10) as any);
+      vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue(
+        scheduleWithLayers(0, 10) as any
+      );
       const users = await resolveEscalationTarget('SCHEDULE', scheduleId, new Date());
       expect(users).toEqual([user2Id]);
     });
@@ -306,8 +315,22 @@ describe('Notification System Tests', () => {
       vi.mocked(prisma.onCallSchedule.findUnique).mockResolvedValue({
         ...scheduleWithLayers(),
         overrides: [
-          { id: 'ovr-1', userId: user1Id, user: { name: 'User 1' }, start: new Date(now.getTime() - 3600_000), end: new Date(now.getTime() + 3600_000), replacesUserId: null },
-          { id: 'ovr-2', userId: user2Id, user: { name: 'User 2' }, start: new Date(now.getTime() - 3600_000), end: new Date(now.getTime() + 3600_000), replacesUserId: null },
+          {
+            id: 'ovr-1',
+            userId: user1Id,
+            user: { name: 'User 1' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
+          {
+            id: 'ovr-2',
+            userId: user2Id,
+            user: { name: 'User 2' },
+            start: new Date(now.getTime() - 3600_000),
+            end: new Date(now.getTime() + 3600_000),
+            replacesUserId: null,
+          },
         ],
       } as any);
       const users = await resolveEscalationTarget('SCHEDULE', scheduleId, now);
@@ -319,7 +342,11 @@ describe('Notification System Tests', () => {
     it('should return only team lead when notifyOnlyTeamLead is true', async () => {
       const teamLeadId = 'lead-1';
       const teamId = 'team-1';
-      vi.mocked(prisma.team.findUnique).mockResolvedValue({ id: teamId, teamLeadId, members: [{ userId: teamLeadId }] } as any);
+      vi.mocked(prisma.team.findUnique).mockResolvedValue({
+        id: teamId,
+        teamLeadId,
+        members: [{ userId: teamLeadId }],
+      } as any);
       vi.mocked(prisma.teamMember.findFirst).mockResolvedValue({ userId: teamLeadId } as any);
       const users = await resolveEscalationTarget('TEAM', teamId, new Date(), true);
       expect(users).toHaveLength(1);
@@ -329,7 +356,11 @@ describe('Notification System Tests', () => {
     it('should return no users when team lead has team notifications disabled', async () => {
       const teamLeadId = 'lead-2';
       const teamId = 'team-2';
-      vi.mocked(prisma.team.findUnique).mockResolvedValue({ id: teamId, teamLeadId, members: [] } as any);
+      vi.mocked(prisma.team.findUnique).mockResolvedValue({
+        id: teamId,
+        teamLeadId,
+        members: [],
+      } as any);
       vi.mocked(prisma.teamMember.findFirst).mockResolvedValue(null);
       const users = await resolveEscalationTarget('TEAM', teamId, new Date(), true);
       expect(users).toHaveLength(0);
@@ -340,7 +371,11 @@ describe('Notification System Tests', () => {
       const member1Id = 'member-1';
       const member2Id = 'member-2';
       const teamId = 'team-1';
-      vi.mocked(prisma.team.findUnique).mockResolvedValue({ id: teamId, teamLeadId, members: [{ userId: teamLeadId }, { userId: member1Id }, { userId: member2Id }] } as any);
+      vi.mocked(prisma.team.findUnique).mockResolvedValue({
+        id: teamId,
+        teamLeadId,
+        members: [{ userId: teamLeadId }, { userId: member1Id }, { userId: member2Id }],
+      } as any);
       const users = await resolveEscalationTarget('TEAM', teamId, new Date(), false);
       expect(users.length).toBe(3);
       expect(users).toContain(teamLeadId);
@@ -351,16 +386,35 @@ describe('Notification System Tests', () => {
 
   describe('Slack Integration', () => {
     it('should send Slack notification via webhook', async () => {
-      const incident = { id: 'test-id', title: 'Test Incident', status: 'OPEN', urgency: 'HIGH', serviceName: 'Test Service', assigneeName: 'Test User' };
+      const incident = {
+        id: 'test-id',
+        title: 'Test Incident',
+        status: 'OPEN',
+        urgency: 'HIGH',
+        serviceName: 'Test Service',
+        assigneeName: 'Test User',
+      };
       global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
-      const result = await sendSlackNotification('triggered', incident, undefined, 'https://hooks.slack.com/test');
+      const result = await sendSlackNotification(
+        'triggered',
+        incident,
+        undefined,
+        'https://hooks.slack.com/test'
+      );
       expect(result.success).toBe(true);
       expect(global.fetch).toHaveBeenCalled();
     });
 
     it('should send Slack message to channel via API', async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
-      const incident = { id: 'test-id', title: 'Test Incident', status: 'OPEN', urgency: 'HIGH', serviceName: 'Test Service', assigneeName: 'Test User' };
+      const incident = {
+        id: 'test-id',
+        title: 'Test Incident',
+        status: 'OPEN',
+        urgency: 'HIGH',
+        serviceName: 'Test Service',
+        assigneeName: 'Test User',
+      };
       vi.mocked(prisma.slackIntegration.findFirst).mockResolvedValue(null);
       const result = await sendSlackMessageToChannel('#incidents', incident, 'triggered', true);
       expect(result.success).toBe(false);
@@ -369,7 +423,18 @@ describe('Notification System Tests', () => {
 
   describe('Webhook Formatters', () => {
     it('should format Google Chat payload correctly', () => {
-      const incident = { id: 'test-id', title: 'Test Incident', description: 'Test description', status: 'OPEN', urgency: 'HIGH', service: { id: 'svc-1', name: 'Test Service' }, assignee: { id: 'user-1', name: 'Test User', email: 'test@example.com' }, createdAt: new Date(), acknowledgedAt: null, resolvedAt: null };
+      const incident = {
+        id: 'test-id',
+        title: 'Test Incident',
+        description: 'Test description',
+        status: 'OPEN',
+        urgency: 'HIGH',
+        service: { id: 'svc-1', name: 'Test Service' },
+        assignee: { id: 'user-1', name: 'Test User', email: 'test@example.com' },
+        createdAt: new Date(),
+        acknowledgedAt: null,
+        resolvedAt: null,
+      };
       const payload = formatGoogleChatPayload(incident, 'triggered', 'https://example.com');
       expect(payload.cards).toBeDefined();
       expect(payload.cards[0].header.title).toContain('Incident Triggered');
@@ -377,7 +442,18 @@ describe('Notification System Tests', () => {
     });
 
     it('should format Microsoft Teams payload correctly', () => {
-      const incident = { id: 'test-id', title: 'Test Incident', description: 'Test description', status: 'OPEN', urgency: 'HIGH', service: { id: 'svc-1', name: 'Test Service' }, assignee: { id: 'user-1', name: 'Test User', email: 'test@example.com' }, createdAt: new Date(), acknowledgedAt: null, resolvedAt: null };
+      const incident = {
+        id: 'test-id',
+        title: 'Test Incident',
+        description: 'Test description',
+        status: 'OPEN',
+        urgency: 'HIGH',
+        service: { id: 'svc-1', name: 'Test Service' },
+        assignee: { id: 'user-1', name: 'Test User', email: 'test@example.com' },
+        createdAt: new Date(),
+        acknowledgedAt: null,
+        resolvedAt: null,
+      };
       const payload = formatMicrosoftTeamsPayload(incident, 'triggered', 'https://example.com');
       expect(payload.type).toBe('message');
       expect(payload.attachments).toBeDefined();
@@ -385,7 +461,18 @@ describe('Notification System Tests', () => {
     });
 
     it('should format Discord payload correctly', () => {
-      const incident = { id: 'test-id', title: 'Test Incident', description: 'Test description', status: 'OPEN', urgency: 'HIGH', service: { id: 'svc-1', name: 'Test Service' }, assignee: { id: 'user-1', name: 'Test User', email: 'test@example.com' }, createdAt: new Date(), acknowledgedAt: null, resolvedAt: null };
+      const incident = {
+        id: 'test-id',
+        title: 'Test Incident',
+        description: 'Test description',
+        status: 'OPEN',
+        urgency: 'HIGH',
+        service: { id: 'svc-1', name: 'Test Service' },
+        assignee: { id: 'user-1', name: 'Test User', email: 'test@example.com' },
+        createdAt: new Date(),
+        acknowledgedAt: null,
+        resolvedAt: null,
+      };
       const payload = formatDiscordPayload(incident, 'triggered', 'https://example.com');
       expect(payload.embeds).toBeDefined();
       expect(payload.embeds[0].title).toContain('Incident Triggered');
@@ -398,9 +485,26 @@ describe('Notification System Tests', () => {
       const userId = 'user-1';
       const incidentId = 'inc-1';
       const serviceId = 'svc-1';
-      vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: userId, phoneNumber: '+1234567890', name: 'Test User' } as any);
-      vi.mocked(prisma.incident.findUnique).mockResolvedValue({ id: incidentId, title: 'Test Incident', urgency: 'HIGH', service: { id: serviceId, name: 'Test Service' }, assignee: null } as any);
-      vi.spyOn(notificationProviders, 'getWhatsAppConfig').mockResolvedValue({ enabled: true, provider: 'twilio', accountSid: 'ACtest-sid', authToken: 'test-token', whatsappNumber: '+1234567890', whatsappContentSid: 'test-content-sid' } as any);
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        id: userId,
+        phoneNumber: '+1234567890',
+        name: 'Test User',
+      } as any);
+      vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+        id: incidentId,
+        title: 'Test Incident',
+        urgency: 'HIGH',
+        service: { id: serviceId, name: 'Test Service' },
+        assignee: null,
+      } as any);
+      vi.spyOn(notificationProviders, 'getWhatsAppConfig').mockResolvedValue({
+        enabled: true,
+        provider: 'twilio',
+        accountSid: 'ACtest-sid',
+        authToken: 'test-token',
+        whatsappNumber: '+1234567890',
+        whatsappContentSid: 'test-content-sid',
+      } as any);
       const result = await sendIncidentWhatsApp(userId, incidentId, 'triggered');
       if (!result.success) console.error('WhatsApp Test Failed with error:', result.error);
       expect(result.success).toBe(true);
@@ -410,9 +514,18 @@ describe('Notification System Tests', () => {
   describe('Channel Priority', () => {
     it('should return channels in priority order: PUSH → SMS → WhatsApp → EMAIL', async () => {
       const userId = 'user-1';
-      vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: userId, emailNotificationsEnabled: true, smsNotificationsEnabled: true, pushNotificationsEnabled: true, whatsappNotificationsEnabled: true } as any);
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        id: userId,
+        emailNotificationsEnabled: true,
+        smsNotificationsEnabled: true,
+        pushNotificationsEnabled: true,
+        whatsappNotificationsEnabled: true,
+      } as any);
       vi.spyOn(notificationProviders, 'isChannelAvailable').mockResolvedValue(true);
-      vi.spyOn(notificationProviders, 'getSMSConfig').mockResolvedValue({ enabled: true, provider: 'twilio' } as any);
+      vi.spyOn(notificationProviders, 'getSMSConfig').mockResolvedValue({
+        enabled: true,
+        provider: 'twilio',
+      } as any);
       const channels = await getUserNotificationChannels(userId);
       const pushIndex = channels.indexOf('PUSH');
       const smsIndex = channels.indexOf('SMS');
@@ -424,14 +537,32 @@ describe('Notification System Tests', () => {
     });
   });
 
-  describe('Escalation Step Channels', () => {
-    it('should use escalation step channels when configured', async () => {
+  describe('Escalation Recipient Routing', () => {
+    it('should execute a configured escalation step without overriding user preferences', async () => {
       const userId = 'user-1';
       const incidentId = 'inc-1';
       const serviceId = 'svc-1';
       vi.mocked(prisma.incident.findUnique).mockResolvedValue({
-        id: incidentId, title: 'Test Incident', status: 'OPEN', currentEscalationStep: 0, escalationStatus: 'ESCALATING',
-        service: { id: serviceId, policy: { steps: [{ stepOrder: 0, delayMinutes: 0, targetType: 'USER', targetUserId: userId, notificationChannels: ['SMS'], targetUser: { name: 'Test User' } }] } },
+        id: incidentId,
+        title: 'Test Incident',
+        status: 'OPEN',
+        currentEscalationStep: 0,
+        escalationStatus: 'ESCALATING',
+        service: {
+          id: serviceId,
+          policy: {
+            steps: [
+              {
+                stepOrder: 0,
+                delayMinutes: 0,
+                targetType: 'USER',
+                targetUserId: userId,
+                notificationChannels: ['SMS'],
+                targetUser: { name: 'Test User' },
+              },
+            ],
+          },
+        },
       } as any);
       vi.mocked(prisma.incident.updateMany).mockResolvedValue({ count: 1 } as any);
       vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
@@ -439,7 +570,10 @@ describe('Notification System Tests', () => {
       const smsSpy = vi.spyOn(sms, 'sendIncidentSMS');
       smsSpy.mockResolvedValue({ success: true });
       const notificationModule = await import('@/lib/user-notifications');
-      vi.spyOn(notificationModule, 'sendUserNotification').mockResolvedValue({ success: true, channelsUsed: [] } as any);
+      vi.spyOn(notificationModule, 'sendUserNotification').mockResolvedValue({
+        success: true,
+        channelsUsed: [],
+      } as any);
       const result = await executeEscalation(incidentId, 0);
       expect(result.escalated).toBe(true);
     });

--- a/tests/lib/notification-system.test.ts
+++ b/tests/lib/notification-system.test.ts
@@ -570,12 +570,18 @@ describe('Notification System Tests', () => {
       const smsSpy = vi.spyOn(sms, 'sendIncidentSMS');
       smsSpy.mockResolvedValue({ success: true });
       const notificationModule = await import('@/lib/user-notifications');
-      vi.spyOn(notificationModule, 'sendUserNotification').mockResolvedValue({
+      const sendUserSpy = vi.spyOn(notificationModule, 'sendUserNotification').mockResolvedValue({
         success: true,
         channelsUsed: [],
       } as any);
       const result = await executeEscalation(incidentId, 0);
       expect(result.escalated).toBe(true);
+      expect(sendUserSpy).toHaveBeenCalledWith(
+        incidentId,
+        userId,
+        expect.any(String),
+        ['SMS']
+      );
     });
   });
 });

--- a/tests/lib/provider-admission.test.ts
+++ b/tests/lib/provider-admission.test.ts
@@ -1,5 +1,52 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-const mocks=vi.hoisted(()=>({transaction:vi.fn(),findUnique:vi.fn(),upsert:vi.fn(),update:vi.fn()}));
-vi.mock('@/lib/prisma',()=>({__esModule:true,default:{$transaction:mocks.transaction}}));
-import { acquireProviderAdmission } from '@/lib/provider-admission';
-describe('provider admission control',()=>{beforeEach(()=>{vi.clearAllMocks();mocks.transaction.mockImplementation(async callback=>callback({rateLimit:{findUnique:mocks.findUnique,upsert:mocks.upsert,update:mocks.update}}));});it('opens a new distributed provider window',async()=>{mocks.findUnique.mockResolvedValue(null);const now=new Date('2026-08-30T12:00:00.000Z');await expect(acquireProviderAdmission('EMAIL','default',now)).resolves.toEqual({allowed:true});expect(mocks.upsert).toHaveBeenCalledWith(expect.objectContaining({where:{key:'provider:email:default'},create:expect.objectContaining({count:1})}));});it('defers without consuming a provider request when the shared budget is full',async()=>{const expiresAt=new Date('2026-08-30T12:00:01.000Z');mocks.findUnique.mockResolvedValue({key:'provider:email:default',count:8,expiresAt});await expect(acquireProviderAdmission('EMAIL','default',new Date('2026-08-30T12:00:00.500Z'))).resolves.toEqual({allowed:false,retryAt:expiresAt,reason:'RATE_LIMITED'});expect(mocks.update).not.toHaveBeenCalled();});});
+const mocks = vi.hoisted(() => ({
+  transaction: vi.fn(),
+  executeRaw: vi.fn(),
+  findUnique: vi.fn(),
+  upsert: vi.fn(),
+  update: vi.fn(),
+}));
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: { $transaction: mocks.transaction, $executeRaw: mocks.executeRaw },
+}));
+import { acquireProviderAdmission, deferProviderAdmission } from '@/lib/provider-admission';
+describe('provider admission control', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.transaction.mockImplementation(async callback =>
+      callback({
+        rateLimit: { findUnique: mocks.findUnique, upsert: mocks.upsert, update: mocks.update },
+      })
+    );
+  });
+  it('opens a new distributed provider window', async () => {
+    mocks.findUnique.mockResolvedValue(null);
+    const now = new Date('2026-08-30T12:00:00.000Z');
+    await expect(acquireProviderAdmission('EMAIL', 'default', now)).resolves.toEqual({
+      allowed: true,
+    });
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: 'provider:email:default' },
+        create: expect.objectContaining({ count: 1 }),
+      })
+    );
+  });
+  it('defers without consuming a provider request when the shared budget is full', async () => {
+    const expiresAt = new Date('2026-08-30T12:00:01.000Z');
+    mocks.findUnique.mockResolvedValue({ key: 'provider:email:default', count: 8, expiresAt });
+    await expect(
+      acquireProviderAdmission('EMAIL', 'default', new Date('2026-08-30T12:00:00.500Z'))
+    ).resolves.toEqual({ allowed: false, retryAt: expiresAt, reason: 'RATE_LIMITED' });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('persists provider cooldowns monotonically', async () => {
+    await deferProviderAdmission('SLACK', 'channel:C123', new Date('2026-08-30T12:01:00.000Z'));
+
+    const query = mocks.executeRaw.mock.calls[0]?.[0] as { strings?: string[] };
+    expect(query.strings?.join('?')).toContain('GREATEST');
+    expect(query.strings?.join('?')).toContain('expiresAt');
+  });
+});

--- a/tests/lib/sla-breach-monitor.test.ts
+++ b/tests/lib/sla-breach-monitor.test.ts
@@ -5,6 +5,14 @@ import {
   type BreachWarning,
 } from '@/lib/sla-breach-monitor';
 
+vi.mock('@/lib/notification-control-plane', () => ({
+  enqueueCentralNotification: vi.fn().mockResolvedValue({
+    id: 'notification_test',
+    created: true,
+    delivered: true,
+  }),
+}));
+
 // Mock prisma
 vi.mock('@/lib/prisma', () => ({
   default: {


### PR DESCRIPTION
## Summary
- introduce a durable, encrypted notification control plane across email, SMS, push, Slack, webhook, WhatsApp, status-page, SLA, administration, and system notifications
- add deterministic intents, atomic leases, bounded retries, attempt history, provider admission/cooldowns, and adaptive scheduling
- add Admin/Auditor notification operations UI/API with filtering, redaction, cursor pagination, and replay controls
- enforce one external mutation per durable attempt for Slack and webhook adapters
- preserve escalation-step channel restrictions and enforce the architecture with contract tests

## Hardening completed
- restored escalation policy `notificationChannels` behavior
- made scheduler deadlines lease-aware
- shred terminal and expired SECURITY payload ciphertext with bounded cleanup
- updated the DB invariant for scrubbed terminal rows
- merged current `main` and resolved settings conflicts
- enabled distributed Slack admission
- persist HTTP 429 / `Retry-After` cooldowns atomically and monotonically
- removed nested Slack/generic/status-page webhook retries under control-plane ownership
- resolved all Advanced Security `no-explicit-any` findings
- configured real-DB producer tests with notification encryption and migrated service-intent assertions
- keep admission, HTTP 429, and open-circuit deferrals PENDING without consuming finite delivery attempts
- narrow permanent-error classification to explicit configuration, unsupported-provider, and invalid-target failures

## Delivery semantics
Email uses a deterministic provider idempotency key. Status-page webhooks carry a stable delivery ID for receiver-side deduplication. Providers without idempotency support remain explicitly at-least-once across a process crash after provider acceptance; the lease prevents concurrent delivery but cannot manufacture exactly-once guarantees from a non-idempotent API.

## Validation
- production Next.js build: passed
- TypeScript: passed
- Prisma schema/client/migration validation: passed
- changed-file ESLint: zero errors
- focused hardening suites: passed (latest 37/37; broader focused pass 73/73)
- full local suite: 1,709 passed, 102 skipped; only the real-DB advisory-lock check cannot run locally because valid PostgreSQL credentials are unavailable
- Bugbot final confirmation: no findings
- Security Review final confirmation: no findings

CI will rerun the real PostgreSQL integration suite on this head commit.
