### PR TITLE
docs(metrics): add Prometheus setup and ingestion guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ docker run -d --name opsknight -p 3000:3000 \
 ```
 
 PostgreSQL 14+ is required. See the
-[deployment guides](docs/v1.4/deployment/README.md) for TLS, connection pooling
+[deployment guides](docs/v1.5/deployment/README.md) for TLS, connection pooling
 and scaling.
 
 ---
@@ -270,9 +270,9 @@ We support multiple deployment strategies to fit your infrastructure needs.
 
 | Method                                                                                                        | Best For                            | Guide                                            |
 | :------------------------------------------------------------------------------------------------------------ | :---------------------------------- | :----------------------------------------------- |
-| ![](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white) **Docker Compose**     | Local Development, small teams      | [Read Guide](docs/v1.4/deployment/docker.md)     |
-| ![](https://img.shields.io/badge/Kubernetes-326CE5?style=flat&logo=kubernetes&logoColor=white) **Helm Chart** | Production Kubernetes (Recommended) | [Read Guide](docs/v1.4/deployment/helm.md)       |
-| ![](https://img.shields.io/badge/-GitOps-black?style=flat&logo=git&logoColor=white) **Kustomize**             | GitOps (ArgoCD/Flux)                | [Read Guide](docs/v1.4/deployment/kubernetes.md) |
+| ![](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white) **Docker Compose**     | Local Development, small teams      | [Read Guide](docs/v1.5/deployment/docker.md)     |
+| ![](https://img.shields.io/badge/Kubernetes-326CE5?style=flat&logo=kubernetes&logoColor=white) **Helm Chart** | Production Kubernetes (Recommended) | [Read Guide](docs/v1.5/deployment/helm.md)       |
+| ![](https://img.shields.io/badge/-GitOps-black?style=flat&logo=git&logoColor=white) **Kustomize**             | GitOps (ArgoCD/Flux)                | [Read Guide](docs/v1.5/deployment/kubernetes.md) |
 
 > **Note:** For production, we recommend using an external managed PostgreSQL database.
 
@@ -296,13 +296,14 @@ OpsKnight runs as a single Next.js application (UI + API routes + server actions
 Everything you need to configure and extend OpsKnight.
 
 - **[Hosted Documentation](https://opsknight.com/docs)** (Recommended)
-- **In-Repo Guides (v1.2)**:
-  - [⚡ Getting Started](docs/v1.4/getting-started/README.md)
-  - [🧩 Core Concepts](docs/v1.4/core-concepts/README.md)
-  - [🔌 Integrations](docs/v1.4/integrations/README.md)
-  - [🛡️ Security](docs/v1.4/security/README.md)
-  - [📡 API Reference](docs/v1.4/api/README.md)
-  - [🔧 Administration](docs/v1.4/administration/README.md)
+- **In-Repo Guides (v1.5)**:
+  - [⚡ Getting Started](docs/v1.5/getting-started/README.md)
+  - [🧩 Core Concepts](docs/v1.5/core-concepts/README.md)
+  - [🔌 Integrations](docs/v1.5/integrations/README.md)
+  - [🛡️ Security](docs/v1.5/security/README.md)
+  - [📡 API Reference](docs/v1.5/api/README.md)
+  - [🔧 Administration](docs/v1.5/administration/README.md)
+  - [📈 Prometheus Metrics](docs/v1.5/deployment/prometheus.md)
 
 ---
 

--- a/docs/v1.5/README.md
+++ b/docs/v1.5/README.md
@@ -18,6 +18,7 @@ This tree is **v1.5**. Switch versions in the sidebar for older releases.
 - [Installation](./getting-started/installation) — Compose, Helm, Kustomize, from source. First boot needs `NEXTAUTH_SECRET` and `ENCRYPTION_KEY`.
 - [Troubleshooting](./troubleshooting) — Compose, database, auth, paging
 - [Notifications](./administration/notifications) — How someone actually gets paged (no voice), including user-controlled Quiet Hours.
+- [Prometheus metrics](./deployment/prometheus) — Secure scraping, Helm/Compose/Kustomize setup, PromQL, recording rules, and alerts.
 - [Incidents](./core-concepts/incidents)
 - [Escalation policies](./core-concepts/escalation-policies)
 - [On-call schedules](./core-concepts/schedules)

--- a/docs/v1.5/architecture/README.md
+++ b/docs/v1.5/architecture/README.md
@@ -22,6 +22,7 @@ Start with these two guides:
 - [System settings](./settings) — settings boundaries, roles, API keys, and secret handling.
 - [Analytics surface matrix](./analytics-parity-audit) — desktop, mobile, executive, and export behavior.
 - [Incident metric contract](./metric-contract) — canonical formulas, scopes, data states, drill-downs, and trend semantics.
+- [Metrics and observability contract](./metrics-observability) — exporter scope, aggregation, availability, and label-safety rules.
 
 ## Important boundaries
 

--- a/docs/v1.5/architecture/metrics-observability.md
+++ b/docs/v1.5/architecture/metrics-observability.md
@@ -3,6 +3,9 @@
 OpsKnight exposes authenticated Prometheus metrics at `/api/metrics`. Configure a high-entropy
 `PROMETHEUS_SCRAPE_TOKEN` through a Secret; never put it in a ConfigMap or image.
 
+Operator setup, the complete metric catalog, safe multi-replica PromQL, recording/alert rules, and
+deployment-specific examples are documented in the [Prometheus metrics guide](../deployment/prometheus).
+
 Metrics declare one of three aggregation scopes. Instance metrics are scraped per replica. Counters
 are aggregated with `sum` or `rate`. Cluster snapshot gauges are deliberately exposed by every
 replica for availability and must use the shipped `max without(instance,pod)` recording rules—never

--- a/docs/v1.5/deployment/README.md
+++ b/docs/v1.5/deployment/README.md
@@ -116,6 +116,7 @@ Restore into an isolated environment with the original encryption key, then veri
 - [Kustomize](./kustomize)
 - [Helm](./helm)
 - [Monitoring](./monitoring)
+- [Prometheus metrics](./prometheus)
 - [Enterprise validation drills](./enterprise-validation)
 - [Maintenance](./maintenance)
 - [Database migrations](./database-migrations)

--- a/docs/v1.5/deployment/docker.md
+++ b/docs/v1.5/deployment/docker.md
@@ -39,6 +39,11 @@ APP_PORT=3000
 OPSKNIGHT_IMAGE=ghcr.io/opsknight-labs/opsknight:1.4.0
 ```
 
