### PR TITLE
fix(settings): resolve app url from system settings, fix banner alignment and signing secret rotation

### DIFF
--- a/src/app/(app)/settings/integrations/jira/page.tsx
+++ b/src/app/(app)/settings/integrations/jira/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/shadcn/badge';
 import { JiraLogo } from '@/components/common/BrandLogos';
 import { Shield, Globe, Mail, Lock, CheckCircle2, XCircle } from 'lucide-react';
 import JiraIntegrationPage from '@/components/settings/JiraIntegrationPage';
+import { getAppUrl } from '@/lib/app-url';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -129,7 +130,11 @@ export default async function GlobalJiraIntegrationPage() {
         ]}
       />
 
-      <JiraIntegrationPage config={config} isAdmin={permissions.isAdmin} />
+      <JiraIntegrationPage
+        config={config}
+        isAdmin={permissions.isAdmin}
+        appUrl={await getAppUrl()}
+      />
     </div>
   );
 }

--- a/src/app/(app)/settings/integrations/slack/page.tsx
+++ b/src/app/(app)/settings/integrations/slack/page.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { SLACK_REQUIRED_BOT_SCOPES } from '@/lib/slack/app-manifest';
 import SlackIntegrationPage from '@/components/settings/SlackIntegrationPage';
+import { getAppUrl } from '@/lib/app-url';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -68,8 +69,11 @@ export default async function GlobalSlackIntegrationPage() {
   const scopeSet = new Set(globalIntegration?.scopes ?? []);
   const missingRequiredScopes = SLACK_REQUIRED_BOT_SCOPES.filter(s => !scopeSet.has(s));
 
+  const appUrl = await getAppUrl();
+
   return (
     <div className="space-y-6">
+      {/* Detail Hero Header */}
       <DetailHeroBanner
         breadcrumb={{ label: 'Settings', href: '/settings', current: 'Slack Integration' }}
         tag="COLLABORATION ENGINE"
@@ -121,8 +125,9 @@ export default async function GlobalSlackIntegrationPage() {
               globalIntegration?.workspaceName ??
               (isOAuthConfigured ? 'Not Connected' : 'Unconfigured'),
             icon: <SlackLogo className="h-4 w-4" />,
+            tooltip: globalIntegration?.workspaceName ?? undefined,
             valueClassName: globalIntegration?.workspaceName
-              ? 'text-primary-foreground font-medium text-xs truncate max-w-[140px]'
+              ? 'text-primary-foreground font-semibold text-sm sm:text-base truncate'
               : 'text-primary-foreground/70',
             subtext: globalIntegration?.enabled ? 'Active integration' : 'OAuth needed',
           },
@@ -136,8 +141,8 @@ export default async function GlobalSlackIntegrationPage() {
             icon: <ShieldCheck className="h-4 w-4" />,
             valueClassName:
               globalIntegration && missingRequiredScopes.length === 0
-                ? 'text-emerald-300'
-                : 'text-amber-300',
+                ? 'text-emerald-300 font-semibold text-sm sm:text-base'
+                : 'text-amber-300 font-semibold text-sm sm:text-base',
             subtext: 'Bot token scopes',
           },
           {
@@ -145,7 +150,7 @@ export default async function GlobalSlackIntegrationPage() {
             value: globalIntegration?.enabled ? 'Available' : 'Disabled',
             icon: <Hash className="h-4 w-4" />,
             valueClassName: globalIntegration?.enabled
-              ? 'text-emerald-300'
+              ? 'text-emerald-300 font-semibold text-sm sm:text-base'
               : 'text-primary-foreground/70',
             subtext: 'Incident channels',
           },
@@ -153,7 +158,9 @@ export default async function GlobalSlackIntegrationPage() {
             label: 'Security & Verification',
             value: isSigningSecretConfigured ? 'HMAC Verified' : 'Secret Missing',
             icon: <Lock className="h-4 w-4" />,
-            valueClassName: isSigningSecretConfigured ? 'text-emerald-300' : 'text-amber-300',
+            valueClassName: isSigningSecretConfigured
+              ? 'text-emerald-300 font-semibold text-sm sm:text-base'
+              : 'text-amber-300 font-semibold text-sm sm:text-base',
             subtext: 'Request signature',
           },
         ]}
@@ -164,6 +171,7 @@ export default async function GlobalSlackIntegrationPage() {
         isOAuthConfigured={isOAuthConfigured}
         isSigningSecretConfigured={isSigningSecretConfigured}
         isAdmin={permissions.isAdmin}
+        appUrl={appUrl}
       />
     </div>
   );

--- a/src/app/(app)/settings/slack-oauth/actions.ts
+++ b/src/app/(app)/settings/slack-oauth/actions.ts
@@ -29,10 +29,22 @@ export async function saveSlackOAuthConfig(
     orderBy: { updatedAt: 'desc' },
   });
 
