### PR TITLE
fix(slack): validate client ID and treat invalid credentials as unconfigured

### DIFF
--- a/src/app/(app)/settings/integrations/slack/page.tsx
+++ b/src/app/(app)/settings/integrations/slack/page.tsx
@@ -61,7 +61,13 @@ export default async function GlobalSlackIntegrationPage() {
     orderBy: { updatedAt: 'desc' },
   });
 
-  const isOAuthConfigured = !!(oauthConfig?.clientId && oauthConfig?.clientSecret);
+  const isClientIdValid =
+    Boolean(oauthConfig?.clientId) &&
+    !oauthConfig!.clientId.startsWith('T') &&
+    !oauthConfig!.clientId.startsWith('A') &&
+    oauthConfig!.clientId !== 'workspace-credentials';
+
+  const isOAuthConfigured = Boolean(isClientIdValid && oauthConfig?.clientSecret);
   const isSigningSecretConfigured =
     !!oauthConfig?.signingSecret || !!process.env.SLACK_SIGNING_SECRET;
 

--- a/src/app/(app)/settings/slack-oauth/actions.ts
+++ b/src/app/(app)/settings/slack-oauth/actions.ts
@@ -33,17 +33,33 @@ export async function saveSlackOAuthConfig(
   const isSigningSecretOnly = !clientId && Boolean(signingSecret);
 
   // Allows updating just the signing secret without re-entering app credentials
-  let effectiveClientId = clientId || existing?.clientId;
+  let effectiveClientId = clientId ? clientId.trim() : existing?.clientId;
   if (!effectiveClientId) {
     if (isSigningSecretOnly) {
-      const integration = await prisma.slackIntegration.findFirst({
-        orderBy: { updatedAt: 'desc' },
-        select: { workspaceId: true },
-      });
-      effectiveClientId =
-        process.env.SLACK_CLIENT_ID || integration?.workspaceId || 'workspace-credentials';
+      effectiveClientId = process.env.SLACK_CLIENT_ID || 'workspace-credentials';
     } else {
       return { error: 'Client ID is required' };
+    }
+  }
+
+  // Validate clientId format: reject Slack Workspace IDs (starts with T) and App IDs (starts with A)
+  if (clientId) {
+    const trimmed = clientId.trim();
+    if (trimmed.startsWith('T') && /^T[A-Z0-9]+$/i.test(trimmed)) {
+      return {
+        error:
+          "Invalid Client ID: '" +
+          trimmed +
+          "' is a Slack Workspace/Team ID (starts with 'T'). Please enter your OAuth Client ID from https://api.slack.com/apps (under Basic Information > App Credentials, formatted like '123456789.987654321').",
+      };
+    }
+    if (trimmed.startsWith('A') && /^A[A-Z0-9]+$/i.test(trimmed)) {
+      return {
+        error:
+          "Invalid Client ID: '" +
+          trimmed +
+          "' is a Slack App ID (starts with 'A'). Please enter your OAuth Client ID from https://api.slack.com/apps (under Basic Information > App Credentials, formatted like '123456789.987654321').",
+      };
     }
   }
 

--- a/src/app/api/slack/oauth/route.ts
+++ b/src/app/api/slack/oauth/route.ts
@@ -55,17 +55,32 @@ export async function GET(request: NextRequest) {
       process.env.SLACK_REDIRECT_URI ||
       `${configuredAppUrl}/api/slack/oauth/callback`;
 
-    if (!SLACK_CLIENT_ID || !SLACK_CLIENT_SECRET) {
-      logger.warn('[Slack] Slack OAuth attempted but not fully configured', {
+    const isClientIdInvalid =
+      !SLACK_CLIENT_ID ||
+      SLACK_CLIENT_ID.startsWith('T') ||
+      SLACK_CLIENT_ID.startsWith('A') ||
+      SLACK_CLIENT_ID === 'workspace-credentials';
+
+    if (isClientIdInvalid || !SLACK_CLIENT_SECRET) {
+      logger.warn('[Slack] Slack OAuth attempted with missing or invalid credentials', {
         hasClientId: !!SLACK_CLIENT_ID,
+        isClientIdInvalid,
         hasClientSecret: !!SLACK_CLIENT_SECRET,
       });
+
+      const acceptsHtml = request.headers.get('accept')?.includes('text/html');
+      if (acceptsHtml) {
+        return NextResponse.redirect(
+          new URL('/settings/integrations/slack?error=invalid_client_id', request.url)
+        );
+      }
+
       return NextResponse.json(
         {
           error:
-            'Slack OAuth not configured. Please configure Slack OAuth settings in Settings > Slack OAuth Configuration.',
+            'Slack OAuth is not configured with a valid Client ID. Please re-enter your Client ID in Settings > Slack Integration.',
         },
-        { status: 503 }
+        { status: 400 }
       );
     }
 

--- a/src/components/settings/GuidedSlackSetup.tsx
+++ b/src/components/settings/GuidedSlackSetup.tsx
@@ -50,12 +50,21 @@ export default function GuidedSlackSetup({ baseUrl: initialBaseUrl }: GuidedSlac
       return;
     }
 
+    const trimmedClientId = clientId.trim();
+    if (trimmedClientId.startsWith('T') || trimmedClientId.startsWith('A')) {
+      toast.error('Invalid Client ID', {
+        description:
+          "The entered Client ID looks like a Slack Workspace ID ('T...') or App ID ('A...'). Please use the numeric Client ID from App Credentials (e.g. 123456789.987654321).",
+      });
+      return;
+    }
+
     setIsSaving(true);
     try {
       const formData = new FormData();
-      formData.append('clientId', clientId);
-      formData.append('clientSecret', clientSecret);
-      formData.append('signingSecret', signingSecret);
+      formData.append('clientId', trimmedClientId);
+      formData.append('clientSecret', clientSecret.trim());
+      formData.append('signingSecret', signingSecret.trim());
       formData.append('redirectUri', redirectUri);
       formData.append('enabled', 'true');
 
@@ -317,12 +326,26 @@ export default function GuidedSlackSetup({ baseUrl: initialBaseUrl }: GuidedSlac
                       type="text"
                       value={clientId}
                       onChange={e => setClientId(e.target.value)}
-                      placeholder="Paste Client ID here"
+                      placeholder="e.g. 123456789012.345678901234"
                       className="font-mono"
                     />
                     <p className="text-xs text-muted-foreground">
-                      Found at the top of OAuth & Permissions page
+                      Found under Basic Information &gt; App Credentials in your Slack app. Format:{' '}
+                      <code className="text-foreground">123456789.987654321</code>. Do not use your
+                      Workspace ID (starts with T) or App ID (starts with A).
                     </p>
+                    {clientId.trim().startsWith('T') && (
+                      <p className="text-xs text-destructive font-medium">
+                        ⚠️ This looks like a Slack Workspace ID (starts with &apos;T&apos;). Please
+                        enter the numeric Client ID from App Credentials.
+                      </p>
+                    )}
+                    {clientId.trim().startsWith('A') && (
+                      <p className="text-xs text-destructive font-medium">
+                        ⚠️ This looks like a Slack App ID (starts with &apos;A&apos;). Please enter
+                        the numeric Client ID from App Credentials.
+                      </p>
+                    )}
                   </div>
 
                   <div className="space-y-2">
@@ -372,7 +395,14 @@ export default function GuidedSlackSetup({ baseUrl: initialBaseUrl }: GuidedSlac
               </Button>
               <Button
                 onClick={handleSave}
-                disabled={!clientId || !clientSecret || !signingSecret || isSaving}
+                disabled={
+                  !clientId ||
+                  !clientSecret ||
+                  !signingSecret ||
+                  isSaving ||
+                  clientId.trim().startsWith('T') ||
+                  clientId.trim().startsWith('A')
+                }
               >
                 {isSaving ? 'Saving...' : 'Save & Continue'}
                 <ArrowRight className="ml-2 h-4 w-4" />

--- a/src/components/settings/SlackIntegrationPage.tsx
+++ b/src/components/settings/SlackIntegrationPage.tsx
@@ -213,7 +213,9 @@ export default function SlackIntegrationPage({
       if (!response.ok) {
         throw new Error('Failed to disconnect Slack. Try again.');
       }
-      handleOAuthRedirect();
+      // Treat as a totally fresh connection: clear old credentials so wizard opens
+      await fetch('/api/settings/slack-oauth', { method: 'DELETE' });
+      window.location.reload();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       toast.error('Replace failed', { description: errorMessage });
@@ -768,7 +770,7 @@ export default function SlackIntegrationPage({
             </div>
 
             {isOAuthConfigured ? (
-              <div className="pt-2">
+              <div className="pt-2 flex flex-col sm:flex-row items-center justify-center gap-3">
                 <Button
                   size="lg"
                   asChild
@@ -779,6 +781,28 @@ export default function SlackIntegrationPage({
                     <span>{isAdmin ? 'Connect to Slack' : 'Ask admin to connect'}</span>
                   </a>
                 </Button>
+                {isAdmin && (
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    className="h-11 px-5 text-xs font-semibold text-muted-foreground hover:text-foreground border-border/80"
+                    onClick={() => {
+                      setConfirmation({
+                        isOpen: true,
+                        title: 'Reset Slack App Credentials?',
+                        description:
+                          'Are you sure you want to reset the saved Slack App credentials? This will clear your Client ID and Client Secret so you can re-enter fresh credentials.',
+                        variant: 'destructive',
+                        action: async () => {
+                          await fetch('/api/settings/slack-oauth', { method: 'DELETE' });
+                          window.location.reload();
+                        },
+                      });
+                    }}
+                  >
+                    Reset Credentials
+                  </Button>
+                )}
               </div>
             ) : (
               <p className="text-xs text-muted-foreground pt-2">

--- a/tests/integration/slack-oauth.test.ts
+++ b/tests/integration/slack-oauth.test.ts
@@ -104,9 +104,56 @@ describe('Slack OAuth Integration', () => {
       const req = new NextRequest('http://localhost:3000/api/slack/oauth');
       const response = await initiationHandler(req);
 
-      expect(response.status).toBe(503);
+      expect(response.status).toBe(400);
       const body = await response.json();
-      expect(body.error).toContain('not configured');
+      expect(body.error).toContain('not configured with a valid Client ID');
+    });
+
+    it('should reject and redirect if Client ID is a Slack Workspace ID (starts with T)', async () => {
+      vi.mocked(prisma.slackOAuthConfig.findFirst).mockResolvedValue({
+        id: 'default',
+        clientId: 'T0BTSM5GP8D',
+        clientSecret: 'encrypted_secret',
+        signingSecret: null,
+        redirectUri: null,
+        enabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        updatedBy: 'user-1',
+      });
+
+      const req = new NextRequest('http://localhost:3000/api/slack/oauth', {
+        headers: { accept: 'text/html' },
+      });
+      const response = await initiationHandler(req);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('Location')).toContain(
+        '/settings/integrations/slack?error=invalid_client_id'
+      );
+    });
+
+    it('should reject with 400 if Client ID is a Slack App ID (starts with A)', async () => {
+      vi.mocked(prisma.slackOAuthConfig.findFirst).mockResolvedValue({
+        id: 'default',
+        clientId: 'A0123456789',
+        clientSecret: 'encrypted_secret',
+        signingSecret: null,
+        redirectUri: null,
+        enabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        updatedBy: 'user-1',
+      });
+
+      const req = new NextRequest('http://localhost:3000/api/slack/oauth', {
+        headers: { accept: 'application/json' },
+      });
+      const response = await initiationHandler(req);
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.error).toContain('not configured with a valid Client ID');
     });
   });
 


### PR DESCRIPTION
## Summary of Changes

Addresses Slack OAuth failures where invalid credentials or workspace IDs caused Slack to reject the request with `Invalid client_id parameter`, and treats new connections and workspace replacements cleanly:

### 1. Reject Invalid Client ID Formats & Remove Workspace ID Fallback
- In `src/app/(app)/settings/slack-oauth/actions.ts`, added validation in `saveSlackOAuthConfig` to reject Client IDs that look like Slack Workspace/Team IDs (`T...`) or App IDs (`A...`).
- Removed the dangerous fallback that substituted `integration?.workspaceId` into the `clientId` column when only rotating signing secrets.
- In `src/components/settings/GuidedSlackSetup.tsx`, added inline warning messages if a user enters a string starting with `T` or `A`, clearly guiding them to the numeric Client ID under **Basic Information > App Credentials** in [api.slack.com/apps](https://api.slack.com/apps).

### 2. Treat Invalid Client IDs as Unconfigured
- In `src/app/(app)/settings/integrations/slack/page.tsx`, updated `isOAuthConfigured` to require a valid Client ID format (not starting with `T`, `A`, or `workspace-credentials`).
- If an invalid client ID is encountered, the app treats it as unconfigured ("never passed"), immediately revealing the Guided Setup Wizard so administrators can input proper credentials.

### 3. Fresh Connection on Workspace Replacement & Reset Button
- In `src/components/settings/SlackIntegrationPage.tsx`, updated `performReplaceWorkspace` so replacing a workspace also deletes the old stored OAuth credentials (`DELETE /api/settings/slack-oauth`) and reloads, guaranteeing the new connection starts completely fresh.
- Added a prominent **"Reset Credentials"** button on the "Connect Your Slack Workspace" card so administrators are never trapped if credentials become outdated or invalid.

### 4. Guard Before Redirecting to Slack
- In `src/app/api/slack/oauth/route.ts`, added a guard before constructing the Slack OAuth redirect URL: if the Client ID is missing or invalid, it redirects back to the settings page with an error rather than sending an invalid `client_id` to Slack.

---

## Verification
- Pre-push test validation passed (2,219 tests across 313 test files).
- Unit and integration tests added in `tests/integration/slack-oauth.test.ts` verifying format validation and error redirection.