+To let Prometheus monitor OpsKnight, also provide a dedicated high-entropy
+`PROMETHEUS_SCRAPE_TOKEN` and configure Prometheus to scrape the authenticated `/api/metrics`
+endpoint. See [Prometheus metrics](./prometheus) for secure token handling, scrape configuration,
+queries, and alerts.
+
 Pin `OPSKNIGHT_IMAGE` to the immutable version or digest you tested. The default remains `latest` for convenience and should not be the production release policy. The `1.4.0` stable image includes fail-closed migrations and is published for amd64 and arm64; the test image built from `main` remains amd64-only.
 
 The checked-in fallbacks are development values, not production secrets. Keep `ENCRYPTION_KEY` stable and backed up with the database; losing it means re-entering encrypted provider/integration credentials.
@@ -163,4 +168,5 @@ docker compose down
 | Managed DB cannot connect               | `OPSKNIGHT_DATABASE_URL`, URI encoding, TLS parameters, firewall/routing.             |
 | Provider credentials fail after restore | Database backup and the original `ENCRYPTION_KEY` must belong together.               |
 
-See [Troubleshooting](../troubleshooting) and [Configuration reference](../getting-started/configuration).
+See [Troubleshooting](../troubleshooting), [Configuration reference](../getting-started/configuration),
+[Prometheus metrics](./prometheus), and [Monitoring](./monitoring).

--- a/docs/v1.5/deployment/helm.md
+++ b/docs/v1.5/deployment/helm.md
@@ -147,6 +147,16 @@ Connection limits are per application process. Size PostgreSQL capacity for the 
 
 The application ServiceAccount token is not mounted by default because OpsKnight does not require Kubernetes API access. Set `serviceAccount.automount: true` only for a deliberate extension that needs it.
 
+## Prometheus metrics
+
+The chart can inject `PROMETHEUS_SCRAPE_TOKEN` from an existing Secret and render an authenticated
+`ServiceMonitor`. Enabling the monitor without `metrics.scrapeTokenSecret.existingSecret` fails chart
+rendering. When NetworkPolicy is enabled, explicitly allow the selected Prometheus pods or namespace
+to reach the application port.
+
+See [Prometheus metrics](./prometheus) for production values, Secret creation, Operator selectors,
+NetworkPolicy, recording rules, PromQL, and validation.
+
 ## Upgrade and rollback
 
 Before upgrading:
