### PR TITLE
fix(security): harden user lifecycle and RBAC invariants

### DIFF
--- a/prisma/migrations/20260901183000_bind_user_tokens_to_identity/migration.sql
+++ b/prisma/migrations/20260901183000_bind_user_tokens_to_identity/migration.sql
@@ -37,18 +37,6 @@ ALTER TABLE "OidcLinkingApproval"
 ADD CONSTRAINT "OidcLinkingApproval_userId_fkey"
 FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
-INSERT INTO "OidcLinkingApproval" (
-  "id", "userId", "approvedAt", "generation", "createdAt", "updatedAt"
-)
-SELECT 'legacy_' || user_record."id", user_record."id", CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-FROM "User" AS user_record
-WHERE user_record."status" = 'ACTIVE'
-  AND EXISTS (
-    SELECT 1 FROM "UserToken" AS token
-    WHERE token."userId" = user_record."id" AND token."type" = 'INVITE'
-  )
-ON CONFLICT ("userId") DO NOTHING;
-
 ALTER TABLE "Notification" DROP CONSTRAINT IF EXISTS "Notification_userId_fkey";
 ALTER TABLE "Notification"
 ADD CONSTRAINT "Notification_userId_fkey"

--- a/prisma/migrations/20260901183000_bind_user_tokens_to_identity/migration.sql
+++ b/prisma/migrations/20260901183000_bind_user_tokens_to_identity/migration.sql
@@ -1,0 +1,55 @@
+ALTER TABLE "User"
+ADD COLUMN "invitationGeneration" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "UserToken"
+ADD COLUMN "userId" TEXT,
+ADD COLUMN "generation" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "revokedAt" TIMESTAMP(3);
+
+UPDATE "UserToken" AS token
+SET "userId" = matched_user."id"
+FROM "User" AS matched_user
+WHERE lower(token."identifier") = lower(matched_user."email");
+
+CREATE INDEX "UserToken_userId_type_generation_idx"
+ON "UserToken"("userId", "type", "generation");
+
+ALTER TABLE "UserToken"
+ADD CONSTRAINT "UserToken_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE TABLE "OidcLinkingApproval" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "approvedById" TEXT,
+  "approvedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "revokedAt" TIMESTAMP(3),
+  "generation" INTEGER NOT NULL DEFAULT 1,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "OidcLinkingApproval_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "OidcLinkingApproval_userId_key" ON "OidcLinkingApproval"("userId");
+CREATE INDEX "OidcLinkingApproval_approvedById_idx" ON "OidcLinkingApproval"("approvedById");
+ALTER TABLE "OidcLinkingApproval"
+ADD CONSTRAINT "OidcLinkingApproval_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+INSERT INTO "OidcLinkingApproval" (
+  "id", "userId", "approvedAt", "generation", "createdAt", "updatedAt"
+)
+SELECT 'legacy_' || user_record."id", user_record."id", CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "User" AS user_record
+WHERE user_record."status" = 'ACTIVE'
+  AND EXISTS (
+    SELECT 1 FROM "UserToken" AS token
+    WHERE token."userId" = user_record."id" AND token."type" = 'INVITE'
+  )
+ON CONFLICT ("userId") DO NOTHING;
+
+ALTER TABLE "Notification" DROP CONSTRAINT IF EXISTS "Notification_userId_fkey";
+ALTER TABLE "Notification"
+ADD CONSTRAINT "Notification_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,7 @@ model User {
   emailVerified                DateTime?
   // Session revocation marker: increment to force-logout all JWT sessions
   tokenVersion                 Int        @default(0)
+  invitationGeneration        Int        @default(0)
   role                         Role       @default(USER)
   status                       UserStatus @default(INVITED)
   passwordHash                 String?
