### PR TITLE
fix(slack): stop queued service delivery after disable

### DIFF
--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -827,7 +827,9 @@ function isPermanentProviderError(message: string): boolean {
 function isLifecycleEventType(
   value: string
 ): value is 'triggered' | 'acknowledged' | 'resolved' | 'updated' {
-  return value === 'triggered' || value === 'acknowledged' || value === 'resolved' || value === 'updated';
+  return (
+    value === 'triggered' || value === 'acknowledged' || value === 'resolved' || value === 'updated'
+  );
 }
 
 async function incidentPayloadSuperseded(
@@ -963,7 +965,10 @@ async function lifecycleDeliveryRevoked(
 ): Promise<string | null> {
   const policy =
     payload.kind === 'SLACK_CHANNEL' || payload.kind === 'SLACK_WEBHOOK'
-      ? payload.lifecyclePolicy ?? { incidentId: payload.incident.id, eventType: payload.eventType }
+      ? (payload.lifecyclePolicy ?? {
+          incidentId: payload.incident.id,
+          eventType: payload.eventType,
+        })
       : payload.kind === 'WEBHOOK'
         ? payload.lifecyclePolicy
         : null;
@@ -985,6 +990,60 @@ async function lifecycleDeliveryRevoked(
   return isLifecycleEventType(policy.eventType)
     ? lifecycleStatusRevocation(policy.eventType, incident.status)
     : null;
+}
+
+async function serviceSlackDeliveryRevoked(
+  payload: CentralNotificationPayload,
+  notification: {
+    sourceType: string | null;
+    sourceId: string | null;
+    recipientId: string | null;
+    templateKey: string | null;
+  }
+): Promise<string | null> {
+  if (payload.kind !== 'SLACK_CHANNEL' && payload.kind !== 'SLACK_WEBHOOK') return null;
+  const inferredLegacyPolicy =
+    notification.sourceType === 'SERVICE_INCIDENT' &&
+    notification.templateKey?.startsWith('service-slack-')
+      ? {
+          serviceId:
+            (payload.kind === 'SLACK_CHANNEL' ? payload.serviceId : undefined) ||
+            notification.recipientId ||
+            notification.sourceId?.split(':')[0] ||
+            '',
+          targetType:
+            payload.kind === 'SLACK_CHANNEL' ? ('CHANNEL' as const) : ('WEBHOOK' as const),
+        }
+      : null;
+  // New rows use lifecyclePolicy and are handled by serviceTargetDeliveryRevoked.
+  // This fallback fences service Slack rows written before that metadata existed.
+  const policy = inferredLegacyPolicy;
+  if (!policy?.serviceId) return null;
+  try {
+    const service = await prisma.service.findUnique({
+      where: { id: policy.serviceId },
+      select: {
+        serviceNotificationChannels: true,
+        slackChannel: true,
+        slackWebhookUrl: true,
+      },
+    });
+    if (!service) return 'Service no longer exists';
+    if (!service.serviceNotificationChannels.includes('SLACK'))
+      return 'Service Slack notifications were disabled';
+    if (payload.kind === 'SLACK_CHANNEL') {
+      const currentChannel = service.slackChannel?.trim();
+      if (!currentChannel || currentChannel !== payload.channel.trim())
+        return 'Service Slack channel was removed or changed';
+    } else {
+      const currentWebhook = service.slackWebhookUrl?.trim();
+      if (!currentWebhook || currentWebhook !== payload.webhookUrl?.trim())
+        return 'Service Slack webhook was removed or changed';
+    }
+    return null;
+  } catch {
+    return 'Service Slack delivery policy could not be revalidated';
+  }
 }
 
 async function statusSubscriberDeliveryRevoked(
@@ -1130,6 +1189,10 @@ export async function deliverCentralNotification(
       lastAttemptAt: true,
       expiresAt: true,
       payloadEncrypted: true,
+      sourceType: true,
+      sourceId: true,
+      recipientId: true,
+      templateKey: true,
     },
   });
   if (!candidate || !candidate.payloadEncrypted) {
@@ -1207,6 +1270,7 @@ export async function deliverCentralNotification(
     supersededReason =
       (await statusSubscriberDeliveryRevoked(payload)) ??
       (await statusWebhookDeliveryRevoked(payload)) ??
+      (await serviceSlackDeliveryRevoked(payload, candidate)) ??
       (await lifecycleDeliveryRevoked(payload)) ??
       (await incidentPayloadSuperseded(payload));
   } catch (error) {

--- a/src/lib/sla-breach-monitor.ts
+++ b/src/lib/sla-breach-monitor.ts
@@ -369,7 +369,7 @@ async function notifyBreachWarning(
   // 1. Send Slack notification if enabled
   if (config.notifySlack) {
     const channels = warning.serviceNotificationChannels || [];
-    const hasSlackEnabled = channels.length === 0 || channels.includes('SLACK');
+    const hasSlackEnabled = channels.includes('SLACK');
     const slackChannel = warning.slackChannel?.trim();
     const slackWebhookUrl = warning.slackWebhookUrl?.trim() || configuredSlackWebhookUrl();
 

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -13,6 +13,7 @@ import { acquireProviderAdmission, acquireProviderConcurrency } from '@/lib/prov
 const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(),
   sendIncidentEmail: vi.fn(),
+  sendSlackMessageToChannel: vi.fn(),
   encrypt: vi.fn(async (value: string) => `encrypted:${value}`),
   decrypt: vi.fn(async (value: string) => value.replace(/^encrypted:/, '')),
 }));
@@ -27,6 +28,7 @@ vi.mock('@/lib/prisma', () => ({
       updateMany: vi.fn(),
     },
     incident: { findUnique: vi.fn() },
+    service: { findUnique: vi.fn() },
     notificationDeliveryAttempt: { create: vi.fn(), count: vi.fn() },
     $queryRaw: vi.fn(),
     $transaction: vi.fn(async (operation: unknown) =>
@@ -47,6 +49,10 @@ vi.mock('@/lib/encryption', () => ({
 vi.mock('@/lib/email', () => ({
   sendEmail: mocks.sendEmail,
   sendIncidentEmail: mocks.sendIncidentEmail,
+}));
+vi.mock('@/lib/slack', () => ({
+  sendSlackMessageToChannel: mocks.sendSlackMessageToChannel,
+  sendSlackNotification: vi.fn(),
 }));
 vi.mock('@/lib/provider-admission', () => ({
   acquireProviderAdmission: vi.fn().mockResolvedValue({ allowed: true }),
@@ -222,27 +228,25 @@ describe('central notification control plane', () => {
       durableMessage: 'encrypted message snapshot',
     };
     vi.mocked(prisma.notification.findUnique).mockResolvedValue({
-        id: 'notification_sibling_channel',
-        status: 'PENDING',
-        category: 'INCIDENT',
-        attempts: 0,
-        maxAttempts: 5,
-        nextAttemptAt: due,
-        scheduledAt: due,
-        lastAttemptAt: null,
-        expiresAt: null,
-        payloadEncrypted: `encrypted:${JSON.stringify(payload)}`,
-      } as never);
-    vi.mocked(prisma.incident.findUnique).mockResolvedValue(
-      {
-        status: 'OPEN',
-        updatedAt: new Date('2026-08-30T12:01:00.000Z'),
-        acknowledgedAt: null,
-        resolvedAt: null,
-        currentEscalationStep: 1,
-        escalationGeneration: 4,
-      } as never
-    );
+      id: 'notification_sibling_channel',
+      status: 'PENDING',
+      category: 'INCIDENT',
+      attempts: 0,
+      maxAttempts: 5,
+      nextAttemptAt: due,
+      scheduledAt: due,
+      lastAttemptAt: null,
+      expiresAt: null,
+      payloadEncrypted: `encrypted:${JSON.stringify(payload)}`,
+    } as never);
+    vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+      status: 'OPEN',
+      updatedAt: new Date('2026-08-30T12:01:00.000Z'),
+      acknowledgedAt: null,
+      resolvedAt: null,
+      currentEscalationStep: 1,
+      escalationGeneration: 4,
+    } as never);
     vi.mocked(prisma.notification.updateMany).mockResolvedValue({ count: 1 } as never);
     mocks.sendIncidentEmail.mockResolvedValue({ success: true, providerMessageId: 'email-1' });
 
@@ -251,6 +255,59 @@ describe('central notification control plane', () => {
       claimed: true,
     });
     expect(mocks.sendIncidentEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a queued service Slack intent after the service checkbox is disabled', async () => {
+    const due = new Date(Date.now() - 60_000);
+    const payload = {
+      kind: 'SLACK_CHANNEL' as const,
+      channel: 'opsknight-alert',
+      incident: {
+        id: 'incident-1',
+        title: 'Workflow failed',
+        status: 'RESOLVED',
+        urgency: 'HIGH',
+        serviceName: 'CI',
+      },
+      eventType: 'resolved' as const,
+      serviceId: 'service-1',
+    };
+    vi.mocked(prisma.notification.findUnique).mockResolvedValue({
+      id: 'notification-disabled-slack',
+      status: 'PENDING',
+      category: 'INCIDENT',
+      attempts: 0,
+      maxAttempts: 3,
+      nextAttemptAt: due,
+      scheduledAt: due,
+      lastAttemptAt: null,
+      expiresAt: null,
+      payloadEncrypted: `encrypted:${JSON.stringify(payload)}`,
+      sourceType: 'SERVICE_INCIDENT',
+      sourceId: 'service-1:incident-1',
+      recipientId: 'service-1',
+      templateKey: 'service-slack-resolved',
+    } as never);
+    vi.mocked(prisma.notification.updateMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(prisma.service.findUnique).mockResolvedValue({
+      serviceNotificationChannels: [],
+      slackChannel: 'opsknight-alert',
+      slackWebhookUrl: null,
+    } as never);
+
+    await expect(deliverCentralNotification('notification-disabled-slack')).resolves.toEqual({
+      success: true,
+      claimed: true,
+    });
+    expect(mocks.sendSlackMessageToChannel).not.toHaveBeenCalled();
+    expect(prisma.notification.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'SKIPPED',
+          errorMsg: 'Service Slack notifications were disabled',
+        }),
+      })
+    );
   });
 
   it('uses lease expiry as the next scheduler deadline for active claims', async () => {

--- a/tests/lib/sla-breach-monitor.test.ts
+++ b/tests/lib/sla-breach-monitor.test.ts
@@ -210,6 +210,41 @@ describe('sla-breach-monitor', () => {
       expect(enqueueCentralNotification).not.toHaveBeenCalled();
     });
 
+    it('does not create an SLA Slack intent when the service Slack checkbox is unchecked', async () => {
+      const { default: prisma } = await import('@/lib/prisma');
+      const now = new Date('2026-01-05T12:00:00Z');
+      vi.setSystemTime(now);
+      vi.mocked(prisma.incident.findMany).mockResolvedValue([
+        {
+          id: 'inc-1',
+          title: 'Test Incident',
+          serviceId: 'svc-1',
+          urgency: 'HIGH',
+          status: 'OPEN',
+          createdAt: new Date(now.getTime() - 12 * 60 * 1000),
+          acknowledgedAt: null,
+          dedupKey: null,
+          escalationProcessingAt: null,
+          snoozedUntil: null,
+          snoozeReason: null,
+          service: {
+            id: 'svc-1',
+            name: 'Test Service',
+            targetAckMinutes: 15,
+            targetResolveMinutes: 120,
+            slackChannel: 'C123',
+            slackWebhookUrl: 'https://hooks.slack.com/services/test',
+            serviceNotificationChannels: [],
+            serviceNotifyOnSlaBreach: true,
+            webhookIntegrations: [],
+          },
+        },
+      ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
+
+      await expect(checkSLABreaches()).resolves.toMatchObject({ warningCount: 1 });
+      expect(enqueueCentralNotification).not.toHaveBeenCalled();
+    });
+
     it('does not commit the SLA dedupe marker when intent materialization fails', async () => {
       const { default: prisma } = await import('@/lib/prisma');
       const now = new Date('2026-01-05T12:00:00Z');
@@ -240,7 +275,9 @@ describe('sla-breach-monitor', () => {
           },
         },
       ] as unknown as Awaited<ReturnType<typeof prisma.incident.findMany>>);
-      vi.mocked(enqueueCentralNotification).mockRejectedValueOnce(new Error('database unavailable'));
+      vi.mocked(enqueueCentralNotification).mockRejectedValueOnce(
+        new Error('database unavailable')
+      );
 
       await expect(checkSLABreaches()).rejects.toThrow('database unavailable');
       expect(prisma.incidentEvent.create).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- revalidate legacy queued service Slack channel and webhook rows immediately before provider delivery
- skip pending/retried rows when the service Slack checkbox is disabled
- skip rows when the configured Slack channel or webhook target changes
- preserve the lifecycle-policy handling already present for newly created rows

## Regression coverage
- queued pre-policy SERVICE_INCIDENT Slack row is marked SKIPPED after Slack is unchecked
- Slack provider is not contacted

## Validation
- TypeScript typecheck passed
- focused notification tests: 34 passed