### PR TITLE
fix(security): deduplicate active sessions by client device profile

### DIFF
--- a/src/app/api/realtime/stream/route.ts
+++ b/src/app/api/realtime/stream/route.ts
@@ -7,6 +7,7 @@ import {
   resolveStreamAuthorization,
   type StreamAuthorization,
 } from '@/lib/realtime-stream-authorization';
+import { recordSessionHeartbeat } from '@/lib/active-sessions';
 
 /**
  * Server-Sent Events (SSE) endpoint for real-time updates
@@ -22,6 +23,14 @@ export async function GET(req: NextRequest) {
       return new Response('Unauthorized', { status: 401 });
     }
     let streamAuthorization: StreamAuthorization = initialAuthorization;
+
+    // Record session heartbeat on realtime stream connect
+    const userAgent = req.headers.get('user-agent') || '';
+    const ip =
+      req.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+      req.headers.get('x-real-ip') ||
+      '127.0.0.1';
+    void recordSessionHeartbeat({ userId: user.id, userAgent, ip }).catch(() => {});
 
     let cleanup: () => void = () => {};
 
@@ -142,6 +151,7 @@ export async function GET(req: NextRequest) {
             if (heartbeatCounter >= 6) {
               heartbeatCounter = 0;
               send(JSON.stringify({ type: 'heartbeat', timestamp: new Date().toISOString() }));
+              void recordSessionHeartbeat({ userId: user.id, userAgent, ip }).catch(() => {});
             }
           } catch (error) {
             logger.error('SSE polling error', { component: 'api-realtime-stream', error });

--- a/src/lib/active-sessions.ts
+++ b/src/lib/active-sessions.ts
@@ -83,7 +83,7 @@ export interface ActiveSession {
 
 // In-memory throttle to avoid writing heartbeats too frequently
 const heartbeatCache = new Map<string, number>();
-const HEARTBEAT_THROTTLE_MS = 10 * 60 * 1000; // 10 minutes
+const HEARTBEAT_THROTTLE_MS = 2 * 60 * 1000; // 2 minutes (keeps open browser tabs firmly in Active Now)
 
 /**
  * Records an active session heartbeat if throttled window has elapsed.
@@ -100,7 +100,7 @@ export async function recordSessionHeartbeat({
   if (!userId) return;
 
   const parsed = parseUserAgent(userAgent);
-  const cacheKey = `${userId}:${parsed.browser}:${parsed.os}:${ip}`;
+  const cacheKey = `${userId}:${parsed.browser}:${parsed.os}:${parsed.deviceType}`;
   const now = Date.now();
   const lastHeartbeat = heartbeatCache.get(cacheKey) ?? 0;
 
@@ -146,8 +146,9 @@ export async function getUserActiveSessions({
 }): Promise<ActiveSession[]> {
   const currentParsed = parseUserAgent(currentUserAgent);
 
-  // Determine cutoff date: either the last session revocation or 30 days ago (max session lifetime)
-  let cutoffDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  // Active session cutoff window: 14 days (stale/dormant devices drop off)
+  const ACTIVE_SESSION_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+  let cutoffDate = new Date(Date.now() - ACTIVE_SESSION_MAX_AGE_MS);
 
   try {
     const lastRevocation = await prisma.auditLog.findFirst({
@@ -184,8 +185,10 @@ export async function getUserActiveSessions({
     },
   });
 
-  // Group events by client identity (Browser + OS + IP or UserAgent)
-  const sessionMap = new Map<string, ActiveSession>();
+  // Group events by distinct client device profile (Browser + OS + DeviceType).
+  // Since sessionLogs are sorted descending by createdAt, the first entry encountered
+  // is guaranteed to be the most recent activity and IP for that physical device.
+  const deviceMap = new Map<string, ActiveSession>();
 
   for (const log of sessionLogs) {
     const details = (log.details as Record<string, unknown>) || {};
@@ -194,41 +197,36 @@ export async function getUserActiveSessions({
     const parsed = parseUserAgent(ua);
     const ip = log.ip || (details.ip as string) || 'Unknown IP';
 
-    // Unique identity key per physical client
-    const key = `${parsed.browser}:${parsed.os}:${ip}`;
+    // Grouping key per physical client device profile
+    const deviceKey = `${parsed.browser}:${parsed.os}:${parsed.deviceType}`;
 
-    const isCurrent =
-      Boolean(currentUserAgent) &&
-      parsed.browser === currentParsed.browser &&
-      parsed.os === currentParsed.os;
-
-    if (!sessionMap.has(key)) {
-      sessionMap.set(key, {
+    if (!deviceMap.has(deviceKey)) {
+      deviceMap.set(deviceKey, {
         id: log.id,
         browser: parsed.browser,
         os: parsed.os,
         deviceType: parsed.deviceType,
         ip,
-        isCurrent,
+        isCurrent: false, // will be explicitly set for the single current device below
         lastActive: log.createdAt.toISOString(),
         tokenVersion,
       });
     }
   }
 
-  // Always ensure current device is present in the list
-  const currentKey = `${currentParsed.browser}:${currentParsed.os}:${currentIp || '127.0.0.1'}`;
-  let hasCurrent = false;
+  // Current client device key
+  const currentDeviceKey = `${currentParsed.browser}:${currentParsed.os}:${currentParsed.deviceType}`;
 
-  for (const session of sessionMap.values()) {
-    if (session.isCurrent) {
-      hasCurrent = true;
-      break;
+  if (deviceMap.has(currentDeviceKey)) {
+    const currentSession = deviceMap.get(currentDeviceKey)!;
+    currentSession.isCurrent = true;
+    currentSession.lastActive = new Date().toISOString();
+    if (currentIp && currentIp !== '127.0.0.1' && currentIp !== 'Unknown IP') {
+      currentSession.ip = currentIp;
     }
-  }
-
-  if (!hasCurrent) {
-    sessionMap.set(currentKey, {
+  } else {
+    // Current device had no prior audit log within the window; register it as current
+    deviceMap.set(currentDeviceKey, {
       id: 'current-session',
       browser: currentParsed.browser,
       os: currentParsed.os,
@@ -240,8 +238,8 @@ export async function getUserActiveSessions({
     });
   }
 
-  // Sort sessions: Current device first, then by lastActive descending
-  const sessions = Array.from(sessionMap.values()).sort((a, b) => {
+  // Sort sessions: Single current device first, then other devices sorted by lastActive descending
+  const sessions = Array.from(deviceMap.values()).sort((a, b) => {
     if (a.isCurrent) return -1;
     if (b.isCurrent) return 1;
     return new Date(b.lastActive).getTime() - new Date(a.lastActive).getTime();

--- a/tests/lib/active-sessions.test.ts
+++ b/tests/lib/active-sessions.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseUserAgent } from '@/lib/active-sessions';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { parseUserAgent, getUserActiveSessions } from '@/lib/active-sessions';
 
 describe('active-sessions: parseUserAgent', () => {
   it('correctly detects Microsoft Edge on Windows', () => {
@@ -45,5 +45,100 @@ describe('active-sessions: parseUserAgent', () => {
     const result = parseUserAgent(null);
     expect(result.browser).toBe('Web Browser');
     expect(result.deviceType).toBe('desktop');
+  });
+});
+
+const mocks = vi.hoisted(() => ({
+  auditLogFindFirst: vi.fn(),
+  auditLogFindMany: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    auditLog: {
+      findFirst: mocks.auditLogFindFirst,
+      findMany: mocks.auditLogFindMany,
+    },
+  },
+}));
+
+describe('active-sessions: getUserActiveSessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auditLogFindFirst.mockResolvedValue(null);
+  });
+
+  it('collapses multiple IP logs from the same browser/OS into exactly ONE session and marks only one current device', async () => {
+    const chromeMacUA =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36';
+    const edgeWinUA =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36 Edg/133.0.0.0';
+
+    // Simulated logs: 4 distinct IPs from Chrome on Mac over time, and 3 distinct IPs from Edge on Windows
+    mocks.auditLogFindMany.mockResolvedValue([
+      {
+        id: 'log-1',
+        action: 'SESSION_HEARTBEAT',
+        ip: '106.51.250.126',
+        details: { metadata: { userAgent: chromeMacUA } },
+        createdAt: new Date('2026-09-03T00:00:00Z'),
+      },
+      {
+        id: 'log-2',
+        action: 'SESSION_HEARTBEAT',
+        ip: '2401:4900:883a:a614::1',
+        details: { metadata: { userAgent: chromeMacUA } },
+        createdAt: new Date('2026-09-02T23:00:00Z'),
+      },
+      {
+        id: 'log-3',
+        action: 'LOGIN_SUCCESS',
+        ip: '127.0.0.1',
+        details: { metadata: { userAgent: chromeMacUA } },
+        createdAt: new Date('2026-09-02T22:00:00Z'),
+      },
+      {
+        id: 'log-4',
+        action: 'SESSION_HEARTBEAT',
+        ip: '106.51.250.126',
+        details: { metadata: { userAgent: edgeWinUA } },
+        createdAt: new Date('2026-09-02T20:00:00Z'),
+      },
+      {
+        id: 'log-5',
+        action: 'SESSION_HEARTBEAT',
+        ip: '223.185.135.171',
+        details: { metadata: { userAgent: edgeWinUA } },
+        createdAt: new Date('2026-09-01T15:00:00Z'),
+      },
+    ]);
+
+    const sessions = await getUserActiveSessions({
+      userId: 'user-1',
+      currentIp: '106.51.250.126',
+      currentUserAgent: chromeMacUA,
+      tokenVersion: 0,
+    });
+
+    // Despite 5 audit logs with multiple IPs, there should be exactly 2 distinct device sessions
+    expect(sessions).toHaveLength(2);
+
+    // Chrome on Mac should be the first session and the ONLY one with isCurrent = true
+    const chromeSession = sessions.find(s => s.browser === 'Google Chrome');
+    expect(chromeSession).toBeDefined();
+    expect(chromeSession?.os).toBe('macOS');
+    expect(chromeSession?.isCurrent).toBe(true);
+
+    // Edge on Windows should be the second session and have isCurrent = false
+    const edgeSession = sessions.find(s => s.browser === 'Microsoft Edge');
+    expect(edgeSession).toBeDefined();
+    expect(edgeSession?.os).toBe('Windows');
+    expect(edgeSession?.isCurrent).toBe(false);
+    expect(edgeSession?.ip).toBe('106.51.250.126'); // Latest IP from log-4
+
+    // Exactly one session in the list has isCurrent === true
+    const currentSessions = sessions.filter(s => s.isCurrent);
+    expect(currentSessions).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary of Changes

Resolves duplicate active session cards and stale session listings in the Security settings panel:

### 1. Group Active Sessions by Device Profile
- In `src/lib/active-sessions.ts`, grouped active sessions by client identity: `${parsed.browser}:${parsed.os}:${parsed.deviceType}`.
- Because audit logs are ordered descending (`createdAt: 'desc'`), the first log processed for each device identity holds its most recent activity timestamp and latest IP address.
- Network IP rotations (IPv4 vs. IPv6 dual stack, Wi-Fi to cellular, VPN) no longer spawn duplicate session entries for the same physical device.

### 2. Single Current Device Guarantee
- Enforced that only the active browser making the current request is assigned `isCurrent: true` with the **"This Device"** badge.
- All other connected devices are strictly marked `isCurrent: false` and labeled **"Connected Device"**.

### 3. Continuous Heartbeats for Open Tabs via SSE Stream
- In `src/app/api/realtime/stream/route.ts`, integrated `recordSessionHeartbeat` into the Server-Sent Events (SSE) stream on initial connection and within the 30s heartbeat loop.
- Combined with a 2-minute in-memory throttle (`HEARTBEAT_THROTTLE_MS = 2 * 60 * 1000`), any open tab on another device (such as Edge on another laptop) continuously maintains its **"Active Now"** status while open, without placing load on the database.

### 4. Prune Stale / Dormant Sessions
- Scoped active session logs to a 14-day window (`ACTIVE_SESSION_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000`), ensuring inactive devices older than 14 days drop off automatically.

---

## Verification
- Unit tests added in `tests/lib/active-sessions.test.ts` verifying that multiple IP logs collapse into 1 session card and that exactly 1 session has `isCurrent: true`.
- Component tests verified in `tests/components/settings/ActiveSessionsSection.test.tsx`.
- Full pre-push test suite passed (2,217 tests across 313 test files).