### PR TITLE
fix(slack): route oauth callback errors to slack settings and prevent identical secrets

### DIFF
--- a/src/app/(app)/settings/integrations/slack/page.tsx
+++ b/src/app/(app)/settings/integrations/slack/page.tsx
@@ -20,7 +20,13 @@ import { getAppUrl } from '@/lib/app-url';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export default async function GlobalSlackIntegrationPage() {
+export default async function GlobalSlackIntegrationPage(props: {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const search = (await props.searchParams) || {};
+  const oauthError = typeof search.error === 'string' ? search.error : null;
+  const oauthMessage = typeof search.message === 'string' ? search.message : null;
+
   const permissions = await getUserPermissions();
 
   if (!permissions) {
@@ -171,6 +177,24 @@ export default async function GlobalSlackIntegrationPage() {
           },
         ]}
       />
+
+      {oauthError && (
+        <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 p-4 sm:p-5 text-xs text-rose-800 dark:text-rose-300 space-y-1.5">
+          <div className="flex items-center gap-2 font-semibold">
+            <AlertTriangle className="h-4 w-4 text-rose-600 dark:text-rose-400 shrink-0" />
+            <span>
+              {oauthMessage === 'bad_client_secret'
+                ? 'Slack Connection Failed: Bad Client Secret'
+                : 'Slack Connection Error'}
+            </span>
+          </div>
+          <p className="leading-relaxed">
+            {oauthMessage === 'bad_client_secret'
+              ? 'The Client Secret entered in OpsKnight does not match your Slack App Client Secret. In https://api.slack.com/apps under Basic Information > App Credentials, click "Show" next to Client Secret and copy that distinct value into OpsKnight (it is different from the Signing Secret).'
+              : oauthMessage || oauthError}
+          </p>
+        </div>
+      )}
 
       <SlackIntegrationPage
         integration={globalIntegration}

--- a/src/app/api/slack/oauth/callback/route.ts
+++ b/src/app/api/slack/oauth/callback/route.ts
@@ -54,17 +54,26 @@ export async function GET(request: NextRequest) {
     const state = searchParams.get('state');
     const error = searchParams.get('error');
 
+    // Get service ID if provided
+    const serviceId = request.cookies.get('slack_oauth_service_id')?.value || null;
+    const errorTarget = serviceId
+      ? `/services/${serviceId}/settings`
+      : '/settings/integrations/slack';
+
     // Check for OAuth errors
     if (error) {
       logger.error('[Slack] OAuth error', { error });
       return NextResponse.redirect(
-        getFullUrl(`/services?error=slack_oauth_error&message=${encodeURIComponent(error)}`, appUrl)
+        getFullUrl(
+          `${errorTarget}?error=slack_oauth_error&message=${encodeURIComponent(error)}`,
+          appUrl
+        )
       );
     }
 
     if (!code || !state) {
       return NextResponse.redirect(
-        getFullUrl('/services?error=slack_oauth_missing_params', appUrl)
+        getFullUrl(`${errorTarget}?error=slack_oauth_missing_params`, appUrl)
       );
     }
 
@@ -72,11 +81,11 @@ export async function GET(request: NextRequest) {
     const storedState = request.cookies.get('slack_oauth_state')?.value;
     if (!storedState || storedState !== state) {
       logger.warn('[Slack] Invalid OAuth state', { state, storedState });
-      return NextResponse.redirect(getFullUrl('/services?error=slack_oauth_invalid_state', appUrl));
+      return NextResponse.redirect(
+        getFullUrl(`${errorTarget}?error=slack_oauth_invalid_state`, appUrl)
+      );
     }
 
-    // Get service ID if provided
-    const serviceId = request.cookies.get('slack_oauth_service_id')?.value || null;
     const user = serviceId ? await assertCanModifyService(serviceId) : await assertAdmin();
 
     // Get OAuth config from database (fallback to env for backward compatibility)
@@ -95,7 +104,7 @@ export async function GET(request: NextRequest) {
     if (!SLACK_CLIENT_ID || !SLACK_CLIENT_SECRET) {
       return NextResponse.redirect(
         getFullUrl(
-          `/services?error=slack_oauth_not_configured&message=${encodeURIComponent('Slack OAuth not configured. Please configure in Settings > Slack OAuth Configuration.')}`,
+          `${errorTarget}?error=slack_oauth_not_configured&message=${encodeURIComponent('Slack OAuth not configured. Please configure in Settings > Slack OAuth Configuration.')}`,
           appUrl
         )
       );
@@ -122,7 +131,7 @@ export async function GET(request: NextRequest) {
       logger.error('[Slack] Token exchange failed', { error: tokenData.error });
       return NextResponse.redirect(
         getFullUrl(
-          `/services?error=slack_oauth_token_error&message=${encodeURIComponent(tokenData.error || 'Unknown error')}`,
+          `${errorTarget}?error=slack_oauth_token_error&message=${encodeURIComponent(tokenData.error || 'Unknown error')}`,
           appUrl
         )
       );
@@ -235,7 +244,10 @@ export async function GET(request: NextRequest) {
       error: error.message,
       stack: error.stack,
     });
-    // Use the determined appUrl (which might have been updated from DB)
-    return NextResponse.redirect(getFullUrl('/services?error=slack_oauth_error', appUrl));
+    const serviceId = request.cookies.get('slack_oauth_service_id')?.value || null;
+    const errorTarget = serviceId
+      ? `/services/${serviceId}/settings`
+      : '/settings/integrations/slack';
+    return NextResponse.redirect(getFullUrl(`${errorTarget}?error=slack_oauth_error`, appUrl));
   }
 }

--- a/src/components/settings/GuidedSlackSetup.tsx
+++ b/src/components/settings/GuidedSlackSetup.tsx
@@ -59,6 +59,14 @@ export default function GuidedSlackSetup({ baseUrl: initialBaseUrl }: GuidedSlac
       return;
     }
 
+    if (clientSecret.trim() === signingSecret.trim()) {
+      toast.error('Identical Secrets Detected', {
+        description:
+          "Client Secret and Signing Secret are two different values in Slack (under Basic Information > App Credentials). Copying the same secret into both will cause Slack to reject token exchange with 'bad_client_secret'.",
+      });
+      return;
+    }
+
     setIsSaving(true);
     try {
       const formData = new FormData();
@@ -383,6 +391,16 @@ export default function GuidedSlackSetup({ baseUrl: initialBaseUrl }: GuidedSlac
                       requests are rejected. Slack never sends this during OAuth, so reconnecting
                       will not fill it in.
                     </p>
+                    {clientSecret.trim() &&
+                      signingSecret.trim() &&
+                      clientSecret.trim() === signingSecret.trim() && (
+                        <p className="text-xs text-destructive font-medium">
+                          ⚠️ Client Secret and Signing Secret are identical. In Slack under Basic
+                          Information &gt; App Credentials, Client Secret and Signing Secret are two
+                          distinct keys. Click &quot;Show&quot; next to each to copy their separate
+                          values.
+                        </p>
+                      )}
                   </div>
                 </div>
               </div>
@@ -401,7 +419,8 @@ export default function GuidedSlackSetup({ baseUrl: initialBaseUrl }: GuidedSlac
                   !signingSecret ||
                   isSaving ||
                   clientId.trim().startsWith('T') ||
-                  clientId.trim().startsWith('A')
+                  clientId.trim().startsWith('A') ||
+                  clientSecret.trim() === signingSecret.trim()
                 }
               >
                 {isSaving ? 'Saving...' : 'Save & Continue'}


### PR DESCRIPTION
## Summary of Changes

Addresses the issue where OAuth token exchange failure redirected users unexpectedly to the `/services` page without error context, and prevents identical secrets from causing `bad_client_secret` failures:

### 1. Proper Error Redirect Target
- In `src/app/api/slack/oauth/callback/route.ts`, updated error handlers to route errors back to `/settings/integrations/slack?error=...&message=...` (or `/services/${serviceId}/settings` if service-scoped), rather than hardcoding `/services`.

### 2. Prominent In-App Error Banners
- In `src/app/(app)/settings/integrations/slack/page.tsx`, added an alert banner displayed when the OAuth callback returns an error. When `bad_client_secret` occurs, it clearly explains that the Client Secret did not match and directs the administrator to copy the Client Secret (distinct from Signing Secret) from [api.slack.com/apps](https://api.slack.com/apps).

### 3. Proactive Validation Against Identical Secrets
- In `src/components/settings/GuidedSlackSetup.tsx`, added validation ensuring **Client Secret** and **Signing Secret** are not identical strings.
- Shows an immediate warning and disables the **Save & Continue** button if the user pastes the same secret into both fields, explaining that they are two distinct keys under **Basic Information > App Credentials**.