### PR TITLE
fix(notifications): preserve aggregate metric cards on status filter and support SENT/DELIVERED matching

### DIFF
--- a/src/app/api/notifications/history/route.ts
+++ b/src/app/api/notifications/history/route.ts
@@ -8,18 +8,148 @@ import { logger } from '@/lib/logger';
 import { AppError } from '@/lib/errors';
 import { notificationDisplayMessage } from '@/lib/notification-payload';
 
-const LEGACY_UNAUTHORIZED_MESSAGE='You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
-const LEGACY_NOT_FOUND_MESSAGE='The requested item could not be found. It may have been deleted or you may not have access to it.';
-export async function GET(req:NextRequest){
-  try{
-    const session=await getServerSession(await getAuthOptions());if(!session?.user?.email)return jsonError(new AppError({code:'AUTHENTICATION_REQUIRED',userMessage:LEGACY_UNAUTHORIZED_MESSAGE}));
-    const user=await prisma.user.findUnique({where:{email:session.user.email},select:{id:true,timeZone:true}});if(!user)return jsonError(new AppError({code:'RESOURCE_NOT_FOUND',userMessage:LEGACY_NOT_FOUND_MESSAGE}));
-    const userTimeZone=getUserTimeZone(user??undefined);const{searchParams}=new URL(req.url);const limitRaw=Number(searchParams.get('limit')||'50');const offsetRaw=Number(searchParams.get('offset')||'0');const limit=Number.isNaN(limitRaw)?50:Math.min(limitRaw,200);const offset=Number.isNaN(offsetRaw)?0:Math.max(offsetRaw,0);const channel=searchParams.get('channel');const status=searchParams.get('status');const query=searchParams.get('q')?.trim();const fromParam=searchParams.get('from');const toParam=searchParams.get('to');
-    const allowedChannels=new Set(['EMAIL','SMS','PUSH','SLACK','WEBHOOK','WHATSAPP']);const allowedStatuses=new Set(['PENDING','SENT','DELIVERED','FAILED','SKIPPED']);const baseWhere:any={userId:user.id};const listWhere:any={...baseWhere};if(channel&&channel!=='all'&&allowedChannels.has(channel)){baseWhere.channel=channel;listWhere.channel=channel;}if(status&&status!=='all'&&allowedStatuses.has(status))listWhere.status=status;if(query){const searchFilter=[{message:{contains:query,mode:'insensitive'}},{incident:{title:{contains:query,mode:'insensitive'}}}];baseWhere.OR=searchFilter;listWhere.OR=searchFilter;}
-    const parseDate=(value:string|null)=>{if(!value)return null;const parsed=new Date(value);return Number.isNaN(parsed.getTime())?null:parsed;};const fromDate=parseDate(fromParam),toDate=parseDate(toParam);if(fromDate||toDate){const range:{gte?:Date;lte?:Date}={};if(fromDate)range.gte=fromDate;if(toDate)range.lte=toDate;baseWhere.createdAt=range;listWhere.createdAt=range;}
-    const[notifications,total,grouped]=await Promise.all([prisma.notification.findMany({where:listWhere,take:limit,skip:offset,orderBy:{createdAt:'desc'},include:{incident:{select:{id:true,title:true,status:true,urgency:true}}}}),prisma.notification.count({where:listWhere}),prisma.notification.groupBy({by:['status'],where:baseWhere,_count:{_all:true}})]);
-    const stats={total:0,sent:0,pending:0,failed:0,skipped:0};for(const entry of grouped){const count=entry._count._all;stats.total+=count;if(entry.status==='SENT'||entry.status==='DELIVERED')stats.sent+=count;else if(entry.status==='PENDING')stats.pending+=count;else if(entry.status==='FAILED')stats.failed+=count;else if(entry.status==='SKIPPED')stats.skipped+=count;}
-    const formattedNotifications=notifications.map(notification=>{const createdAtMs=notification.createdAt.getTime();const endMs=notification.deliveredAt?.getTime()??notification.sentAt?.getTime()??notification.failedAt?.getTime()??null;return{id:notification.id,channel:notification.channel,status:notification.status,message:notificationDisplayMessage(notification.message),attempts:notification.attempts,incident:notification.incident?{id:notification.incident.id,title:notification.incident.title,status:notification.incident.status,urgency:notification.incident.urgency}:null,sentAt:notification.sentAt?formatDateTime(notification.sentAt,userTimeZone,{format:'datetime'}):null,deliveredAt:notification.deliveredAt?formatDateTime(notification.deliveredAt,userTimeZone,{format:'datetime'}):null,failedAt:notification.failedAt?formatDateTime(notification.failedAt,userTimeZone,{format:'datetime'}):null,errorMsg:notification.errorMsg,createdAt:formatDateTime(notification.createdAt,userTimeZone,{format:'datetime'}),latencyMs:endMs!==null?Math.max(0,endMs-createdAtMs):null,pendingForMs:notification.status==='PENDING'?Math.max(0,Date.now()-createdAtMs):null};});
-    return jsonOk({notifications:formattedNotifications,total,limit,offset,stats},200,{'Cache-Control':'private, max-age=15, stale-while-revalidate=30'});
-  }catch(error){logger.error('api.notifications.history.fetch_error',{error:error instanceof Error?error.message:String(error)});return jsonError('Failed to fetch notification history',500);}
+import type { NotificationChannel, NotificationStatus, Prisma } from '@prisma/client';
+
+const LEGACY_UNAUTHORIZED_MESSAGE =
+  'You do not have permission to perform this action. Please contact an administrator if you believe this is an error.';
+const LEGACY_NOT_FOUND_MESSAGE =
+  'The requested item could not be found. It may have been deleted or you may not have access to it.';
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession(await getAuthOptions());
+    if (!session?.user?.email) {
+      return jsonError(
+        new AppError({
+          code: 'AUTHENTICATION_REQUIRED',
+          userMessage: LEGACY_UNAUTHORIZED_MESSAGE,
+        })
+      );
+    }
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { id: true, timeZone: true },
+    });
+    if (!user) {
+      return jsonError(
+        new AppError({ code: 'RESOURCE_NOT_FOUND', userMessage: LEGACY_NOT_FOUND_MESSAGE })
+      );
+    }
+    const userTimeZone = getUserTimeZone(user ?? undefined);
+    const { searchParams } = new URL(req.url);
+    const limitRaw = Number(searchParams.get('limit') || '50');
+    const offsetRaw = Number(searchParams.get('offset') || '0');
+    const limit = Number.isNaN(limitRaw) ? 50 : Math.min(limitRaw, 200);
+    const offset = Number.isNaN(offsetRaw) ? 0 : Math.max(offsetRaw, 0);
+    const channel = searchParams.get('channel');
+    const status = searchParams.get('status');
+    const query = searchParams.get('q')?.trim();
+    const fromParam = searchParams.get('from');
+    const toParam = searchParams.get('to');
+
+    const allowedChannels = new Set(['EMAIL', 'SMS', 'PUSH', 'SLACK', 'WEBHOOK', 'WHATSAPP']);
+    const allowedStatuses = new Set(['PENDING', 'SENT', 'DELIVERED', 'FAILED', 'SKIPPED']);
+
+    const baseWhere: Prisma.NotificationWhereInput = { userId: user.id };
+    const listWhere: Prisma.NotificationWhereInput = { ...baseWhere };
+
+    if (channel && channel !== 'all' && allowedChannels.has(channel)) {
+      baseWhere.channel = channel as NotificationChannel;
+      listWhere.channel = channel as NotificationChannel;
+    }
+    if (status && status !== 'all' && allowedStatuses.has(status)) {
+      if (status === 'SENT' || status === 'DELIVERED') {
+        listWhere.status = { in: ['SENT', 'DELIVERED'] };
+      } else {
+        listWhere.status = status as NotificationStatus;
+      }
+    }
+    if (query) {
+      const searchFilter = [
+        { message: { contains: query, mode: 'insensitive' as const } },
+        { incident: { title: { contains: query, mode: 'insensitive' as const } } },
+      ];
+      baseWhere.OR = searchFilter;
+      listWhere.OR = searchFilter;
+    }
+    const parseDate = (value: string | null) => {
+      if (!value) return null;
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    };
+    const fromDate = parseDate(fromParam);
+    const toDate = parseDate(toParam);
+    if (fromDate || toDate) {
+      const range: { gte?: Date; lte?: Date } = {};
+      if (fromDate) range.gte = fromDate;
+      if (toDate) range.lte = toDate;
+      baseWhere.createdAt = range;
+      listWhere.createdAt = range;
+    }
+    const [notifications, total, grouped] = await Promise.all([
+      prisma.notification.findMany({
+        where: listWhere,
+        take: limit,
+        skip: offset,
+        orderBy: { createdAt: 'desc' },
+        include: { incident: { select: { id: true, title: true, status: true, urgency: true } } },
+      }),
+      prisma.notification.count({ where: listWhere }),
+      prisma.notification.groupBy({ by: ['status'], where: baseWhere, _count: { _all: true } }),
+    ]);
+    const stats = { total: 0, sent: 0, pending: 0, failed: 0, skipped: 0 };
+    for (const entry of grouped) {
+      const count = entry._count._all;
+      stats.total += count;
+      if (entry.status === 'SENT' || entry.status === 'DELIVERED') stats.sent += count;
+      else if (entry.status === 'PENDING') stats.pending += count;
+      else if (entry.status === 'FAILED') stats.failed += count;
+      else if (entry.status === 'SKIPPED') stats.skipped += count;
+    }
+    const formattedNotifications = notifications.map(notification => {
+      const createdAtMs = notification.createdAt.getTime();
+      const endMs =
+        notification.deliveredAt?.getTime() ??
+        notification.sentAt?.getTime() ??
+        notification.failedAt?.getTime() ??
+        null;
+      return {
+        id: notification.id,
+        channel: notification.channel,
+        status: notification.status,
+        message: notificationDisplayMessage(notification.message),
+        attempts: notification.attempts,
+        incident: notification.incident
+          ? {
+              id: notification.incident.id,
+              title: notification.incident.title,
+              status: notification.incident.status,
+              urgency: notification.incident.urgency,
+            }
+          : null,
+        sentAt: notification.sentAt
+          ? formatDateTime(notification.sentAt, userTimeZone, { format: 'datetime' })
+          : null,
+        deliveredAt: notification.deliveredAt
+          ? formatDateTime(notification.deliveredAt, userTimeZone, { format: 'datetime' })
+          : null,
+        failedAt: notification.failedAt
+          ? formatDateTime(notification.failedAt, userTimeZone, { format: 'datetime' })
+          : null,
+        errorMsg: notification.errorMsg,
+        createdAt: formatDateTime(notification.createdAt, userTimeZone, { format: 'datetime' }),
+        latencyMs: endMs !== null ? Math.max(0, endMs - createdAtMs) : null,
+        pendingForMs:
+          notification.status === 'PENDING' ? Math.max(0, Date.now() - createdAtMs) : null,
+      };
+    });
+    return jsonOk({ notifications: formattedNotifications, total, limit, offset, stats }, 200, {
+      'Cache-Control': 'private, max-age=15, stale-while-revalidate=30',
+    });
+  } catch (error) {
+    logger.error('api.notifications.history.fetch_error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return jsonError('Failed to fetch notification history', 500);
+  }
 }