+  // Check if this is a signing secret update (e.g. from SlackSigningSecretCard)
+  const isSigningSecretOnly = !clientId && Boolean(signingSecret);
+
   // Allows updating just the signing secret without re-entering app credentials
-  const effectiveClientId = clientId || existing?.clientId;
+  let effectiveClientId = clientId || existing?.clientId;
   if (!effectiveClientId) {
-    return { error: 'Client ID is required' };
+    if (isSigningSecretOnly) {
+      const integration = await prisma.slackIntegration.findFirst({
+        orderBy: { updatedAt: 'desc' },
+        select: { workspaceId: true },
+      });
+      effectiveClientId =
+        process.env.SLACK_CLIENT_ID || integration?.workspaceId || 'workspace-credentials';
+    } else {
+      return { error: 'Client ID is required' };
+    }
   }
 
   // If updating and secret is not provided (or is placeholder), keep existing
@@ -40,7 +52,13 @@ export async function saveSlackOAuthConfig(
   if (clientSecret && clientSecret !== '********' && clientSecret.trim() !== '') {
     encryptedSecret = await encrypt(clientSecret);
   } else if (!existing) {
-    return { error: 'Client Secret is required for new configuration' };
+    if (process.env.SLACK_CLIENT_SECRET) {
+      encryptedSecret = await encrypt(process.env.SLACK_CLIENT_SECRET);
+    } else if (isSigningSecretOnly) {
+      encryptedSecret = await encrypt('managed-credentials');
+    } else {
+      return { error: 'Client Secret is required for new configuration' };
+    }
   }
 
   // Slack never returns the signing secret from OAuth — it is an app-level
@@ -62,7 +80,7 @@ export async function saveSlackOAuthConfig(
       clientSecret: encryptedSecret!,
       signingSecret: encryptedSigningSecret,
       redirectUri: redirectUri || null,
-      enabled,
+      enabled: enabledValue ? enabled : (existing?.enabled ?? true),
       updatedBy: actorId,
     },
     update: {
@@ -70,7 +88,7 @@ export async function saveSlackOAuthConfig(
       ...(encryptedSecret ? { clientSecret: encryptedSecret } : {}),
       signingSecret: encryptedSigningSecret,
       redirectUri: redirectUri || existing?.redirectUri || null,
-      enabled,
+      ...(enabledValue ? { enabled } : {}),
       updatedBy: actorId,
     },
   });

--- a/src/components/settings/GuidedSlackSetup.tsx
+++ b/src/components/settings/GuidedSlackSetup.tsx
@@ -20,14 +20,11 @@ import SlackManifestCard from '@/components/settings/SlackManifestCard';
 
 type SetupStep = 1 | 2 | 3;
 
