### PR TITLE
fix(ui): prevent stat capsule overflow and text collision in DetailHeroBanner

### DIFF
--- a/src/app/(app)/settings/integrations/jira/page.tsx
+++ b/src/app/(app)/settings/integrations/jira/page.tsx
@@ -30,11 +30,23 @@ export default async function GlobalJiraIntegrationPage() {
   });
 
   let siteHostname = 'Not configured';
+  let siteDisplayName = 'Not configured';
+  let siteSubtext = 'Site URL needed';
   if (config?.baseUrl) {
     try {
-      siteHostname = new URL(config.baseUrl).hostname;
+      const parsed = new URL(config.baseUrl);
+      siteHostname = parsed.hostname;
+      if (parsed.hostname.toLowerCase().endsWith('.atlassian.net')) {
+        siteDisplayName = parsed.hostname.replace(/\.atlassian\.net$/i, '');
+        siteSubtext = 'Atlassian Cloud';
+      } else {
+        siteDisplayName = parsed.hostname;
+        siteSubtext = 'Self-hosted Jira';
+      }
     } catch {
       siteHostname = config.baseUrl;
+      siteDisplayName = config.baseUrl;
+      siteSubtext = 'Jira Instance';
     }
   }
 
@@ -82,19 +94,21 @@ export default async function GlobalJiraIntegrationPage() {
         stats={[
           {
             label: 'Jira Site',
-            value: siteHostname,
+            value: siteDisplayName,
             icon: <JiraLogo className="h-4 w-4" />,
+            tooltip: siteHostname,
             valueClassName: config?.baseUrl
-              ? 'text-primary-foreground font-mono text-xs'
+              ? 'text-primary-foreground font-semibold text-xs sm:text-sm font-mono truncate max-w-full'
               : 'text-primary-foreground/70',
-            subtext: config?.baseUrl ? 'Atlassian Cloud' : 'Site URL needed',
+            subtext: siteSubtext,
           },
           {
             label: 'Service Account',
             value: config?.userEmail ?? 'None',
             icon: <Mail className="h-4 w-4" />,
+            tooltip: config?.userEmail ?? undefined,
             valueClassName: config?.userEmail
-              ? 'text-primary-foreground text-xs font-mono'
+              ? 'text-primary-foreground text-xs font-mono truncate max-w-full'
               : 'text-primary-foreground/70',
             subtext: config?.userEmail ? 'API token auth' : 'Email required',
           },

--- a/src/components/ui/DetailHeroBanner.tsx
+++ b/src/components/ui/DetailHeroBanner.tsx
@@ -12,6 +12,7 @@ export type DetailStatItem = {
   valueClassName?: string;
   href?: string;
   active?: boolean;
+  tooltip?: string;
 };
 
 export type DetailBreadcrumb = {
@@ -122,15 +123,23 @@ export default function DetailHeroBanner({
                         </p>
                         <div
                           className={cn(
-                            'mt-0.5 flex items-center justify-center gap-1 text-sm font-semibold text-primary-foreground',
+                            'mt-0.5 flex items-center justify-center gap-1 text-sm font-semibold text-primary-foreground min-w-0 max-w-full',
                             stat.valueClassName
                           )}
                         >
-                          {stat.icon}
-                          <span>{stat.value}</span>
+                          {stat.icon && <span className="shrink-0">{stat.icon}</span>}
+                          <span
+                            className="truncate max-w-full"
+                            title={
+                              stat.tooltip ??
+                              (typeof stat.value === 'string' ? stat.value : undefined)
+                            }
+                          >
+                            {stat.value}
+                          </span>
                         </div>
                         {stat.subtext && (
-                          <p className="text-[9px] text-primary-foreground/70 mt-0.5">
+                          <p className="text-[9px] text-primary-foreground/70 mt-0.5 truncate">
                             {stat.subtext}
                           </p>
                         )}
@@ -138,7 +147,7 @@ export default function DetailHeroBanner({
                     );
 
                     const itemClassName = cn(
-                      'min-w-0 rounded-md px-2.5 py-1.5 text-center transition-all duration-150',
+                      'min-w-0 overflow-hidden rounded-md px-2.5 py-1.5 text-center transition-all duration-150',
                       idx > 0 && stats.length <= 3 && 'border-l border-primary-foreground/20',
                       idx > 0 &&
                         stats.length === 4 &&
@@ -200,12 +209,19 @@ export default function DetailHeroBanner({
                   </p>
                   <div
                     className={cn(
-                      'mt-1 flex items-center justify-center gap-1.5 text-base sm:text-lg font-bold text-primary-foreground',
+                      'mt-1 flex items-center justify-center gap-1.5 text-base sm:text-lg font-bold text-primary-foreground min-w-0 max-w-full px-1',
                       stat.valueClassName
                     )}
                   >
-                    {stat.icon}
-                    <span>{stat.value}</span>
+                    {stat.icon && <span className="shrink-0">{stat.icon}</span>}
+                    <span
+                      className="truncate max-w-full"
+                      title={
+                        stat.tooltip ?? (typeof stat.value === 'string' ? stat.value : undefined)
+                      }
+                    >
+                      {stat.value}
+                    </span>
                   </div>
                   {stat.subtext && (
                     <p className="text-[9px] text-primary-foreground/70 mt-0.5 truncate">
@@ -216,7 +232,7 @@ export default function DetailHeroBanner({
               );
 
               const itemClassName = cn(
-                'min-w-0 rounded-lg border border-primary-foreground/20 bg-primary-foreground/10 p-2.5 text-center backdrop-blur-sm transition-all duration-150',
+                'min-w-0 overflow-hidden rounded-lg border border-primary-foreground/20 bg-primary-foreground/10 p-2.5 text-center backdrop-blur-sm transition-all duration-150',
                 stat.href &&
                   'hover:bg-primary-foreground/20 hover:scale-[1.01] hover:border-primary-foreground/30 cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary-foreground/50',
                 stat.active &&


### PR DESCRIPTION
## Summary

This PR addresses the visual regression where long values (such as Jira Cloud site hostnames and service account email addresses) in `DetailHeroBanner` bottom stat capsules overflow their container borders and collide into neighboring cards.

### Key Changes
1. **DetailHeroBanner Stat Container Hardening**:
   - Added `overflow-hidden` to `itemClassName` for both inline and bottom stat cards.
   - Added `min-w-0` and `max-w-full` to the value flex containers.
   - Added `shrink-0` to stat icons so they never compress when text is long.
   - Wrapped stat value text in `truncate max-w-full` with hover tooltip support (`title={stat.tooltip ?? stat.value}`).
2. **DetailStatItem Type Enhancement**:
   - Added optional `tooltip?: string` prop to `DetailStatItem` to display full un-truncated text on hover.
3. **Jira Settings Page Display Polish**:
   - Intelligently parses Atlassian Cloud domains (e.g. `dushyantrahangdale4.atlassian.net`) to display the clean workspace subdomain (`dushyantrahangdale4`) with `Atlassian Cloud` subtext, while providing the full domain in the hover tooltip.
   - Truncates Service Account email addresses cleanly within their grid cell with full email shown on hover.

### Verification
- **TypeScript**: `npx tsc --noEmit` passed with 0 errors.
- **ESLint**: `npx eslint` passed with 0 errors and 0 warnings.
- **Tests**: All Jira, ChatOps, and settings integration tests passed. Full pre-push test suite passed (2,209 / 2,209 tests).