### PR TITLE
fix(workers): surface critical lane degradation

### DIFF
--- a/src/lib/escalation/worker.ts
+++ b/src/lib/escalation/worker.ts
@@ -34,6 +34,8 @@ export interface CriticalEscalationCycleResult {
   /** Whether reconciliation ran, and what it repaired. */
   reconciled: boolean;
   repairs: number;
+  /** Failures that degraded this cycle without stopping independent stages. */
+  errors: string[];
 }
 
 let lastFallbackScanAt = 0;
@@ -68,6 +70,12 @@ export function resetCriticalEscalationCadence(): void {
   wakeRequested = false;
 }
 
+function scanIsDue(now: number, lastScanAt: number, intervalMs: number): boolean {
+  // Wall clocks can move backwards after NTP correction or VM resume. Treat
+  // that as immediately due instead of suppressing recovery until time catches up.
+  return lastScanAt === 0 || now < lastScanAt || now - lastScanAt >= intervalMs;
+}
+
 /**
  * One pass of the critical lane.
  *
@@ -86,6 +94,7 @@ export async function runCriticalEscalationCycle(
     fallbackProcessed: 0,
     reconciled: false,
     repairs: 0,
+    errors: [],
   };
 
   try {
@@ -98,25 +107,29 @@ export async function runCriticalEscalationCycle(
     result.jobsProcessed = jobs.processed;
     result.jobsFailed = jobs.failed;
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result.errors.push(`job batch: ${message}`);
     logger.error('escalation.worker.job_batch_failed', {
-      error: error instanceof Error ? error.message : String(error),
+      error: message,
     });
   }
 
-  if (now - lastFallbackScanAt >= FALLBACK_SCAN_INTERVAL_MS) {
+  if (scanIsDue(now, lastFallbackScanAt, FALLBACK_SCAN_INTERVAL_MS)) {
     lastFallbackScanAt = now;
     try {
       // Durable state, not the job row, decides what is owed.
       const fallback = await processPendingEscalations();
       result.fallbackProcessed = fallback.processed;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`fallback scan: ${message}`);
       logger.error('escalation.worker.fallback_scan_failed', {
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
       });
     }
   }
 
-  if (now - lastReconcileAt >= RECONCILE_INTERVAL_MS) {
+  if (scanIsDue(now, lastReconcileAt, RECONCILE_INTERVAL_MS)) {
     lastReconcileAt = now;
     try {
       const report = await reconcileEscalations();
@@ -126,9 +139,12 @@ export async function runCriticalEscalationCycle(
         report.dueJobsRecreated +
         report.staleJobsCancelled +
         report.leasesReleased;
+      result.errors.push(...report.errors.map(error => `reconciliation: ${error}`));
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`reconciliation: ${message}`);
       logger.error('escalation.worker.reconcile_failed', {
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
       });
     }
   }

--- a/src/lib/job-worker.ts
+++ b/src/lib/job-worker.ts
@@ -139,8 +139,20 @@ async function runOnce(): Promise<void> {
     const notifications = await runCriticalNotificationCycle();
 
     const result = await processPendingJobs(workerConfig.batchSize, workerConfig.concurrency);
-    lastSuccessAt = new Date();
-    lastError = null;
+    const laneErrors = [...escalation.errors, ...notifications.errors];
+    if (escalation.jobsFailed > 0) {
+      laneErrors.push(`${escalation.jobsFailed} escalation job(s) failed`);
+    }
+    if (notifications.centralFailed > 0) {
+      laneErrors.push(`${notifications.centralFailed} central notification(s) failed`);
+    }
+    if (laneErrors.length === 0) {
+      lastSuccessAt = new Date();
+      lastError = null;
+    } else {
+      lastError = laneErrors.join('; ');
+      logger.warn('[JobWorker] Critical lane degraded', { errors: laneErrors });
+    }
 
     logger.debug('[JobWorker] Batch processed', {
       processed: result.processed,

--- a/src/lib/notification-recovery.ts
+++ b/src/lib/notification-recovery.ts
@@ -48,6 +48,8 @@ export interface CriticalNotificationCycleResult {
   /** Whether each scan ran, so an idle lane is distinguishable from a skipped one. */
   scannedCentral: boolean;
   scannedLegacy: boolean;