@@ -175,5 +185,6 @@ helm upgrade opsknight helm/opsknight \
 - [Kubernetes](./kubernetes)
 - [Kustomize](./kustomize)
 - [Docker Compose](./docker)
+- [Prometheus metrics](./prometheus)
 - [Configuration reference](../getting-started/configuration)
 - [Maintenance](./maintenance)

--- a/docs/v1.5/deployment/kubernetes.md
+++ b/docs/v1.5/deployment/kubernetes.md
@@ -26,6 +26,7 @@ Do not install both into the same namespace. Their resource names and lifecycle 
 - A PostgreSQL topology with durable storage, capacity monitoring, backups, and a tested restore.
 - A secrets-delivery process for the database password, `NEXTAUTH_SECRET`, and 64-hex-character `ENCRYPTION_KEY`.
 - External collection for application/container logs and platform/database metrics.
+- A dedicated Secret and Prometheus/Operator discovery plan when scraping `/api/metrics`.
 
 Validate rendered API versions and admission/security policies against the actual target cluster. v1.4 does not declare one universal Kubernetes-version support matrix.
 
@@ -179,6 +180,7 @@ A Deployment or Helm rollback changes application resources; it does not reverse
 - [Kustomize](./kustomize)
 - [Helm](./helm)
 - [Monitoring](./monitoring)
+- [Prometheus metrics](./prometheus)
 - [Database migrations](./database-migrations)
 - [Backup and restore](./backup-restore)
 - [Upgrade and rollback](./upgrade-rollback)

--- a/docs/v1.5/deployment/kustomize.md
+++ b/docs/v1.5/deployment/kustomize.md
@@ -32,6 +32,11 @@ At minimum customize:
 - resource requests/limits, replicas, HPA and PDB;
 - NetworkPolicy ingress namespace labels and database destinations.
 
+For Prometheus Operator, add the optional `k8s/monitoring/servicemonitor.yaml` from the production
+overlay, inject `PROMETHEUS_SCRAPE_TOKEN` into the application from a dedicated Secret, and allow the
+monitoring source through NetworkPolicy. The monitor is intentionally excluded from the base so
+clusters without the `ServiceMonitor` CRD remain deployable. See [Prometheus metrics](./prometheus).
+
 Use your platform secret controller/store for production values. Do not commit rendered production Secrets.
 
 ## Render and validate
@@ -72,4 +77,5 @@ Kubernetes rollout rollback does not undo PostgreSQL migrations. Confirm schema 
 - [Deployment](./README)
 - [Helm](./helm)
 - [Monitoring](./monitoring)
+- [Prometheus metrics](./prometheus)
 - [Configuration reference](../getting-started/configuration)

--- a/docs/v1.5/deployment/monitoring.md
+++ b/docs/v1.5/deployment/monitoring.md
@@ -8,6 +8,10 @@ description: Monitor health, database readiness, logs, resources, scheduled work
 
 Monitor OpsKnight as part of the incident-delivery path. A reachable login page alone does not prove that database work, integrations, escalation, or outbound notifications operate correctly.
 
