### PR TITLE
fix(incidents): make SLA history immutable

### DIFF
--- a/prisma/migrations/20260902203000_immutable_incident_sla_contract/migration.sql
+++ b/prisma/migrations/20260902203000_immutable_incident_sla_contract/migration.sql
@@ -1,0 +1,193 @@
+-- Freeze the effective SLA contract on incidents and daily SLA materializations.
+-- This makes historical compliance stable when service or SLA policy configuration changes.
+
+ALTER TABLE "Incident"
+  ADD COLUMN "slaAckTargetMs" INTEGER,
+  ADD COLUMN "slaResolveTargetMs" INTEGER,
+  ADD COLUMN "slaTargetSource" TEXT,
+  ADD COLUMN "slaTargetCapturedAt" TIMESTAMP(3);
+
+-- Canonical priority backfill. This is explicitly marked as a migration-time
+-- reconstruction because pre-migration policy versions were not stored on incidents.
+UPDATE "Incident"
+SET
+  "slaAckTargetMs" = CASE CONCAT('P', REGEXP_REPLACE(BTRIM(UPPER(COALESCE("priority", ''))), '^P', ''))
+    WHEN 'P1' THEN 300000
+    WHEN 'P2' THEN 900000
+    WHEN 'P3' THEN 1800000
+    WHEN 'P4' THEN 3600000
+    WHEN 'P5' THEN 7200000
+  END,
+  "slaResolveTargetMs" = CASE CONCAT('P', REGEXP_REPLACE(BTRIM(UPPER(COALESCE("priority", ''))), '^P', ''))
+    WHEN 'P1' THEN 3600000
+    WHEN 'P2' THEN 14400000
+    WHEN 'P3' THEN 28800000
+    WHEN 'P4' THEN 86400000
+    WHEN 'P5' THEN 172800000
+  END,
+  "slaTargetSource" = 'PRIORITY_BACKFILL_CANONICAL',
+  "slaTargetCapturedAt" = CURRENT_TIMESTAMP
+WHERE CONCAT('P', REGEXP_REPLACE(BTRIM(UPPER(COALESCE("priority", ''))), '^P', '')) IN ('P1', 'P2', 'P3', 'P4', 'P5');
+
+-- Service-scoped legacy incidents cannot be reconstructed exactly because historical
+-- service targets were never versioned. Freeze the best available current value and
+-- retain provenance rather than silently pretending it is original history.
+UPDATE "Incident" AS i
+SET
+  "slaAckTargetMs" = COALESCE(NULLIF(s."targetAckMinutes", 0), 15) * 60000,
+  "slaResolveTargetMs" = COALESCE(NULLIF(s."targetResolveMinutes", 0), 120) * 60000,
+  "slaTargetSource" = 'SERVICE_BACKFILL_CURRENT',
+  "slaTargetCapturedAt" = CURRENT_TIMESTAMP
+FROM "Service" AS s
+WHERE i."slaAckTargetMs" IS NULL
+  AND s."id" = i."serviceId";
+
+UPDATE "Incident"
+SET
+  "slaAckTargetMs" = 900000,
+  "slaResolveTargetMs" = 7200000,
+  "slaTargetSource" = 'DEFAULT_BACKFILL',
+  "slaTargetCapturedAt" = CURRENT_TIMESTAMP
+WHERE "slaAckTargetMs" IS NULL;
+
+CREATE OR REPLACE FUNCTION opsknight_capture_incident_sla_target()
+RETURNS TRIGGER AS $$
+DECLARE
+  normalized_priority TEXT;
+  ack_minutes INTEGER;
+  resolve_minutes INTEGER;
+BEGIN
+  IF NEW."slaAckTargetMs" IS NOT NULL AND NEW."slaAckTargetMs" > 0
+     AND NEW."slaResolveTargetMs" IS NOT NULL AND NEW."slaResolveTargetMs" > 0 THEN
+    NEW."slaTargetSource" := COALESCE(NULLIF(NEW."slaTargetSource", ''), 'EXPLICIT');
+    NEW."slaTargetCapturedAt" := COALESCE(NEW."slaTargetCapturedAt", CURRENT_TIMESTAMP);
+    RETURN NEW;
+  END IF;
+
+  normalized_priority := CONCAT('P', REGEXP_REPLACE(BTRIM(UPPER(COALESCE(NEW."priority", ''))), '^P', ''));
+  CASE normalized_priority
+    WHEN 'P1' THEN ack_minutes := 5; resolve_minutes := 60;
+    WHEN 'P2' THEN ack_minutes := 15; resolve_minutes := 240;
+    WHEN 'P3' THEN ack_minutes := 30; resolve_minutes := 480;
+    WHEN 'P4' THEN ack_minutes := 60; resolve_minutes := 1440;
+    WHEN 'P5' THEN ack_minutes := 120; resolve_minutes := 2880;
+    ELSE
+      SELECT NULLIF("targetAckMinutes", 0), NULLIF("targetResolveMinutes", 0)
+      INTO ack_minutes, resolve_minutes
+      FROM "Service"
+      WHERE "id" = NEW."serviceId";
+  END CASE;
+
+  IF normalized_priority IN ('P1', 'P2', 'P3', 'P4', 'P5') THEN
+    NEW."slaTargetSource" := 'PRIORITY';
+  ELSIF ack_minutes IS NOT NULL OR resolve_minutes IS NOT NULL THEN
+    NEW."slaTargetSource" := 'SERVICE';
+  ELSE
+    NEW."slaTargetSource" := 'DEFAULT';
+  END IF;
+
+  NEW."slaAckTargetMs" := COALESCE(ack_minutes, 15) * 60000;
+  NEW."slaResolveTargetMs" := COALESCE(resolve_minutes, 120) * 60000;
+  NEW."slaTargetCapturedAt" := CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER incident_capture_sla_target
+BEFORE INSERT ON "Incident"
+FOR EACH ROW EXECUTE FUNCTION opsknight_capture_incident_sla_target();
+
+ALTER TABLE "Incident"
+  ADD CONSTRAINT incident_sla_target_contract_check CHECK (
+    "slaAckTargetMs" IS NOT NULL AND "slaAckTargetMs" > 0
+    AND "slaResolveTargetMs" IS NOT NULL AND "slaResolveTargetMs" > 0
+    AND "slaTargetSource" IS NOT NULL AND BTRIM("slaTargetSource") <> ''
+    AND "slaTargetCapturedAt" IS NOT NULL
+  );
+
+CREATE OR REPLACE FUNCTION opsknight_prevent_incident_sla_target_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW."slaAckTargetMs" IS DISTINCT FROM OLD."slaAckTargetMs"
+     OR NEW."slaResolveTargetMs" IS DISTINCT FROM OLD."slaResolveTargetMs"
+     OR NEW."slaTargetSource" IS DISTINCT FROM OLD."slaTargetSource"
+     OR NEW."slaTargetCapturedAt" IS DISTINCT FROM OLD."slaTargetCapturedAt" THEN
+    RAISE EXCEPTION 'incident SLA target contract is immutable' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER incident_prevent_sla_target_mutation
+BEFORE UPDATE ON "Incident"
+FOR EACH ROW EXECUTE FUNCTION opsknight_prevent_incident_sla_target_mutation();
+
+ALTER TABLE "SLASnapshot"
+  ADD COLUMN "targetAckMinutes" INTEGER,
+  ADD COLUMN "targetResolveMinutes" INTEGER,
+  ADD COLUMN "definitionVersion" INTEGER,
+  ADD COLUMN "targetCapturedAt" TIMESTAMP(3),
+  ADD COLUMN "targetSource" TEXT;
+
+UPDATE "SLASnapshot" AS ss
+SET
+  "targetAckMinutes" = d."targetAckTime",
+  "targetResolveMinutes" = d."targetResolveTime",
+  "definitionVersion" = d."version",
+  "targetCapturedAt" = CURRENT_TIMESTAMP,
+  "targetSource" = 'DEFINITION_BACKFILL_CURRENT'
+FROM "SLADefinition" AS d
+WHERE d."id" = ss."slaDefinitionId";
+
+CREATE OR REPLACE FUNCTION opsknight_capture_sla_snapshot_target()
+RETURNS TRIGGER AS $$
+DECLARE
+  definition_record "SLADefinition"%ROWTYPE;
+BEGIN
+  SELECT * INTO definition_record
+  FROM "SLADefinition"
+  WHERE "id" = NEW."slaDefinitionId";
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SLA definition % not found', NEW."slaDefinitionId" USING ERRCODE = '23503';
+  END IF;
+
+  NEW."targetAckMinutes" := COALESCE(NEW."targetAckMinutes", definition_record."targetAckTime");
+  NEW."targetResolveMinutes" := COALESCE(NEW."targetResolveMinutes", definition_record."targetResolveTime");
+  NEW."definitionVersion" := COALESCE(NEW."definitionVersion", definition_record."version");
+  NEW."targetCapturedAt" := COALESCE(NEW."targetCapturedAt", CURRENT_TIMESTAMP);
+  NEW."targetSource" := COALESCE(NULLIF(NEW."targetSource", ''), 'DEFINITION_CAPTURED');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER sla_snapshot_capture_target
+BEFORE INSERT ON "SLASnapshot"
+FOR EACH ROW EXECUTE FUNCTION opsknight_capture_sla_snapshot_target();
+
+ALTER TABLE "SLASnapshot"
+  ADD CONSTRAINT sla_snapshot_target_contract_check CHECK (
+    "definitionVersion" IS NOT NULL AND "definitionVersion" > 0
+    AND "targetCapturedAt" IS NOT NULL
+    AND "targetSource" IS NOT NULL AND BTRIM("targetSource") <> ''
+    AND ("targetAckMinutes" IS NULL OR "targetAckMinutes" > 0)
+    AND ("targetResolveMinutes" IS NULL OR "targetResolveMinutes" > 0)
+  );
+
+CREATE OR REPLACE FUNCTION opsknight_prevent_sla_snapshot_target_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW."targetAckMinutes" IS DISTINCT FROM OLD."targetAckMinutes"
+     OR NEW."targetResolveMinutes" IS DISTINCT FROM OLD."targetResolveMinutes"
+     OR NEW."definitionVersion" IS DISTINCT FROM OLD."definitionVersion"
+     OR NEW."targetCapturedAt" IS DISTINCT FROM OLD."targetCapturedAt"
+     OR NEW."targetSource" IS DISTINCT FROM OLD."targetSource" THEN
+    RAISE EXCEPTION 'SLA snapshot target contract is immutable' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER sla_snapshot_prevent_target_mutation
+BEFORE UPDATE ON "SLASnapshot"
+FOR EACH ROW EXECUTE FUNCTION opsknight_prevent_sla_snapshot_target_mutation();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -536,6 +536,10 @@ model Incident {
   snoozeReason           String? // Reason for snoozing
   slaPausedMs            BigInt             @default(0) // Materialized closed SLA pause duration
   slaPauseStartedAt      DateTime? // Current open SLA pause, if any
+  slaAckTargetMs         Int? // Immutable effective ACK target captured when the incident is created
+  slaResolveTargetMs     Int? // Immutable effective resolve target captured when the incident is created
+  slaTargetSource        String? // Provenance for the frozen target (priority/service/default/backfill)
+  slaTargetCapturedAt    DateTime? // When the immutable target contract was captured
   // ChatOps War-Room fields
   slackChannelId         String? // Slack channel ID of dedicated war-room (e.g. "C0123456789")
   slackChannelName       String? // Channel name (e.g. "inc-104-payments-api")
@@ -1551,6 +1555,11 @@ model SLASnapshot {
   evaluatedResolveCount Int     @default(0)
   complianceScore       Float? // null when no SLA sample was evaluated
   denominatorUnknown    Boolean @default(false) // legacy snapshot awaiting canonical regeneration
+  targetAckMinutes      Int? // Immutable definition ACK target used for this materialization
+  targetResolveMinutes  Int? // Immutable definition resolve target used for this materialization
+  definitionVersion     Int? // Immutable SLA definition version used for this materialization
+  targetCapturedAt      DateTime? // When the snapshot target contract was captured
+  targetSource          String? // Provenance for legacy/current target capture
 
   slaDefinition SLADefinition @relation(fields: [slaDefinitionId], references: [id])
 

--- a/src/lib/analytics-metrics.ts
+++ b/src/lib/analytics-metrics.ts
@@ -1,3 +1,6 @@
+import { effectiveElapsedMs } from './metrics/domain/sla-clock';
+import { resolveSlaTarget } from './metrics/domain/sla-target';
+
 export type StatusAgeEntry = { status: string; avgMs: number | null };
 
 export type OnCallShift = {
@@ -173,6 +176,10 @@ export function buildServiceSlaTable(
     resolvedAt: Date | null;
     updatedAt: Date | null;
     serviceId: string;
+    priority?: string | null;
+    slaAckTargetMs?: number | null;
+    slaResolveTargetMs?: number | null;
+    slaPauses?: Array<{ startedAt: Date; endedAt: Date | null }>;
   }>,
   ackMap: Map<string, Date>,
   serviceTargets: Map<string, { ackMinutes: number; resolveMinutes: number }>,
@@ -189,39 +196,51 @@ export function buildServiceSlaTable(
 
   for (const incident of incidents) {
     const targets = serviceTargets.get(incident.serviceId);
-    const ackTargetMinutes = targets?.ackMinutes ?? defaultAckMinutes;
-    const resolveTargetMinutes = targets?.resolveMinutes ?? defaultResolveMinutes;
+    const target = resolveSlaTarget({
+      incidentTargets: {
+        ackTargetMs: incident.slaAckTargetMs,
+        resolveTargetMs: incident.slaResolveTargetMs,
+      },
+      priority: incident.priority,
+      serviceTargets: targets,
+      globalDefaults: {
+        ackMinutes: defaultAckMinutes,
+        resolveMinutes: defaultResolveMinutes,
+      },
+    });
     const current = serviceSlaStats.get(incident.serviceId) || {
       ackMet: 0,
       ackTotal: 0,
       resolveMet: 0,
       resolveTotal: 0,
     };
+    const elapsedAt = (evaluationAt: Date) =>
+      effectiveElapsedMs({
+        startedAt: incident.createdAt,
+        evaluationAt,
+        pauses: incident.slaPauses ?? [],
+      });
 
     const ackedAt = ackMap.get(incident.id);
     if (ackedAt) {
       current.ackTotal += 1;
-      const diffMinutes = (ackedAt.getTime() - incident.createdAt.getTime()) / 60000;
-      if (diffMinutes <= ackTargetMinutes) {
-        current.ackMet += 1;
-      }
-    } else if (incident.status !== 'RESOLVED') {
-      // Active incidents become evaluated SLA breaches once their
-      // acknowledgement deadline passes. Omitting them from the denominator
-      // can otherwise report 100% compliance while incidents remain unacked.
-      const ageMinutes = (now.getTime() - incident.createdAt.getTime()) / 60000;
-      if (ageMinutes > ackTargetMinutes) current.ackTotal += 1;
+      if (elapsedAt(ackedAt) <= target.ackTargetMs) current.ackMet += 1;
+    } else if (incident.status === 'RESOLVED') {
+      // Resolution is not acknowledgement. A resolved incident with no ACK event
+      // is an evaluated ACK miss rather than disappearing from the denominator.
+      current.ackTotal += 1;
+    } else if (elapsedAt(now) > target.ackTargetMs) {
+      current.ackTotal += 1;
     }
 
     if (incident.status === 'RESOLVED') {
       const resolvedAt = incident.resolvedAt || incident.updatedAt;
       if (resolvedAt) {
         current.resolveTotal += 1;
-        const diffMinutes = (resolvedAt.getTime() - incident.createdAt.getTime()) / 60000;
-        if (diffMinutes <= resolveTargetMinutes) {
-          current.resolveMet += 1;
-        }
+        if (elapsedAt(resolvedAt) <= target.resolveTargetMs) current.resolveMet += 1;
       }
+    } else if (elapsedAt(now) > target.resolveTargetMs) {
+      current.resolveTotal += 1;
     }
 
     serviceSlaStats.set(incident.serviceId, current);

--- a/src/lib/metric-rollup.ts
+++ b/src/lib/metric-rollup.ts
@@ -157,6 +157,8 @@ export async function generateDailyRollup(
             updatedAt: true,
             slaPausedMs: true,
             slaPauseStartedAt: true,
+            slaAckTargetMs: true,
+            slaResolveTargetMs: true,
             slaPauses: { select: { startedAt: true, endedAt: true } },
             serviceId: true,
             service: {
@@ -293,6 +295,10 @@ export async function generateDailyRollup(
           const resolvedTime =
             incident.resolvedAt ?? (incident.status === 'RESOLVED' ? incident.updatedAt : null);
           const target = resolveSlaTarget({
+            incidentTargets: {
+              ackTargetMs: incident.slaAckTargetMs,
+              resolveTargetMs: incident.slaResolveTargetMs,
+            },
             priority: incident.priority,
             serviceTargets: {
               ackMinutes: incident.service?.targetAckMinutes,

--- a/src/lib/metrics/domain/sla-target-sql.ts
+++ b/src/lib/metrics/domain/sla-target-sql.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import { MINUTE_MS, PRIORITY_SLA_TARGETS } from './sla-target';
 
 type ServiceTarget = { ackMinutes: number; resolveMinutes: number };
+type IncidentSlaColumn = 'priority' | 'serviceId' | 'slaAckTargetMs' | 'slaResolveTargetMs';
 
 function priorityMinutes(
   target: (typeof PRIORITY_SLA_TARGETS)[number],
@@ -10,7 +11,7 @@ function priorityMinutes(
   return kind === 'ackMinutes' ? target.ackMinutes : target.resolveMinutes;
 }
 
-function column(alias: string | undefined, name: 'priority' | 'serviceId') {
+function column(alias: string | undefined, name: IncidentSlaColumn) {
   if (alias !== undefined && !/^[a-z][a-z0-9_]*$/i.test(alias)) {
     throw new Error('Invalid SQL alias');
   }
@@ -33,7 +34,7 @@ function serviceTargetExpression(
   ), ${fallbackMinutes * MINUTE_MS})`;
 }
 
-/** SQL equivalent of resolveSlaTarget priority > service > global precedence. */
+/** SQL equivalent of resolveSlaTarget incident > priority > service > global precedence. */
 export function slaTargetSql(input: {
   kind: 'ackMinutes' | 'resolveMinutes';
   serviceTargetMap: ReadonlyMap<string, ServiceTarget>;
@@ -45,13 +46,20 @@ export function slaTargetSql(input: {
       Prisma.sql`WHEN CONCAT('P', REGEXP_REPLACE(BTRIM(UPPER(${column(input.alias, 'priority')})), '^P', '')) = ${target.priority}
       THEN ${priorityMinutes(target, input.kind) * MINUTE_MS}`
   );
-  return Prisma.sql`CASE
-    ${Prisma.join(priorityCases, ' ')}
-    ELSE ${serviceTargetExpression(
-      input.serviceTargetMap,
-      input.kind,
-      input.fallbackMinutes,
-      input.alias
-    )}
-  END`;
+  const frozenColumn = column(
+    input.alias,
+    input.kind === 'ackMinutes' ? 'slaAckTargetMs' : 'slaResolveTargetMs'
+  );
+  return Prisma.sql`COALESCE(
+    NULLIF(${frozenColumn}, 0),
+    CASE
+      ${Prisma.join(priorityCases, ' ')}
+      ELSE ${serviceTargetExpression(
+        input.serviceTargetMap,
+        input.kind,
+        input.fallbackMinutes,
+        input.alias
+      )}
+    END
+  )`;
 }

--- a/src/lib/metrics/domain/sla-target.ts
+++ b/src/lib/metrics/domain/sla-target.ts
@@ -1,5 +1,9 @@
-export type SlaTargetSource = 'definition' | 'priority' | 'service' | 'global';
+export type SlaTargetSource = 'incident' | 'definition' | 'priority' | 'service' | 'global';
 export type SlaTarget = { ackTargetMs: number; resolveTargetMs: number; source: SlaTargetSource };
+export type IncidentSlaTargetSnapshot = {
+  ackTargetMs?: number | null;
+  resolveTargetMs?: number | null;
+};
 
 export const MINUTE_MS = 60_000;
 export const PRIORITY_SLA_TARGETS = [
@@ -18,13 +22,30 @@ function normalizePriority(priority?: string | null): string | null {
   return match ? `P${match[1]}` : null;
 }
 
+function isPositiveFinite(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
 export function resolveSlaTarget(input: {
+  incidentTargets?: IncidentSlaTargetSnapshot | null;
   priority?: string | null;
   serviceTargets?: { ackMinutes?: number | null; resolveMinutes?: number | null };
   definitionOverride?: { ackMinutes?: number | null; resolveMinutes?: number | null } | null;
   globalDefaults?: { ackMinutes: number; resolveMinutes: number };
 }): SlaTarget {
   const defaults = input.globalDefaults ?? { ackMinutes: 15, resolveMinutes: 120 };
+  const incidentTargets = input.incidentTargets;
+  if (
+    isPositiveFinite(incidentTargets?.ackTargetMs) &&
+    isPositiveFinite(incidentTargets?.resolveTargetMs)
+  ) {
+    return {
+      ackTargetMs: incidentTargets.ackTargetMs,
+      resolveTargetMs: incidentTargets.resolveTargetMs,
+      source: 'incident',
+    };
+  }
+
   const override = input.definitionOverride;
   if (override?.ackMinutes != null || override?.resolveMinutes != null) {
     return {

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -1034,6 +1034,8 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     resolvedAt: true,
     slaPausedMs: true,
     slaPauseStartedAt: true,
+    slaAckTargetMs: true,
+    slaResolveTargetMs: true,
     slaPauses: { select: { startedAt: true, endedAt: true } },
     service: {
       select: {
@@ -1079,6 +1081,8 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
         serviceId: true,
         createdAt: true,
         acknowledgedAt: true,
+        slaAckTargetMs: true,
+        slaResolveTargetMs: true,
         slaPauses: { select: { startedAt: true, endedAt: true } },
       },
     }),
@@ -1722,6 +1726,10 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     // In-memory calculation for small datasets
     for (const incident of recentIncidents) {
       const target = resolveSlaTarget({
+        incidentTargets: {
+          ackTargetMs: incident.slaAckTargetMs,
+          resolveTargetMs: incident.slaResolveTargetMs,
+        },
         priority: incident.priority,
         serviceTargets: {
           ackMinutes: incident.service.targetAckMinutes,
@@ -1835,6 +1843,10 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
         trendEntry.ackCount += 1;
         const serviceTargets = serviceTargetMap.get(incident.serviceId);
         const target = resolveSlaTarget({
+          incidentTargets: {
+            ackTargetMs: incident.slaAckTargetMs,
+            resolveTargetMs: incident.slaResolveTargetMs,
+          },
           priority: incident.priority,
           serviceTargets,
           globalDefaults: {
@@ -1938,6 +1950,10 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
 
     s.count++;
     const target = resolveSlaTarget({
+      incidentTargets: {
+        ackTargetMs: incident.slaAckTargetMs,
+        resolveTargetMs: incident.slaResolveTargetMs,
+      },
       priority: incident.priority,
       serviceTargets: {
         ackMinutes: incident.service.targetAckMinutes,
@@ -2189,6 +2205,10 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     ? activeIncidentsData.map(incident => {
         const serviceTargets = serviceTargetMap.get(incident.serviceId);
         const target = resolveSlaTarget({
+          incidentTargets: {
+            ackTargetMs: incident.slaAckTargetMs,
+            resolveTargetMs: incident.slaResolveTargetMs,
+          },
           priority: incident.priority,
           serviceTargets,
         });
@@ -2529,6 +2549,33 @@ export async function generateDailySnapshot(definitionId: string, date: Date): P
   const end = new Date(date);
   end.setUTCHours(23, 59, 59, 999);
 
+  const existingSnapshot = await prisma.sLASnapshot.findUnique({
+    where: {
+      date_slaDefinitionId: {
+        date: start,
+        slaDefinitionId: definitionId,
+      },
+    },
+    select: {
+      targetAckMinutes: true,
+      targetResolveMinutes: true,
+      definitionVersion: true,
+      targetCapturedAt: true,
+      targetSource: true,
+    },
+  });
+  const targetAckTime = existingSnapshot
+    ? existingSnapshot.targetAckMinutes
+    : definition.targetAckTime;
+  const targetResolveTime = existingSnapshot
+    ? existingSnapshot.targetResolveMinutes
+    : definition.targetResolveTime;
+  const snapshotDefinitionVersion = existingSnapshot
+    ? existingSnapshot.definitionVersion
+    : definition.version;
+  const snapshotTargetCapturedAt = existingSnapshot?.targetCapturedAt ?? new Date();
+  const snapshotTargetSource = existingSnapshot?.targetSource ?? 'DEFINITION_CAPTURED';
+
   // Filter incidents based on definition scope
   const whereClause: Prisma.IncidentWhereInput = {
     createdAt: { gte: start, lte: end },
@@ -2546,6 +2593,8 @@ export async function generateDailySnapshot(definitionId: string, date: Date): P
       status: true,
       slaPausedMs: true,
       slaPauseStartedAt: true,
+      slaAckTargetMs: true,
+      slaResolveTargetMs: true,
       slaPauses: { select: { startedAt: true, endedAt: true } },
     },
   });
@@ -2558,9 +2607,6 @@ export async function generateDailySnapshot(definitionId: string, date: Date): P
   // Manual callers can request today's snapshot. Never evaluate against a
   // future end-of-day, which would manufacture breaches that have not happened.
   const evaluationTime = new Date(Math.min(end.getTime(), Date.now()));
-  const targetAckTime = (definition as { targetAckTime?: number }).targetAckTime;
-  const targetResolveTime = (definition as { targetResolveTime?: number }).targetResolveTime;
-
   for (const incident of incidents) {
     const elapsedAt = (at: Date) =>
       effectiveElapsedMs({
@@ -2626,6 +2672,11 @@ export async function generateDailySnapshot(definitionId: string, date: Date): P
       evaluatedResolveCount: totalResolveEvaluated,
       denominatorUnknown: false,
       complianceScore: score,
+      targetAckMinutes: targetAckTime,
+      targetResolveMinutes: targetResolveTime,
+      definitionVersion: snapshotDefinitionVersion,
+      targetCapturedAt: snapshotTargetCapturedAt,
+      targetSource: snapshotTargetSource,
     },
     update: {
       totalIncidents: total,
@@ -2652,6 +2703,10 @@ export async function checkIncidentSLA(incidentId: string): Promise<IncidentSLAR
 
   const now = new Date();
   const target = resolveSlaTarget({
+    incidentTargets: {
+      ackTargetMs: incident.slaAckTargetMs,
+      resolveTargetMs: incident.slaResolveTargetMs,
+    },
     priority: incident.priority,
     serviceTargets: {
       ackMinutes: incident.service.targetAckMinutes,

--- a/tests/components/SLABreachWarningBadge.test.tsx
+++ b/tests/components/SLABreachWarningBadge.test.tsx
@@ -72,6 +72,10 @@ describe('SLABreachWarningBadge', () => {
     warRoomArchivedAt: null,
     slaPausedMs: BigInt(0),
     slaPauseStartedAt: null,
+    slaAckTargetMs: null,
+    slaResolveTargetMs: null,
+    slaTargetSource: null,
+    slaTargetCapturedAt: null,
   };
 
   it('renders correctly with Date objects', () => {

--- a/tests/integration/sla-history-immutability.test.ts
+++ b/tests/integration/sla-history-immutability.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createTestIncident,
+  createTestService,
+  resetDatabase,
+  testPrisma,
+} from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+describeIfRealDB('SLA history immutability', () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    await testPrisma.$disconnect();
+  });
+
+  it('freezes service targets at incident creation even when the service changes later', async () => {
+    const service = await createTestService('sla-service', null, {
+      targetAckMinutes: 10,
+      targetResolveMinutes: 90,
+    });
+    const incident = await createTestIncident('frozen SLA incident', service.id);
+
+    expect(incident.slaAckTargetMs).toBe(10 * 60_000);
+    expect(incident.slaResolveTargetMs).toBe(90 * 60_000);
+    expect(incident.slaTargetSource).toBe('SERVICE');
+    expect(incident.slaTargetCapturedAt).not.toBeNull();
+
+    await testPrisma.service.update({
+      where: { id: service.id },
+      data: { targetAckMinutes: 5, targetResolveMinutes: 30 },
+    });
+    const afterServiceChange = await testPrisma.incident.findUniqueOrThrow({
+      where: { id: incident.id },
+    });
+    expect(afterServiceChange.slaAckTargetMs).toBe(10 * 60_000);
+    expect(afterServiceChange.slaResolveTargetMs).toBe(90 * 60_000);
+  });
+
+  it('enforces immutable incident SLA targets in the database', async () => {
+    const service = await createTestService('immutable-service');
+    const incident = await createTestIncident('immutable contract', service.id);
+
+    await expect(
+      testPrisma.incident.update({
+        where: { id: incident.id },
+        data: { slaAckTargetMs: 123 },
+      })
+    ).rejects.toThrow(/immutable/i);
+  });
+
+  it('captures canonical priority SLA before the service target', async () => {
+    const service = await createTestService('priority-service', null, {
+      targetAckMinutes: 99,
+      targetResolveMinutes: 999,
+    });
+    const incident = await createTestIncident('priority contract', service.id, { priority: 'P2' });
+    expect(incident.slaAckTargetMs).toBe(15 * 60_000);
+    expect(incident.slaResolveTargetMs).toBe(240 * 60_000);
+    expect(incident.slaTargetSource).toBe('PRIORITY');
+  });
+
+  it('freezes the definition version and targets used by a daily SLA snapshot', async () => {
+    const definition = await testPrisma.sLADefinition.create({
+      data: {
+        name: 'Snapshot SLA',
+        targetAckTime: 10,
+        targetResolveTime: 60,
+        target: 99.9,
+        window: '30d',
+        metricType: 'MTTA',
+        version: 3,
+      },
+    });
+    const snapshot = await testPrisma.sLASnapshot.create({
+      data: {
+        slaDefinitionId: definition.id,
+        date: new Date('2026-01-01T00:00:00Z'),
+        totalIncidents: 1,
+        metAckTime: 1,
+        metResolveTime: 1,
+      },
+    });
+
+    expect(snapshot.targetAckMinutes).toBe(10);
+    expect(snapshot.targetResolveMinutes).toBe(60);
+    expect(snapshot.definitionVersion).toBe(3);
+    expect(snapshot.targetSource).toBe('DEFINITION_CAPTURED');
+
+    await testPrisma.sLADefinition.update({
+      where: { id: definition.id },
+      data: { targetAckTime: 5, targetResolveTime: 30, version: 4 },
+    });
+    const afterDefinitionChange = await testPrisma.sLASnapshot.findUniqueOrThrow({
+      where: { id: snapshot.id },
+    });
+    expect(afterDefinitionChange.targetAckMinutes).toBe(10);
+    expect(afterDefinitionChange.targetResolveMinutes).toBe(60);
+    expect(afterDefinitionChange.definitionVersion).toBe(3);
+
+    await expect(
+      testPrisma.sLASnapshot.update({
+        where: { id: snapshot.id },
+        data: { definitionVersion: 99 },
+      })
+    ).rejects.toThrow(/immutable/i);
+  });
+});

--- a/tests/lib/analytics-metrics.test.ts
+++ b/tests/lib/analytics-metrics.test.ts
@@ -107,7 +107,7 @@ describe('analytics-metrics utilities', () => {
     // i2 is still open and well beyond the 15-minute acknowledgement target,
     // so it belongs in the denominator as a breach rather than disappearing.
     expect(table[0].ackRate).toBe(50);
-    expect(table[0].resolveRate).toBe(100);
+    expect(table[0].resolveRate).toBe(50);
   });
 
   it('smooths series with trailing window average', () => {

--- a/tests/lib/analytics-sla-consistency.test.ts
+++ b/tests/lib/analytics-sla-consistency.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { buildServiceSlaTable } from '@/lib/analytics-metrics';
+
+describe('service SLA table canonical semantics', () => {
+  it('uses frozen targets and the pause-aware SLA clock', () => {
+    const createdAt = new Date('2026-01-01T00:00:00Z');
+    const table = buildServiceSlaTable(
+      [
+        {
+          id: 'i1',
+          serviceId: 's1',
+          status: 'ACKNOWLEDGED',
+          createdAt,
+          resolvedAt: null,
+          updatedAt: null,
+          slaAckTargetMs: 15 * 60_000,
+          slaResolveTargetMs: 120 * 60_000,
+          slaPauses: [
+            {
+              startedAt: new Date('2026-01-01T00:05:00Z'),
+              endedAt: new Date('2026-01-01T00:15:00Z'),
+            },
+          ],
+        },
+      ],
+      new Map([['i1', new Date('2026-01-01T00:20:00Z')]]),
+      new Map([['s1', { ackMinutes: 1, resolveMinutes: 1 }]]),
+      new Map([['s1', 'Service One']]),
+      15,
+      120,
+      8,
+      new Date('2026-01-01T00:20:00Z')
+    );
+
+    expect(table[0].ackRate).toBe(100);
+  });
+
+  it('counts resolved-without-ACK and overdue active resolve as breaches', () => {
+    const table = buildServiceSlaTable(
+      [
+        {
+          id: 'resolved-no-ack',
+          serviceId: 's1',
+          status: 'RESOLVED',
+          createdAt: new Date('2026-01-01T00:00:00Z'),
+          resolvedAt: new Date('2026-01-01T00:05:00Z'),
+          updatedAt: new Date('2026-01-01T00:05:00Z'),
+          slaAckTargetMs: 10 * 60_000,
+          slaResolveTargetMs: 60 * 60_000,
+        },
+        {
+          id: 'active-overdue',
+          serviceId: 's1',
+          status: 'OPEN',
+          createdAt: new Date('2026-01-01T00:00:00Z'),
+          resolvedAt: null,
+          updatedAt: null,
+          slaAckTargetMs: 10 * 60_000,
+          slaResolveTargetMs: 30 * 60_000,
+        },
+      ],
+      new Map(),
+      new Map([['s1', { ackMinutes: 999, resolveMinutes: 999 }]]),
+      new Map([['s1', 'Service One']]),
+      15,
+      120,
+      8,
+      new Date('2026-01-01T02:00:00Z')
+    );
+
+    expect(table[0].ackRate).toBe(0);
+    expect(table[0].resolveRate).toBe(50);
+    expect(table[0].total).toBe(2);
+  });
+});

--- a/tests/lib/sla-snapshot.test.ts
+++ b/tests/lib/sla-snapshot.test.ts
@@ -1,17 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { definitionFindMock, incidentFindManyMock, snapshotUpsertMock } = vi.hoisted(() => ({
-  definitionFindMock: vi.fn(),
-  incidentFindManyMock: vi.fn(),
-  snapshotUpsertMock: vi.fn(),
-}));
+const { definitionFindMock, incidentFindManyMock, snapshotFindMock, snapshotUpsertMock } = vi.hoisted(
+  () => ({
+    definitionFindMock: vi.fn(),
+    incidentFindManyMock: vi.fn(),
+    snapshotFindMock: vi.fn(),
+    snapshotUpsertMock: vi.fn(),
+  })
+);
 
 vi.mock('@/lib/prisma', () => ({
   __esModule: true,
   default: {
     sLADefinition: { findUnique: definitionFindMock },
     incident: { findMany: incidentFindManyMock },
-    sLASnapshot: { upsert: snapshotUpsertMock },
+    sLASnapshot: { findUnique: snapshotFindMock, upsert: snapshotUpsertMock },
   },
 }));
 
@@ -29,7 +32,9 @@ describe('generateDailySnapshot', () => {
       serviceId: null,
       targetAckTime: 15,
       targetResolveTime: 120,
+      version: 1,
     });
+    snapshotFindMock.mockResolvedValue(null);
   });
 
   it('counts a resolved but never acknowledged incident as an ACK breach', async () => {
@@ -41,6 +46,7 @@ describe('generateDailySnapshot', () => {
         resolvedAt: new Date('2026-08-01T01:00:00.000Z'),
         updatedAt: new Date('2026-08-01T01:00:00.000Z'),
         status: 'RESOLVED',
+        slaPauses: [],
       },
     ]);
 
@@ -63,6 +69,7 @@ describe('generateDailySnapshot', () => {
         resolvedAt: null,
         updatedAt: new Date('2026-08-01T01:00:00.000Z'),
         status: 'RESOLVED',
+        slaPauses: [],
       },
     ]);
 

--- a/tests/lib/sla-target-immutability.test.ts
+++ b/tests/lib/sla-target-immutability.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSlaTarget } from '@/lib/metrics/domain/sla-target';
+
+describe('immutable incident SLA targets', () => {
+  it('prefers the incident target over later definition, priority, and service changes', () => {
+    expect(
+      resolveSlaTarget({
+        incidentTargets: { ackTargetMs: 600_000, resolveTargetMs: 5_400_000 },
+        definitionOverride: { ackMinutes: 1, resolveMinutes: 2 },
+        priority: 'P1',
+        serviceTargets: { ackMinutes: 3, resolveMinutes: 4 },
+      })
+    ).toEqual({
+      ackTargetMs: 600_000,
+      resolveTargetMs: 5_400_000,
+      source: 'incident',
+    });
+  });
+
+  it('rejects an incomplete frozen contract and falls back to canonical resolution', () => {
+    const target = resolveSlaTarget({
+      incidentTargets: { ackTargetMs: 600_000, resolveTargetMs: null },
+      priority: 'P2',
+      serviceTargets: { ackMinutes: 99, resolveMinutes: 999 },
+    });
+    expect(target.source).toBe('priority');
+    expect(target.ackTargetMs).toBe(15 * 60_000);
+    expect(target.resolveTargetMs).toBe(240 * 60_000);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining verified SLA correctness gap from the incident-lifecycle enterprise-readiness audit: historical incidents and regenerated SLA materializations must never be re-evaluated using today's mutable service/policy configuration.

## What this changes

- Captures the effective ACK and resolve SLA targets on every incident at creation time.
- Persists target provenance and capture timestamp alongside the frozen targets.
- Enforces the incident SLA contract at the PostgreSQL boundary so older application instances or forgotten create paths during a rolling deployment cannot bypass it.
- Rejects later mutation of an incident's frozen SLA target contract.
- Backfills existing priority incidents from the canonical priority contract and records that this was a migration-time reconstruction.
- Backfills legacy service-scoped incidents from the best available current service targets with explicit `SERVICE_BACKFILL_CURRENT` provenance rather than presenting the reconstruction as exact historical data.
- Makes the SQL aggregate path prefer frozen incident SLA targets.
- Makes in-memory SLA metrics, active SLA summaries, `checkIncidentSLA`, trend/service calculations, and metric rollup regeneration prefer the same frozen target contract.
- Makes the service SLA table use the canonical pause-aware SLA clock.
- Counts resolved-without-ACK incidents as ACK misses instead of dropping them from the denominator.
- Counts active incidents that are past the resolve deadline as evaluated resolve breaches.
- Freezes SLA definition targets/version on each daily `SLASnapshot` so regenerating an old day cannot silently adopt a later policy revision.
- Enforces snapshot target/version immutability in PostgreSQL as well.

## Historical-data semantics

Pre-migration service SLA history cannot be reconstructed perfectly because OpsKnight did not previously persist the service target/version that governed each incident. This migration therefore freezes the best available value once and records its provenance. From this migration onward, incident SLA results and regenerated daily snapshots are stable even when services or SLA definitions change.

## Reliability / deployment properties

- Database `BEFORE INSERT` capture protects rolling deployments and non-centralized writers.
- Database `BEFORE UPDATE` guards prevent accidental historical rewrites.
- Existing notification outbox, retry/idempotency control plane, escalation generation/claim logic, and recovery architecture are intentionally preserved rather than duplicated or replaced.
- The implementation has one commit on top of current `main` for a compact review history.

## Regression coverage

Adds tests for:

- frozen incident targets overriding later definition/priority/service inputs;
- invalid/incomplete frozen contracts falling back to canonical target resolution;
- pause-aware service SLA evaluation;
- resolved-without-ACK denominator correctness;
- active overdue resolve denominator correctness;
- service SLA changes not rewriting an existing incident's targets;
- database rejection of incident SLA target mutation;
- canonical priority capture taking precedence over service targets;
- daily SLA snapshot target/version capture and immutability.

## Migration

Adds `20260902203000_immutable_incident_sla_contract` with backfill, capture triggers, immutability triggers, and integrity constraints for incident and daily-snapshot SLA contracts.

This PR is intentionally focused on the remaining **verified code-level** enterprise-readiness blocker rather than rewriting notification/escalation subsystems that already have durable outbox, deduplication, generation fencing, and resilience coverage.