--- a/src/components/settings/NotificationOperations.tsx
+++ b/src/components/settings/NotificationOperations.tsx
@@ -230,7 +230,7 @@ export default function NotificationOperations({ canRetry }: Props) {
   const skipped = stats.SKIPPED || 0;
 
   const handleStatusFilterClick = (targetStatus: string) => {
-    if (status === targetStatus) {
+    if (status === targetStatus || (targetStatus === 'SENT' && status === 'DELIVERED')) {
       setStatus('all');
     } else {
       setStatus(targetStatus);
@@ -396,7 +396,7 @@ export default function NotificationOperations({ canRetry }: Props) {
 
         <button
           type="button"
-          onClick={() => handleStatusFilterClick('DELIVERED')}
+          onClick={() => handleStatusFilterClick('SENT')}
           className={`text-left p-4 rounded-xl border transition-all ${
             status === 'DELIVERED' || status === 'SENT'
               ? 'bg-emerald-500/10 border-emerald-500/40 ring-1 ring-emerald-500/40 shadow-xs'

--- a/src/lib/notification-operations.ts
+++ b/src/lib/notification-operations.ts
@@ -87,10 +87,15 @@ export async function getNotificationOperations(
   const defaultFrom = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
   const cursor = decodeCursor(filters.cursor);
   const query = filters.query?.trim().slice(0, 120);
-  const baseWhere: Prisma.NotificationWhereInput = {
+  const statusCondition =
+    filters.status === 'SENT' || filters.status === 'DELIVERED'
+      ? { in: ['SENT', 'DELIVERED'] as NotificationStatus[] }
+      : filters.status
+        ? filters.status
+        : undefined;
+
+  const baseFilters: Prisma.NotificationWhereInput = {
     ...(filters.channel ? { channel: filters.channel } : {}),
-    ...(filters.status ? { status: filters.status } : {}),
-    ...(filters.category ? { category: filters.category } : {}),
     createdAt: {
       gte: filters.from ?? defaultFrom,
       ...(filters.to ? { lte: filters.to } : {}),
@@ -107,6 +112,23 @@ export async function getNotificationOperations(
         }
       : {}),
   };
+
+  const statusStatsWhere: Prisma.NotificationWhereInput = {
+    ...baseFilters,
+    ...(filters.category ? { category: filters.category } : {}),
+  };
+
+  const categoryStatsWhere: Prisma.NotificationWhereInput = {
+    ...baseFilters,
+    ...(statusCondition ? { status: statusCondition } : {}),
+  };
+
+  const baseWhere: Prisma.NotificationWhereInput = {
+    ...baseFilters,
+    ...(statusCondition ? { status: statusCondition } : {}),
+    ...(filters.category ? { category: filters.category } : {}),
+  };
+
   const where: Prisma.NotificationWhereInput = {
     ...baseWhere,
     ...(cursor
@@ -155,8 +177,16 @@ export async function getNotificationOperations(
         },
       },
     }),
-    prisma.notification.groupBy({ by: ['status'], where: baseWhere, _count: { _all: true } }),
-    prisma.notification.groupBy({ by: ['category'], where: baseWhere, _count: { _all: true } }),
+    prisma.notification.groupBy({
+      by: ['status'],
+      where: statusStatsWhere,
+      _count: { _all: true },
+    }),
+    prisma.notification.groupBy({
+      by: ['category'],
+      where: categoryStatsWhere,
+      _count: { _all: true },
+    }),
   ]);
 
   const hasMore = rows.length > limit;

--- a/tests/lib/notification-operations.test.ts
+++ b/tests/lib/notification-operations.test.ts
@@ -35,11 +35,14 @@ describe('notification operations query', () => {
 
     const rowArgs = vi.mocked(prisma.notification.findMany).mock.calls[0]![0]!;
     const statusArgs = vi.mocked(prisma.notification.groupBy).mock.calls[0]![0]!;
+    const categoryArgs = vi.mocked(prisma.notification.groupBy).mock.calls[1]![0]!;
     const rowWhere = rowArgs.where;
     const statusWhere = statusArgs.where;
+    const categoryWhere = categoryArgs.where;
     expect(rowWhere).toHaveProperty('AND');
     expect(statusWhere).not.toHaveProperty('AND');
-    expect(statusWhere).toMatchObject({ status: 'FAILED' });
+    expect(statusWhere).not.toHaveProperty('status');
+    expect(categoryWhere).toMatchObject({ status: 'FAILED' });
   });
 
   it('caps page size to protect the operations database path', async () => {


### PR DESCRIPTION
## Summary

This PR resolves the issue where selecting status filters (e.g., clicking **Delivered**, **Pending**, or **Failed**) caused the aggregate metric cards across the top of the Operations / History views to drop to 0.

### Key Changes
1. **Preserve Metric Overview Aggregates**:
   - In `src/lib/notification-operations.ts`, split the list pagination `where` filter from `statusStatsWhere` and `categoryStatsWhere`.
   - The status aggregate cards now compute across the selected date range and channel slice without restricting to the single selected status, keeping the total and comparative counts visible when filtering table rows.
2. **Unified SENT / DELIVERED Status Mapping**:
   - In OpsKnight notification delivery persistence, successful notifications are persisted with status `SENT`.
   - Updated `src/lib/notification-operations.ts` and `src/app/api/notifications/history/route.ts` so filtering by `SENT` or `DELIVERED` maps to `{ in: ['SENT', 'DELIVERED'] }`.
3. **Interactive Metric Cards & Toggle Reset**:
   - In `src/components/settings/NotificationOperations.tsx`, updated the Delivered card to match `SENT | DELIVERED`.
   - Updated `handleStatusFilterClick` so clicking an active status filter resets back to `'all'`.
4. **Unit Tests Updated**:
   - Updated `tests/lib/notification-operations.test.ts` to verify that status grouping keeps health totals intact when status filtering is active.

---

## Verification
- **Unit Tests**: 277 test files (2,063+ tests) passing cleanly (`npm run test:ci:unit`).
- **TypeScript**: `npx tsc --noEmit` compiled with 0 errors.
- **ESLint**: 0 errors, 0 warnings.
- **Production Build**: `next build --webpack` (101/101 routes) completed successfully.