+OpsKnight publishes authenticated, low-cardinality Prometheus metrics at `/api/metrics`. See the
+[Prometheus metrics guide](./prometheus) for the complete metric catalog, Bearer-token setup,
+Compose and Kubernetes configuration, recording rules, PromQL, alerts, and troubleshooting.
+
 ## Health endpoint
 
 ```bash
@@ -58,6 +62,7 @@ Avoid routing an OpsKnight-self outage solely through the same OpsKnight install
 
 ## Related topics
 
+- [Prometheus metrics](./prometheus)
 - [Deployment](./README)
 - [Notifications](../administration/notifications)
 - [Troubleshooting](../troubleshooting)

--- a/docs/v1.5/deployment/prometheus.md
+++ b/docs/v1.5/deployment/prometheus.md
@@ -1,0 +1,366 @@
+---
+order: 7
+title: Prometheus metrics
+description: Securely scrape OpsKnight metrics with Prometheus, Prometheus Operator, Helm, Kustomize, Docker Compose, and Grafana.
+---
+
+# Prometheus metrics
+
+OpsKnight exposes Prometheus text-format operational metrics from:
+
+```text
+GET /api/metrics
+```
+
+The endpoint is authenticated. For unattended scraping, every OpsKnight replica must receive the
+same high-entropy `PROMETHEUS_SCRAPE_TOKEN`, and the scraper must send it as a Bearer token.
+
+This is different from the Prometheus Alertmanager integration:
+
+- **Prometheus scrapes OpsKnight** at `GET /api/metrics` to monitor OpsKnight itself.
+- **Alertmanager sends alerts to OpsKnight** at `POST /api/integrations/prometheus` to create and
+  resolve incidents. Configure that separately in the
+  [Prometheus / Alertmanager integration guide](../integrations/metrics-alerting/prometheus).
+
+## What the exporter covers
+
+The exporter publishes low-cardinality operational signals for HTTP traffic, active incidents and
+users, durable jobs, notification backlog, escalation lag, analytics-rollup freshness, and exporter
+collector/cache health. It does not replace PostgreSQL, container, node, ingress, certificate, or
+backup monitoring. Collect those with the platform's normal exporters and alerts.
+
+## Authentication and endpoint behavior
+
+Generate a dedicated token with at least 32 random bytes:
+
+```bash
+openssl rand -hex 32
+```
+
+Store the result in the deployment secret system as `PROMETHEUS_SCRAPE_TOKEN`. Do not place it in a
+ConfigMap, container image, source-controlled values file, scrape URL, dashboard variable, or metric
+label.
+
+Verify the endpoint from a trusted machine without printing the token:
+
+```bash
+read -rsp 'Prometheus scrape token: ' PROMETHEUS_TOKEN; echo
+curl --fail --show-error \
+  --header "Authorization: Bearer ${PROMETHEUS_TOKEN}" \
+  https://ops.example.com/api/metrics
+unset PROMETHEUS_TOKEN
+```
+
+Expected behavior:
+
+- a valid Bearer token returns HTTP 200 and `text/plain; version=0.0.4`;
+- a missing or invalid token returns HTTP 401, unless the request carries a valid Admin session;
+- an Admin can inspect the endpoint interactively without configuring a scrape token;
+- an unset `PROMETHEUS_SCRAPE_TOKEN` does **not** allow anonymous scraping; and
+- a failed database collector does not discard healthy process metrics. The response reports the
+  partial failure through `opsknight_metrics_collection_errors`.
+
+Database-backed collectors have a two-second timeout. Successful snapshots are cached for about ten
+seconds; degraded snapshots back off for about one minute to avoid a scrape-driven query storm.
+
+## Standalone Prometheus configuration
+
+Mount the token into Prometheus as a read-only file, then add this job to `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: opsknight
+    scheme: https
+    metrics_path: /api/metrics
+    scrape_interval: 30s
+    scrape_timeout: 5s
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/secrets/opsknight/scrape-token
+    static_configs:
+      - targets:
+          - ops.example.com
+```
+
+Use the internal Service DNS name and `scheme: http` when Prometheus runs inside the same trusted
+cluster. Use the public HTTPS origin only when cluster-local routing is unavailable. Do not disable
+TLS verification to work around certificate or hostname errors.
+
+Reload Prometheus, then open **Status → Targets** and confirm that `job="opsknight"` is `UP`:
+
+```bash
+promtool check config /etc/prometheus/prometheus.yml
+curl --fail http://prometheus.example.com/-/ready
+```
+
+The expression `up{job="opsknight"}` should return `1` for every scraped replica.
+
+## Docker Compose
+
+The supplied `docker-compose.yml` passes `PROMETHEUS_SCRAPE_TOKEN` from the host environment into the
+application container. Add the token to the protected `.env` or your Compose secret-injection layer:
+
+```dotenv
+PROMETHEUS_SCRAPE_TOKEN=REPLACE_WITH_64_HEX_CHARACTERS
+```
+
+Recreate the application so it receives the new value:
+
+```bash
+docker compose up -d --force-recreate opsknight-app
+docker compose exec opsknight-app printenv PROMETHEUS_SCRAPE_TOKEN >/dev/null
+```
+
+Do not use `docker compose config` in shared logs after adding production secrets because rendered
+environment values may be displayed. Configure Prometheus with the same token through a protected
+credentials file. If Prometheus joins `opsknight-network`, its target can be
+`opsknight-app:3000`; otherwise scrape the protected HTTPS origin.
+
+## Helm with Prometheus Operator
+
+The chart can render a `ServiceMonitor`. It intentionally fails rendering when the monitor is enabled
+without an existing token Secret, preventing an unauthenticated or permanently failing monitor.
+
+Create the Secret in the OpsKnight namespace:
+
+```bash
+kubectl create namespace opsknight --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n opsknight create secret generic opsknight-metrics \
+  --from-literal=PROMETHEUS_SCRAPE_TOKEN="$(openssl rand -hex 32)"
+```
+
+Add this to the production values file:
+
+```yaml
+metrics:
+  enabled: true
+  path: /api/metrics
+  scrapeTokenSecret:
+    existingSecret: opsknight-metrics
+    key: PROMETHEUS_SCRAPE_TOKEN
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 5s
+    labels:
+      release: kube-prometheus-stack # change to match your Prometheus selector
+```
+
+The chart injects the same Secret key into the OpsKnight Deployment and references it from the
+`ServiceMonitor`. Render and verify both references before upgrading:
+
+```bash
+helm lint helm/opsknight --values values.production.yaml
+helm template opsknight helm/opsknight \
+  --namespace opsknight \
+  --values values.production.yaml > /tmp/opsknight-rendered.yaml
+kubectl apply --dry-run=server -f /tmp/opsknight-rendered.yaml
+```
+
+The Prometheus custom resource must select both the `ServiceMonitor` labels and the `opsknight`
+namespace. Inspect its `serviceMonitorSelector` and `serviceMonitorNamespaceSelector`; do not assume
+every monitor is discovered.
+
+If `networkPolicy.enabled=true`, allow the Prometheus pods or monitoring namespace to reach the
+OpsKnight application port. The chart cannot infer the monitoring namespace. Add an explicitly
+scoped policy through your platform layer, for example:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: opsknight-from-prometheus
+  namespace: opsknight
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opsknight
+      app.kubernetes.io/instance: opsknight
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 3000
+```
+
+Adjust release names, labels, namespace, and port to the rendered resources.
+
+## Raw Kubernetes and Kustomize
+
+`k8s/monitoring/servicemonitor.yaml` is optional and is not part of the base kustomization because
+clusters without the Prometheus Operator do not have the `ServiceMonitor` CRD.
+
+For an Operator-enabled production overlay:
+
+1. Create an externally managed `opsknight-metrics` Secret containing
+   `PROMETHEUS_SCRAPE_TOKEN`.
+2. Patch `deployment/opsknight-app` so its `PROMETHEUS_SCRAPE_TOKEN` environment variable reads the
+   same Secret key.
+3. Add `k8s/monitoring/servicemonitor.yaml` as an overlay resource.
+4. Add the labels required by the Prometheus `serviceMonitorSelector`.
+5. If NetworkPolicy is enforced, allow ingress from the monitoring namespace or Prometheus pods.
+
+Example Deployment patch:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opsknight-app
+  namespace: opsknight
+spec:
+  template:
+    spec:
+      containers:
+        - name: opsknight
+          env:
+            - name: PROMETHEUS_SCRAPE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: opsknight-metrics
+                  key: PROMETHEUS_SCRAPE_TOKEN
+```
+
+Render the overlay and check that `ServiceMonitor.spec.selector.matchLabels` exactly matches the
+labels on `service/opsknight-service`:
+
+```bash
+kubectl kustomize deploy/overlays/production > /tmp/opsknight-rendered.yaml
+kubectl apply --server-side --dry-run=server -f /tmp/opsknight-rendered.yaml
+```
+
+## Metric reference and aggregation
+
+OpsKnight metrics have one of three scopes:
+
+- **Counter** metrics are process-local and reset on restart. Use `sum(rate(...))` across replicas.
+- **Instance** gauges describe one process. Keep the `instance` or `pod` label when diagnosing a
+  replica; use `max` for an installation-level presence signal.
+- **Cluster snapshot** gauges query shared database state and are emitted by every replica for
+  availability. Use `max without(instance,pod)`, never `sum`, or replica count will multiply the
+  value.
+
+| Metric                                                   | Kind and scope         | Labels                            | Meaning                                                  |
+| -------------------------------------------------------- | ---------------------- | --------------------------------- | -------------------------------------------------------- |
+| `opsknight_http_requests_total`                          | counter                | `method`, `route`, `status_class` | Completed requests by normalized route and status class. |
+| `opsknight_http_request_duration_seconds`                | histogram/counter      | `method`, `route`                 | Request latency histogram.                               |
+| `opsknight_http_requests_in_flight`                      | gauge/instance         | `route`                           | Requests currently executing in a process.               |
+| `opsknight_build_info`                                   | gauge/instance         | `version`                         | Running build identity.                                  |
+| `opsknight_active_incidents`                             | gauge/cluster snapshot | none                              | Current active incidents.                                |
+| `opsknight_active_users`                                 | gauge/cluster snapshot | none                              | Current active users.                                    |
+| `opsknight_job_queue`                                    | gauge/cluster snapshot | `status`                          | Legacy queue count by bounded status.                    |
+| `opsknight_jobs_pending`                                 | gauge/cluster snapshot | `type`                            | Pending durable jobs by bounded type.                    |
+| `opsknight_jobs_processing`                              | gauge/cluster snapshot | `type`                            | Processing durable jobs by bounded type.                 |
+| `opsknight_jobs_oldest_pending_age_seconds`              | gauge/cluster snapshot | `type`                            | Oldest pending job age.                                  |
+| `opsknight_notifications_undelivered`                    | gauge/cluster snapshot | none                              | Pending or retryable failed deliveries.                  |
+| `opsknight_notifications_oldest_undelivered_age_seconds` | gauge/cluster snapshot | none                              | Oldest undelivered notification age.                     |
+| `opsknight_escalations_overdue`                          | gauge/cluster snapshot | none                              | Escalations past their scheduled execution time.         |
+| `opsknight_escalation_max_lag_seconds`                   | gauge/cluster snapshot | none                              | Maximum lag among overdue escalations.                   |
+| `opsknight_rollup_freshness_age_seconds`                 | gauge/cluster snapshot | none                              | Age of the newest daily analytics rollup.                |
+| `opsknight_metrics_collection_errors`                    | gauge/instance         | none                              | Collectors that failed in the current cached snapshot.   |
+| `opsknight_metrics_cache_hits_total`                     | counter                | none                              | Process-local exporter cache hits.                       |
+| `opsknight_metrics_cache_misses_total`                   | counter                | none                              | Process-local exporter cache misses.                     |
+| `opsknight_metrics_cache_age_seconds`                    | gauge/instance         | none                              | Age of the process-local exporter snapshot.              |
+
+Metrics can be absent before a process observes the relevant operation or when their collector is
+unavailable. Absence is not the same as zero. The registry forbids identifiers, contact data, URLs,
+request IDs, IP addresses, and exception messages as labels to control cardinality and disclosure.
+
+## Recording rules and useful PromQL
+
+The repository ships rules in `monitoring/prometheus/`:
+
+- `opsknight-recording-rules.yaml` safely collapses duplicated cluster-snapshot gauges;
+- `opsknight-alerts.yaml` covers collector failure, stale jobs, escalation lag, stale notification
+  delivery, rollup freshness, HTTP errors, and HTTP p95 latency.
+
+Mount these files into Prometheus and include them under `rule_files`, or package their `groups`
+inside your Prometheus Operator's `PrometheusRule` resource. Validate them before rollout:
+
+```bash
+promtool check rules monitoring/prometheus/opsknight-recording-rules.yaml
+promtool check rules monitoring/prometheus/opsknight-alerts.yaml
+```
+
+Useful queries:
+
+```promql
+# Requests per second across all replicas
+sum(rate(opsknight_http_requests_total[5m]))
+
+# HTTP 5xx percentage
+100 * sum(rate(opsknight_http_requests_total{status_class="5xx"}[5m]))
+  / clamp_min(sum(rate(opsknight_http_requests_total[5m])), 0.001)
+
+# Installation-wide p95 request latency
+histogram_quantile(
+  0.95,
+  sum by (le) (rate(opsknight_http_request_duration_seconds_bucket[5m]))
+)
+
+# Shared notification backlog without replica multiplication
+max without(instance, pod) (opsknight_notifications_undelivered)
+
+# Oldest pending job age by type
+max without(instance, pod) (opsknight_jobs_oldest_pending_age_seconds)
+```
+
+Use the same expressions in Grafana after adding Prometheus as a data source. Keep `job`, cluster,
+namespace, and environment selectors in dashboards when one Prometheus installation scrapes several
+OpsKnight deployments.
+
+Tune alert thresholds against normal workload and incident-delivery objectives. Do not route the
+only alert for an OpsKnight outage back through the same OpsKnight installation; keep an independent
+monitoring and emergency-contact path.
+
+## Token rotation
+
+The exporter accepts one token at a time. Rotate it as a coordinated change:
+
+1. create or update the protected deployment Secret;
+2. restart/roll out every OpsKnight replica so it receives the new environment value;
+3. update the Prometheus credentials file or Secret and reload/reconcile Prometheus;
+4. confirm all targets are `UP` and `opsknight_metrics_collection_errors` is zero; and
+5. remove the previous secret version according to the secret manager's policy.
+
+A brief 401 scrape gap is possible because there is no dual-token overlap. Do not weaken endpoint
+authentication to avoid that gap.
+
+## Troubleshooting
+
+| Symptom                                     | Likely cause and check                                                                                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HTTP 401                                    | Token missing from the app, scraper using a different value, malformed `Authorization: Bearer` header, or pods not restarted after Secret rotation. |
+| Target is absent                            | Prometheus does not select the `ServiceMonitor` label/namespace, or the monitor selector does not match the Service.                                |
+| Target is `DOWN` with timeout               | NetworkPolicy, DNS, Service port name, ingress, TLS, or scrape timeout. Test from the Prometheus pod.                                               |
+| Metrics return but some families are absent | No observation exists yet or the corresponding database collector failed. Check `opsknight_metrics_collection_errors` and application logs.         |
+| Counts grow with replica count              | A cluster-snapshot gauge was summed. Use `max without(instance,pod)` or the shipped recording rule.                                                 |
+| HTTP percentiles are empty                  | The process has not observed traffic yet, the query omitted `_bucket`, or histogram buckets were aggregated without `le`.                           |
+| Scrapes increase database load              | Keep the 30-second interval, inspect collector errors/cache misses, and avoid duplicate scrape jobs.                                                |
+
+## Acceptance checklist
+
+- [ ] Every OpsKnight replica receives the same dedicated scrape token from a Secret.
+- [ ] Prometheus reads the token from a protected file or Secret and sends Bearer authentication.
+- [ ] The target is `UP`; unauthenticated requests return 401.
+- [ ] ServiceMonitor label and namespace selectors are verified against the Prometheus resource.
+- [ ] NetworkPolicy permits only the intended monitoring source to reach the application port.
+- [ ] Cluster-snapshot gauges use `max`, while counters and histograms aggregate across replicas.
+- [ ] Recording and alert rules pass `promtool check rules`.
+- [ ] Alerts have an independent delivery path for an OpsKnight-wide outage.
+- [ ] PostgreSQL, container, ingress/TLS, and backup health are monitored separately.
+- [ ] Token rotation and target verification are included in the operations runbook.
+
+## Related topics
+
+- [Monitoring OpsKnight](./monitoring)
+- [Configuration reference](../getting-started/configuration)
+- [Helm deployment](./helm)
+- [Kustomize](./kustomize)
+- [Docker Compose](./docker)
+- [Metrics architecture contract](../architecture/metrics-observability)
+- [Prometheus / Alertmanager integration](../integrations/metrics-alerting/prometheus)

--- a/docs/v1.5/getting-started/configuration.md
+++ b/docs/v1.5/getting-started/configuration.md
@@ -132,17 +132,17 @@ Set the public and private variables together. The database-backed Web Push prov
 
 ## Operations and observability
 
-| Variable                                  | Default                    | Description                                                                                                                       |
-| ----------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `LOG_LEVEL`                               | `info`                     | Minimum structured-log level: `debug`, `info`, `warn`, or `error`.                                                                |
-| `LOG_FORMAT`                              | Environment dependent      | Set to `json` for JSON output.                                                                                                    |
-| `LOG_BUFFER_MAX`                          | `500`                      | Maximum in-memory log-buffer size.                                                                                                |
-| `SENTRY_DSN`                              | —                          | Requests optional Sentry initialization when a custom build includes `@sentry/nextjs`; the standard v1.4 dependency set does not. |
-| `SENTRY_ENVIRONMENT`                      | `NODE_ENV`                 | Optional Sentry environment label for such a custom build.                                                                        |
-| `SENTRY_FORCE_ENABLE`                     | `false`                    | Enables that optional Sentry path outside production when `true`.                                                                 |
-| `NEXT_PUBLIC_ENABLE_WEB_VITALS`           | `false` outside production | Enables browser Web Vitals reporting outside production.                                                                          |
-| `APP_VERSION` / `NEXT_PUBLIC_APP_VERSION` | Package version            | Server/public version label override.                                                                                             |
-| `PROMETHEUS_SCRAPE_TOKEN`                 | —                          | Bearer token for authenticated scraping of `/api/metrics`; use a high-entropy secret.                                             |
+| Variable                                  | Default                    | Description                                                                                                                                               |
+| ----------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOG_LEVEL`                               | `info`                     | Minimum structured-log level: `debug`, `info`, `warn`, or `error`.                                                                                        |
+| `LOG_FORMAT`                              | Environment dependent      | Set to `json` for JSON output.                                                                                                                            |
+| `LOG_BUFFER_MAX`                          | `500`                      | Maximum in-memory log-buffer size.                                                                                                                        |
+| `SENTRY_DSN`                              | —                          | Requests optional Sentry initialization when a custom build includes `@sentry/nextjs`; the standard v1.4 dependency set does not.                         |
+| `SENTRY_ENVIRONMENT`                      | `NODE_ENV`                 | Optional Sentry environment label for such a custom build.                                                                                                |
+| `SENTRY_FORCE_ENABLE`                     | `false`                    | Enables that optional Sentry path outside production when `true`.                                                                                         |
+| `NEXT_PUBLIC_ENABLE_WEB_VITALS`           | `false` outside production | Enables browser Web Vitals reporting outside production.                                                                                                  |
+| `APP_VERSION` / `NEXT_PUBLIC_APP_VERSION` | Package version            | Server/public version label override.                                                                                                                     |
+| `PROMETHEUS_SCRAPE_TOKEN`                 | —                          | Bearer token for authenticated scraping of `/api/metrics`; use a high-entropy secret and follow the [Prometheus metrics guide](../deployment/prometheus). |
 
 OpenTelemetry variables are not consumed by the v1.4 application code and are therefore not part of this reference.
 