+  /** Failures that degraded this cycle without stopping the worker loop. */
+  errors: string[];
 }
 
 let lastCentralScanAt = 0;
@@ -68,7 +70,12 @@ function emptyResult(): CriticalNotificationCycleResult {
     legacySucceeded: 0,
     scannedCentral: false,
     scannedLegacy: false,
+    errors: [],
   };
+}
+
+function scanIsDue(now: number, lastScanAt: number, intervalMs: number): boolean {
+  return lastScanAt === 0 || now < lastScanAt || now - lastScanAt >= intervalMs;
 }
 
 /**
@@ -81,7 +88,7 @@ export async function runCriticalNotificationCycle(
   const now = options.now ?? Date.now();
   const result = emptyResult();
 
-  if (now - lastCentralScanAt >= CENTRAL_QUEUE_INTERVAL_MS) {
+  if (scanIsDue(now, lastCentralScanAt, CENTRAL_QUEUE_INTERVAL_MS)) {
     lastCentralScanAt = now;
     result.scannedCentral = true;
     try {
@@ -91,13 +98,15 @@ export async function runCriticalNotificationCycle(
       result.centralSucceeded = central.succeeded;
       result.centralFailed = central.failed;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`central queue: ${message}`);
       logger.error('notification.worker.central_queue_failed', {
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
       });
     }
   }
 
-  if (now - lastLegacyScanAt >= LEGACY_RETRY_INTERVAL_MS) {
+  if (scanIsDue(now, lastLegacyScanAt, LEGACY_RETRY_INTERVAL_MS)) {
     lastLegacyScanAt = now;
     result.scannedLegacy = true;
     try {
@@ -106,8 +115,10 @@ export async function runCriticalNotificationCycle(
       result.legacyRetried = legacy.retried;
       result.legacySucceeded = legacy.succeeded;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`legacy retry: ${message}`);
       logger.error('notification.worker.legacy_retry_failed', {
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
       });
     }
   }

--- a/tests/lib/escalation/worker.test.ts
+++ b/tests/lib/escalation/worker.test.ts
@@ -128,7 +128,31 @@ describe('runCriticalEscalationCycle', () => {
       jobsClaimed: 0,
       fallbackProcessed: 0,
       reconciled: false,
+      errors: [
+        'job batch: queue down',
+        'fallback scan: scan down',
+        'reconciliation: recovery down',
+      ],
     });
+  });
+
+  it('surfaces reconciliation repair errors without stopping the cycle', async () => {
+    mocks.reconcileEscalations.mockResolvedValue({
+      ...noRepairs(),
+      errors: ['recreate inc-1: database unavailable'],
+    });
+
+    const result = await runCriticalEscalationCycle({ now: T0 });
+
+    expect(result.errors).toEqual(['reconciliation: recreate inc-1: database unavailable']);
+  });
+
+  it('rescans recovery immediately when the wall clock moves backwards', async () => {
+    await runCriticalEscalationCycle({ now: T0 });
+    await runCriticalEscalationCycle({ now: T0 - 60_000 });
+
+    expect(mocks.processPendingEscalations).toHaveBeenCalledTimes(2);
+    expect(mocks.reconcileEscalations).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/tests/lib/job-worker.test.ts
+++ b/tests/lib/job-worker.test.ts
@@ -61,6 +61,7 @@ describe('dedicated job worker', () => {
       fallbackProcessed: 0,
       reconciled: false,
       repairs: 0,
+      errors: [],
     });
     vi.mocked(runCriticalNotificationCycle).mockResolvedValue({
       centralProcessed: 0,
@@ -70,6 +71,7 @@ describe('dedicated job worker', () => {
       legacySucceeded: 0,
       scannedCentral: false,
       scannedLegacy: false,
+      errors: [],
     });
     vi.mocked(criticalEscalationCycleWasBusy).mockReturnValue(false);
     vi.mocked(criticalNotificationCycleWasBusy).mockReturnValue(false);
@@ -130,6 +132,7 @@ describe('dedicated job worker', () => {
         fallbackProcessed: 0,
         reconciled: false,
         repairs: 0,
+        errors: [],
       };
     });
     vi.mocked(runCriticalNotificationCycle).mockImplementation(async () => {
@@ -142,6 +145,7 @@ describe('dedicated job worker', () => {
         legacySucceeded: 0,
         scannedCentral: false,
         scannedLegacy: false,
+        errors: [],
       };
     });
     vi.mocked(processPendingJobs).mockImplementation(async () => {
@@ -168,6 +172,57 @@ describe('dedicated job worker', () => {
     // full idle poll for the next cycle.
     await vi.advanceTimersByTimeAsync(100);
     expect(processPendingJobs).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports partial critical-lane failure as degraded worker health', async () => {
+    vi.mocked(runCriticalNotificationCycle).mockResolvedValue({
+      centralProcessed: 0,
+      centralSucceeded: 0,
+      centralFailed: 0,
+      legacyRetried: 0,
+      legacySucceeded: 0,
+      scannedCentral: true,
+      scannedLegacy: true,
+      errors: ['central queue: database unavailable'],
+    });
+
+    startJobWorker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(getJobWorkerStatus()).toMatchObject({
+      lastSuccessAt: null,
+      lastError: 'central queue: database unavailable',
+    });
+  });
+
+  it('clears degraded health only after every critical lane succeeds', async () => {
+    vi.mocked(runCriticalEscalationCycle)
+      .mockResolvedValueOnce({
+        jobsClaimed: 0,
+        jobsProcessed: 0,
+        jobsFailed: 0,
+        fallbackProcessed: 0,
+        reconciled: false,
+        repairs: 0,
+        errors: ['job batch: database unavailable'],
+      })
+      .mockResolvedValue({
+        jobsClaimed: 0,
+        jobsProcessed: 0,
+        jobsFailed: 0,
+        fallbackProcessed: 0,
+        reconciled: false,
+        repairs: 0,
+        errors: [],
+      });
+
+    startJobWorker();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getJobWorkerStatus().lastError).toContain('database unavailable');
+
+    await vi.advanceTimersByTimeAsync(1_250);
+    expect(getJobWorkerStatus().lastError).toBeNull();
+    expect(getJobWorkerStatus().lastSuccessAt).toBeInstanceOf(Date);
   });
 
   it('does not overlap queue batches within a worker process', async () => {

--- a/tests/lib/notification-recovery.test.ts
+++ b/tests/lib/notification-recovery.test.ts
@@ -98,6 +98,7 @@ describe('runCriticalNotificationCycle', () => {
     await expect(runCriticalNotificationCycle({ now: T0 })).resolves.toMatchObject({
       centralProcessed: 0,
       legacyRetried: 0,
+      errors: ['central queue: control plane down', 'legacy retry: sweeper down'],
     });
   });
 
@@ -108,5 +109,13 @@ describe('runCriticalNotificationCycle', () => {
     await runCriticalNotificationCycle({ now: T0 + 500 });
 
     expect(mocks.processCentralNotificationQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('rescans immediately when the wall clock moves backwards', async () => {
+    await runCriticalNotificationCycle({ now: T0 });
+    await runCriticalNotificationCycle({ now: T0 - 60_000 });
+
+    expect(mocks.processCentralNotificationQueue).toHaveBeenCalledTimes(2);
+    expect(mocks.retryFailedNotifications).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- propagate escalation and notification recovery failures into worker health
- prevent false-green health while a critical lane is degraded
- recover immediately after backward wall-clock adjustments
- add regression coverage for partial failures, recovery errors, and health restoration

## Validation
- 1,975/1,975 unit tests
- 267/267 focused escalation and notification recovery tests
- TypeScript
- changed-file ESLint
- git diff --check