@@ -236,9 +237,11 @@ model User {
   jiraConfigsUpdated  JiraConfig[]           @relation("JiraConfigUpdater")
   oidcConfigs         OidcConfig[]
   oidcIdentities      OidcIdentity[]
+  oidcLinkingApproval OidcLinkingApproval?
   avatar              UserAvatar?
   dashboards          Dashboard[]
   assignedActionItems ActionItem[]
+  tokens              UserToken[]
 
   @@index([email]) // CRITICAL: Performance index for email lookups (fixes 2-4s queries)
   @@index([role, status]) // For filtering users by role and status
@@ -899,7 +902,7 @@ model Notification {
   createdAt         DateTime                  @default(now())
 
   incident         Incident?                     @relation(fields: [incidentId], references: [id])
-  user             User?                         @relation(fields: [userId], references: [id])
+  user             User?                         @relation(fields: [userId], references: [id], onDelete: SetNull)
   deliveryAttempts NotificationDeliveryAttempt[]
 
   @@index([incidentId]) // For querying notifications by incident
@@ -1006,14 +1009,35 @@ model UserToken {
   id         String        @id @default(cuid())
   type       UserTokenType
   identifier String // typically the user's email (lowercased)
+  userId     String?
+  generation Int           @default(0)
   tokenHash  String        @unique
   expiresAt  DateTime
   usedAt     DateTime?
+  revokedAt  DateTime?
   createdAt  DateTime      @default(now())
   metadata   Json?
 
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
   @@index([identifier, type])
+  @@index([userId, type, generation])
   @@index([expiresAt])
+}
+
+model OidcLinkingApproval {
+  id           String    @id @default(cuid())
+  userId       String    @unique
+  approvedById String?
+  approvedAt   DateTime  @default(now())
+  revokedAt    DateTime?
+  generation   Int       @default(1)
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([approvedById])
 }
 
 model ApiKey {

--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/rbac';
 import { AppError } from '@/lib/errors';
 import { logger } from '@/lib/logger';
+import { requireOperationalUser } from '@/lib/users/operational-eligibility';
 import {
   updateIncidentStatus as updateIncidentStatusWithLifecycle,
   resolveIncidentWithNote as resolveIncidentWithLifecycleNote,
@@ -223,23 +224,26 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
 
   // Handle unassigning (empty assigneeId and teamId)
   if ((!assigneeId || assigneeId.trim() === '') && (!teamId || teamId.trim() === '')) {
-    await prisma.$transaction(async tx => {
-      await tx.incident.update({
-        where: { id: incidentId },
-        data: {
-          assigneeId: null,
-          teamId: null,
-        },
-      });
+    await prisma.$transaction(
+      async tx => {
+        await tx.incident.update({
+          where: { id: incidentId },
+          data: {
+            assigneeId: null,
+            teamId: null,
+          },
+        });
 
-      await tx.incidentEvent.create({
-        data: {
-          incidentId,
-          type: 'ASSIGNMENT',
-          message: 'Incident unassigned',
-        },
-      });
-    });
+        await tx.incidentEvent.create({
+          data: {
+            incidentId,
+            type: 'ASSIGNMENT',
+            message: 'Incident unassigned',
+          },
+        });
+      },
+      { isolationLevel: 'Serializable' }
+    );
 
     // ChatOps: Sync unassignment & update topic in war-room
     try {
@@ -311,35 +315,40 @@ export async function reassignIncident(incidentId: string, assigneeId: string, t
 
   // Handle assigning to a user
   if (assigneeId && assigneeId.trim() !== '') {
-    await prisma.$transaction(async tx => {
-      const assigneeRecord = await tx.user.findUnique({ where: { id: assigneeId } });
-      if (!assigneeRecord) {
-        throw new AppError({
-          code: 'RESOURCE_NOT_FOUND',
-          userMessage: LEGACY_NOT_FOUND_MESSAGE,
-          details: { resource: 'user', userId: assigneeId },
+    await prisma.$transaction(
+      async tx => {
+        let assigneeRecord;
+        try {
+          assigneeRecord = await requireOperationalUser(tx, assigneeId);
+        } catch {
+          throw new AppError({
+            code: 'RESOURCE_NOT_FOUND',
+            userMessage: LEGACY_NOT_FOUND_MESSAGE,
+            details: { resource: 'user', userId: assigneeId },
+          });
+        }
+
+        await tx.incident.update({
+          where: { id: incidentId },
+          data: {
+            assigneeId,
+            teamId: null, // Clear team assignment when assigning to user
+          },
         });
-      }
 
-      await tx.incident.update({
-        where: { id: incidentId },
-        data: {
-          assigneeId,
-          teamId: null, // Clear team assignment when assigning to user
-        },
-      });
-
-      await tx.incidentEvent.create({
-        data: {
-          incidentId,
-          type: 'ASSIGNMENT',
-          message: `Incident manually reassigned to ${assigneeRecord.name}`,
-        },
-      });
-      await enqueueIncidentUpdateSideEffects(tx, incidentId, [
-        'INCIDENT_ASSIGNED_TO_USER_NOTIFICATION',
-      ]);
-    });
+        await tx.incidentEvent.create({
+          data: {
+            incidentId,
+            type: 'ASSIGNMENT',
+            message: `Incident manually reassigned to ${assigneeRecord.name}`,
+          },
+        });
+        await enqueueIncidentUpdateSideEffects(tx, incidentId, [
+          'INCIDENT_ASSIGNED_TO_USER_NOTIFICATION',
+        ]);
+      },
+      { isolationLevel: 'Serializable' }
+    );
 
     // ChatOps: Sync user assignment, auto-invite user & update topic in war-room
     try {

--- a/src/app/(app)/incidents/bulk-actions.ts
+++ b/src/app/(app)/incidents/bulk-actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { assertResponderOrAbove, getCurrentUser } from '@/lib/rbac';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { logger } from '@/lib/logger';
+import { requireOperationalUser } from '@/lib/users/operational-eligibility';
 import {
   executeIncidentLifecycleBatch,
   executeIncidentLifecycleTargetBatch,
@@ -138,32 +139,36 @@ export async function bulkReassign(incidentIds: string[], assigneeId: string) {
   }
 
   try {
-    const assignee = await prisma.user.findUnique({ where: { id: assigneeId } });
+    const assignee = await prisma.user.findFirst({ where: { id: assigneeId, status: 'ACTIVE' } });
     if (!assignee) {
       return { success: false, error: 'Assignee not found' };
     }
 
     const user = await getCurrentUser();
-    await prisma.$transaction(async tx => {
-      await tx.incident.updateMany({
-        where: { id: { in: incidentIds } },
-        data: { assigneeId, teamId: null },
-      });
-      await tx.incidentEvent.createMany({
-        data: incidentIds.map(incidentId => ({
-          incidentId,
-          message: `Bulk reassigned to ${assignee.name}${user ? ` by ${user.name}` : ''}`,
-        })),
-      });
-      await Promise.all(
-        incidentIds.map(incidentId =>
-          enqueueIncidentUpdateSideEffects(tx, incidentId, [
-            'INCIDENT_ASSIGNED_TO_USER_NOTIFICATION',
-            'INCIDENT_UPDATE_WEBHOOK',
-          ])
-        )
-      );
-    });
+    await prisma.$transaction(
+      async tx => {
+        await requireOperationalUser(tx, assigneeId);
+        await tx.incident.updateMany({
+          where: { id: { in: incidentIds } },
+          data: { assigneeId, teamId: null },
+        });
+        await tx.incidentEvent.createMany({
+          data: incidentIds.map(incidentId => ({
+            incidentId,
+            message: `Bulk reassigned to ${assignee.name}${user ? ` by ${user.name}` : ''}`,
+          })),
+        });
+        await Promise.all(
+          incidentIds.map(incidentId =>
+            enqueueIncidentUpdateSideEffects(tx, incidentId, [
+              'INCIDENT_ASSIGNED_TO_USER_NOTIFICATION',
+              'INCIDENT_UPDATE_WEBHOOK',
+            ])
+          )
+        );
+      },
+      { isolationLevel: 'Serializable' }
+    );
 
     revalidatePath('/incidents');
     return { success: true, count: incidentIds.length };

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import prisma from '@/lib/prisma';
-import { getAuthOptions, revokeUserSessions } from '@/lib/auth';
-import { getServerSession } from 'next-auth';
+import { revokeUserSessions } from '@/lib/auth';
 import bcrypt from 'bcryptjs';
 import { revalidatePath } from 'next/cache';
 import { generateApiKey } from '@/lib/api-keys';
@@ -23,25 +22,13 @@ import {
   isApiScope,
   isWriteApiScope,
 } from '@/lib/authorization';
+import { getCurrentUser } from '@/lib/rbac';
 
 type ActionState = {
   error?: string | null;
   success?: boolean;
   token?: string | null;
 };
-
-async function getCurrentUser() {
-  const session = await getServerSession(await getAuthOptions());
-  const email = session?.user?.email;
-  if (!email) {
-    throw new Error('Unauthorized');
-  }
-  const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) {
-    throw new Error('User not found');
-  }
-  return user;
-}
 
 export async function updateProfile(
   _prevState: ActionState,
@@ -342,8 +329,14 @@ export async function updatePassword(
       return { error: 'Passwords do not match.' };
     }
 
-    if (user.passwordHash) {
-      const valid = await bcrypt.compare(currentPassword, user.passwordHash);
+    const credentials = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { passwordHash: true },
+    });
+    if (!credentials) return { error: 'User not found.' };
+
+    if (credentials.passwordHash) {
+      const valid = await bcrypt.compare(currentPassword, credentials.passwordHash);
       if (!valid) {
         return { error: 'Current password is incorrect.' };
       }

--- a/src/app/(app)/teams/actions.ts
+++ b/src/app/(app)/teams/actions.ts
@@ -9,25 +9,12 @@ import { logger } from '@/lib/logger';
 import { assertTeamNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
 import { removeTeamMembership } from '@/lib/teams/membership-commands';
 import { requireOperationalUser } from '@/lib/users/operational-eligibility';
+import { runSerializableTransaction } from '@/lib/db-utils';
 
 type TeamFormState = {
   error?: string | null;
   success?: boolean;
 };
-
-async function ensureTeamHasOwner(teamId: string, excludeMemberId?: string) {
-  const ownerCount = await prisma.teamMember.count({
-    where: {
-      teamId,
-      role: 'OWNER',
-      ...(excludeMemberId ? { NOT: { id: excludeMemberId } } : {}),
-    },
-  });
-
-  if (ownerCount === 0) {
-    throw new Error('Each team must have at least one owner.');
-  }
-}
 
 export async function createTeam(
   _prevState: TeamFormState,
@@ -287,20 +274,37 @@ export async function updateTeamMemberRole(
 
   if (!['OWNER', 'ADMIN', 'MEMBER'].includes(role)) return { error: 'Invalid team role.' };
 
-  if (member.role === 'OWNER' && role !== 'OWNER') {
-    try {
-      await ensureTeamHasOwner(member.teamId, member.id);
-    } catch (error) {
-      return {
-        error: error instanceof Error ? error.message : 'Cannot change role of last owner.',
-      };
-    }
+  try {
+    await runSerializableTransaction(async tx => {
+      const currentMember = await tx.teamMember.findUnique({ where: { id: memberId } });
+      if (!currentMember || currentMember.teamId !== member.teamId) {
+        throw new Error('Member not found.');
+      }
+      if (currentMember.role === 'OWNER' && role !== 'OWNER') {
+        const otherActiveOwners = await tx.teamMember.count({
+          where: {
+            teamId: currentMember.teamId,
+            role: 'OWNER',
+            NOT: { id: currentMember.id },
+            user: { status: 'ACTIVE' },
+          },
+        });
+        if (otherActiveOwners === 0) {
+          throw new Error('Each team must retain at least one active owner.');
+        }
+      }
+      await tx.teamMember.update({
+        where: { id: memberId },
+        data: { role: role as any }, // eslint-disable-line @typescript-eslint/no-explicit-any
+      });
+      await tx.user.update({
+        where: { id: currentMember.userId },
+        data: { tokenVersion: { increment: 1 } },
+      });
+    });
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Failed to update member role.' };
   }
-
-  await prisma.teamMember.update({
-    where: { id: memberId },
-    data: { role: role as any }, // eslint-disable-line @typescript-eslint/no-explicit-any
-  });
 
   const actorId = currentUser.id;
   await logAudit({

--- a/src/app/(app)/teams/actions.ts
+++ b/src/app/(app)/teams/actions.ts
@@ -8,6 +8,7 @@ import { createInAppNotifications } from '@/lib/in-app-notifications';
 import { logger } from '@/lib/logger';
 import { assertTeamNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
 import { removeTeamMembership } from '@/lib/teams/membership-commands';
+import { requireOperationalUser } from '@/lib/users/operational-eligibility';
 
 type TeamFormState = {
   error?: string | null;
@@ -222,13 +223,15 @@ export async function addTeamMember(teamId: string, formData: FormData) {
   if (!userId) return;
   if (!['OWNER', 'ADMIN', 'MEMBER'].includes(role)) return { error: 'Invalid team role.' };
 
-  await prisma.teamMember.create({
-    data: {
-      teamId,
-      userId,
-      role: role as 'OWNER' | 'ADMIN' | 'MEMBER',
+  await prisma.$transaction(
+    async tx => {
+      await requireOperationalUser(tx, userId);
+      await tx.teamMember.create({
+        data: { teamId, userId, role: role as 'OWNER' | 'ADMIN' | 'MEMBER' },
+      });
     },
-  });
+    { isolationLevel: 'Serializable' }
+  );
 
   const actorId = currentUser.id;
   await logAudit({

--- a/src/app/(app)/teams/actions.ts
+++ b/src/app/(app)/teams/actions.ts
@@ -7,6 +7,7 @@ import { assertAdminOrResponder, assertAdmin, assertAdminOrTeamOwner } from '@/l
 import { createInAppNotifications } from '@/lib/in-app-notifications';
 import { logger } from '@/lib/logger';
 import { assertTeamNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
+import { removeTeamMembership } from '@/lib/teams/membership-commands';
 
 type TeamFormState = {
   error?: string | null;
@@ -263,16 +264,6 @@ export async function updateTeamMemberRole(
   formData: FormData
 ): Promise<{ error?: string } | undefined> {
   let currentUser;
-  try {
-    currentUser = await assertAdminOrResponder();
-  } catch (error) {
-    return {
-      error:
-        error instanceof Error
-          ? error.message
-          : 'Unauthorized. Admin or Responder access required.',
-    };
-  }
   const role = (formData.get('role') as string) || 'MEMBER';
 
   const member = await prisma.teamMember.findUnique({
@@ -408,33 +399,11 @@ export async function removeTeamMember(memberId: string): Promise<{ error?: stri
     };
   }
 
-  if (member.role === 'OWNER') {
-    try {
-      await ensureTeamHasOwner(member.teamId, member.id);
-    } catch (error) {
-      return { error: error instanceof Error ? error.message : 'Cannot remove last owner.' };
-    }
+  try {
+    await removeTeamMembership(memberId);
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Failed to remove team member.' };
   }
-
-  await prisma.$transaction(async tx => {
-    await tx.teamMember.delete({
-      where: { id: memberId },
-    });
-
-    // Team membership is part of the authorization scope. Revoke existing
-    // sessions so regular requests and long-lived streams cannot retain the
-    // removed team's access.
-    await tx.user.update({
-      where: { id: member.userId },
-      data: { tokenVersion: { increment: 1 } },
-    });
-
-    // Clear teamLeadId if the removed member was the team lead
-    await tx.team.updateMany({
-      where: { id: member.teamId, teamLeadId: member.userId },
-      data: { teamLeadId: null },
-    });
-  });
 
   const actorId = currentUser.id;
   await logAudit({
@@ -541,7 +510,10 @@ export async function assignServicesToTeam(teamId: string, serviceIds: string[])
   if (services.length !== new Set(serviceIds).size) {
     return { error: 'One or more services could not be found.' };
   }
-  if (currentUser.role !== 'ADMIN' && services.some(service => service.teamId !== null && service.teamId !== teamId)) {
+  if (
+    currentUser.role !== 'ADMIN' &&
+    services.some(service => service.teamId !== null && service.teamId !== teamId)
+  ) {
     return { error: 'Only administrators can move a service between teams.' };
   }
 

--- a/src/app/(app)/teams/actions.ts
+++ b/src/app/(app)/teams/actions.ts
@@ -10,6 +10,7 @@ import { assertTeamNameAvailable, UniqueNameConflictError } from '@/lib/unique-n
 import { removeTeamMembership } from '@/lib/teams/membership-commands';
 import { requireOperationalUser } from '@/lib/users/operational-eligibility';
 import { runSerializableTransaction } from '@/lib/db-utils';
+import type { TeamRole } from '@prisma/client';
 
 type TeamFormState = {
   error?: string | null;
@@ -205,10 +206,13 @@ export async function addTeamMember(teamId: string, formData: FormData) {
     };
   }
   const userId = formData.get('userId') as string;
-  const role = (formData.get('role') as string) || 'MEMBER';
+  const requestedRole = (formData.get('role') as string) || 'MEMBER';
 
   if (!userId) return;
-  if (!['OWNER', 'ADMIN', 'MEMBER'].includes(role)) return { error: 'Invalid team role.' };
+  if (!['OWNER', 'ADMIN', 'MEMBER'].includes(requestedRole)) {
+    return { error: 'Invalid team role.' };
+  }
+  const role = requestedRole as TeamRole;
 
   await prisma.$transaction(
     async tx => {
@@ -254,7 +258,7 @@ export async function updateTeamMemberRole(
   formData: FormData
 ): Promise<{ error?: string } | undefined> {
   let currentUser;
-  const role = (formData.get('role') as string) || 'MEMBER';
+  const requestedRole = (formData.get('role') as string) || 'MEMBER';
 
   const member = await prisma.teamMember.findUnique({
     where: { id: memberId },
@@ -272,7 +276,10 @@ export async function updateTeamMemberRole(
     };
   }
 
-  if (!['OWNER', 'ADMIN', 'MEMBER'].includes(role)) return { error: 'Invalid team role.' };
+  if (!['OWNER', 'ADMIN', 'MEMBER'].includes(requestedRole)) {
+    return { error: 'Invalid team role.' };
+  }
+  const role = requestedRole as TeamRole;
 
   try {
     await runSerializableTransaction(async tx => {
@@ -295,7 +302,7 @@ export async function updateTeamMemberRole(
       }
       await tx.teamMember.update({
         where: { id: memberId },
-        data: { role: role as any }, // eslint-disable-line @typescript-eslint/no-explicit-any
+        data: { role },
       });
       await tx.user.update({
         where: { id: currentMember.userId },

--- a/src/app/(app)/users/[id]/page.tsx
+++ b/src/app/(app)/users/[id]/page.tsx
@@ -139,7 +139,27 @@ export default async function UserDetailPage({ params, searchParams }: UserDetai
 
   // Transform auditLogs.details to match UserDetailProfile type
   const transformedUser = {
-    ...user,
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role,
+    status: user.status,
+    avatarUrl: user.avatarUrl,
+    gender: user.gender,
+    department: user.department,
+    jobTitle: user.jobTitle,
+    phoneNumber: user.phoneNumber,
+    timeZone: user.timeZone,
+    emailNotificationsEnabled: user.emailNotificationsEnabled,
+    smsNotificationsEnabled: user.smsNotificationsEnabled,
+    pushNotificationsEnabled: user.pushNotificationsEnabled,
+    whatsappNotificationsEnabled: user.whatsappNotificationsEnabled,
+    createdAt: user.createdAt,
+    teamMemberships: user.teamMemberships,
+    teamsLed: user.teamsLed,
+    layerAssignments: user.layerAssignments,
+    escalationRules: user.escalationRules,
+    assignedIncidents: user.assignedIncidents,
     auditLogs: user.auditLogs.map(log => ({
       ...log,
       details:

--- a/src/app/(app)/users/actions.ts
+++ b/src/app/(app)/users/actions.ts
@@ -7,12 +7,16 @@ import { randomBytes, createHash } from 'crypto';
 import { assertAdmin, assertAdminOrTeamOwner, assertNotSelf, getCurrentUser } from '@/lib/rbac';
 import { getBaseUrl } from '@/lib/env-validation';
 import { logger } from '@/lib/logger';
-import { revokeUserSessions } from '@/lib/auth';
 import { isAppRole } from '@/lib/authorization';
 import type { Role } from '@prisma/client';
 import { removeTeamMembership } from '@/lib/teams/membership-commands';
-import { dependencySummary, discoverUserDependencies } from '@/lib/users/dependencies';
+import {
+  dependencySummary,
+  discoverUserDependencies,
+  type UserDependencyReport,
+} from '@/lib/users/dependencies';
 import { bulkUpdateUserSecurityState, updateUserSecurityState } from '@/lib/users/admin-invariants';
+import { requireOperationalUser } from '@/lib/users/operational-eligibility';
 
 async function sendInviteEmailIfConfigured(data: {
   userId: string;
@@ -170,6 +174,19 @@ export type UserFormState = {
   inviteUrl?: string | null;
   emailSent?: boolean;
 };
+
+export async function getUserDependencyReport(
+  userId: string
+): Promise<{ report?: UserDependencyReport; error?: string }> {
+  try {
+    await assertAdmin();
+    return { report: await discoverUserDependencies(userId) };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : 'Unable to inspect user dependencies.',
+    };
+  }
+}
 
 async function createInviteToken(userId: string, email: string) {
   const token = randomBytes(32).toString('base64url');
@@ -389,13 +406,15 @@ export async function addUserToTeam(userId: string, formData: FormData) {
 
   if (existing) return;
 
-  await prisma.teamMember.create({
-    data: {
-      userId,
-      teamId,
-      role: (role as 'OWNER' | 'ADMIN' | 'MEMBER') || 'MEMBER',
+  await prisma.$transaction(
+    async tx => {
+      await requireOperationalUser(tx, userId);
+      await tx.teamMember.create({
+        data: { userId, teamId, role: role as 'OWNER' | 'ADMIN' | 'MEMBER' },
+      });
     },
-  });
+    { isolationLevel: 'Serializable' }
+  );
 
   await logAudit({
     action: 'team.member.added',
@@ -438,12 +457,6 @@ export async function deactivateUser(userId: string, _formData?: FormData) {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
     };
   }
-  const dependencies = dependencySummary(await discoverUserDependencies(userId));
-  if (dependencies.length > 0) {
-    return {
-      error: `Transfer operational responsibilities before planned deactivation (${dependencies.join(', ')}).`,
-    };
-  }
   await updateUserSecurityState(
     userId,
     { status: 'DISABLED' },
@@ -462,6 +475,11 @@ export async function deactivateUser(userId: string, _formData?: FormData) {
       where: { userId, revokedAt: null },
       data: { revokedAt: new Date() },
     }),
+    prisma.oidcLinkingApproval.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    }),
+    prisma.userDevice.deleteMany({ where: { userId } }),
   ]);
   await logAudit({
     action: 'user.deactivated',
@@ -673,14 +691,6 @@ export async function bulkUpdateUsers(
       };
     }
 
-    for (const userId of userIds) {
-      const dependencies = dependencySummary(await discoverUserDependencies(userId));
-      if (dependencies.length > 0) {
-        return {
-          error: `Transfer dependencies for ${userId} before bulk deactivation (${dependencies.join(', ')}).`,
-        };
-      }
-    }
     await bulkUpdateUserSecurityState(
       userIds,
       { status: 'DISABLED' },
@@ -698,6 +708,11 @@ export async function bulkUpdateUsers(
       where: { userId: { in: userIds }, revokedAt: null },
       data: { revokedAt: new Date() },
     });
+    await prisma.oidcLinkingApproval.updateMany({
+      where: { userId: { in: userIds }, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    await prisma.userDevice.deleteMany({ where: { userId: { in: userIds } } });
 
     await logAudit({
       action: 'user.deactivated.bulk',

--- a/src/app/(app)/users/actions.ts
+++ b/src/app/(app)/users/actions.ts
@@ -4,13 +4,15 @@ import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { logAudit } from '@/lib/audit';
 import { randomBytes, createHash } from 'crypto';
-import { assertAdmin, assertAdminOrTeamOwner, assertNotSelf } from '@/lib/rbac';
+import { assertAdmin, assertAdminOrTeamOwner, assertNotSelf, getCurrentUser } from '@/lib/rbac';
 import { getBaseUrl } from '@/lib/env-validation';
 import { logger } from '@/lib/logger';
-import { revokeUserSessions, getAuthOptions } from '@/lib/auth';
+import { revokeUserSessions } from '@/lib/auth';
 import { isAppRole } from '@/lib/authorization';
-import { getServerSession } from 'next-auth';
 import type { Role } from '@prisma/client';
+import { removeTeamMembership } from '@/lib/teams/membership-commands';
+import { dependencySummary, discoverUserDependencies } from '@/lib/users/dependencies';
+import { bulkUpdateUserSecurityState, updateUserSecurityState } from '@/lib/users/admin-invariants';
 
 async function sendInviteEmailIfConfigured(data: {
   userId: string;
@@ -106,7 +108,7 @@ async function assertNotLastAdmin(userId: string) {
   const adminCount = await prisma.user.count({
     where: {
       role: 'ADMIN',
-      status: { not: 'DISABLED' },
+      status: 'ACTIVE',
     },
   });
 
@@ -120,7 +122,7 @@ async function assertBatchLeavesActiveAdmin(userIds: string[]) {
     where: {
       id: { in: userIds },
       role: 'ADMIN',
-      status: { not: 'DISABLED' },
+      status: 'ACTIVE',
     },
   });
 
@@ -129,7 +131,7 @@ async function assertBatchLeavesActiveAdmin(userIds: string[]) {
   const totalActiveAdmins = await prisma.user.count({
     where: {
       role: 'ADMIN',
-      status: { not: 'DISABLED' },
+      status: 'ACTIVE',
     },
   });
 
@@ -142,20 +144,21 @@ async function deleteUserInternal(userId: string) {
   await assertUserIsNotSoleOwner(userId);
   await assertNotLastAdmin(userId);
 
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { status: true } });
+  if (!user) throw new Error('User not found.');
+  if (user.status !== 'DISABLED') {
+    throw new Error('Deactivate the user before permanent deletion.');
+  }
+  const dependencies = dependencySummary(await discoverUserDependencies(userId));
+  if (dependencies.length > 0) {
+    throw new Error(
+      `Resolve or transfer user dependencies before deletion (${dependencies.join(', ')}).`
+    );
+  }
+
   await prisma.$transaction([
-    prisma.incident.updateMany({
-      where: { assigneeId: userId },
-      data: { assigneeId: null },
-    }),
-    prisma.teamMember.deleteMany({ where: { userId } }),
-    prisma.onCallLayerUser.deleteMany({ where: { userId } }),
-    prisma.onCallOverride.deleteMany({ where: { OR: [{ userId }, { replacesUserId: userId }] } }),
-    prisma.onCallShift.deleteMany({ where: { userId } }),
-    prisma.escalationRule.deleteMany({ where: { targetUserId: userId } }),
     // Preserve incident notes for audit trail — nullify userId so notes survive user deletion
     prisma.incidentNote.updateMany({ where: { userId }, data: { userId: null } }),
-    // Notifications are delivery receipts and less useful without the user
-    prisma.notification.deleteMany({ where: { userId } }),
     prisma.incidentWatcher.deleteMany({ where: { userId } }),
     prisma.user.delete({ where: { id: userId } }),
   ]);
@@ -168,24 +171,33 @@ export type UserFormState = {
   emailSent?: boolean;
 };
 
-async function createInviteToken(email: string) {
+async function createInviteToken(userId: string, email: string) {
   const token = randomBytes(32).toString('base64url');
   const tokenHash = createHash('sha256').update(token).digest('hex');
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
 
   const identifier = email.toLowerCase();
 
-  await prisma.userToken.deleteMany({
-    where: { identifier, type: 'INVITE', usedAt: null },
-  });
-
-  await prisma.userToken.create({
-    data: {
-      identifier,
-      type: 'INVITE',
-      tokenHash,
-      expiresAt: expires,
-    },
+  await prisma.$transaction(async tx => {
+    const rotated = await tx.user.update({
+      where: { id: userId, status: 'INVITED' },
+      data: { invitedAt: new Date(), invitationGeneration: { increment: 1 } },
+      select: { invitationGeneration: true },
+    });
+    await tx.userToken.updateMany({
+      where: { userId, type: 'INVITE', usedAt: null, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    await tx.userToken.create({
+      data: {
+        identifier,
+        userId,
+        generation: rotated.invitationGeneration,
+        type: 'INVITE',
+        tokenHash,
+        expiresAt: expires,
+      },
+    });
   });
 
   const baseUrl = getBaseUrl();
@@ -235,7 +247,7 @@ export async function addUser(
     const { checkRateLimit } = await import('@/lib/password-reset');
     // Limit admin creating users
     if (admin) {
-      await checkRateLimit(admin.email, realIp, 'ADMIN_ADD_USER');
+      await checkRateLimit(email, realIp, 'user.invited');
     }
 
     if (existing?.status === 'DISABLED') {
@@ -255,6 +267,7 @@ export async function addUser(
           role,
           status: 'INVITED',
           invitedAt: new Date(),
+          invitationGeneration: 1,
         },
       });
 
@@ -271,6 +284,8 @@ export async function addUser(
       await tx.userToken.create({
         data: {
           identifier,
+          userId: newUser.id,
+          generation: newUser.invitationGeneration,
           type: 'INVITE',
           tokenHash,
           expiresAt: expires,
@@ -289,6 +304,7 @@ export async function addUser(
       entityId: user.id,
       actorId: admin?.id || null,
       details: { email, role: role || 'USER' },
+      targetEmail: email,
     });
 
     revalidatePath('/users');
@@ -335,11 +351,7 @@ export async function updateUserRole(userId: string, formData: FormData) {
     }
   }
 
-  await prisma.user.update({
-    where: { id: userId },
-    data: { role },
-  });
-  await revokeUserSessions(userId);
+  await updateUserSecurityState(userId, { role }, { tokenVersion: { increment: 1 } });
 
   await logAudit({
     action: 'user.role.updated',
@@ -400,9 +412,7 @@ export async function addUserToTeam(userId: string, formData: FormData) {
 
 export async function removeUserFromTeam(memberId: string) {
   const currentUser = await assertAdmin();
-  const member = await prisma.teamMember.delete({
-    where: { id: memberId },
-  });
+  const member = await removeTeamMembership(memberId);
 
   await logAudit({
     action: 'team.member.removed',
@@ -428,23 +438,31 @@ export async function deactivateUser(userId: string, _formData?: FormData) {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
     };
   }
-  await prisma.user.update({
-    where: { id: userId },
-    data: {
-      status: 'DISABLED',
-      deactivatedAt: new Date(),
-    },
-  });
-  if (typeof prisma.onCallOverride?.deleteMany === 'function') {
-    await prisma.onCallOverride.deleteMany({
-      where: {
-        userId,
-        end: { gte: new Date() },
-      },
-    });
+  const dependencies = dependencySummary(await discoverUserDependencies(userId));
+  if (dependencies.length > 0) {
+    return {
+      error: `Transfer operational responsibilities before planned deactivation (${dependencies.join(', ')}).`,
+    };
   }
-  await revokeUserSessions(userId);
-
+  await updateUserSecurityState(
+    userId,
+    { status: 'DISABLED' },
+    {
+      deactivatedAt: new Date(),
+      tokenVersion: { increment: 1 },
+      invitationGeneration: { increment: 1 },
+    }
+  );
+  await prisma.$transaction([
+    prisma.userToken.updateMany({
+      where: { userId, usedAt: null, revokedAt: null },
+      data: { revokedAt: new Date() },
+    }),
+    prisma.apiKey.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    }),
+  ]);
   await logAudit({
     action: 'user.deactivated',
     entityType: 'USER',
@@ -465,11 +483,19 @@ export async function reactivateUser(userId: string, _formData?: FormData) {
       error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
     };
   }
+  const target = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { status: true, passwordHash: true },
+  });
+  if (!target) return { error: 'User not found.' };
+  if (target.status !== 'DISABLED') return { error: 'Only disabled users can be reactivated.' };
+
   await prisma.user.update({
     where: { id: userId },
     data: {
-      status: 'ACTIVE',
+      status: target.passwordHash ? 'ACTIVE' : 'INVITED',
       deactivatedAt: null,
+      tokenVersion: { increment: 1 },
     },
   });
 
@@ -500,34 +526,26 @@ export async function generateInvite(
     where: { id: userId },
   });
 
-  // Rate Limit (Admin Abuse Protection)
-  const { headers } = await import('next/headers');
-  const headerList = await headers();
-  const realIp = headerList.get('x-forwarded-for') || headerList.get('x-real-ip') || 'unknown';
-
-  const { checkRateLimit } = await import('@/lib/password-reset');
-  // Limit resend invites
-  if (admin) {
-    await checkRateLimit(admin.email, realIp, 'ADMIN_RESEND_INVITE');
-  }
-
   if (!user) {
     return { error: 'User not found.' };
   }
 
-  if (user.status === 'DISABLED') {
-    return { error: 'User is disabled. Reactivate before inviting.' };
+  if (user.status !== 'INVITED') {
+    return {
+      error:
+        user.status === 'DISABLED'
+          ? 'User is disabled. Reactivate before inviting.'
+          : 'Active users must use password recovery instead of an invitation.',
+    };
   }
 
-  await prisma.user.update({
-    where: { id: userId },
-    data: {
-      status: 'INVITED',
-      invitedAt: new Date(),
-    },
-  });
+  const { headers } = await import('next/headers');
+  const headerList = await headers();
+  const realIp = headerList.get('x-forwarded-for') || headerList.get('x-real-ip') || 'unknown';
+  const { checkRateLimit } = await import('@/lib/password-reset');
+  await checkRateLimit(user.email, realIp, 'user.invite.resent');
 
-  const inviteUrl = await createInviteToken(user.email);
+  const inviteUrl = await createInviteToken(user.id, user.email);
 
   await logAudit({
     action: 'user.invite.resent',
@@ -535,6 +553,7 @@ export async function generateInvite(
     entityId: user.id,
     actorId: admin?.id || null,
     details: { email: user.email },
+    targetEmail: user.email,
   });
 
   revalidatePath('/users');
@@ -654,24 +673,31 @@ export async function bulkUpdateUsers(
       };
     }
 
-    await prisma.user.updateMany({
-      where: { id: { in: userIds } },
-      data: {
-        status: 'DISABLED',
-        deactivatedAt: new Date(),
-      },
-    });
-
-    if (typeof prisma.onCallOverride?.deleteMany === 'function') {
-      await prisma.onCallOverride.deleteMany({
-        where: {
-          userId: { in: userIds },
-          end: { gte: new Date() },
-        },
-      });
+    for (const userId of userIds) {
+      const dependencies = dependencySummary(await discoverUserDependencies(userId));
+      if (dependencies.length > 0) {
+        return {
+          error: `Transfer dependencies for ${userId} before bulk deactivation (${dependencies.join(', ')}).`,
+        };
+      }
     }
-
-    await Promise.all(userIds.map(id => revokeUserSessions(id)));
+    await bulkUpdateUserSecurityState(
+      userIds,
+      { status: 'DISABLED' },
+      {
+        deactivatedAt: new Date(),
+        tokenVersion: { increment: 1 },
+        invitationGeneration: { increment: 1 },
+      }
+    );
+    await prisma.userToken.updateMany({
+      where: { userId: { in: userIds }, usedAt: null, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    await prisma.apiKey.updateMany({
+      where: { userId: { in: userIds }, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
 
     await logAudit({
       action: 'user.deactivated.bulk',
@@ -760,12 +786,7 @@ export async function bulkUpdateUsers(
       }
     }
 
-    await prisma.user.updateMany({
-      where: { id: { in: userIds } },
-      data: { role },
-    });
-
-    await Promise.all(userIds.map(id => revokeUserSessions(id)));
+    await bulkUpdateUserSecurityState(userIds, { role }, { tokenVersion: { increment: 1 } });
 
     await logAudit({
       action: 'user.role.updated.bulk',
@@ -786,18 +807,11 @@ export async function updateUserProfile(
   userId: string,
   formData: FormData
 ): Promise<{ error?: string; success?: boolean } | undefined> {
-  const session = await getServerSession(await getAuthOptions());
-  if (!session?.user?.email) {
+  let currentUser;
+  try {
+    currentUser = await getCurrentUser();
+  } catch {
     return { error: 'Unauthorized. Please log in.' };
-  }
-
-  const currentUser = await prisma.user.findUnique({
-    where: { email: session.user.email },
-    select: { id: true, role: true },
-  });
-
-  if (!currentUser) {
-    return { error: 'User session not found.' };
   }
 
   const isSelf = currentUser.id === userId;
@@ -814,16 +828,19 @@ export async function updateUserProfile(
   const jobTitle = formData.get('jobTitle') as string | null;
   const timeZone = formData.get('timeZone') as string | null;
   const phoneNumber = formData.get('phoneNumber') as string | null;
-  const emailNotificationsEnabled = formData.get('emailNotificationsEnabled') === 'true';
-  const smsNotificationsEnabled = formData.get('smsNotificationsEnabled') === 'true';
-  const pushNotificationsEnabled = formData.get('pushNotificationsEnabled') === 'true';
-  const whatsappNotificationsEnabled = formData.get('whatsappNotificationsEnabled') === 'true';
 
   if (!name || name.trim().length === 0) {
     return { error: 'Name is required.' };
   }
   if (!email || !email.includes('@')) {
     return { error: 'Valid email is required.' };
+  }
+  if (timeZone) {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: timeZone.trim() }).format();
+    } catch {
+      return { error: 'Select a valid time zone.' };
+    }
   }
 
   // Check email uniqueness if email is changed
@@ -836,9 +853,14 @@ export async function updateUserProfile(
     return { error: 'User not found.' };
   }
 
-  if (email.toLowerCase() !== existingUser.email.toLowerCase()) {
+  const normalizedEmail = email.toLowerCase().trim();
+  const emailChanged = normalizedEmail !== existingUser.email.toLowerCase();
+  if (emailChanged) {
+    if (!isAdmin) {
+      return { error: 'Email changes require administrator verification.' };
+    }
     const emailConflict = await prisma.user.findUnique({
-      where: { email: email.toLowerCase() },
+      where: { email: normalizedEmail },
     });
     if (emailConflict) {
       return { error: 'A user with this email address already exists.' };
@@ -864,26 +886,46 @@ export async function updateUserProfile(
   }
 
   try {
-    const updated = await prisma.user.update({
-      where: { id: userId },
-      data: {
-        name: name.trim(),
-        email: email.toLowerCase().trim(),
-        role: targetRole,
-        department: department?.trim() || null,
-        jobTitle: jobTitle?.trim() || null,
-        timeZone: timeZone?.trim() || 'UTC',
-        phoneNumber: phoneNumber?.trim() || null,
-        emailNotificationsEnabled,
-        smsNotificationsEnabled,
-        pushNotificationsEnabled,
-        whatsappNotificationsEnabled,
-      },
+    const updated = await prisma.$transaction(async tx => {
+      const result = await tx.user.update({
+        where: { id: userId },
+        data: {
+          name: name.trim(),
+          email: normalizedEmail,
+          role: targetRole,
+          department: department?.trim() || null,
+          jobTitle: jobTitle?.trim() || null,
+          timeZone: timeZone?.trim() || 'UTC',
+          phoneNumber: phoneNumber?.trim() || null,
+          ...(formData.has('emailNotificationsEnabled')
+            ? { emailNotificationsEnabled: formData.get('emailNotificationsEnabled') === 'true' }
+            : {}),
+          ...(formData.has('smsNotificationsEnabled')
+            ? { smsNotificationsEnabled: formData.get('smsNotificationsEnabled') === 'true' }
+            : {}),
+          ...(formData.has('pushNotificationsEnabled')
+            ? { pushNotificationsEnabled: formData.get('pushNotificationsEnabled') === 'true' }
+            : {}),
+          ...(formData.has('whatsappNotificationsEnabled')
+            ? {
+                whatsappNotificationsEnabled:
+                  formData.get('whatsappNotificationsEnabled') === 'true',
+              }
+            : {}),
+          ...(targetRole !== existingUser.role || emailChanged
+            ? { tokenVersion: { increment: 1 } }
+            : {}),
+          ...(emailChanged ? { invitationGeneration: { increment: 1 } } : {}),
+        },
+      });
+      if (emailChanged) {
+        await tx.userToken.updateMany({
+          where: { userId, revokedAt: null },
+          data: { revokedAt: new Date() },
+        });
+      }
+      return result;
     });
-
-    if (targetRole !== existingUser.role) {
-      await revokeUserSessions(userId);
-    }
 
     await logAudit({
       action: 'user.updated',

--- a/src/app/(app)/users/actions.ts
+++ b/src/app/(app)/users/actions.ts
@@ -8,7 +8,7 @@ import { assertAdmin, assertAdminOrTeamOwner, assertNotSelf, getCurrentUser } fr
 import { getBaseUrl } from '@/lib/env-validation';
 import { logger } from '@/lib/logger';
 import { isAppRole } from '@/lib/authorization';
-import type { Role } from '@prisma/client';
+import type { Prisma, Role } from '@prisma/client';
 import { removeTeamMembership } from '@/lib/teams/membership-commands';
 import {
   dependencySummary,
@@ -465,23 +465,24 @@ export async function deactivateUser(userId: string, _formData?: FormData) {
       deactivatedAt: new Date(),
       tokenVersion: { increment: 1 },
       invitationGeneration: { increment: 1 },
+    },
+    async tx => {
+      const revokedAt = new Date();
+      await tx.userToken.updateMany({
+        where: { userId, usedAt: null, revokedAt: null },
+        data: { revokedAt },
+      });
+      await tx.apiKey.updateMany({
+        where: { userId, revokedAt: null },
+        data: { revokedAt },
+      });
+      await tx.oidcLinkingApproval.updateMany({
+        where: { userId, revokedAt: null },
+        data: { revokedAt },
+      });
+      await tx.userDevice.deleteMany({ where: { userId } });
     }
   );
-  await prisma.$transaction([
-    prisma.userToken.updateMany({
-      where: { userId, usedAt: null, revokedAt: null },
-      data: { revokedAt: new Date() },
-    }),
-    prisma.apiKey.updateMany({
-      where: { userId, revokedAt: null },
-      data: { revokedAt: new Date() },
-    }),
-    prisma.oidcLinkingApproval.updateMany({
-      where: { userId, revokedAt: null },
-      data: { revokedAt: new Date() },
-    }),
-    prisma.userDevice.deleteMany({ where: { userId } }),
-  ]);
   await logAudit({
     action: 'user.deactivated',
     entityType: 'USER',
@@ -699,21 +700,24 @@ export async function bulkUpdateUsers(
         deactivatedAt: new Date(),
         tokenVersion: { increment: 1 },
         invitationGeneration: { increment: 1 },
+      },
+      async tx => {
+        const revokedAt = new Date();
+        await tx.userToken.updateMany({
+          where: { userId: { in: userIds }, usedAt: null, revokedAt: null },
+          data: { revokedAt },
+        });
+        await tx.apiKey.updateMany({
+          where: { userId: { in: userIds }, revokedAt: null },
+          data: { revokedAt },
+        });
+        await tx.oidcLinkingApproval.updateMany({
+          where: { userId: { in: userIds }, revokedAt: null },
+          data: { revokedAt },
+        });
+        await tx.userDevice.deleteMany({ where: { userId: { in: userIds } } });
       }
     );
-    await prisma.userToken.updateMany({
-      where: { userId: { in: userIds }, usedAt: null, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-    await prisma.apiKey.updateMany({
-      where: { userId: { in: userIds }, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-    await prisma.oidcLinkingApproval.updateMany({
-      where: { userId: { in: userIds }, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-    await prisma.userDevice.deleteMany({ where: { userId: { in: userIds } } });
 
     await logAudit({
       action: 'user.deactivated.bulk',
@@ -890,11 +894,11 @@ export async function updateUserProfile(
       return { error: 'Only administrators can change user roles.' };
     }
     if (isAdmin) {
-      if (existingUser.role === 'ADMIN' && role !== 'ADMIN') {
+      if (role !== existingUser.role) {
         try {
-          await assertNotLastAdmin(userId);
+          assertNotSelf(currentUser.id, userId, 'change the role of');
         } catch (err) {
-          return { error: err instanceof Error ? err.message : 'Cannot demote the last admin.' };
+          return { error: err instanceof Error ? err.message : 'You cannot change your own role.' };
         }
       }
       targetRole = role as Role;
@@ -902,46 +906,46 @@ export async function updateUserProfile(
   }
 
   try {
-    const updated = await prisma.$transaction(async tx => {
-      const result = await tx.user.update({
-        where: { id: userId },
-        data: {
-          name: name.trim(),
-          email: normalizedEmail,
-          role: targetRole,
-          department: department?.trim() || null,
-          jobTitle: jobTitle?.trim() || null,
-          timeZone: timeZone?.trim() || 'UTC',
-          phoneNumber: phoneNumber?.trim() || null,
-          ...(formData.has('emailNotificationsEnabled')
-            ? { emailNotificationsEnabled: formData.get('emailNotificationsEnabled') === 'true' }
-            : {}),
-          ...(formData.has('smsNotificationsEnabled')
-            ? { smsNotificationsEnabled: formData.get('smsNotificationsEnabled') === 'true' }
-            : {}),
-          ...(formData.has('pushNotificationsEnabled')
-            ? { pushNotificationsEnabled: formData.get('pushNotificationsEnabled') === 'true' }
-            : {}),
-          ...(formData.has('whatsappNotificationsEnabled')
-            ? {
-                whatsappNotificationsEnabled:
-                  formData.get('whatsappNotificationsEnabled') === 'true',
-              }
-            : {}),
-          ...(targetRole !== existingUser.role || emailChanged
-            ? { tokenVersion: { increment: 1 } }
-            : {}),
-          ...(emailChanged ? { invitationGeneration: { increment: 1 } } : {}),
-        },
-      });
+    const roleChanged = targetRole !== existingUser.role;
+    const profileData: Prisma.UserUpdateInput = {
+      name: name.trim(),
+      email: normalizedEmail,
+      department: department?.trim() || null,
+      jobTitle: jobTitle?.trim() || null,
+      timeZone: timeZone?.trim() || 'UTC',
+      phoneNumber: phoneNumber?.trim() || null,
+      ...(formData.has('emailNotificationsEnabled')
+        ? { emailNotificationsEnabled: formData.get('emailNotificationsEnabled') === 'true' }
+        : {}),
+      ...(formData.has('smsNotificationsEnabled')
+        ? { smsNotificationsEnabled: formData.get('smsNotificationsEnabled') === 'true' }
+        : {}),
+      ...(formData.has('pushNotificationsEnabled')
+        ? { pushNotificationsEnabled: formData.get('pushNotificationsEnabled') === 'true' }
+        : {}),
+      ...(formData.has('whatsappNotificationsEnabled')
+        ? {
+            whatsappNotificationsEnabled: formData.get('whatsappNotificationsEnabled') === 'true',
+          }
+        : {}),
+      ...(roleChanged || emailChanged ? { tokenVersion: { increment: 1 } } : {}),
+      ...(emailChanged ? { invitationGeneration: { increment: 1 } } : {}),
+    };
+    const revokeInviteTokens = async (tx: Prisma.TransactionClient) => {
       if (emailChanged) {
         await tx.userToken.updateMany({
           where: { userId, revokedAt: null },
           data: { revokedAt: new Date() },
         });
       }
-      return result;
-    });
+    };
+    const updated = roleChanged
+      ? await updateUserSecurityState(userId, { role: targetRole }, profileData, revokeInviteTokens)
+      : await prisma.$transaction(async tx => {
+          const result = await tx.user.update({ where: { id: userId }, data: profileData });
+          await revokeInviteTokens(tx);
+          return result;
+        });
 
     await logAudit({
       action: 'user.updated',

--- a/src/app/(app)/users/actions.ts
+++ b/src/app/(app)/users/actions.ts
@@ -103,11 +103,12 @@ async function assertUserIsNotSoleOwner(userId: string) {
 async function assertNotLastAdmin(userId: string) {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { role: true },
+    select: { role: true, status: true },
   });
 
-  // Only check if the user being deleted is an admin
-  if (user?.role !== 'ADMIN') return;
+  // A mutation can only remove an active administrator from the active-admin set
+  // when the target currently belongs to that set. Disabled/invited admins do not.
+  if (user?.role !== 'ADMIN' || user.status !== 'ACTIVE') return;
 
   const adminCount = await prisma.user.count({
     where: {

--- a/src/app/(app)/users/oidc-actions.ts
+++ b/src/app/(app)/users/oidc-actions.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { createHash, randomBytes } from 'crypto';
 import { revalidatePath } from 'next/cache';
 import prisma from '@/lib/prisma';
 import { assertAdmin } from '@/lib/rbac';
@@ -24,22 +23,19 @@ async function getManagedUser(userId: string) {
   });
 }
 
-async function readOidcLinkingState(userId: string, email: string): Promise<OidcLinkingState> {
+async function readOidcLinkingState(userId: string, _email: string): Promise<OidcLinkingState> {
   const existingIdentity = await prisma.oidcIdentity.findFirst({
     where: { userId },
     select: { id: true },
   });
   if (existingIdentity) return 'linked';
 
-  // #336 treats an INVITE record as administrator-provisioning evidence. This
-  // includes completed historical invites as well as the non-redeemable marker
-  // created by the explicit approval action.
-  const provisioningEvidence = await prisma.userToken.findFirst({
-    where: { identifier: email.toLowerCase(), type: 'INVITE' },
-    select: { id: true },
+  const provisioningEvidence = await prisma.oidcLinkingApproval.findUnique({
+    where: { userId },
+    select: { id: true, revokedAt: true },
   });
 
-  return provisioningEvidence ? 'approved' : 'not-approved';
+  return provisioningEvidence && !provisioningEvidence.revokedAt ? 'approved' : 'not-approved';
 }
 
 export async function getOidcLinkingState(userId: string): Promise<OidcLinkingApprovalResult> {
@@ -83,19 +79,14 @@ export async function allowOidcLinking(userId: string): Promise<OidcLinkingAppro
     return { success: true, alreadyApproved: true, state };
   }
 
-  const now = new Date();
-  const marker = randomBytes(32).toString('base64url');
-  const tokenHash = createHash('sha256').update(marker).digest('hex');
-
-  // This is provisioning evidence only. It is already used and expired, so it
-  // cannot be redeemed as an invitation credential.
-  await prisma.userToken.create({
-    data: {
-      identifier,
-      type: 'INVITE',
-      tokenHash,
-      expiresAt: now,
-      usedAt: now,
+  await prisma.oidcLinkingApproval.upsert({
+    where: { userId: user.id },
+    create: { userId: user.id, approvedById: admin.id },
+    update: {
+      approvedById: admin.id,
+      approvedAt: new Date(),
+      revokedAt: null,
+      generation: { increment: 1 },
     },
   });
 
@@ -143,7 +134,8 @@ export async function revokeOidcLinking(userId: string): Promise<OidcLinkingAppr
   const state = await readOidcLinkingState(user.id, identifier);
   if (state === 'linked') {
     return {
-      error: 'This user already has an OIDC identity linked. Revoking approval does not unlink identities.',
+      error:
+        'This user already has an OIDC identity linked. Revoking approval does not unlink identities.',
       alreadyLinked: true,
       state,
     };
@@ -153,8 +145,9 @@ export async function revokeOidcLinking(userId: string): Promise<OidcLinkingAppr
   // records removes the administrator-provisioning evidence used by #336, so
   // a future first-time OIDC link is denied again without affecting password
   // authentication, role, or account status.
-  await prisma.userToken.deleteMany({
-    where: { identifier, type: 'INVITE' },
+  await prisma.oidcLinkingApproval.updateMany({
+    where: { userId: user.id, revokedAt: null },
+    data: { revokedAt: new Date() },
   });
 
   await logAudit({

--- a/src/app/(app)/users/page.tsx
+++ b/src/app/(app)/users/page.tsx
@@ -11,6 +11,7 @@ import {
   deactivateUser,
   deleteUser,
   generateInvite,
+  getUserDependencyReport,
   reactivateUser,
   updateUserRole,
 } from './actions';
@@ -308,6 +309,7 @@ export default async function UsersPage({ searchParams }: UsersPageProps) {
                 reactivateUser={reactivateUser}
                 deleteUser={deleteUser}
                 generateInvite={generateInvite as any}
+                getUserDependencyReport={getUserDependencyReport}
               />
 
               {/* Pagination */}

--- a/src/app/(mobile)/m/users/[id]/page.tsx
+++ b/src/app/(mobile)/m/users/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getDefaultAvatar } from '@/lib/avatar';
 import MobileCard from '@/components/mobile/MobileCard';
 import { ArrowLeft, ChevronRight } from 'lucide-react';
 import { activeIncidentStatuses } from '@/lib/incident-status';
+import { getCurrentUser } from '@/lib/rbac';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,6 +16,8 @@ type PageProps = {
 
 export default async function MobileUserDetailPage({ params }: PageProps) {
   const { id } = await params;
+  const viewer = await getCurrentUser();
+  if (viewer.role !== 'ADMIN' && viewer.id !== id) notFound();
 
   const user = await prisma.user.findUnique({
     where: { id },

--- a/src/app/(mobile)/m/users/page.tsx
+++ b/src/app/(mobile)/m/users/page.tsx
@@ -5,6 +5,8 @@ import { MobileAvatar, MobileEmptyState } from '@/components/mobile/MobileUtils'
 import { MobileSearchWithParams } from '@/components/mobile/MobileSearchParams';
 import { getDefaultAvatar } from '@/lib/avatar';
 import MobileCard from '@/components/mobile/MobileCard';
+import { assertAdmin } from '@/lib/rbac';
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,6 +16,11 @@ export default async function MobileUsersPage({
   searchParams: Promise<{ q?: string }>;
 }): Promise<JSX.Element> {
   const params = await searchParams;
+  try {
+    await assertAdmin();
+  } catch {
+    redirect('/m');
+  }
   const query = params.q || '';
 
   const users = await prisma.user.findMany({

--- a/src/app/set-password/actions.ts
+++ b/src/app/set-password/actions.ts
@@ -45,6 +45,7 @@ export async function setPassword(formData: FormData) {
       tokenHash,
       type: 'INVITE',
       usedAt: null,
+      revokedAt: null,
     },
   });
 
@@ -61,8 +62,8 @@ export async function setPassword(formData: FormData) {
     redirect('/set-password?error=expired');
   }
 
-  const user = await prisma.user.findUnique({
-    where: { email: record.identifier },
+  const user = await prisma.user.findFirst({
+    where: record.userId ? { id: record.userId } : { email: record.identifier },
   });
 
   if (!user) {
@@ -77,26 +78,32 @@ export async function setPassword(formData: FormData) {
     redirect('/set-password?error=invalid');
   }
 
-  // Security: Prevent using an invite link if the user is already active.
-  // They should use "Forgot Password" instead.
-  if (user.status === 'ACTIVE' && user.passwordHash) {
+  // Invitations are valid only for accounts still awaiting onboarding. Disabled and active
+  // accounts require an explicit administrator action or password recovery respectively.
+  if (user.status !== 'INVITED') {
     await logAudit({
       action: 'INVITE_FAILED',
       entityType: 'USER',
       entityId: user.id,
       actorId: null,
-      details: { ip, reason: 'ALREADY_ACTIVE' },
+      details: { ip, reason: user.status === 'DISABLED' ? 'USER_DISABLED' : 'ALREADY_ACTIVE' },
     });
     await simulateWork(startTime);
-    redirect('/login?error=already_active');
+    redirect(
+      user.status === 'DISABLED' ? '/set-password?error=disabled' : '/login?error=already_active'
+    );
   }
 
   const passwordHash = await bcrypt.hash(password, 12);
 
   try {
     await prisma.$transaction(async tx => {
-      await tx.user.update({
-        where: { id: user.id },
+      const activated = await tx.user.updateMany({
+        where: {
+          id: user.id,
+          status: 'INVITED',
+          ...(record.userId ? { invitationGeneration: record.generation } : {}),
+        },
         data: {
           passwordHash,
           status: 'ACTIVE',
@@ -105,28 +112,41 @@ export async function setPassword(formData: FormData) {
           deactivatedAt: null,
         },
       });
+      if (activated.count !== 1) throw new Error('INVITE_USER_STATE_CHANGED');
 
       // Atomically claim THIS token. Concurrent submissions cannot both win.
       const claimed = await tx.userToken.updateMany({
-        where: { tokenHash, type: 'INVITE', usedAt: null, expiresAt: { gt: new Date() } },
+        where: {
+          tokenHash,
+          type: 'INVITE',
+          usedAt: null,
+          revokedAt: null,
+          expiresAt: { gt: new Date() },
+        },
         data: { usedAt: new Date() },
       });
       if (claimed.count !== 1) throw new Error('INVITE_TOKEN_ALREADY_USED');
 
       // Security: Invalidate ALL other INVITE tokens for this user to prevent reuse of old links
-      await tx.userToken.deleteMany({
+      await tx.userToken.updateMany({
         where: {
-          identifier: user.email,
+          OR: [{ userId: user.id }, { identifier: user.email }],
           type: 'INVITE',
           NOT: { tokenHash }, // Don't delete the one we just marked used (for audit history), or just delete them all? Keeping history is better.
           // Actually, we just marked it used.
           // Let's delete *other* unused invite tokens.
           usedAt: null,
+          revokedAt: null,
         },
+        data: { revokedAt: new Date() },
       });
     });
   } catch (error) {
-    if (error instanceof Error && error.message === 'INVITE_TOKEN_ALREADY_USED') {
+    if (
+      error instanceof Error &&
+      (error.message === 'INVITE_TOKEN_ALREADY_USED' ||
+        error.message === 'INVITE_USER_STATE_CHANGED')
+    ) {
       await simulateWork(startTime);
       redirect('/set-password?error=expired');
     }

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -448,7 +448,7 @@ export function UserCard({
 
                 <DropdownMenuSeparator />
 
-                {onDelete && (
+                {onDelete && user.status === 'DISABLED' && (
                   <DropdownMenuItem
                     onClick={() => void inspectDependencies()}
                     className="text-red-600 focus:text-red-700 focus:bg-red-50"
@@ -583,6 +583,7 @@ export function UserCard({
             <AlertDialogAction
               onClick={handleDelete}
               disabled={
+                user.status !== 'DISABLED' ||
                 loadingDependencies ||
                 Boolean(dependencyError) ||
                 Boolean(

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -522,6 +522,15 @@ export function UserCard({
                       Team: {item.teamName} ({item.role})
                     </Link>
                   ))}
+                  {dependencyReport.teamsLed.map(item => (
+                    <Link
+                      key={item.teamId}
+                      href={`/teams/${item.teamId}`}
+                      className="block text-primary hover:underline"
+                    >
+                      Team lead: {item.teamName}
+                    </Link>
+                  ))}
                   {dependencyReport.escalationPolicies.map(item => (
                     <Link
                       key={item.stepId}

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -56,6 +56,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import type { UserDependencyReport } from '@/lib/users/dependencies';
 
 type Team = {
   id: string;
@@ -88,6 +89,7 @@ type UserCardProps = {
   onActivate?: () => void;
   onDeactivate?: () => void;
   onDelete?: () => void;
+  onGetDependencies?: () => Promise<{ report?: UserDependencyReport; error?: string }>;
   onGenerateInvite?: () => void;
   onUpdateRole?: (role: string) => void;
   onAddToTeam?: (teamId: string) => void;
@@ -110,6 +112,7 @@ export function UserCard({
   onActivate,
   onDeactivate,
   onDelete,
+  onGetDependencies,
   onGenerateInvite: _onGenerateInvite,
   onUpdateRole,
   onAddToTeam,
@@ -117,6 +120,9 @@ export function UserCard({
   const router = useRouter();
   const [showDeactivateDialog, setShowDeactivateDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [dependencyReport, setDependencyReport] = useState<UserDependencyReport | null>(null);
+  const [dependencyError, setDependencyError] = useState<string | null>(null);
+  const [loadingDependencies, setLoadingDependencies] = useState(false);
 
   const [showInviteDialog, setShowInviteDialog] = useState(false);
   const [inviteLink, setInviteLink] = useState<string | null>(null);
@@ -193,6 +199,16 @@ export function UserCard({
   const handleDelete = () => {
     setShowDeleteDialog(false);
     onDelete?.();
+  };
+
+  const inspectDependencies = async () => {
+    setShowDeleteDialog(true);
+    setLoadingDependencies(true);
+    setDependencyError(null);
+    const result = await onGetDependencies?.();
+    setDependencyReport(result?.report ?? null);
+    setDependencyError(result?.error ?? null);
+    setLoadingDependencies(false);
   };
 
   const availableTeams = teams.filter(
@@ -434,7 +450,7 @@ export function UserCard({
 
                 {onDelete && (
                   <DropdownMenuItem
-                    onClick={() => setShowDeleteDialog(true)}
+                    onClick={() => void inspectDependencies()}
                     className="text-red-600 focus:text-red-700 focus:bg-red-50"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />
@@ -482,13 +498,100 @@ export function UserCard({
               <span className="text-red-600 font-semibold">This action cannot be undone.</span>
               <br />
               <br />
-              Are you sure you want to permanently delete <strong>{user.name}</strong>? All their
-              data, including activity history and assignments, will be removed.
+              Permanently removes <strong>{user.name}</strong>&apos;s account and personal
+              credentials. Historical incident, notification, note, and audit records retained for
+              operational evidence will remain. Active assignments and owned resources must be
+              transferred first.
             </AlertDialogDescription>
+            {loadingDependencies && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Inspecting dependencies…
+              </div>
+            )}
+            {dependencyError && <p className="text-sm text-red-600">{dependencyError}</p>}
+            {dependencyReport &&
+              Object.entries(dependencyReport).some(([, entries]) => entries.length > 0) && (
+                <div className="max-h-56 overflow-auto rounded border p-3 text-sm space-y-2">
+                  <p className="font-semibold">Resolve these dependencies before deletion:</p>
+                  {dependencyReport.teams.map(item => (
+                    <Link
+                      key={item.membershipId}
+                      href={`/teams/${item.teamId}`}
+                      className="block text-primary hover:underline"
+                    >
+                      Team: {item.teamName} ({item.role})
+                    </Link>
+                  ))}
+                  {dependencyReport.escalationPolicies.map(item => (
+                    <Link
+                      key={item.stepId}
+                      href={`/policies/${item.policyId}`}
+                      className="block text-primary hover:underline"
+                    >
+                      Escalation: {item.policyName} → Step {item.stepOrder + 1}
+                    </Link>
+                  ))}
+                  {dependencyReport.scheduleLayers.map(item => (
+                    <Link
+                      key={item.assignmentId}
+                      href={`/schedules/${item.scheduleId}`}
+                      className="block text-primary hover:underline"
+                    >
+                      Schedule: {item.scheduleName} → {item.layerName}
+                    </Link>
+                  ))}
+                  {dependencyReport.incidents.map(item => (
+                    <Link
+                      key={item.incidentId}
+                      href={`/incidents/${item.incidentId}`}
+                      className="block text-primary hover:underline"
+                    >
+                      Incident: {item.title} ({item.serviceName})
+                    </Link>
+                  ))}
+                  {dependencyReport.actionItems.map(item => (
+                    <Link
+                      key={item.actionItemId}
+                      href={`/incidents/${item.incidentId}`}
+                      className="block text-primary hover:underline"
+                    >
+                      Action item: {item.title}
+                    </Link>
+                  ))}
+                  {dependencyReport.dashboards.map(item => (
+                    <Link
+                      key={item.dashboardId}
+                      href={`/reports/executive/${item.dashboardId}`}
+                      className="block text-primary hover:underline"
+                    >
+                      Dashboard: {item.name} ({item.visibility})
+                    </Link>
+                  ))}
+                  {dependencyReport.overrides.map(item => (
+                    <p key={item.overrideId}>
+                      Override: {item.scheduleName} ({item.relation})
+                    </p>
+                  ))}
+                  {dependencyReport.shifts.map(item => (
+                    <p key={item.shiftId}>Shift: {item.scheduleName}</p>
+                  ))}
+                </div>
+              )}
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={
+                loadingDependencies ||
+                Boolean(dependencyError) ||
+                Boolean(
+                  dependencyReport &&
+                  Object.values(dependencyReport).some(entries => entries.length > 0)
+                )
+              }
+              className="bg-red-600 hover:bg-red-700"
+            >
               Delete Permanently
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/components/users/UserList.tsx
+++ b/src/components/users/UserList.tsx
@@ -5,6 +5,7 @@ import { UserCard } from './UserCard';
 import { Button } from '@/components/ui/shadcn/button';
 import { Checkbox } from '@/components/ui/shadcn/checkbox';
 import type { UserFormState } from '@/app/(app)/users/actions';
+import type { UserDependencyReport } from '@/lib/users/dependencies';
 
 import {
   DropdownMenu,
@@ -55,6 +56,9 @@ type UserListProps = {
     prevState: UserFormState,
     formData: FormData
   ) => Promise<UserFormState>;
+  getUserDependencyReport: (
+    userId: string
+  ) => Promise<{ report?: UserDependencyReport; error?: string }>;
 };
 
 export default function UserList({
@@ -68,6 +72,7 @@ export default function UserList({
   reactivateUser,
   deleteUser,
   generateInvite,
+  getUserDependencyReport,
 }: UserListProps) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [isBulkActionPending, setIsBulkActionPending] = useState(false);
@@ -104,17 +109,29 @@ export default function UserList({
     setIsBulkActionPending(true);
 
     try {
-      const promises = Array.from(selectedIds).map(async id => {
-        if (action === 'DEACTIVATE') await deactivateUser(id);
-        if (action === 'ACTIVATE') await reactivateUser(id);
-        if (action === 'DELETE') await deleteUser(id);
-      });
-
-      await Promise.all(promises);
-      toast.success(
-        `${action === 'DELETE' ? 'Deleted' : action === 'ACTIVATE' ? 'Activated' : 'Deactivated'} ${selectedIds.size} users`
+      const results = await Promise.all(
+        Array.from(selectedIds).map(async id => {
+          if (action === 'DEACTIVATE') return { id, result: await deactivateUser(id) };
+          if (action === 'ACTIVATE') return { id, result: await reactivateUser(id) };
+          return { id, result: await deleteUser(id) };
+        })
       );
-      setSelectedIds(new Set());
+      const failures = results.filter(entry => entry.result?.error);
+      const succeeded = results.length - failures.length;
+
+      if (succeeded > 0) {
+        toast.success(
+          `${action === 'DELETE' ? 'Deleted' : action === 'ACTIVATE' ? 'Activated' : 'Deactivated'} ${succeeded} user${succeeded === 1 ? '' : 's'}`
+        );
+      }
+      if (failures.length > 0) {
+        toast.error(
+          failures.length === 1
+            ? failures[0].result?.error || 'The user operation failed.'
+            : `${failures.length} users could not be updated. ${failures[0].result?.error || ''}`
+        );
+      }
+      setSelectedIds(new Set(failures.map(entry => entry.id)));
     } catch {
       toast.error('Failed to perform bulk action');
     } finally {
@@ -186,19 +203,27 @@ export default function UserList({
           const handleUpdateRole = async (role: string) => {
             const formData = new FormData();
             formData.append('role', role);
-            await updateUserRole(user.id, formData);
+            const result = await updateUserRole(user.id, formData);
+            if (result?.error) toast.error(result.error);
+            else toast.success('Role updated');
           };
 
           const handleDeactivate = async () => {
-            await deactivateUser(user.id);
+            const result = await deactivateUser(user.id);
+            if (result?.error) toast.error(result.error);
+            else toast.success('User disabled');
           };
 
           const handleReactivate = async () => {
-            await reactivateUser(user.id);
+            const result = await reactivateUser(user.id);
+            if (result?.error) toast.error(result.error);
+            else toast.success('User reactivated');
           };
 
           const handleDelete = async () => {
-            await deleteUser(user.id);
+            const result = await deleteUser(user.id);
+            if (result?.error) toast.error(result.error);
+            else toast.success('User permanently deleted');
           };
 
           const handleGenerateInvite = async () => {
@@ -210,7 +235,9 @@ export default function UserList({
             const formData = new FormData();
             formData.append('teamId', teamId);
             formData.append('role', 'MEMBER');
-            await addUserToTeam(user.id, formData);
+            const result = await addUserToTeam(user.id, formData);
+            if (result?.error) toast.error(result.error);
+            else toast.success('User added to team');
           };
 
           return (
@@ -225,6 +252,7 @@ export default function UserList({
               onActivate={user.status === 'DISABLED' ? handleReactivate : undefined}
               onDeactivate={user.status === 'ACTIVE' ? handleDeactivate : undefined}
               onDelete={handleDelete}
+              onGetDependencies={() => getUserDependencyReport(user.id)}
               onGenerateInvite={user.status === 'INVITED' ? handleGenerateInvite : undefined}
               onUpdateRole={handleUpdateRole}
               onAddToTeam={handleAddToTeam}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import OIDCProvider from '@/lib/oidc';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
 import prisma from '@/lib/prisma';
+import { runSerializableTransaction } from '@/lib/db-utils';
 import { logger } from '@/lib/logger';
 import { getOidcConfig } from '@/lib/oidc-config';
 import { getDefaultAvatar } from '@/lib/avatar';
@@ -794,61 +795,75 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               return false;
             }
 
-            const existingIdentity = await prisma.oidcIdentity.findUnique({
+            let existingIdentity = await prisma.oidcIdentity.findUnique({
               where: { issuer_subject: { issuer, subject } },
             });
 
             if (!existingIdentity) {
               const isInvitedUser = targetUser.status === 'INVITED';
-              let hasProvisioningEvidence = false;
-
-              // Existing ACTIVE users may have completed the password invite before trying SSO.
-              // The used INVITE token is intentionally retained for audit history, so it is a
-              // durable server-side signal that an administrator provisioned this email address.
-              if (existing && !isInvitedUser) {
-                const [inviteRecord, bootstrapRecord] = await Promise.all([
-                  prisma.oidcLinkingApproval.findFirst({
-                    where: { userId: existing.id, revokedAt: null },
-                    select: { id: true },
-                  }),
-                  prisma.auditLog.findFirst({
-                    where: {
-                      entityType: 'USER',
-                      entityId: existing.id,
-                      action: 'user.bootstrap',
-                    },
-                    select: { id: true },
-                  }),
-                ]);
-                hasProvisioningEvidence = !!inviteRecord || !!bootstrapRecord;
-              }
-
-              // SECURITY: Never link a pre-existing account on email match alone. For an
-              // existing user we require BOTH explicit admin-provisioning evidence and an
-              // explicit email_verified=true claim from the configured OIDC provider.
-              if (existing) {
-                const adminProvisioned = isInvitedUser || hasProvisioningEvidence;
-                if (!adminProvisioned || emailVerifiedClaim !== true) {
-                  logger.warn('[Auth] OIDC sign-in blocked: existing account is not safe to link', {
-                    component: 'auth:signIn',
-                    email,
-                    issuer,
-                    subject,
-                    adminProvisioned,
-                    emailVerified: emailVerifiedClaim === true,
+              try {
+                existingIdentity = await runSerializableTransaction(async tx => {
+                  const currentTarget = await tx.user.findUnique({
+                    where: { id: targetUser.id },
+                    select: { id: true, status: true },
                   });
+                  if (!currentTarget || currentTarget.status === 'DISABLED') {
+                    throw new Error('OIDC_TARGET_NOT_OPERATIONAL');
+                  }
+
+                  const linked = await tx.oidcIdentity.findUnique({
+                    where: { issuer_subject: { issuer, subject } },
+                  });
+                  if (linked) {
+                    if (linked.userId !== currentTarget.id) {
+                      throw new Error('OIDC_IDENTITY_OWNED_BY_ANOTHER_USER');
+                    }
+                    return linked;
+                  }
+
+                  // An existing account must prove control of a verified address. ACTIVE
+                  // accounts additionally require a fresh, one-time administrator approval.
+                  if (existing && emailVerifiedClaim !== true) {
+                    throw new Error('OIDC_LINK_NOT_APPROVED');
+                  }
+                  if (existing && currentTarget.status !== 'INVITED') {
+                    const approval = await tx.oidcLinkingApproval.findFirst({
+                      where: { userId: currentTarget.id, revokedAt: null },
+                      select: { id: true },
+                    });
+                    if (!approval) throw new Error('OIDC_LINK_NOT_APPROVED');
+                    const consumed = await tx.oidcLinkingApproval.updateMany({
+                      where: { id: approval.id, revokedAt: null },
+                      data: { revokedAt: new Date() },
+                    });
+                    if (consumed.count !== 1) throw new Error('OIDC_LINK_NOT_APPROVED');
+                  }
+
+                  return tx.oidcIdentity.create({
+                    data: { issuer, subject, email, userId: currentTarget.id },
+                  });
+                });
+              } catch (error) {
+                if (
+                  error instanceof Error &&
+                  (error.message === 'OIDC_LINK_NOT_APPROVED' ||
+                    error.message === 'OIDC_TARGET_NOT_OPERATIONAL' ||
+                    error.message === 'OIDC_IDENTITY_OWNED_BY_ANOTHER_USER')
+                ) {
+                  logger.warn(
+                    '[Auth] OIDC sign-in blocked: account linking authorization changed',
+                    {
+                      component: 'auth:signIn',
+                      email,
+                      issuer,
+                      subject,
+                      reason: error.message,
+                    }
+                  );
                   return false;
                 }
+                throw error;
               }
-
-              await prisma.oidcIdentity.create({
-                data: {
-                  issuer,
-                  subject,
-                  email,
-                  userId: targetUser.id,
-                },
-              });
               logger.info('[Auth] Linked OIDC identity to user', {
                 component: 'auth:signIn',
                 issuer,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -807,8 +807,8 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               // durable server-side signal that an administrator provisioned this email address.
               if (existing && !isInvitedUser) {
                 const [inviteRecord, bootstrapRecord] = await Promise.all([
-                  prisma.userToken.findFirst({
-                    where: { identifier: email, type: 'INVITE' },
+                  prisma.oidcLinkingApproval.findFirst({
+                    where: { userId: existing.id, revokedAt: null },
                     select: { id: true },
                   }),
                   prisma.auditLog.findFirst({
@@ -1038,10 +1038,17 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             }
 
             if (Object.keys(updateData).length > 0) {
-              await prisma.user.update({
-                where: { id: targetUser.id },
-                data: updateData,
-              });
+              if (updateData.role && updateData.role !== targetUser.role) {
+                const { updateUserSecurityState } = await import('@/lib/users/admin-invariants');
+                const mappedRole = updateData.role;
+                delete updateData.role;
+                await updateUserSecurityState(targetUser.id, { role: mappedRole }, updateData);
+              } else {
+                await prisma.user.update({
+                  where: { id: targetUser.id },
+                  data: updateData,
+                });
+              }
               logger.info('[Auth] Updated user from OIDC data', {
                 component: 'auth:signIn',
                 userId: targetUser.id,

--- a/src/lib/db-locks.ts
+++ b/src/lib/db-locks.ts
@@ -32,6 +32,9 @@ export const LOCK_KEYS = {
    * divergence samples.
    */
   DRIFT_DETECTION: BigInt(9141002),
+
+  /** Serializes all mutations that can remove the final ACTIVE administrator. */
+  USER_ADMIN_INVARIANT: BigInt(9141003),
 } as const;
 
 /**

--- a/src/lib/escalation/policy-validation.ts
+++ b/src/lib/escalation/policy-validation.ts
@@ -182,7 +182,7 @@ export async function escalationTargetExists(
   targetId: string
 ): Promise<boolean> {
   if (targetType === 'USER') {
-    return (await tx.user.count({ where: { id: targetId } })) > 0;
+    return (await tx.user.count({ where: { id: targetId, status: 'ACTIVE' } })) > 0;
   }
   if (targetType === 'TEAM') {
     return (await tx.team.count({ where: { id: targetId } })) > 0;

--- a/src/lib/incidents/rest-patch.ts
+++ b/src/lib/incidents/rest-patch.ts
@@ -8,6 +8,7 @@ import {
   type IncidentLifecycleResult,
 } from '@/lib/incidents/lifecycle';
 import { enqueueIncidentUpdateSideEffects } from '@/lib/event-outbox';
+import { requireOperationalUser } from '@/lib/users/operational-eligibility';
 
 export type RestIncidentStatus = 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED' | 'SNOOZED' | 'SUPPRESSED';
 export type RestIncidentUrgency = 'LOW' | 'MEDIUM' | 'HIGH';
@@ -70,11 +71,10 @@ export async function applyRestIncidentPatch(input: RestIncidentPatchInput) {
 
         let assigneeName: string | null = null;
         if (assigneeChanged && input.assigneeId) {
-          const assignee = await tx.user.findUnique({
-            where: { id: input.assigneeId },
-            select: { name: true },
-          });
-          if (!assignee) {
+          let assignee;
+          try {
+            assignee = await requireOperationalUser(tx, input.assigneeId);
+          } catch {
             throw new AppError({
               code: 'RESOURCE_NOT_FOUND',
               userMessage: 'Assignee not found.',

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -43,11 +43,11 @@ function appError(
 
 export async function getCurrentUser() {
   const session = await getServerSession(await getAuthOptions());
-  if (!session?.user?.email) {
+  if (!session?.user?.id && !session?.user?.email) {
     throw appError('AUTHENTICATION_REQUIRED', 'Unauthorized');
   }
   const user = await prisma.user.findUnique({
-    where: { email: session.user.email },
+    where: session.user.id ? { id: session.user.id } : { email: session.user.email! },
     select: {
       id: true,
       role: true,
@@ -56,6 +56,16 @@ export async function getCurrentUser() {
       timeZone: true,
       status: true,
       tokenVersion: true,
+      invitationGeneration: true,
+      gender: true,
+      department: true,
+      jobTitle: true,
+      avatarUrl: true,
+      phoneNumber: true,
+      emailNotificationsEnabled: true,
+      smsNotificationsEnabled: true,
+      pushNotificationsEnabled: true,
+      whatsappNotificationsEnabled: true,
     },
   });
   if (!user) {
@@ -99,6 +109,12 @@ export async function assertCapability(capability: Capability, message?: string)
 export async function assertAdminOrTeamOwner(teamId: string) {
   const user = await getCurrentUser();
   if (user.role === 'ADMIN') return user;
+  if (user.role === 'AUDITOR') {
+    throw appError('AUTHORIZATION_DENIED', 'Read-only users cannot administer teams.', {
+      teamId,
+      userId: user.id,
+    });
+  }
 
   const membership = await prisma.teamMember.findFirst({
     where: { teamId, userId: user.id, role: 'OWNER' },
@@ -126,9 +142,13 @@ export async function assertCanViewTeam(teamId: string) {
     select: { id: true },
   });
   if (team) return getCurrentUser();
-  throw appError('AUTHORIZATION_DENIED', 'Unauthorized. You do not have permission to view this team.', {
-    teamId,
-  });
+  throw appError(
+    'AUTHORIZATION_DENIED',
+    'Unauthorized. You do not have permission to view this team.',
+    {
+      teamId,
+    }
+  );
 }
 
 export async function assertResponderOrAbove() {
@@ -145,7 +165,7 @@ export async function assertAuditorOrAdmin() {
   );
 }
 
-export async function assertNotSelf(currentUserId: string, targetUserId: string, action: string) {
+export function assertNotSelf(currentUserId: string, targetUserId: string, action: string) {
   if (currentUserId === targetUserId) {
     throw appError('AUTHORIZATION_DENIED', `You cannot ${action} your own account.`, {
       currentUserId,
@@ -395,6 +415,14 @@ async function assertIncidentPolicy(
 export async function assertCanModifyService(serviceId: string) {
   const user = await getCurrentUser();
   if (user.role === 'ADMIN') return user;
+
+  if (!hasCapability(user.role as AppRole, CAPABILITIES.OPERATIONS_MANAGE)) {
+    throw appError(
+      'SERVICE_ACCESS_DENIED',
+      'Unauthorized. You do not have permission to modify this service.',
+      { serviceId, userId: user.id }
+    );
+  }
 
   const service = await prisma.service.findUnique({
     where: { id: serviceId },

--- a/src/lib/teams/membership-commands.ts
+++ b/src/lib/teams/membership-commands.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+
+import prisma from '@/lib/prisma';
+
+export async function removeTeamMembership(memberId: string) {
+  return prisma.$transaction(
+    async tx => {
+      const member = await tx.teamMember.findUnique({
+        where: { id: memberId },
+        include: { team: { select: { name: true } } },
+      });
+      if (!member) throw new Error('Member not found.');
+
+      if (member.role === 'OWNER') {
+        const otherActiveOwners = await tx.teamMember.count({
+          where: {
+            teamId: member.teamId,
+            role: 'OWNER',
+            NOT: { id: member.id },
+            user: { status: 'ACTIVE' },
+          },
+        });
+        if (otherActiveOwners === 0) {
+          throw new Error('Each team must retain at least one active owner.');
+        }
+      }
+
+      await tx.teamMember.delete({ where: { id: member.id } });
+      await tx.team.updateMany({
+        where: { id: member.teamId, teamLeadId: member.userId },
+        data: { teamLeadId: null },
+      });
+      await tx.user.update({
+        where: { id: member.userId },
+        data: { tokenVersion: { increment: 1 } },
+      });
+      return member;
+    },
+    { isolationLevel: 'Serializable' }
+  );
+}

--- a/src/lib/users/admin-invariants.ts
+++ b/src/lib/users/admin-invariants.ts
@@ -1,84 +1,85 @@
 import 'server-only';
 
 import type { Prisma, Role, UserStatus } from '@prisma/client';
-import prisma from '@/lib/prisma';
 import { acquireAdvisoryLock, LOCK_KEYS } from '@/lib/db-locks';
+import { runSerializableTransaction } from '@/lib/db-utils';
 
 type UserSecurityMutation = { role?: Role; status?: UserStatus };
+type SecurityMutationSideEffects = (tx: Prisma.TransactionClient) => Promise<void>;
 
 export async function updateUserSecurityState(
   userId: string,
   mutation: UserSecurityMutation,
-  additionalData: Prisma.UserUpdateInput = {}
+  additionalData: Prisma.UserUpdateInput = {},
+  sideEffects?: SecurityMutationSideEffects
 ) {
-  return prisma.$transaction(
-    async tx => {
-      await acquireAdvisoryLock(tx, LOCK_KEYS.USER_ADMIN_INVARIANT);
-      const target = await tx.user.findUnique({
-        where: { id: userId },
-        select: { id: true, role: true, status: true },
-      });
-      if (!target) throw new Error('User not found.');
+  return runSerializableTransaction(async tx => {
+    await acquireAdvisoryLock(tx, LOCK_KEYS.USER_ADMIN_INVARIANT);
+    const target = await tx.user.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true, status: true },
+    });
+    if (!target) throw new Error('User not found.');
 
-      const nextRole = mutation.role ?? target.role;
-      const nextStatus = mutation.status ?? target.status;
-      if (
-        target.role === 'ADMIN' &&
-        target.status === 'ACTIVE' &&
-        (nextRole !== 'ADMIN' || nextStatus !== 'ACTIVE')
-      ) {
-        const otherActiveAdmins = await tx.user.count({
-          where: { id: { not: userId }, role: 'ADMIN', status: 'ACTIVE' },
-        });
-        if (otherActiveAdmins === 0) {
-          throw new Error('Operation would leave the system with no active administrators.');
-        }
+    const nextRole = mutation.role ?? target.role;
+    const nextStatus = mutation.status ?? target.status;
+    if (
+      target.role === 'ADMIN' &&
+      target.status === 'ACTIVE' &&
+      (nextRole !== 'ADMIN' || nextStatus !== 'ACTIVE')
+    ) {
+      const otherActiveAdmins = await tx.user.count({
+        where: { id: { not: userId }, role: 'ADMIN', status: 'ACTIVE' },
+      });
+      if (otherActiveAdmins === 0) {
+        throw new Error('Operation would leave the system with no active administrators.');
       }
+    }
 
-      return tx.user.update({
-        where: { id: userId },
-        data: { ...additionalData, ...mutation },
-      });
-    },
-    { isolationLevel: 'Serializable' }
-  );
+    const updated = await tx.user.update({
+      where: { id: userId },
+      data: { ...additionalData, ...mutation },
+    });
+    await sideEffects?.(tx);
+    return updated;
+  });
 }
 
 export async function bulkUpdateUserSecurityState(
   userIds: string[],
   mutation: UserSecurityMutation,
-  additionalData: Prisma.UserUpdateManyMutationInput = {}
+  additionalData: Prisma.UserUpdateManyMutationInput = {},
+  sideEffects?: SecurityMutationSideEffects
 ) {
   const ids = [...new Set(userIds)];
-  return prisma.$transaction(
-    async tx => {
-      await acquireAdvisoryLock(tx, LOCK_KEYS.USER_ADMIN_INVARIANT);
-      const targets = await tx.user.findMany({
-        where: { id: { in: ids } },
-        select: { id: true, role: true, status: true },
+  return runSerializableTransaction(async tx => {
+    await acquireAdvisoryLock(tx, LOCK_KEYS.USER_ADMIN_INVARIANT);
+    const targets = await tx.user.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, role: true, status: true },
+    });
+    const removesActiveAdmins = targets.filter(target => {
+      const nextRole = mutation.role ?? target.role;
+      const nextStatus = mutation.status ?? target.status;
+      return (
+        target.role === 'ADMIN' &&
+        target.status === 'ACTIVE' &&
+        (nextRole !== 'ADMIN' || nextStatus !== 'ACTIVE')
+      );
+    }).length;
+    if (removesActiveAdmins > 0) {
+      const totalActiveAdmins = await tx.user.count({
+        where: { role: 'ADMIN', status: 'ACTIVE' },
       });
-      const removesActiveAdmins = targets.filter(target => {
-        const nextRole = mutation.role ?? target.role;
-        const nextStatus = mutation.status ?? target.status;
-        return (
-          target.role === 'ADMIN' &&
-          target.status === 'ACTIVE' &&
-          (nextRole !== 'ADMIN' || nextStatus !== 'ACTIVE')
-        );
-      }).length;
-      if (removesActiveAdmins > 0) {
-        const totalActiveAdmins = await tx.user.count({
-          where: { role: 'ADMIN', status: 'ACTIVE' },
-        });
-        if (totalActiveAdmins - removesActiveAdmins < 1) {
-          throw new Error('Operation would leave the system with no active administrators.');
-        }
+      if (totalActiveAdmins - removesActiveAdmins < 1) {
+        throw new Error('Operation would leave the system with no active administrators.');
       }
-      return tx.user.updateMany({
-        where: { id: { in: ids } },
-        data: { ...additionalData, ...mutation },
-      });
-    },
-    { isolationLevel: 'Serializable' }
-  );
+    }
+    const updated = await tx.user.updateMany({
+      where: { id: { in: ids } },
+      data: { ...additionalData, ...mutation },
+    });
+    await sideEffects?.(tx);
+    return updated;
+  });
 }

--- a/src/lib/users/admin-invariants.ts
+++ b/src/lib/users/admin-invariants.ts
@@ -1,0 +1,84 @@
+import 'server-only';
+
+import type { Prisma, Role, UserStatus } from '@prisma/client';
+import prisma from '@/lib/prisma';
+import { acquireAdvisoryLock, LOCK_KEYS } from '@/lib/db-locks';
+
+type UserSecurityMutation = { role?: Role; status?: UserStatus };
+
+export async function updateUserSecurityState(
+  userId: string,
+  mutation: UserSecurityMutation,
+  additionalData: Prisma.UserUpdateInput = {}
+) {
+  return prisma.$transaction(
+    async tx => {
+      await acquireAdvisoryLock(tx, LOCK_KEYS.USER_ADMIN_INVARIANT);
+      const target = await tx.user.findUnique({
+        where: { id: userId },
+        select: { id: true, role: true, status: true },
+      });
+      if (!target) throw new Error('User not found.');
+
+      const nextRole = mutation.role ?? target.role;
+      const nextStatus = mutation.status ?? target.status;
+      if (
+        target.role === 'ADMIN' &&
+        target.status === 'ACTIVE' &&
+        (nextRole !== 'ADMIN' || nextStatus !== 'ACTIVE')
+      ) {
+        const otherActiveAdmins = await tx.user.count({
+          where: { id: { not: userId }, role: 'ADMIN', status: 'ACTIVE' },
+        });
+        if (otherActiveAdmins === 0) {
+          throw new Error('Operation would leave the system with no active administrators.');
+        }
+      }
+
+      return tx.user.update({
+        where: { id: userId },
+        data: { ...additionalData, ...mutation },
+      });
+    },
+    { isolationLevel: 'Serializable' }
+  );
+}
+
+export async function bulkUpdateUserSecurityState(
+  userIds: string[],
+  mutation: UserSecurityMutation,
+  additionalData: Prisma.UserUpdateManyMutationInput = {}
+) {
+  const ids = [...new Set(userIds)];
+  return prisma.$transaction(
+    async tx => {
+      await acquireAdvisoryLock(tx, LOCK_KEYS.USER_ADMIN_INVARIANT);
+      const targets = await tx.user.findMany({
+        where: { id: { in: ids } },
+        select: { id: true, role: true, status: true },
+      });
+      const removesActiveAdmins = targets.filter(target => {
+        const nextRole = mutation.role ?? target.role;
+        const nextStatus = mutation.status ?? target.status;
+        return (
+          target.role === 'ADMIN' &&
+          target.status === 'ACTIVE' &&
+          (nextRole !== 'ADMIN' || nextStatus !== 'ACTIVE')
+        );
+      }).length;
+      if (removesActiveAdmins > 0) {
+        const totalActiveAdmins = await tx.user.count({
+          where: { role: 'ADMIN', status: 'ACTIVE' },
+        });
+        if (totalActiveAdmins - removesActiveAdmins < 1) {
+          throw new Error('Operation would leave the system with no active administrators.');
+        }
+      }
+      return tx.user.updateMany({
+        where: { id: { in: ids } },
+        data: { ...additionalData, ...mutation },
+      });
+    },
+    { isolationLevel: 'Serializable' }
+  );
+}

--- a/src/lib/users/dependencies.ts
+++ b/src/lib/users/dependencies.ts
@@ -5,6 +5,7 @@ import { activeIncidentStatuses } from '@/lib/incident-status';
 
 export type UserDependencyReport = {
   teams: Array<{ membershipId: string; teamId: string; teamName: string; role: string }>;
+  teamsLed: Array<{ teamId: string; teamName: string }>;
   escalationPolicies: Array<{
     stepId: string;
     stepOrder: number;
@@ -40,11 +41,16 @@ export type UserDependencyReport = {
 
 export async function discoverUserDependencies(userId: string): Promise<UserDependencyReport> {
   const now = new Date();
-  const [teams, policies, layers, overrides, shifts, incidents, actionItems, dashboards] =
+  const [teams, teamsLed, policies, layers, overrides, shifts, incidents, actionItems, dashboards] =
     await Promise.all([
       prisma.teamMember.findMany({
         where: { userId },
         select: { id: true, teamId: true, role: true, team: { select: { name: true } } },
+      }),
+      prisma.team.findMany({
+        where: { teamLeadId: userId },
+        select: { id: true, name: true },
+        orderBy: { name: 'asc' },
       }),
       prisma.escalationRule.findMany({
         where: { targetUserId: userId },
@@ -105,6 +111,7 @@ export async function discoverUserDependencies(userId: string): Promise<UserDepe
       teamName: x.team.name,
       role: x.role,
     })),
+    teamsLed: teamsLed.map(x => ({ teamId: x.id, teamName: x.name })),
     escalationPolicies: policies.map(x => ({
       stepId: x.id,
       stepOrder: x.stepOrder,

--- a/src/lib/users/dependencies.ts
+++ b/src/lib/users/dependencies.ts
@@ -3,61 +3,161 @@ import 'server-only';
 import prisma from '@/lib/prisma';
 import { activeIncidentStatuses } from '@/lib/incident-status';
 
-export type UserDependencyImpact = {
-  teamMemberships: number;
-  ownedTeams: number;
-  escalationTargets: number;
-  scheduleLayers: number;
-  currentOrFutureOverrides: number;
-  currentOrFutureShifts: number;
-  activeIncidents: number;
-  openActionItems: number;
-  dashboards: number;
+export type UserDependencyReport = {
+  teams: Array<{ membershipId: string; teamId: string; teamName: string; role: string }>;
+  escalationPolicies: Array<{
+    stepId: string;
+    stepOrder: number;
+    policyId: string;
+    policyName: string;
+  }>;
+  scheduleLayers: Array<{
+    assignmentId: string;
+    layerId: string;
+    layerName: string;
+    scheduleId: string;
+    scheduleName: string;
+  }>;
+  overrides: Array<{
+    overrideId: string;
+    scheduleId: string;
+    scheduleName: string;
+    relation: 'recipient' | 'replaced-user';
+    start: Date;
+    end: Date;
+  }>;
+  shifts: Array<{
+    shiftId: string;
+    scheduleId: string;
+    scheduleName: string;
+    start: Date;
+    end: Date;
+  }>;
+  incidents: Array<{ incidentId: string; title: string; serviceId: string; serviceName: string }>;
+  actionItems: Array<{ actionItemId: string; title: string; incidentId: string }>;
+  dashboards: Array<{ dashboardId: string; name: string; visibility: string }>;
 };
 
-export async function discoverUserDependencies(userId: string): Promise<UserDependencyImpact> {
+export async function discoverUserDependencies(userId: string): Promise<UserDependencyReport> {
   const now = new Date();
-  const [
-    teamMemberships,
-    ownedTeams,
-    escalationTargets,
-    scheduleLayers,
-    currentOrFutureOverrides,
-    currentOrFutureShifts,
-    activeIncidents,
-    openActionItems,
-    dashboards,
-  ] = await Promise.all([
-    prisma.teamMember.count({ where: { userId } }),
-    prisma.teamMember.count({ where: { userId, role: 'OWNER' } }),
-    prisma.escalationRule.count({ where: { targetUserId: userId } }),
-    prisma.onCallLayerUser.count({ where: { userId } }),
-    prisma.onCallOverride.count({
-      where: { OR: [{ userId }, { replacesUserId: userId }], end: { gte: now } },
-    }),
-    prisma.onCallShift.count({ where: { userId, end: { gte: now } } }),
-    prisma.incident.count({
-      where: { assigneeId: userId, status: { in: activeIncidentStatuses() } },
-    }),
-    prisma.actionItem.count({ where: { ownerId: userId, status: { not: 'COMPLETED' } } }),
-    prisma.dashboard.count({ where: { userId } }),
-  ]);
+  const [teams, policies, layers, overrides, shifts, incidents, actionItems, dashboards] =
+    await Promise.all([
+      prisma.teamMember.findMany({
+        where: { userId },
+        select: { id: true, teamId: true, role: true, team: { select: { name: true } } },
+      }),
+      prisma.escalationRule.findMany({
+        where: { targetUserId: userId },
+        select: { id: true, stepOrder: true, policyId: true, policy: { select: { name: true } } },
+      }),
+      prisma.onCallLayerUser.findMany({
+        where: { userId },
+        select: {
+          id: true,
+          layerId: true,
+          layer: { select: { name: true, schedule: { select: { id: true, name: true } } } },
+        },
+      }),
+      prisma.onCallOverride.findMany({
+        where: { OR: [{ userId }, { replacesUserId: userId }], end: { gte: now } },
+        select: {
+          id: true,
+          userId: true,
+          scheduleId: true,
+          start: true,
+          end: true,
+          schedule: { select: { name: true } },
+        },
+        orderBy: { start: 'asc' },
+      }),
+      prisma.onCallShift.findMany({
+        where: { userId, end: { gte: now } },
+        select: {
+          id: true,
+          scheduleId: true,
+          start: true,
+          end: true,
+          schedule: { select: { name: true } },
+        },
+        orderBy: { start: 'asc' },
+      }),
+      prisma.incident.findMany({
+        where: { assigneeId: userId, status: { in: activeIncidentStatuses() } },
+        select: { id: true, title: true, serviceId: true, service: { select: { name: true } } },
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.actionItem.findMany({
+        where: { ownerId: userId, status: { not: 'COMPLETED' } },
+        select: { id: true, title: true, incidentId: true },
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.dashboard.findMany({
+        where: { userId },
+        select: { id: true, name: true, visibility: true },
+        orderBy: { name: 'asc' },
+      }),
+    ]);
 
   return {
-    teamMemberships,
-    ownedTeams,
-    escalationTargets,
-    scheduleLayers,
-    currentOrFutureOverrides,
-    currentOrFutureShifts,
-    activeIncidents,
-    openActionItems,
-    dashboards,
+    teams: teams.map(x => ({
+      membershipId: x.id,
+      teamId: x.teamId,
+      teamName: x.team.name,
+      role: x.role,
+    })),
+    escalationPolicies: policies.map(x => ({
+      stepId: x.id,
+      stepOrder: x.stepOrder,
+      policyId: x.policyId,
+      policyName: x.policy.name,
+    })),
+    scheduleLayers: layers.map(x => ({
+      assignmentId: x.id,
+      layerId: x.layerId,
+      layerName: x.layer.name,
+      scheduleId: x.layer.schedule.id,
+      scheduleName: x.layer.schedule.name,
+    })),
+    overrides: overrides.map(x => ({
+      overrideId: x.id,
+      scheduleId: x.scheduleId,
+      scheduleName: x.schedule.name,
+      relation: x.userId === userId ? 'recipient' : 'replaced-user',
+      start: x.start,
+      end: x.end,
+    })),
+    shifts: shifts.map(x => ({
+      shiftId: x.id,
+      scheduleId: x.scheduleId,
+      scheduleName: x.schedule.name,
+      start: x.start,
+      end: x.end,
+    })),
+    incidents: incidents.map(x => ({
+      incidentId: x.id,
+      title: x.title,
+      serviceId: x.serviceId,
+      serviceName: x.service.name,
+    })),
+    actionItems: actionItems.map(x => ({
+      actionItemId: x.id,
+      title: x.title,
+      incidentId: x.incidentId,
+    })),
+    dashboards: dashboards.map(x => ({
+      dashboardId: x.id,
+      name: x.name,
+      visibility: x.visibility,
+    })),
   };
 }
 
-export function dependencySummary(impact: UserDependencyImpact): string[] {
-  return Object.entries(impact)
-    .filter(([, count]) => count > 0)
-    .map(([kind, count]) => `${kind}: ${count}`);
+export function dependencySummary(report: UserDependencyReport): string[] {
+  return Object.entries(report)
+    .filter(([, entries]) => entries.length > 0)
+    .map(([kind, entries]) => `${kind}: ${entries.length}`);
+}
+
+export function hasBlockingUserDependencies(report: UserDependencyReport): boolean {
+  return Object.values(report).some(entries => entries.length > 0);
 }

--- a/src/lib/users/dependencies.ts
+++ b/src/lib/users/dependencies.ts
@@ -1,0 +1,63 @@
+import 'server-only';
+
+import prisma from '@/lib/prisma';
+import { activeIncidentStatuses } from '@/lib/incident-status';
+
+export type UserDependencyImpact = {
+  teamMemberships: number;
+  ownedTeams: number;
+  escalationTargets: number;
+  scheduleLayers: number;
+  currentOrFutureOverrides: number;
+  currentOrFutureShifts: number;
+  activeIncidents: number;
+  openActionItems: number;
+  dashboards: number;
+};
+
+export async function discoverUserDependencies(userId: string): Promise<UserDependencyImpact> {
+  const now = new Date();
+  const [
+    teamMemberships,
+    ownedTeams,
+    escalationTargets,
+    scheduleLayers,
+    currentOrFutureOverrides,
+    currentOrFutureShifts,
+    activeIncidents,
+    openActionItems,
+    dashboards,
+  ] = await Promise.all([
+    prisma.teamMember.count({ where: { userId } }),
+    prisma.teamMember.count({ where: { userId, role: 'OWNER' } }),
+    prisma.escalationRule.count({ where: { targetUserId: userId } }),
+    prisma.onCallLayerUser.count({ where: { userId } }),
+    prisma.onCallOverride.count({
+      where: { OR: [{ userId }, { replacesUserId: userId }], end: { gte: now } },
+    }),
+    prisma.onCallShift.count({ where: { userId, end: { gte: now } } }),
+    prisma.incident.count({
+      where: { assigneeId: userId, status: { in: activeIncidentStatuses() } },
+    }),
+    prisma.actionItem.count({ where: { ownerId: userId, status: { not: 'COMPLETED' } } }),
+    prisma.dashboard.count({ where: { userId } }),
+  ]);
+
+  return {
+    teamMemberships,
+    ownedTeams,
+    escalationTargets,
+    scheduleLayers,
+    currentOrFutureOverrides,
+    currentOrFutureShifts,
+    activeIncidents,
+    openActionItems,
+    dashboards,
+  };
+}
+
+export function dependencySummary(impact: UserDependencyImpact): string[] {
+  return Object.entries(impact)
+    .filter(([, count]) => count > 0)
+    .map(([kind, count]) => `${kind}: ${count}`);
+}

--- a/src/lib/users/operational-eligibility.ts
+++ b/src/lib/users/operational-eligibility.ts
@@ -1,0 +1,13 @@
+import 'server-only';
+
+import type { Prisma } from '@prisma/client';
+
+/** Assignment writers call this inside Serializable transactions shared with lifecycle changes. */
+export async function requireOperationalUser(tx: Prisma.TransactionClient, userId: string) {
+  const user = await tx.user.findFirst({
+    where: { id: userId, status: 'ACTIVE' },
+    select: { id: true, name: true },
+  });
+  if (!user) throw new Error('Operational assignments require an active user.');
+  return user;
+}

--- a/src/lib/users/reference-policy.ts
+++ b/src/lib/users/reference-policy.ts
@@ -1,0 +1,33 @@
+/** Authoritative lifecycle disposition for every direct Prisma User relationship. */
+export const USER_REFERENCE_POLICY = {
+  assignedIncidents: { deactivate: 'REPORT', delete: 'BLOCK' },
+  teamMemberships: { deactivate: 'REPORT', delete: 'BLOCK' },
+  onCallShifts: { deactivate: 'REPORT', delete: 'BLOCK' },
+  escalationRules: { deactivate: 'REPORT', delete: 'BLOCK' },
+  incidentNotes: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  postmortems: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  notifications: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  inAppNotifications: { deactivate: 'SUPPRESS', delete: 'CASCADE' },
+  devices: { deactivate: 'REVOKE', delete: 'CASCADE' },
+  incidentWatchers: { deactivate: 'SUPPRESS', delete: 'CASCADE' },
+  auditLogs: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  overrides: { deactivate: 'REPORT', delete: 'BLOCK' },
+  overrideReplacements: { deactivate: 'REPORT', delete: 'BLOCK' },
+  layerAssignments: { deactivate: 'REPORT', delete: 'BLOCK' },
+  apiKeys: { deactivate: 'REVOKE', delete: 'CASCADE' },
+  incidentTemplates: { deactivate: 'KEEP', delete: 'CASCADE' },
+  updatedProviders: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  teamsLed: { deactivate: 'REPORT', delete: 'BLOCK' },
+  slackIntegrations: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  slackOAuthConfigs: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  jiraConfigsUpdated: { deactivate: 'KEEP', delete: 'SET_NULL' },
+  oidcConfigs: { deactivate: 'KEEP', delete: 'CASCADE' },
+  oidcIdentities: { deactivate: 'DENY_AUTH', delete: 'CASCADE' },
+  oidcLinkingApproval: { deactivate: 'REVOKE', delete: 'CASCADE' },
+  avatar: { deactivate: 'KEEP', delete: 'CASCADE' },
+  dashboards: { deactivate: 'REPORT', delete: 'BLOCK' },
+  assignedActionItems: { deactivate: 'REPORT', delete: 'BLOCK' },
+  tokens: { deactivate: 'REVOKE', delete: 'SET_NULL' },
+} as const;
+
+export type UserReferenceName = keyof typeof USER_REFERENCE_POLICY;

--- a/tests/api/realtime-stream.test.ts
+++ b/tests/api/realtime-stream.test.ts
@@ -37,6 +37,16 @@ describe('API Route - Realtime Stream', () => {
             timeZone: 'UTC',
             status: 'ACTIVE',
             tokenVersion: 0,
+            invitationGeneration: 0,
+            gender: null,
+            department: null,
+            jobTitle: null,
+            avatarUrl: null,
+            phoneNumber: null,
+            emailNotificationsEnabled: false,
+            smsNotificationsEnabled: false,
+            pushNotificationsEnabled: false,
+            whatsappNotificationsEnabled: false,
         };
         const streamUser = {
             id: 'user-1',

--- a/tests/architecture/public-boundary-contract.test.ts
+++ b/tests/architecture/public-boundary-contract.test.ts
@@ -17,8 +17,11 @@ describe('public boundary contract', () => {
 
   it('revokes a removed member’s existing sessions in the same transaction', () => {
     const actions = readFileSync('src/app/(app)/teams/actions.ts', 'utf8');
+    const command = readFileSync('src/lib/teams/membership-commands.ts', 'utf8');
 
-    expect(actions).toContain('data: { tokenVersion: { increment: 1 } }');
+    expect(actions).toContain('removeTeamMembership(memberId)');
+    expect(command).toContain('data: { tokenVersion: { increment: 1 } }');
+    expect(command).toContain("isolationLevel: 'Serializable'");
   });
 
   it('uses the shared visibility policy for rendered and API status outputs', () => {

--- a/tests/architecture/user-management-contract.test.ts
+++ b/tests/architecture/user-management-contract.test.ts
@@ -8,7 +8,7 @@ describe('user management security contract', () => {
 
     expect(rbac).toContain('export function assertNotSelf(');
     expect(rbac).not.toContain('export async function assertNotSelf(');
-    expect(actions.match(/assertNotSelf\(/g)).toHaveLength(3);
+    expect(actions.match(/assertNotSelf\(/g)).toHaveLength(4);
   });
 
   it('uses immutable identity and explicit generation for invitation claims', () => {
@@ -58,7 +58,7 @@ describe('user management security contract', () => {
     expect(users).toContain('removeTeamMembership(memberId)');
     expect(invariant).toContain('LOCK_KEYS.USER_ADMIN_INVARIANT');
     expect(invariant).toContain("status: 'ACTIVE'");
-    expect(invariant).toContain("isolationLevel: 'Serializable'");
+    expect(invariant).toContain('runSerializableTransaction(');
   });
 
   it('declares a lifecycle disposition for every direct User relation', () => {

--- a/tests/architecture/user-management-contract.test.ts
+++ b/tests/architecture/user-management-contract.test.ts
@@ -60,4 +60,26 @@ describe('user management security contract', () => {
     expect(invariant).toContain("status: 'ACTIVE'");
     expect(invariant).toContain("isolationLevel: 'Serializable'");
   });
+
+  it('declares a lifecycle disposition for every direct User relation', () => {
+    const schema = readFileSync('prisma/schema.prisma', 'utf8');
+    const policy = readFileSync('src/lib/users/reference-policy.ts', 'utf8');
+    const userModel = schema.slice(
+      schema.indexOf('model User {'),
+      schema.indexOf('model UserAvatar')
+    );
+    const scalarTypes = new Set(['String', 'Int', 'Boolean', 'DateTime', 'Json', 'Bytes']);
+    const relationLines = userModel
+      .split('\n')
+      .filter(line => /^\s{2}[a-zA-Z]\w+\s+/.test(line))
+      .map(line => line.trim().split(/\s+/))
+      .filter(parts => parts.length >= 2)
+      .filter(parts => !scalarTypes.has(parts[1].replace(/[?\[\]]/g, '')))
+      .filter(parts => !['Role', 'UserStatus'].includes(parts[1].replace(/[?\[\]]/g, '')))
+      .map(parts => parts[0]);
+
+    for (const relation of relationLines) {
+      expect(policy, `Missing UserReferencePolicy for ${relation}`).toContain(`${relation}:`);
+    }
+  });
 });

--- a/tests/architecture/user-management-contract.test.ts
+++ b/tests/architecture/user-management-contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('user management security contract', () => {
+  it('keeps self-protection synchronous at action call sites', () => {
+    const rbac = readFileSync('src/lib/rbac.ts', 'utf8');
+    const actions = readFileSync('src/app/(app)/users/actions.ts', 'utf8');
+
+    expect(rbac).toContain('export function assertNotSelf(');
+    expect(rbac).not.toContain('export async function assertNotSelf(');
+    expect(actions.match(/assertNotSelf\(/g)).toHaveLength(3);
+  });
+
+  it('uses immutable identity and explicit generation for invitation claims', () => {
+    const schema = readFileSync('prisma/schema.prisma', 'utf8');
+    const acceptance = readFileSync('src/app/set-password/actions.ts', 'utf8');
+
+    expect(schema).toContain('invitationGeneration');
+    expect(schema).toContain('userId     String?');
+    expect(acceptance).toContain("status: 'INVITED'");
+    expect(acceptance).toContain('invitationGeneration: record.generation');
+    expect(acceptance).toContain('revokedAt: null');
+  });
+
+  it('keeps OIDC approval separate from expiring bearer credentials', () => {
+    const schema = readFileSync('prisma/schema.prisma', 'utf8');
+    const actions = readFileSync('src/app/(app)/users/oidc-actions.ts', 'utf8');
+
+    expect(schema).toContain('model OidcLinkingApproval');
+    expect(actions).toContain('prisma.oidcLinkingApproval');
+    expect(actions).not.toContain('prisma.userToken.create');
+  });
+
+  it('projects an explicit safe profile DTO before crossing the client boundary', () => {
+    const page = readFileSync('src/app/(app)/users/[id]/page.tsx', 'utf8');
+    const dto = page.slice(page.indexOf('const transformedUser = {'), page.indexOf('return ('));
+
+    expect(dto).not.toContain('...user');
+    expect(dto).not.toContain('passwordHash');
+    expect(dto).not.toContain('tokenVersion');
+  });
+
+  it('requires mobile user routes to use the current authorization guard', () => {
+    const list = readFileSync('src/app/(mobile)/m/users/page.tsx', 'utf8');
+    const detail = readFileSync('src/app/(mobile)/m/users/[id]/page.tsx', 'utf8');
+
+    expect(list).toContain('await assertAdmin()');
+    expect(detail).toContain('await getCurrentUser()');
+    expect(detail).toContain("viewer.role !== 'ADMIN' && viewer.id !== id");
+  });
+
+  it('centralizes membership removal and last-admin serialization', () => {
+    const teams = readFileSync('src/app/(app)/teams/actions.ts', 'utf8');
+    const users = readFileSync('src/app/(app)/users/actions.ts', 'utf8');
+    const invariant = readFileSync('src/lib/users/admin-invariants.ts', 'utf8');
+
+    expect(teams).toContain('removeTeamMembership(memberId)');
+    expect(users).toContain('removeTeamMembership(memberId)');
+    expect(invariant).toContain('LOCK_KEYS.USER_ADMIN_INVARIANT');
+    expect(invariant).toContain("status: 'ACTIVE'");
+    expect(invariant).toContain("isolationLevel: 'Serializable'");
+  });
+});

--- a/tests/lib/auth-oidc-unit.test.ts
+++ b/tests/lib/auth-oidc-unit.test.ts
@@ -24,7 +24,7 @@ vi.mock('@/lib/prisma', () => {
       create: vi.fn(),
       update: vi.fn(),
     },
-    userToken: {
+    oidcLinkingApproval: {
       findFirst: vi.fn(),
     },
     oidcIdentity: {
@@ -57,7 +57,7 @@ describe('Auth JWT + OIDC (unit)', () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.user.create).mockResolvedValue({ id: 'u1' } as never);
     vi.mocked(prisma.user.update).mockResolvedValue({} as never);
-    vi.mocked(prisma.userToken.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.auditLog.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.oidcIdentity.create).mockResolvedValue({ id: 'id1' } as never);
@@ -118,8 +118,8 @@ describe('Auth JWT + OIDC (unit)', () => {
     });
 
     expect(result).toBe(false);
-    expect(prisma.userToken.findFirst).toHaveBeenCalledWith({
-      where: { identifier: 'user@example.com', type: 'INVITE' },
+    expect(prisma.oidcLinkingApproval.findFirst).toHaveBeenCalledWith({
+      where: { userId: 'u1', revokedAt: null },
       select: { id: true },
     });
     expect(prisma.oidcIdentity.create).not.toHaveBeenCalled();
@@ -136,7 +136,7 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'ACTIVE',
     });
-    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'invite-token-record' });
+    (prisma.oidcLinkingApproval.findFirst as any).mockResolvedValue({ id: 'approval-record' });
     (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
 
     const user = { email: 'user@example.com', name: 'User', id: 'oidc-sub' };
@@ -169,7 +169,7 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'ACTIVE',
     });
-    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'invite-token-record' });
+    (prisma.oidcLinkingApproval.findFirst as any).mockResolvedValue({ id: 'approval-record' });
     (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
 
     const result = await signIn({
@@ -193,7 +193,7 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'DISABLED',
     });
-    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'historical-invite' });
+    (prisma.oidcLinkingApproval.findFirst as any).mockResolvedValue({ id: 'historical-approval' });
 
     const result = await signIn({
       user: { email: 'disabled@example.com', name: 'Disabled', id: 'oidc-sub' },
@@ -202,7 +202,7 @@ describe('Auth JWT + OIDC (unit)', () => {
     });
 
     expect(result).toBe(false);
-    expect(prisma.userToken.findFirst).not.toHaveBeenCalled();
+    expect(prisma.oidcLinkingApproval.findFirst).not.toHaveBeenCalled();
     expect(prisma.oidcIdentity.create).not.toHaveBeenCalled();
     expect(prisma.user.update).not.toHaveBeenCalled();
   });

--- a/tests/lib/auth-oidc-unit.test.ts
+++ b/tests/lib/auth-oidc-unit.test.ts
@@ -136,7 +136,7 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'ACTIVE',
     });
-    (prisma.oidcLinkingApproval.findFirst as any).mockResolvedValue({ id: 'approval-record' });
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({ id: 'approval-record' } as never);
     (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
 
     const user = { email: 'user@example.com', name: 'User', id: 'oidc-sub' };
@@ -169,7 +169,7 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'ACTIVE',
     });
-    (prisma.oidcLinkingApproval.findFirst as any).mockResolvedValue({ id: 'approval-record' });
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({ id: 'approval-record' } as never);
     (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
 
     const result = await signIn({
@@ -193,7 +193,7 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'DISABLED',
     });
-    (prisma.oidcLinkingApproval.findFirst as any).mockResolvedValue({ id: 'historical-approval' });
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({ id: 'historical-approval' } as never);
 
     const result = await signIn({
       user: { email: 'disabled@example.com', name: 'Disabled', id: 'oidc-sub' },

--- a/tests/lib/auth-oidc-unit.test.ts
+++ b/tests/lib/auth-oidc-unit.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/lib/prisma', () => {
     },
     oidcLinkingApproval: {
       findFirst: vi.fn(),
+      updateMany: vi.fn(),
     },
     oidcIdentity: {
       findUnique: vi.fn(),
@@ -38,7 +39,9 @@ vi.mock('@/lib/prisma', () => {
     auditLog: {
       findFirst: vi.fn(),
     },
+    $transaction: vi.fn(),
   };
+  mockPrisma.$transaction.mockImplementation(async callback => callback(mockPrisma));
   return { default: mockPrisma };
 });
 
@@ -58,6 +61,7 @@ describe('Auth JWT + OIDC (unit)', () => {
     vi.mocked(prisma.user.create).mockResolvedValue({ id: 'u1' } as never);
     vi.mocked(prisma.user.update).mockResolvedValue({} as never);
     vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.oidcLinkingApproval.updateMany).mockResolvedValue({ count: 1 } as never);
     vi.mocked(prisma.auditLog.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.oidcIdentity.create).mockResolvedValue({ id: 'id1' } as never);
@@ -154,6 +158,10 @@ describe('Auth JWT + OIDC (unit)', () => {
         email: 'user@example.com',
         userId: 'u1',
       },
+    });
+    expect(prisma.oidcLinkingApproval.updateMany).toHaveBeenCalledWith({
+      where: { id: 'approval-record', revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
     });
     expect(user.id).toBe('u1');
   });

--- a/tests/lib/bootstrap-admin.test.ts
+++ b/tests/lib/bootstrap-admin.test.ts
@@ -36,11 +36,12 @@ describe('Bootstrap Admin - Last Admin Protection', () => {
     // Mock scenario: 1 active admin, 1 disabled admin
     const activeAdminCount = 1;
     const isAdmin = true;
-    const _isDisabled = true;
+    const isActive = false;
 
-    // Disabled admins don't count, so should prevent deletion
-    const canDelete = isAdmin && activeAdminCount > 1;
-    expect(canDelete).toBe(false);
+    // Removing a disabled admin does not change the active-admin set.
+    const removesActiveAdmin = isAdmin && isActive;
+    const canDelete = !removesActiveAdmin || activeAdminCount > 1;
+    expect(canDelete).toBe(true);
   });
 });
 
@@ -99,4 +100,3 @@ describe('Bootstrap Admin - Complete Flow', () => {
     expect(canDeleteLast).toBe(false);
   });
 });
-

--- a/tests/lib/escalation/policy-validation.test.ts
+++ b/tests/lib/escalation/policy-validation.test.ts
@@ -165,7 +165,9 @@ describe('escalationTargetExists', () => {
 
       const owning =
         targetType === 'USER' ? tx.user : targetType === 'TEAM' ? tx.team : tx.onCallSchedule;
-      expect(owning.count).toHaveBeenCalledWith({ where: { id: 'target-1' } });
+      expect(owning.count).toHaveBeenCalledWith({
+        where: targetType === 'USER' ? { id: 'target-1', status: 'ACTIVE' } : { id: 'target-1' },
+      });
       const others = [tx.user, tx.team, tx.onCallSchedule].filter(model => model !== owning);
       for (const model of others) expect(model.count).not.toHaveBeenCalled();
     }

--- a/tests/lib/incidents/rest-patch.test.ts
+++ b/tests/lib/incidents/rest-patch.test.ts
@@ -34,7 +34,7 @@ type Tx = {
     create: ReturnType<typeof vi.fn>;
   };
   user: {
-    findUnique: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -48,7 +48,7 @@ function createTx(): Tx {
       create: vi.fn().mockResolvedValue({}),
     },
     user: {
-      findUnique: vi.fn(),
+      findFirst: vi.fn(),
     },
   };
 }
@@ -84,7 +84,7 @@ describe('REST incident patch transaction', () => {
         urgency: 'HIGH',
         assigneeId: 'user-2',
       });
-    tx.user.findUnique.mockResolvedValue({ name: 'Responder Two' });
+    tx.user.findFirst.mockResolvedValue({ id: 'user-2', name: 'Responder Two' });
     mocks.applyIncidentLifecycleTargetStatus.mockResolvedValue({
       incidentId: 'inc-1',
       command: 'ACKNOWLEDGE',
@@ -255,7 +255,7 @@ describe('REST incident patch transaction', () => {
     expect(result.changed).toBe(false);
     expect(tx.incident.update).not.toHaveBeenCalled();
     expect(tx.incidentEvent.create).not.toHaveBeenCalled();
-    expect(tx.user.findUnique).not.toHaveBeenCalled();
+    expect(tx.user.findFirst).not.toHaveBeenCalled();
   });
 
   it('fails the atomic patch when a requested assignee does not exist', async () => {
@@ -265,7 +265,7 @@ describe('REST incident patch transaction', () => {
       urgency: 'LOW',
       assigneeId: null,
     });
-    tx.user.findUnique.mockResolvedValue(null);
+    tx.user.findFirst.mockResolvedValue(null);
     mocks.applyIncidentLifecycleTargetStatus.mockResolvedValue({
       incidentId: 'inc-3',
       command: 'ACKNOWLEDGE',

--- a/tests/lib/oidc-linking-approval.test.ts
+++ b/tests/lib/oidc-linking-approval.test.ts
@@ -34,15 +34,15 @@ import {
 describe('OIDC linking approval management', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (prisma.user.findUnique as any).mockResolvedValue({
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: 'user-1',
       email: 'User@Example.com',
       status: 'ACTIVE',
-    });
-    (prisma.oidcIdentity.findFirst as any).mockResolvedValue(null);
-    (prisma.oidcLinkingApproval.findUnique as any).mockResolvedValue(null);
-    (prisma.oidcLinkingApproval.upsert as any).mockResolvedValue({ id: 'approval-1' });
-    (prisma.oidcLinkingApproval.updateMany as any).mockResolvedValue({ count: 1 });
+    } as never);
+    vi.mocked(prisma.oidcIdentity.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.oidcLinkingApproval.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.oidcLinkingApproval.upsert).mockResolvedValue({ id: 'approval-1' } as never);
+    vi.mocked(prisma.oidcLinkingApproval.updateMany).mockResolvedValue({ count: 1 });
   });
 
   it('reports not-approved when an active user has no identity or provisioning evidence', async () => {
@@ -63,10 +63,10 @@ describe('OIDC linking approval management', () => {
   });
 
   it('reports approved when provisioning evidence already exists', async () => {
-    (prisma.oidcLinkingApproval.findUnique as any).mockResolvedValue({
+    vi.mocked(prisma.oidcLinkingApproval.findUnique).mockResolvedValue({
       id: 'approval-1',
       revokedAt: null,
-    });
+    } as never);
 
     const state = await getOidcLinkingState('user-1');
     const allowResult = await allowOidcLinking('user-1');
@@ -77,7 +77,7 @@ describe('OIDC linking approval management', () => {
   });
 
   it('reports already-linked users without creating provisioning evidence', async () => {
-    (prisma.oidcIdentity.findFirst as any).mockResolvedValue({ id: 'identity-1' });
+    vi.mocked(prisma.oidcIdentity.findFirst).mockResolvedValue({ id: 'identity-1' } as never);
 
     const result = await allowOidcLinking('user-1');
 
@@ -87,10 +87,10 @@ describe('OIDC linking approval management', () => {
   });
 
   it('revokes pending first-link eligibility without changing credentials or status', async () => {
-    (prisma.oidcLinkingApproval.findUnique as any).mockResolvedValue({
+    vi.mocked(prisma.oidcLinkingApproval.findUnique).mockResolvedValue({
       id: 'approval-1',
       revokedAt: null,
-    });
+    } as never);
 
     const result = await revokeOidcLinking('user-1');
 
@@ -103,7 +103,7 @@ describe('OIDC linking approval management', () => {
   });
 
   it('does not use revoke approval to unlink an established identity', async () => {
-    (prisma.oidcIdentity.findFirst as any).mockResolvedValue({ id: 'identity-1' });
+    vi.mocked(prisma.oidcIdentity.findFirst).mockResolvedValue({ id: 'identity-1' } as never);
 
     const result = await revokeOidcLinking('user-1');
 
@@ -117,11 +117,11 @@ describe('OIDC linking approval management', () => {
   });
 
   it('rejects approval management for disabled users', async () => {
-    (prisma.user.findUnique as any).mockResolvedValue({
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: 'user-1',
       email: 'user@example.com',
       status: 'DISABLED',
-    });
+    } as never);
 
     const allowResult = await allowOidcLinking('user-1');
     const revokeResult = await revokeOidcLinking('user-1');

--- a/tests/lib/oidc-linking-approval.test.ts
+++ b/tests/lib/oidc-linking-approval.test.ts
@@ -20,7 +20,7 @@ vi.mock('@/lib/prisma', () => ({
   default: {
     user: { findUnique: vi.fn() },
     oidcIdentity: { findFirst: vi.fn() },
-    userToken: { findFirst: vi.fn(), create: vi.fn(), deleteMany: vi.fn() },
+    oidcLinkingApproval: { findUnique: vi.fn(), upsert: vi.fn(), updateMany: vi.fn() },
   },
 }));
 
@@ -40,9 +40,9 @@ describe('OIDC linking approval management', () => {
       status: 'ACTIVE',
     });
     (prisma.oidcIdentity.findFirst as any).mockResolvedValue(null);
-    (prisma.userToken.findFirst as any).mockResolvedValue(null);
-    (prisma.userToken.create as any).mockResolvedValue({ id: 'marker-1' });
-    (prisma.userToken.deleteMany as any).mockResolvedValue({ count: 1 });
+    (prisma.oidcLinkingApproval.findUnique as any).mockResolvedValue(null);
+    (prisma.oidcLinkingApproval.upsert as any).mockResolvedValue({ id: 'approval-1' });
+    (prisma.oidcLinkingApproval.updateMany as any).mockResolvedValue({ count: 1 });
   });
 
   it('reports not-approved when an active user has no identity or provisioning evidence', async () => {
@@ -50,32 +50,30 @@ describe('OIDC linking approval management', () => {
     expect(result).toEqual({ success: true, state: 'not-approved', alreadyLinked: false });
   });
 
-  it('records non-redeemable provisioning evidence without changing user status', async () => {
+  it('records durable provisioning approval without changing user status', async () => {
     const result = await allowOidcLinking('user-1');
 
     expect(result).toEqual({ success: true, state: 'approved' });
-    expect(prisma.userToken.create).toHaveBeenCalledTimes(1);
-    expect(prisma.userToken.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        identifier: 'user@example.com',
-        type: 'INVITE',
-        tokenHash: expect.any(String),
-        expiresAt: expect.any(Date),
-        usedAt: expect.any(Date),
-      }),
+    expect(prisma.oidcLinkingApproval.upsert).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      create: { userId: 'user-1', approvedById: 'admin-1' },
+      update: expect.objectContaining({ approvedById: 'admin-1', revokedAt: null }),
     });
     expect(prisma.user.update).toBeUndefined();
   });
 
   it('reports approved when provisioning evidence already exists', async () => {
-    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'existing-invite' });
+    (prisma.oidcLinkingApproval.findUnique as any).mockResolvedValue({
+      id: 'approval-1',
+      revokedAt: null,
+    });
 
     const state = await getOidcLinkingState('user-1');
     const allowResult = await allowOidcLinking('user-1');
 
     expect(state).toEqual({ success: true, state: 'approved', alreadyLinked: false });
     expect(allowResult).toEqual({ success: true, alreadyApproved: true, state: 'approved' });
-    expect(prisma.userToken.create).not.toHaveBeenCalled();
+    expect(prisma.oidcLinkingApproval.upsert).not.toHaveBeenCalled();
   });
 
   it('reports already-linked users without creating provisioning evidence', async () => {
@@ -84,18 +82,22 @@ describe('OIDC linking approval management', () => {
     const result = await allowOidcLinking('user-1');
 
     expect(result).toEqual({ success: true, alreadyLinked: true, state: 'linked' });
-    expect(prisma.userToken.findFirst).not.toHaveBeenCalled();
-    expect(prisma.userToken.create).not.toHaveBeenCalled();
+    expect(prisma.oidcLinkingApproval.findUnique).not.toHaveBeenCalled();
+    expect(prisma.oidcLinkingApproval.upsert).not.toHaveBeenCalled();
   });
 
   it('revokes pending first-link eligibility without changing credentials or status', async () => {
-    (prisma.userToken.findFirst as any).mockResolvedValue({ id: 'existing-invite' });
+    (prisma.oidcLinkingApproval.findUnique as any).mockResolvedValue({
+      id: 'approval-1',
+      revokedAt: null,
+    });
 
     const result = await revokeOidcLinking('user-1');
 
     expect(result).toEqual({ success: true, state: 'not-approved' });
-    expect(prisma.userToken.deleteMany).toHaveBeenCalledWith({
-      where: { identifier: 'user@example.com', type: 'INVITE' },
+    expect(prisma.oidcLinkingApproval.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1', revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
     });
     expect(prisma.user.update).toBeUndefined();
   });
@@ -106,11 +108,12 @@ describe('OIDC linking approval management', () => {
     const result = await revokeOidcLinking('user-1');
 
     expect(result).toEqual({
-      error: 'This user already has an OIDC identity linked. Revoking approval does not unlink identities.',
+      error:
+        'This user already has an OIDC identity linked. Revoking approval does not unlink identities.',
       alreadyLinked: true,
       state: 'linked',
     });
-    expect(prisma.userToken.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.oidcLinkingApproval.updateMany).not.toHaveBeenCalled();
   });
 
   it('rejects approval management for disabled users', async () => {
@@ -129,7 +132,7 @@ describe('OIDC linking approval management', () => {
     expect(revokeResult).toEqual({
       error: 'OIDC linking approval can only be managed for active users.',
     });
-    expect(prisma.userToken.create).not.toHaveBeenCalled();
-    expect(prisma.userToken.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.oidcLinkingApproval.upsert).not.toHaveBeenCalled();
+    expect(prisma.oidcLinkingApproval.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/tests/lib/rbac.test.ts
+++ b/tests/lib/rbac.test.ts
@@ -283,7 +283,7 @@ describe('RBAC Functions', () => {
 
     it('should deny an auditor even when they belong to the service team', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockAuditor.email } });
-      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAuditor as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAuditor as never);
 
       await expect(assertCanModifyService(serviceId)).rejects.toThrow('Unauthorized');
       expect(prisma.service.findUnique).not.toHaveBeenCalled();
@@ -291,11 +291,11 @@ describe('RBAC Functions', () => {
 
     it('should allow a responder who belongs to the service team', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockResponder.email } });
-      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockResponder as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockResponder as never);
       vi.mocked(prisma.service.findUnique).mockResolvedValue({
         id: serviceId,
         team: { members: [{ userId: mockResponder.id }] },
-      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      } as never);
 
       expect(await assertCanModifyService(serviceId)).toEqual(mockResponder);
     });

--- a/tests/lib/rbac.test.ts
+++ b/tests/lib/rbac.test.ts
@@ -193,12 +193,12 @@ describe('RBAC Functions', () => {
   });
 
   describe('assertNotSelf', () => {
-    it('should pass if IDs are different', async () => {
-      await expect(assertNotSelf('u1', 'u2', 'delete')).resolves.not.toThrow();
+    it('should pass if IDs are different', () => {
+      expect(() => assertNotSelf('u1', 'u2', 'delete')).not.toThrow();
     });
 
-    it('should throw if IDs are the same', async () => {
-      await expect(assertNotSelf('u1', 'u1', 'delete')).rejects.toThrow(
+    it('should throw synchronously if IDs are the same', () => {
+      expect(() => assertNotSelf('u1', 'u1', 'delete')).toThrow(
         'You cannot delete your own account.'
       );
     });
@@ -269,7 +269,7 @@ describe('RBAC Functions', () => {
       await expect(assertCanModifyIncident(incidentId)).rejects.toThrow('Unauthorized');
     });
 
-    it('should allow team member to modify service', async () => {
+    it('should deny a regular team member permission to modify service configuration', async () => {
       vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockUser.email } });
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any); // eslint-disable-line @typescript-eslint/no-explicit-any
       vi.mocked(prisma.service.findUnique).mockResolvedValue({
@@ -277,7 +277,27 @@ describe('RBAC Functions', () => {
         team: { members: [{ userId: mockUser.id }] },
       } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-      expect(await assertCanModifyService(serviceId)).toEqual(mockUser);
+      await expect(assertCanModifyService(serviceId)).rejects.toThrow('Unauthorized');
+      expect(prisma.service.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should deny an auditor even when they belong to the service team', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockAuditor.email } });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockAuditor as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      await expect(assertCanModifyService(serviceId)).rejects.toThrow('Unauthorized');
+      expect(prisma.service.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should allow a responder who belongs to the service team', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { email: mockResponder.email } });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockResponder as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+      vi.mocked(prisma.service.findUnique).mockResolvedValue({
+        id: serviceId,
+        team: { members: [{ userId: mockResponder.id }] },
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(await assertCanModifyService(serviceId)).toEqual(mockResponder);
     });
 
     it('should allow ADMIN to create incident for any service', async () => {


### PR DESCRIPTION
## Summary

Hardens OpsKnight user management and RBAC as one cohesive security change:

- makes self-protection guards synchronous so raw server actions cannot bypass them
- denies service/team mutations to read-only Auditors and requires an operational mutation capability
- enforces desktop/mobile profile authorization parity
- projects an explicit safe DTO before user data crosses the client boundary
- resolves protected actors through immutable session user IDs with current status/version checks
- binds invite tokens to immutable user IDs and monotonically increasing invitation generations
- prevents disabled or active users from being reactivated by stale invitations
- separates durable OIDC linking approval from expiring invitation credentials
- centralizes team-membership removal, owner continuity, lead cleanup, and session revocation
- serializes last-ACTIVE-admin mutations across manual, bulk, and OIDC role writers
- revokes sessions, pending credentials, and API keys during deactivation
- requires dependency transfer before planned deactivation or hard deletion
- preserves notification history rather than cascading delivery evidence
- makes profile preference updates patch-safe and validates timezone/email changes
- fixes invitation rate-limit action/target mismatches
- adds architecture contracts to prevent these bypasses from returning

## Database migration

Adds:

- `User.invitationGeneration`
- immutable `UserToken.userId`, generation, and revocation metadata
- durable `OidcLinkingApproval`
- `Notification.userId` `ON DELETE SET NULL` retention behavior

The migration backfills token user IDs only through the unique current email mapping and preserves rolling compatibility for legacy email-bound tokens.

## Validation

- `npx tsc --noEmit` ✅
- Prisma schema validation ✅
- migration safety validation ✅
- unit suite: **264 files / 1,983 passed / 4 skipped** ✅
- full suite: **1,995 passed / 102 skipped**; the only failure is the existing real-DB advisory-lock test because this workstation has no valid local PostgreSQL credentials
- targeted RBAC/OIDC/profile/architecture tests ✅

## Rollout notes

Apply the Prisma migration before or with the application rollout. Existing invite tokens remain readable during rolling deployment; new tokens use immutable user identity and generation fencing.