--- a/k8s/monitoring/servicemonitor.yaml
+++ b/k8s/monitoring/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: opsknight
+      app: opsknight-app
   endpoints:
     - port: http
       path: /api/metrics

--- a/tests/lib/deployment-config-unit.test.ts
+++ b/tests/lib/deployment-config-unit.test.ts
@@ -58,6 +58,14 @@ describe('deployment configuration invariants', () => {
     expect(serviceMonitor).toContain('bearerTokenSecret:');
   });
 
+  it('keeps the raw ServiceMonitor selector aligned with the application Service', () => {
+    const service = read('k8s/service.yaml');
+    const serviceMonitor = read('k8s/monitoring/servicemonitor.yaml');
+    expect(service).toContain('app: opsknight-app');
+    expect(serviceMonitor).toContain('app: opsknight-app');
+    expect(serviceMonitor).not.toContain('app: opsknight\n');
+  });
+
   it('protects long migration starts and fails closed on migration failure', () => {
     expect(read('k8s/deployment.yaml')).toContain('startupProbe:');
     expect(read('helm/opsknight/templates/deployment.yaml')).toContain('startupProbe:');


### PR DESCRIPTION
## Summary

- add a complete Prometheus exporter operations guide for standalone Prometheus, Compose, Helm/Prometheus Operator, Kustomize, NetworkPolicy, Grafana, rules, rotation, and troubleshooting
- document every exported metric family and the required multi-replica aggregation semantics
- distinguish scraping OpsKnight metrics from sending Alertmanager events into OpsKnight
- link the guide from deployment, monitoring, configuration, architecture, and root documentation
- fix the raw ServiceMonitor selector so it matches the OpsKnight Service, with regression coverage

## Validation

- npm run docs:links
- npm run docs:capabilities
- npx vitest run tests/api/metrics.test.ts tests/lib/operational-metric-registry.test.ts tests/lib/deployment-config-unit.test.ts
- Prettier check for the new guide, ServiceMonitor, and regression test
- YAML parse validation for the ServiceMonitor and shipped Prometheus rules

Note: Helm is not installed in the local environment; repository deployment CI performs chart rendering and validation.