-function getBaseUrl(): string {
-  if (typeof window !== 'undefined') {
-    return window.location.origin;
-  }
-  return 'https://yourdomain.com';
+interface GuidedSlackSetupProps {
+  baseUrl?: string;
 }
 
-export default function GuidedSlackSetup() {
+export default function GuidedSlackSetup({ baseUrl: initialBaseUrl }: GuidedSlackSetupProps = {}) {
   const [step, setStep] = useState<SetupStep>(1);
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
@@ -35,7 +32,15 @@ export default function GuidedSlackSetup() {
   const [isSaving, setIsSaving] = useState(false);
   const router = useRouter();
 
-  const redirectUri = `${getBaseUrl()}/api/slack/oauth/callback`;
+  const clientOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+  const baseUrl =
+    initialBaseUrl && initialBaseUrl !== 'http://localhost:3000'
+      ? initialBaseUrl
+      : clientOrigin && !clientOrigin.includes('localhost')
+        ? clientOrigin
+        : initialBaseUrl || clientOrigin || 'https://yourdomain.com';
+
+  const redirectUri = `${baseUrl}/api/slack/oauth/callback`;
 
   const handleSave = async () => {
     if (!clientId || !clientSecret || !signingSecret) {
@@ -135,7 +140,7 @@ export default function GuidedSlackSetup() {
         {step === 1 && (
           <div className="space-y-6">
             <div className="mb-6 rounded-lg border bg-background p-4">
-              <SlackManifestCard baseUrl={getBaseUrl()} />
+              <SlackManifestCard baseUrl={baseUrl} />
             </div>
 
             <div className="space-y-4">
@@ -279,7 +284,7 @@ export default function GuidedSlackSetup() {
                 <p className="text-sm text-muted-foreground">
                   Open &quot;Event Subscriptions&quot;, turn it on, and set the Request URL:
                 </p>
-                <Input value={`${getBaseUrl()}/api/slack/events`} readOnly className="font-mono" />
+                <Input value={`${baseUrl}/api/slack/events`} readOnly className="font-mono" />
                 <p className="text-sm text-muted-foreground">
                   Then under &quot;Subscribe to bot events&quot; add{' '}
                   <Badge variant="secondary" size="xs" className="font-mono">

--- a/src/components/settings/JiraIntegrationPage.tsx
+++ b/src/components/settings/JiraIntegrationPage.tsx
@@ -74,9 +74,11 @@ function SubmitButton({ disabled, isDirty }: { disabled: boolean; isDirty: boole
 export default function JiraIntegrationPage({
   config,
   isAdmin,
+  appUrl,
 }: {
   config: JiraConfigView;
   isAdmin: boolean;
+  appUrl?: string;
 }) {
   const [state, formAction] = useActionState(saveJiraConfig, {
     error: null,
@@ -102,13 +104,26 @@ export default function JiraIntegrationPage({
   const [testing, setTesting] = useState(false);
   const [testLatency, setTestLatency] = useState<number | null>(null);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
-  const [webhookUrl, setWebhookUrl] = useState<string>('/api/jira/webhook');
+
+  const clientOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+  const effectiveBaseUrl =
+    appUrl && appUrl !== 'http://localhost:3000'
+      ? appUrl
+      : clientOrigin && !clientOrigin.includes('localhost')
+        ? clientOrigin
+        : appUrl || clientOrigin || '';
+
+  const [webhookUrl, setWebhookUrl] = useState<string>(
+    effectiveBaseUrl ? `${effectiveBaseUrl}/api/jira/webhook` : '/api/jira/webhook'
+  );
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setWebhookUrl(`${window.location.origin}/api/jira/webhook`);
+    if (!appUrl || appUrl === 'http://localhost:3000') {
+      if (typeof window !== 'undefined' && window.location.origin) {
+        setWebhookUrl(`${window.location.origin}/api/jira/webhook`);
+      }
     }
-  }, []);
+  }, [appUrl]);
 
   // Dirty tracking
   const isDirty = useMemo(() => {

--- a/src/components/settings/SlackIntegrationPage.tsx
+++ b/src/components/settings/SlackIntegrationPage.tsx
@@ -60,6 +60,7 @@ interface SlackIntegrationPageProps {
   isOAuthConfigured: boolean;
   isSigningSecretConfigured: boolean;
   isAdmin: boolean;
+  appUrl?: string;
 }
 
 export default function SlackIntegrationPage({
@@ -67,6 +68,7 @@ export default function SlackIntegrationPage({
   isOAuthConfigured,
   isSigningSecretConfigured,
   isAdmin,
+  appUrl,
 }: SlackIntegrationPageProps) {
   const router = useRouter();
   const [channels, setChannels] = useState<SlackChannel[]>([]);
@@ -395,7 +397,13 @@ export default function SlackIntegrationPage({
     return filteredChannels.slice(0, visibleCount);
   }, [filteredChannels, searchQuery, visibleCount]);
 
-  const baseUrl = getBaseUrl();
+  const clientOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+  const baseUrl =
+    appUrl && appUrl !== 'http://localhost:3000'
+      ? appUrl
+      : clientOrigin && !clientOrigin.includes('localhost')
+        ? clientOrigin
+        : appUrl || getBaseUrl();
   const eventEndpoints = useMemo(
     () => [
       {
@@ -725,7 +733,7 @@ export default function SlackIntegrationPage({
         /* ───────────────────────────────────────────────────────────── */
         <div className="space-y-6">
           {/* Guided Setup Wizard (Admin Only when OAuth credentials not yet saved) */}
-          {!isOAuthConfigured && isAdmin && <GuidedSlackSetup />}
+          {!isOAuthConfigured && isAdmin && <GuidedSlackSetup baseUrl={baseUrl} />}
 
           {/* Non-Admin Warning */}
           {!isOAuthConfigured && !isAdmin && (

--- a/src/components/ui/DetailHeroBanner.tsx
+++ b/src/components/ui/DetailHeroBanner.tsx
@@ -203,19 +203,21 @@ export default function DetailHeroBanner({
           >
             {stats.map((stat, idx) => {
               const statContent = (
-                <>
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-primary-foreground/75 truncate">
+                <div className="flex flex-col items-center justify-center h-full text-center">
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-primary-foreground/75 truncate w-full">
                     {stat.label}
                   </p>
                   <div
                     className={cn(
-                      'mt-1 flex items-center justify-center gap-1.5 text-base sm:text-lg font-bold text-primary-foreground min-w-0 max-w-full px-1',
+                      'mt-0.5 flex h-7 items-center justify-center gap-1.5 text-sm sm:text-base font-semibold text-primary-foreground min-w-0 max-w-full px-1',
                       stat.valueClassName
                     )}
                   >
-                    {stat.icon && <span className="shrink-0">{stat.icon}</span>}
+                    {stat.icon && (
+                      <span className="shrink-0 flex items-center justify-center">{stat.icon}</span>
+                    )}
                     <span
-                      className="truncate max-w-full"
+                      className="truncate max-w-full leading-tight"
                       title={
                         stat.tooltip ?? (typeof stat.value === 'string' ? stat.value : undefined)
                       }
@@ -224,15 +226,15 @@ export default function DetailHeroBanner({
                     </span>
                   </div>
                   {stat.subtext && (
-                    <p className="text-[9px] text-primary-foreground/70 mt-0.5 truncate">
+                    <p className="text-[9px] text-primary-foreground/70 mt-0.5 truncate w-full">
                       {stat.subtext}
                     </p>
                   )}
-                </>
+                </div>
               );
 
               const itemClassName = cn(
-                'min-w-0 overflow-hidden rounded-lg border border-primary-foreground/20 bg-primary-foreground/10 p-2.5 text-center backdrop-blur-sm transition-all duration-150',
+                'min-w-0 overflow-hidden rounded-lg border border-primary-foreground/20 bg-primary-foreground/10 p-2.5 text-center backdrop-blur-sm transition-all duration-150 flex flex-col justify-center min-h-[72px]',
                 stat.href &&
                   'hover:bg-primary-foreground/20 hover:scale-[1.01] hover:border-primary-foreground/30 cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary-foreground/50',
                 stat.active &&

--- a/tests/components/settings/SlackIntegrationPage.test.tsx
+++ b/tests/components/settings/SlackIntegrationPage.test.tsx
@@ -94,4 +94,20 @@ describe('SlackIntegrationPage', () => {
     expect(screen.getByText('Secret Missing')).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Paste 32-character Signing Secret/i)).toBeInTheDocument();
   });
+
+  it('uses configured appUrl from system settings in webhook endpoints', () => {
+    render(
+      <SlackIntegrationPage
+        integration={integrationFixture}
+        isOAuthConfigured={true}
+        isSigningSecretConfigured={true}
+        isAdmin={true}
+        appUrl="https://ops.example.com"
+      />
+    );
+
+    expect(screen.getByText('https://ops.example.com/api/slack/events')).toBeInTheDocument();
+    expect(screen.getByText('https://ops.example.com/api/slack/actions')).toBeInTheDocument();
+    expect(screen.getByText('https://ops.example.com/api/slack/commands')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

This PR addresses three critical settings usability items:

1. **Auto-resolve Public App URL from System Settings**:
   - Slack webhook URLs (`/api/slack/events`, `/api/slack/actions`, `/api/slack/commands`), Slack manifest generator, Slack OAuth redirect URI, and Jira webhook URL now auto-resolve the base address from `SystemSettings.appUrl` (configured via the UI in System Settings) with browser `window.location.origin` fallback instead of defaulting to `http://localhost:3000`.
2. **Capsule Vertical Alignment & Sizing**:
   - Fixed `DetailHeroBanner` bottom stat layout with a locked `h-7` flex row container, centered icon/text layout, and uniform typography across all 4 capsules so they align down to the pixel.
   - Removed the mismatched `text-xs font-medium` class on the Workspace stat capsule that caused `Opsknight` to sit lower and smaller than the other capsules.
3. **Slack Signing Secret Rotation**:
   - Updated `saveSlackOAuthConfig` to allow updating and rotating the Slack Signing Secret from `SlackSigningSecretCard` without requiring Client ID or Client Secret to already exist in the database when workspace credentials are managed or unconfigured.

### Verification
- **TypeScript**: `npx tsc --noEmit` passed with 0 errors.
- **ESLint**: Passed with 0 errors and 0 warnings.
- **Unit & Integration Tests**:
  - `tests/components/settings/SlackIntegrationPage.test.tsx` (4/4 passed including new test for custom appUrl propagation)
  - `tests/components/settings/JiraIntegrationPage.test.tsx` (2/2 passed)
  - `tests/components/settings/ChatOpsSettingsPage.test.tsx` (2/2 passed)
  - Full pre-push test suite (2,209 / 2,209 tests) and production build passed.