### PR TITLE
hardening(integrations): make integration boundary retry-safe and durable

### DIFF
--- a/src/app/api/integrations/github/route.ts
+++ b/src/app/api/integrations/github/route.ts
@@ -11,103 +11,84 @@ import { withIntegrationMiddleware } from '@/lib/integrations/handler';
 import { validatePayload, GitHubEventSchema } from '@/lib/integrations/schemas';
 import {
   IntegrationBodyTooLargeError,
+  claimWebhookDelivery,
+  completeWebhookDelivery,
+  failWebhookDelivery,
   readIntegrationBody,
-  rejectWebhookReplay,
+  webhookDeliveryResponse,
+  type WebhookDeliveryClaim,
 } from '@/lib/integrations/request-security';
 
 const VERIFY_SIGNATURES = process.env.INTEGRATION_VERIFY_SIGNATURES !== 'false';
 
-/**
- * GitHub/GitLab Webhook Endpoint
- * POST /api/integrations/github?integrationId=xxx
- *
- * Features:
- * - Rate limiting (100 req/min per integration)
- * - HMAC signature verification (X-Hub-Signature-256)
- * - Payload validation via Zod schemas
- * - Metrics tracking (success rate, latency)
- */
+/** GitHub webhook endpoint. */
 export async function POST(req: NextRequest) {
   return withIntegrationMiddleware(req, 'GITHUB', async () => {
     const startTime = Date.now();
+    let deliveryClaim: WebhookDeliveryClaim = { tracked: false };
 
     try {
       const { searchParams } = new URL(req.url);
       const integrationId = searchParams.get('integrationId');
+      if (!integrationId) return jsonError('integrationId is required', 400);
 
-      if (!integrationId) {
-        return jsonError('integrationId is required', 400);
-      }
-
-      // Get raw body for signature verification
       const rawBody = await readIntegrationBody(req);
-
-      // Verify integration exists and get service
       const integration = await prisma.integration.findUnique({
         where: { id: integrationId },
         include: { service: true },
       });
+      if (!integration) return jsonError('Integration not found', 404);
+      if (!integration.enabled) return jsonError('Integration is disabled', 403);
 
-      if (!integration) {
-        return jsonError('Integration not found', 404);
-      }
-
-      if (!integration.enabled) {
-        return jsonError('Integration is disabled', 403);
-      }
-
-      // Verify GitHub signature if secret is configured
       if (VERIFY_SIGNATURES && integration.signatureSecret) {
         const signature = req.headers.get('x-hub-signature-256');
         if (!signature) {
           logger.warn('api.integration.github_missing_signature', { integrationId });
           return jsonError('Missing X-Hub-Signature-256 header', 401);
         }
-
         const signatureSecret = await decryptStoredSecret(integration.signatureSecret);
         if (!verifyGitHubSignature(rawBody, signature, signatureSecret)) {
           logger.warn('api.integration.github_invalid_signature', { integrationId });
           return jsonError('Invalid webhook signature', 401);
         }
-        if (await rejectWebhookReplay(integration.id, req.headers.get('x-github-delivery'))) {
-          return jsonError('Duplicate webhook delivery', 409);
-        }
+
+        deliveryClaim = await claimWebhookDelivery(
+          integration.id,
+          'github',
+          req.headers.get('x-github-delivery')
+        );
+        const claimedResponse = webhookDeliveryResponse(deliveryClaim);
+        if (claimedResponse) return claimedResponse;
       }
 
-      let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      let body: unknown;
       try {
         body = JSON.parse(rawBody);
-      } catch (_error) {
+      } catch {
+        await failWebhookDelivery(deliveryClaim, new Error('Invalid JSON payload'));
         return jsonError('Invalid JSON in request body.', 400);
       }
 
-      // Validate payload
       const validation = validatePayload(GitHubEventSchema, body);
       if (!validation.success) {
-        logger.warn('api.integration.github_validation_failed', {
-          errors: validation.errors,
-          integrationId,
-        });
+        await failWebhookDelivery(deliveryClaim, new Error('Invalid GitHub webhook payload'));
+        logger.warn('api.integration.github_validation_failed', { errors: validation.errors, integrationId });
         return jsonError('Invalid GitHub webhook payload', 400, { errors: validation.errors });
       }
 
-      // Transform to standard event format
       const event = transformGitHubToEvent(validation.data as GitHubEvent);
-
-      // Process the event
       const result = await processEvent(event, integration.serviceId, integration.id);
+      await completeWebhookDelivery(deliveryClaim);
 
       logger.info('api.integration.github_success', {
         integrationId,
         action: result.action,
         latencyMs: Date.now() - startTime,
       });
-
       return jsonOk({ status: 'success', result }, 202);
     } catch (error: unknown) {
-      if (error instanceof IntegrationBodyTooLargeError) {
-        return jsonError(error.message, 413);
-      }
+      await failWebhookDelivery(deliveryClaim, error).catch(() => {});
+      if (error instanceof IntegrationBodyTooLargeError) return jsonError(error.message, 413);
       logger.error('api.integration.github_error', {
         error: error instanceof Error ? error.message : String(error),
       });

--- a/src/app/api/integrations/grafana/route.ts
+++ b/src/app/api/integrations/grafana/route.ts
@@ -11,42 +11,34 @@ import { withIntegrationMiddleware } from '@/lib/integrations/handler';
 import { validatePayload, GrafanaAlertSchema } from '@/lib/integrations/schemas';
 import {
   IntegrationBodyTooLargeError,
+  claimWebhookDelivery,
+  completeWebhookDelivery,
+  failWebhookDelivery,
   readIntegrationBody,
-  rejectWebhookReplay,
+  webhookDeliveryResponse,
+  type WebhookDeliveryClaim,
 } from '@/lib/integrations/request-security';
 
 const VERIFY_SIGNATURES = process.env.INTEGRATION_VERIFY_SIGNATURES !== 'false';
 
-/**
- * Grafana Webhook Endpoint
- * POST /api/integrations/grafana?integrationId=xxx
- */
+/** Grafana webhook endpoint. */
 export async function POST(req: NextRequest) {
   return withIntegrationMiddleware(req, 'GRAFANA', async () => {
     const startTime = Date.now();
+    let deliveryClaim: WebhookDeliveryClaim = { tracked: false };
 
     try {
       const { searchParams } = new URL(req.url);
       const integrationId = searchParams.get('integrationId');
-
-      if (!integrationId) {
-        return jsonError('integrationId is required', 400);
-      }
+      if (!integrationId) return jsonError('integrationId is required', 400);
 
       const rawBody = await readIntegrationBody(req);
-
       const integration = await prisma.integration.findUnique({
         where: { id: integrationId },
         include: { service: true },
       });
-
-      if (!integration) {
-        return jsonError('Integration not found', 404);
-      }
-
-      if (!integration.enabled) {
-        return jsonError('Integration is disabled', 403);
-      }
+      if (!integration) return jsonError('Integration not found', 404);
+      if (!integration.enabled) return jsonError('Integration is disabled', 403);
 
       if (VERIFY_SIGNATURES && integration.signatureSecret) {
         const signature = req.headers.get('x-grafana-signature');
@@ -59,41 +51,38 @@ export async function POST(req: NextRequest) {
           logger.warn('api.integration.grafana_invalid_signature', { integrationId });
           return jsonError('Invalid webhook signature', 401);
         }
-        if (
-          await rejectWebhookReplay(
-            integration.id,
-            req.headers.get('x-request-id') || req.headers.get('x-grafana-delivery')
-          )
-        ) {
-          return jsonError('Duplicate webhook delivery', 409);
-        }
+        deliveryClaim = await claimWebhookDelivery(
+          integration.id,
+          'grafana',
+          req.headers.get('x-request-id') || req.headers.get('x-grafana-delivery')
+        );
+        const claimedResponse = webhookDeliveryResponse(deliveryClaim);
+        if (claimedResponse) return claimedResponse;
       }
 
-      let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      let body: unknown;
       try {
         body = JSON.parse(rawBody);
-      } catch (_error) {
+      } catch {
+        await failWebhookDelivery(deliveryClaim, new Error('Invalid JSON payload'));
         return jsonError('Invalid JSON in request body.', 400);
       }
 
       const validation = validatePayload(GrafanaAlertSchema, body);
       if (!validation.success) {
-        logger.warn('api.integration.grafana_validation_failed', {
-          errors: validation.errors,
-          integrationId,
-        });
+        await failWebhookDelivery(deliveryClaim, new Error('Invalid Grafana webhook payload'));
+        logger.warn('api.integration.grafana_validation_failed', { errors: validation.errors, integrationId });
         return jsonError('Invalid Grafana webhook payload', 400, { errors: validation.errors });
       }
 
       const events = transformGrafanaToEvents(validation.data as GrafanaAlert);
       const results = [];
       for (const event of events) {
-        const result = await processEvent(event, integration.serviceId, integration.id);
-        results.push(result);
+        results.push(await processEvent(event, integration.serviceId, integration.id));
       }
+      await completeWebhookDelivery(deliveryClaim);
 
       const primaryResult = results[0] || { action: 'ignored' };
-
       logger.info('api.integration.grafana_success', {
         integrationId,
         action: primaryResult.action,
@@ -102,9 +91,8 @@ export async function POST(req: NextRequest) {
       });
       return jsonOk({ status: 'success', result: primaryResult, results }, 202);
     } catch (error: unknown) {
-      if (error instanceof IntegrationBodyTooLargeError) {
-        return jsonError(error.message, 413);
-      }
+      await failWebhookDelivery(deliveryClaim, error).catch(() => {});
+      if (error instanceof IntegrationBodyTooLargeError) return jsonError(error.message, 413);
       logger.error('api.integration.grafana_error', {
         error: error instanceof Error ? error.message : String(error),
       });

--- a/src/app/api/integrations/pagerduty/route.ts
+++ b/src/app/api/integrations/pagerduty/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { processEvent } from '@/lib/events';
@@ -7,17 +8,23 @@ import { checkRateLimit, createRateLimitHeaders } from '@/lib/integrations/rate-
 import { recordWebhookReceived } from '@/lib/integrations/metrics';
 import {
   IntegrationBodyTooLargeError,
+  claimWebhookDelivery,
+  completeWebhookDelivery,
+  failWebhookDelivery,
   readIntegrationBody,
+  webhookDeliveryResponse,
+  type WebhookDeliveryClaim,
 } from '@/lib/integrations/request-security';
 
 export async function POST(req: NextRequest) {
   const startTime = performance.now();
   let integrationId: string | null = null;
+  let deliveryClaim: WebhookDeliveryClaim = { tracked: false };
 
   try {
     const { searchParams } = new URL(req.url);
     const rawBody = await readIntegrationBody(req);
-    let body: any;
+    let body: unknown;
     try {
       body = JSON.parse(rawBody);
     } catch {
@@ -59,14 +66,9 @@ export async function POST(req: NextRequest) {
     }
 
     const integration = paramId
-      ? await prisma.integration.findUnique({
-          where: { id: paramId },
-        })
+      ? await prisma.integration.findUnique({ where: { id: paramId } })
       : await prisma.integration.findFirst({
-          where: {
-            key: providedKey || '',
-            enabled: true,
-          },
+          where: { key: providedKey || '', enabled: true, type: 'PAGERDUTY' },
         });
 
     if (!integration || !integration.enabled) {
@@ -74,6 +76,15 @@ export async function POST(req: NextRequest) {
         JSON.stringify({ status: 'error', message: 'Integration not found or disabled' }),
         { status: 404, headers: { 'Content-Type': 'application/json' } }
       );
+    }
+
+    // A routing key is scoped to its configured provider. Do not let a key for
+    // another integration type enter PagerDuty's parser/domain adapter.
+    if (integration.type !== 'PAGERDUTY') {
+      return new Response(JSON.stringify({ status: 'error', message: 'Invalid integration key' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     const { safeCompare } = await import('@/lib/integrations/signature-verification');
@@ -85,11 +96,8 @@ export async function POST(req: NextRequest) {
     }
 
     integrationId = integration.id;
-
-    // Rate limit
     const rateResult = await checkRateLimit(integration.id);
     if (!rateResult.allowed) {
-      const headers = createRateLimitHeaders(rateResult);
       recordWebhookReceived(
         'PAGERDUTY',
         integration.id,
@@ -99,46 +107,54 @@ export async function POST(req: NextRequest) {
       );
       return new Response(JSON.stringify({ status: 'error', message: 'Rate limit exceeded' }), {
         status: 429,
-        headers: { 'Content-Type': 'application/json', ...headers },
+        headers: { 'Content-Type': 'application/json', ...createRateLimitHeaders(rateResult) },
       });
     }
 
+    // Events API v2 payloads do not always carry a delivery UUID. Prefer one
+    // when present, otherwise derive a stable composite from the action,
+    // deduplication key and exact signed/received body. This identifies a retry
+    // without collapsing a later, materially different lifecycle event.
+    const explicitDeliveryId = req.headers.get('x-request-id') || req.headers.get('x-pagerduty-delivery');
+    const dedupKey = typeof payload.dedup_key === 'string' ? payload.dedup_key : '';
+    const action = typeof payload.event_action === 'string' ? payload.event_action : 'event';
+    const compositeDeliveryId = dedupKey
+      ? `${action}:${dedupKey}:${createHash('sha256').update(rawBody).digest('hex')}`
+      : null;
+    deliveryClaim = await claimWebhookDelivery(
+      integration.id,
+      'pagerduty',
+      explicitDeliveryId || compositeDeliveryId
+    );
+    const claimedResponse = webhookDeliveryResponse(deliveryClaim);
+    if (claimedResponse) return claimedResponse;
+
     const event = transformPagerDutyToEvent(payload);
     const result = await processEvent(event, integration.serviceId, integration.id);
+    await completeWebhookDelivery(deliveryClaim);
 
     recordWebhookReceived('PAGERDUTY', integration.id, true, performance.now() - startTime);
-
     return new Response(
-      JSON.stringify({
-        status: 'success',
-        message: 'Event processed',
-        dedup_key: event.dedup_key,
-      }),
-      {
-        status: 202,
-        headers: { 'Content-Type': 'application/json' },
-      }
+      JSON.stringify({ status: 'success', message: 'Event processed', dedup_key: event.dedup_key, result }),
+      { status: 202, headers: { 'Content-Type': 'application/json' } }
     );
   } catch (error) {
+    await failWebhookDelivery(deliveryClaim, error).catch(() => {});
     if (error instanceof IntegrationBodyTooLargeError) {
       return new Response(JSON.stringify({ status: 'error', message: error.message }), {
         status: 413,
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    const duration = performance.now() - startTime;
     recordWebhookReceived(
       'PAGERDUTY',
       integrationId || 'unknown',
       false,
-      duration,
+      performance.now() - startTime,
       'INTERNAL_ERROR'
     );
     return new Response(
-      JSON.stringify({
-        status: 'error',
-        message: error instanceof Error ? error.message : 'Internal error',
-      }),
+      JSON.stringify({ status: 'error', message: 'Internal server error' }),
       { status: 500, headers: { 'Content-Type': 'application/json' } }
     );
   }

--- a/src/app/api/integrations/sentry/route.ts
+++ b/src/app/api/integrations/sentry/route.ts
@@ -11,42 +11,34 @@ import { withIntegrationMiddleware } from '@/lib/integrations/handler';
 import { validatePayload, SentryEventSchema } from '@/lib/integrations/schemas';
 import {
   IntegrationBodyTooLargeError,
+  claimWebhookDelivery,
+  completeWebhookDelivery,
+  failWebhookDelivery,
   readIntegrationBody,
-  rejectWebhookReplay,
+  webhookDeliveryResponse,
+  type WebhookDeliveryClaim,
 } from '@/lib/integrations/request-security';
 
 const VERIFY_SIGNATURES = process.env.INTEGRATION_VERIFY_SIGNATURES !== 'false';
 
-/**
- * Sentry Webhook Endpoint
- * POST /api/integrations/sentry?integrationId=xxx
- */
+/** Sentry webhook endpoint. */
 export async function POST(req: NextRequest) {
   return withIntegrationMiddleware(req, 'SENTRY', async () => {
     const startTime = Date.now();
+    let deliveryClaim: WebhookDeliveryClaim = { tracked: false };
 
     try {
       const { searchParams } = new URL(req.url);
       const integrationId = searchParams.get('integrationId');
-
-      if (!integrationId) {
-        return jsonError('integrationId is required', 400);
-      }
+      if (!integrationId) return jsonError('integrationId is required', 400);
 
       const rawBody = await readIntegrationBody(req);
-
       const integration = await prisma.integration.findUnique({
         where: { id: integrationId },
         include: { service: true },
       });
-
-      if (!integration) {
-        return jsonError('Integration not found', 404);
-      }
-
-      if (!integration.enabled) {
-        return jsonError('Integration is disabled', 403);
-      }
+      if (!integration) return jsonError('Integration not found', 404);
+      if (!integration.enabled) return jsonError('Integration is disabled', 403);
 
       if (VERIFY_SIGNATURES && integration.signatureSecret) {
         const signature = req.headers.get('sentry-hook-signature');
@@ -60,34 +52,33 @@ export async function POST(req: NextRequest) {
           return jsonError('Invalid webhook signature', 401);
         }
         const timestamp = req.headers.get('sentry-hook-timestamp');
-        if (
-          await rejectWebhookReplay(
-            integration.id,
-            req.headers.get('sentry-hook-id') || (timestamp ? `${timestamp}:${signature}` : null)
-          )
-        ) {
-          return jsonError('Duplicate webhook delivery', 409);
-        }
+        deliveryClaim = await claimWebhookDelivery(
+          integration.id,
+          'sentry',
+          req.headers.get('sentry-hook-id') || (timestamp ? `${timestamp}:${signature}` : null)
+        );
+        const claimedResponse = webhookDeliveryResponse(deliveryClaim);
+        if (claimedResponse) return claimedResponse;
       }
 
-      let body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      let body: unknown;
       try {
         body = JSON.parse(rawBody);
-      } catch (_error) {
+      } catch {
+        await failWebhookDelivery(deliveryClaim, new Error('Invalid JSON payload'));
         return jsonError('Invalid JSON in request body.', 400);
       }
 
       const validation = validatePayload(SentryEventSchema, body);
       if (!validation.success) {
-        logger.warn('api.integration.sentry_validation_failed', {
-          errors: validation.errors,
-          integrationId,
-        });
+        await failWebhookDelivery(deliveryClaim, new Error('Invalid Sentry webhook payload'));
+        logger.warn('api.integration.sentry_validation_failed', { errors: validation.errors, integrationId });
         return jsonError('Invalid Sentry webhook payload', 400, { errors: validation.errors });
       }
 
       const event = transformSentryToEvent(validation.data as SentryEvent);
       const result = await processEvent(event, integration.serviceId, integration.id);
+      await completeWebhookDelivery(deliveryClaim);
 
       logger.info('api.integration.sentry_success', {
         integrationId,
@@ -96,9 +87,8 @@ export async function POST(req: NextRequest) {
       });
       return jsonOk({ status: 'success', result }, 202);
     } catch (error: unknown) {
-      if (error instanceof IntegrationBodyTooLargeError) {
-        return jsonError(error.message, 413);
-      }
+      await failWebhookDelivery(deliveryClaim, error).catch(() => {});
+      if (error instanceof IntegrationBodyTooLargeError) return jsonError(error.message, 413);
       logger.error('api.integration.sentry_error', {
         error: error instanceof Error ? error.message : String(error),
       });

--- a/src/app/api/slack/commands/route.ts
+++ b/src/app/api/slack/commands/route.ts
@@ -1,11 +1,18 @@
-import { after, NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
-import { handleSlashCommand } from '@/lib/chatops/slash-commands';
-import { verifySlackSignature, toSlackResponseUrl } from '@/lib/slack-signature';
+import { verifySlackSignature } from '@/lib/slack-signature';
+import { enqueueChatOpsIntent } from '@/lib/chatops/intent';
+import {
+  IntegrationBodyTooLargeError,
+  readIntegrationBody,
+} from '@/lib/integrations/request-security';
+
+const MAX_SLACK_COMMAND_BYTES = 64 * 1024;
+const MAX_SLACK_TEXT_LENGTH = 4_000;
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.text();
+    const body = await readIntegrationBody(request, MAX_SLACK_COMMAND_BYTES);
     const signature = request.headers.get('x-slack-signature') || '';
     const timestamp = request.headers.get('x-slack-request-timestamp') || '';
 
@@ -16,10 +23,17 @@ export async function POST(request: NextRequest) {
     }
 
     const params = new URLSearchParams(body);
+    const text = params.get('text') || '';
+    if (text.length > MAX_SLACK_TEXT_LENGTH) {
+      return NextResponse.json(
+        { response_type: 'ephemeral', text: '⚠️ Command text is too long.' },
+        { status: 400 }
+      );
+    }
 
     const payload = {
       command: params.get('command') || '',
-      text: params.get('text') || '',
+      text,
       channel_id: params.get('channel_id') || '',
       channel_name: params.get('channel_name') || '',
       user_id: params.get('user_id') || '',
@@ -28,56 +42,34 @@ export async function POST(request: NextRequest) {
       response_url: params.get('response_url') || '',
     };
 
-    const handlePromise = handleSlashCommand(payload);
-    const timeoutPromise = new Promise<{ timeout: true }>(resolve =>
-      setTimeout(() => resolve({ timeout: true }), 1500)
-    );
-
-    const raceResult = await Promise.race([handlePromise, timeoutPromise]);
-
-    if ('timeout' in raceResult && raceResult.timeout) {
-      // Processing taking longer than 1.5s -> finish in background and post to response_url
-      // Rebuilt against a literal origin, so this can only ever reach Slack
-      const responseUrl = toSlackResponseUrl(payload.response_url);
-      after(async () => {
-        try {
-          const result = await handlePromise;
-          // Attacker-controlled input — only ever POST back to Slack's own host
-          if (responseUrl && result) {
-            try {
-              await fetch(responseUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(result),
-              });
-            } catch (err) {
-              logger.error('[Slack] Failed to post async command response to response_url', {
-                error: err,
-              });
-            }
-          }
-        } catch (err) {
-          logger.error('[Slack] Error in async slash command processing', { error: err });
-        }
-      });
-
-      // Return immediate HTTP 200 to Slack within 1.5s to prevent 3000ms operation_timeout
-      return NextResponse.json({
-        response_type: 'ephemeral',
-        text: '⚙️ Processing `/incident` command...',
-      });
+    if (!payload.team_id || !payload.user_id || !payload.channel_id) {
+      return NextResponse.json({ error: 'Missing Slack request identity' }, { status: 400 });
     }
 
-    return NextResponse.json(await handlePromise);
-  } catch (error: any) {
-    logger.error('[Slack] Commands API error', {
-      error: error.message,
-      stack: error.stack,
+    // Acknowledge Slack only after a durable, encrypted intent exists. The
+    // deterministic signature/timestamp identity makes Slack retries idempotent
+    // across replicas and process restarts.
+    await enqueueChatOpsIntent({
+      kind: 'SLASH_COMMAND',
+      workspaceId: payload.team_id,
+      requestIdentity: `${timestamp}:${signature}`,
+      payload,
     });
 
     return NextResponse.json({
       response_type: 'ephemeral',
-      text: 'An error occurred while processing your command.',
+      text: '⚙️ Processing `/incident` command...',
     });
+  } catch (error: unknown) {
+    if (error instanceof IntegrationBodyTooLargeError) {
+      return NextResponse.json({ error: 'Slack command payload too large' }, { status: 413 });
+    }
+    logger.error('[Slack] Commands API error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { response_type: 'ephemeral', text: 'An error occurred while accepting your command.' },
+      { status: 500 }
+    );
   }
 }

--- a/src/lib/chatops/authorization.ts
+++ b/src/lib/chatops/authorization.ts
@@ -1,0 +1,89 @@
+import 'server-only';
+
+import { isAppRole } from '@/lib/authorization';
+import {
+  AUTHORIZATION_ACTIONS,
+  authorize,
+  type AuthorizationAction,
+  type AuthorizationActor,
+  type AuthorizationResource,
+} from '@/lib/authorization-policy';
+import { AppError } from '@/lib/errors';
+import prisma from '@/lib/prisma';
+
+export type ChatOpsPermission = 'READ' | 'NOTE' | 'ACKNOWLEDGE' | 'MANAGE' | 'ESCALATE';
+
+const ACTIONS: Record<ChatOpsPermission, AuthorizationAction> = {
+  READ: AUTHORIZATION_ACTIONS.INCIDENT_READ,
+  NOTE: AUTHORIZATION_ACTIONS.INCIDENT_NOTE,
+  ACKNOWLEDGE: AUTHORIZATION_ACTIONS.INCIDENT_ACKNOWLEDGE,
+  MANAGE: AUTHORIZATION_ACTIONS.INCIDENT_MANAGE,
+  ESCALATE: AUTHORIZATION_ACTIONS.INCIDENT_ESCALATE,
+};
+
+export async function assertChatOpsIncidentPermission(input: {
+  userId: string;
+  incidentId: string;
+  permission: ChatOpsPermission;
+}): Promise<void> {
+  const [user, incident] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: input.userId },
+      select: {
+        id: true,
+        role: true,
+        status: true,
+        teamMemberships: { select: { teamId: true } },
+      },
+    }),
+    prisma.incident.findUnique({
+      where: { id: input.incidentId },
+      select: {
+        assigneeId: true,
+        teamId: true,
+        visibility: true,
+        watchers: { select: { userId: true } },
+        service: { select: { teamId: true } },
+      },
+    }),
+  ]);
+
+  if (!user || !isAppRole(user.role) || user.status !== 'ACTIVE') {
+    throw new AppError({
+      code: 'AUTHORIZATION_DENIED',
+      userMessage: 'Your OpsKnight account is not allowed to change this incident.',
+    });
+  }
+  if (!incident) {
+    throw new AppError({ code: 'INCIDENT_NOT_FOUND', userMessage: 'Incident not found.' });
+  }
+
+  const actor: AuthorizationActor = {
+    id: user.id,
+    role: user.role,
+    status: user.status,
+    teamIds: user.teamMemberships.map(membership => membership.teamId),
+  };
+  const resource: Extract<AuthorizationResource, { type: 'incident' }> = {
+    type: 'incident',
+    assigneeId: incident.assigneeId,
+    assignedTeamId: incident.teamId,
+    visibility: incident.visibility,
+    watcherIds: incident.watchers.map(watcher => watcher.userId),
+    serviceTeamId: incident.service.teamId,
+  };
+  const decision = authorize({ actor, action: ACTIONS[input.permission], resource });
+  if (!decision.allowed) {
+    throw new AppError({
+      code: input.permission === 'READ' ? 'INCIDENT_ACCESS_DENIED' : 'INCIDENT_MODIFY_DENIED',
+      userMessage: 'You do not have permission to perform this incident action.',
+      details: {
+        userId: input.userId,
+        incidentId: input.incidentId,
+        permission: input.permission,
+        reason: decision.reason,
+        source: 'CHATOPS',
+      },
+    });
+  }
+}

--- a/src/lib/chatops/intent.ts
+++ b/src/lib/chatops/intent.ts
@@ -1,0 +1,127 @@
+import 'server-only';
+
+import { createHash } from 'crypto';
+import prisma from '@/lib/prisma';
+import { decrypt, encrypt } from '@/lib/encryption';
+import { logger } from '@/lib/logger';
+import { toSlackResponseUrl } from '@/lib/slack-signature';
+
+export const CHATOPS_COMMAND_TASK = 'CHATOPS_COMMAND';
+const MAX_CHATOPS_PAYLOAD_BYTES = 128 * 1024;
+
+type ChatOpsIntentKind = 'SLASH_COMMAND' | 'INTERACTIVE_ACTION';
+
+type PersistedChatOpsIntent = {
+  task: typeof CHATOPS_COMMAND_TASK;
+  kind: ChatOpsIntentKind;
+  requestHash: string;
+  workspaceId: string;
+  encryptedPayload: string;
+};
+
+function stableIntentId(kind: ChatOpsIntentKind, workspaceId: string, requestIdentity: string): string {
+  const digest = createHash('sha256')
+    .update(`${kind}\0${workspaceId}\0${requestIdentity}`)
+    .digest('hex');
+  return `chatops:${digest}`;
+}
+
+export async function enqueueChatOpsIntent(input: {
+  kind: ChatOpsIntentKind;
+  workspaceId: string;
+  requestIdentity: string;
+  payload: unknown;
+}): Promise<{ id: string; duplicate: boolean }> {
+  if (!input.workspaceId.trim()) throw new Error('Slack workspace identity is required');
+  if (!input.requestIdentity.trim()) throw new Error('Slack request identity is required');
+
+  const serialized = JSON.stringify(input.payload);
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_CHATOPS_PAYLOAD_BYTES) {
+    throw new Error('Slack payload exceeds the durable command limit');
+  }
+
+  const id = stableIntentId(input.kind, input.workspaceId, input.requestIdentity);
+  const encryptedPayload = await encrypt(serialized);
+  const requestHash = createHash('sha256').update(input.requestIdentity).digest('hex');
+
+  try {
+    await prisma.backgroundJob.create({
+      data: {
+        id,
+        type: 'SCHEDULED_TASK',
+        status: 'PENDING',
+        scheduledAt: new Date(),
+        maxAttempts: 5,
+        payload: {
+          task: CHATOPS_COMMAND_TASK,
+          kind: input.kind,
+          requestHash,
+          workspaceId: input.workspaceId,
+          encryptedPayload,
+        },
+      },
+    });
+    return { id, duplicate: false };
+  } catch (error) {
+    // A deterministic primary key is the cross-replica idempotency fence. Only
+    // an actually-existing job is a duplicate; database failures still bubble.
+    const existing = await prisma.backgroundJob.findUnique({ where: { id }, select: { id: true } });
+    if (existing) return { id, duplicate: true };
+    throw error;
+  }
+}
+
+function parseIntent(payload: unknown): PersistedChatOpsIntent {
+  if (!payload || Array.isArray(payload) || typeof payload !== 'object') {
+    throw new Error('Invalid ChatOps job payload');
+  }
+  const value = payload as Record<string, unknown>;
+  if (
+    value.task !== CHATOPS_COMMAND_TASK ||
+    (value.kind !== 'SLASH_COMMAND' && value.kind !== 'INTERACTIVE_ACTION') ||
+    typeof value.requestHash !== 'string' ||
+    typeof value.workspaceId !== 'string' ||
+    typeof value.encryptedPayload !== 'string'
+  ) {
+    throw new Error('Invalid ChatOps job payload');
+  }
+  return value as PersistedChatOpsIntent;
+}
+
+async function postDeferredSlackResponse(responseUrl: unknown, body: unknown): Promise<void> {
+  const url = typeof responseUrl === 'string' ? toSlackResponseUrl(responseUrl) : null;
+  if (!url) return;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    redirect: 'error',
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`Slack deferred response failed with HTTP ${response.status}`);
+}
+
+/** Process one leased BackgroundJob. Throwing delegates retry/backoff/dead-letter to the queue. */
+export async function processChatOpsIntent(rawJobPayload: unknown): Promise<void> {
+  const intent = parseIntent(rawJobPayload);
+  const decrypted = await decrypt(intent.encryptedPayload);
+  const payload = JSON.parse(decrypted) as Record<string, unknown>;
+
+  if (intent.kind === 'SLASH_COMMAND') {
+    const { handleSlashCommand } = await import('@/lib/chatops/slash-commands');
+    const result = await handleSlashCommand(payload as any); // validated by the transport and handler
+    await postDeferredSlackResponse(payload.response_url, result);
+    return;
+  }
+
+  const { handleSlackActionRequest } = await import('@/app/api/slack/actions/route');
+  const result = await handleSlackActionRequest(payload as any);
+  const resultBody = await result.json();
+  await postDeferredSlackResponse(payload.response_url, resultBody);
+
+  logger.info('chatops.intent_completed', {
+    kind: intent.kind,
+    workspaceId: intent.workspaceId,
+    requestHash: intent.requestHash,
+  });
+}

--- a/src/lib/chatops/intent.ts
+++ b/src/lib/chatops/intent.ts
@@ -5,6 +5,7 @@ import prisma from '@/lib/prisma';
 import { decrypt, encrypt } from '@/lib/encryption';
 import { logger } from '@/lib/logger';
 import { toSlackResponseUrl } from '@/lib/slack-signature';
+import type { SlashCommandPayload } from '@/lib/chatops/slash-commands';
 
 export const CHATOPS_COMMAND_TASK = 'CHATOPS_COMMAND';
 const MAX_CHATOPS_PAYLOAD_BYTES = 128 * 1024;
@@ -88,6 +89,21 @@ function parseIntent(payload: unknown): PersistedChatOpsIntent {
   return value as PersistedChatOpsIntent;
 }
 
+function isSlashCommandPayload(value: unknown): value is SlashCommandPayload {
+  if (!value || Array.isArray(value) || typeof value !== 'object') return false;
+  const payload = value as Record<string, unknown>;
+  return (
+    typeof payload.command === 'string' &&
+    typeof payload.text === 'string' &&
+    typeof payload.channel_id === 'string' &&
+    typeof payload.channel_name === 'string' &&
+    typeof payload.user_id === 'string' &&
+    typeof payload.user_name === 'string' &&
+    typeof payload.team_id === 'string' &&
+    typeof payload.response_url === 'string'
+  );
+}
+
 async function postDeferredSlackResponse(responseUrl: unknown, body: unknown): Promise<void> {
   const url = typeof responseUrl === 'string' ? toSlackResponseUrl(responseUrl) : null;
   if (!url) return;
@@ -108,9 +124,11 @@ export async function processChatOpsIntent(rawJobPayload: unknown): Promise<void
   const payload = JSON.parse(decrypted) as Record<string, unknown>;
 
   if (intent.kind === 'SLASH_COMMAND') {
+    if (!isSlashCommandPayload(payload)) {
+      throw new Error('Invalid persisted Slack slash command payload');
+    }
     const { handleSlashCommand } = await import('@/lib/chatops/slash-commands');
-    const slashPayload = payload as Parameters<typeof handleSlashCommand>[0];
-    const result = await handleSlashCommand(slashPayload);
+    const result = await handleSlashCommand(payload);
     await postDeferredSlackResponse(payload.response_url, result);
     return;
   }

--- a/src/lib/chatops/intent.ts
+++ b/src/lib/chatops/intent.ts
@@ -109,13 +109,15 @@ export async function processChatOpsIntent(rawJobPayload: unknown): Promise<void
 
   if (intent.kind === 'SLASH_COMMAND') {
     const { handleSlashCommand } = await import('@/lib/chatops/slash-commands');
-    const result = await handleSlashCommand(payload as any); // validated by the transport and handler
+    const slashPayload = payload as Parameters<typeof handleSlashCommand>[0];
+    const result = await handleSlashCommand(slashPayload);
     await postDeferredSlackResponse(payload.response_url, result);
     return;
   }
 
   const { handleSlackActionRequest } = await import('@/app/api/slack/actions/route');
-  const result = await handleSlackActionRequest(payload as any);
+  const actionPayload = payload as Parameters<typeof handleSlackActionRequest>[0];
+  const result = await handleSlackActionRequest(actionPayload);
   const resultBody = await result.json();
   await postDeferredSlackResponse(payload.response_url, resultBody);
 

--- a/src/lib/chatops/slack-workspace.ts
+++ b/src/lib/chatops/slack-workspace.ts
@@ -1,0 +1,72 @@
+import 'server-only';
+
+import prisma from '@/lib/prisma';
+import { AppError } from '@/lib/errors';
+
+/**
+ * Assert that a signed Slack request came from the workspace installed for the
+ * incident's service. Signature verification proves Slack sent the request;
+ * this binding proves it came from the correct tenant.
+ *
+ * The check deliberately happens before token decryption/provider calls.
+ */
+export async function assertSlackWorkspaceForService(
+  serviceId: string,
+  requestWorkspaceId: string | null | undefined
+): Promise<void> {
+  const workspaceId = requestWorkspaceId?.trim();
+  if (!workspaceId) {
+    throw new AppError({
+      code: 'AUTHORIZATION_DENIED',
+      userMessage: 'Slack workspace identity is missing.',
+      details: { serviceId, source: 'SLACK' },
+    });
+  }
+
+  const service = await prisma.service.findUnique({
+    where: { id: serviceId },
+    select: {
+      slackWorkspaceId: true,
+      slackIntegration: {
+        select: { workspaceId: true, enabled: true },
+      },
+    },
+  });
+  if (!service) {
+    throw new AppError({ code: 'INTERNAL_ERROR', details: { reason: 'Service not found', serviceId } });
+  }
+
+  const configuredWorkspaceId =
+    (service.slackIntegration?.enabled ? service.slackIntegration.workspaceId : null) ||
+    service.slackWorkspaceId;
+
+  if (configuredWorkspaceId) {
+    if (configuredWorkspaceId !== workspaceId) {
+      throw new AppError({
+        code: 'AUTHORIZATION_DENIED',
+        userMessage: 'This Slack workspace is not connected to the incident service.',
+        details: { serviceId, source: 'SLACK', workspaceMismatch: true },
+      });
+    }
+    return;
+  }
+
+  // A service may intentionally inherit a global workspace integration. Require
+  // an enabled installation with the exact workspace ID; never accept "any
+  // signed workspace" merely because a global integration exists.
+  const globalIntegration = await prisma.slackIntegration.findFirst({
+    where: {
+      workspaceId,
+      enabled: true,
+      services: { none: {} },
+    },
+    select: { id: true },
+  });
+  if (!globalIntegration) {
+    throw new AppError({
+      code: 'AUTHORIZATION_DENIED',
+      userMessage: 'This Slack workspace is not connected to OpsKnight for this service.',
+      details: { serviceId, source: 'SLACK', workspaceMismatch: true },
+    });
+  }
+}

--- a/src/lib/integrations/handler.ts
+++ b/src/lib/integrations/handler.ts
@@ -1,12 +1,6 @@
 /**
  * Integration Handler Middleware
- *
- * Common middleware for all integration webhooks providing:
- * - Rate limiting
- * - Signature verification (optional)
- * - Payload validation
- * - Metrics recording
- * - Error handling
+ * Common policy for authenticated inbound integrations.
  */
 
 import { NextRequest } from 'next/server';
@@ -25,25 +19,23 @@ import type { z } from 'zod';
 import { decryptStoredSecret } from '@/lib/encryption';
 import {
   IntegrationBodyTooLargeError,
+  claimWebhookDelivery,
+  completeWebhookDelivery,
+  failWebhookDelivery,
   readIntegrationBody,
-  rejectWebhookReplay,
+  webhookDeliveryResponse,
+  type WebhookDeliveryClaim,
 } from './request-security';
 
 const VERIFY_SIGNATURES = process.env.INTEGRATION_VERIFY_SIGNATURES !== 'false';
 const RATE_LIMIT_ENABLED = process.env.INTEGRATION_RATE_LIMIT !== 'false';
-
 const LEGACY_NOT_FOUND_MESSAGE =
   'The requested item could not be found. It may have been deleted or you may not have access to it.';
 const LEGACY_INVALID_INPUT_MESSAGE = 'Please check your input and try again.';
 const LEGACY_REQUIRED_MESSAGE = 'Please fill in all required fields.';
 
 export interface IntegrationContext<T> {
-  integration: {
-    id: string;
-    type: string;
-    serviceId: string;
-    enabled: boolean;
-  };
+  integration: { id: string; type: string; serviceId: string; enabled: boolean };
   payload: T;
   rawPayload: string;
   headers: Record<string, string | null>;
@@ -67,50 +59,29 @@ export function createIntegrationHandler<T>(
     const startTime = performance.now();
     let integrationId: string | null = null;
     let integrationType: string = options.integrationType;
+    let deliveryClaim: WebhookDeliveryClaim = { tracked: false };
 
     try {
       const { searchParams } = new URL(req.url);
       integrationId = searchParams.get('integrationId');
-
-      if (!integrationId) {
-        throw IntegrationErrors.invalidPayload('integrationId is required');
-      }
+      if (!integrationId) throw IntegrationErrors.invalidPayload('integrationId is required');
 
       const integration = await prisma.integration.findUnique({
         where: { id: integrationId },
-        select: {
-          id: true,
-          type: true,
-          serviceId: true,
-          enabled: true,
-          signatureSecret: true,
-          key: true,
-        },
+        select: { id: true, type: true, serviceId: true, enabled: true, signatureSecret: true, key: true },
       });
-
-      if (!integration) {
-        throw IntegrationErrors.notFound(integrationId);
-      }
-
-      if (!integration.enabled) {
-        throw IntegrationErrors.unauthorized('Integration is disabled');
-      }
-
+      if (!integration) throw IntegrationErrors.notFound(integrationId);
+      if (!integration.enabled) throw IntegrationErrors.unauthorized('Integration is disabled');
       if (integration.type !== options.integrationType) {
-        throw IntegrationErrors.unauthorized(
-          `Integration type mismatch: expected ${options.integrationType}`
-        );
+        throw IntegrationErrors.unauthorized(`Integration type mismatch: expected ${options.integrationType}`);
       }
-
       if (!isIntegrationAuthorized(req, integration.key)) {
         throw IntegrationErrors.invalidPayload('Invalid integration key');
       }
-
       integrationType = integration.type;
 
       if (RATE_LIMIT_ENABLED && !options.skipRateLimit) {
         const rateResult = await checkRateLimit(integrationId);
-
         if (!rateResult.allowed) {
           const headers = createRateLimitHeaders(rateResult);
           recordWebhookReceived(
@@ -120,20 +91,14 @@ export function createIntegrationHandler<T>(
             performance.now() - startTime,
             'RATE_LIMITED'
           );
-
-          // Preserve the integration-specific wire contract for rate limits.
-          return new Response(
-            JSON.stringify({ error: 'RATE_LIMITED', message: 'Rate limit exceeded' }),
-            {
-              status: 429,
-              headers: { 'Content-Type': 'application/json', ...headers },
-            }
-          );
+          return new Response(JSON.stringify({ error: 'RATE_LIMITED', message: 'Rate limit exceeded' }), {
+            status: 429,
+            headers: { 'Content-Type': 'application/json', ...headers },
+          });
         }
       }
 
       const rawPayload = await readIntegrationBody(req);
-
       const headers: Record<string, string | null> = {
         'x-hub-signature-256': req.headers.get('x-hub-signature-256'),
         'x-gitlab-token': req.headers.get('x-gitlab-token'),
@@ -150,21 +115,17 @@ export function createIntegrationHandler<T>(
         const provider = options.signatureProvider || 'generic';
         const signatureSecret = await decryptStoredSecret(integration.signatureSecret);
         const sigResult = verifyWebhookSignature(provider, rawPayload, headers, signatureSecret);
-
         if (!sigResult.valid) {
           logger.warn('integration.signature_verification_failed', {
             integrationId,
             provider,
             error: sigResult.error,
           });
-
-          if (sigResult.error === 'EXPIRED_TIMESTAMP') {
-            throw IntegrationErrors.expiredTimestamp(300);
-          } else if (sigResult.error === 'MISSING_SIGNATURE') {
+          if (sigResult.error === 'EXPIRED_TIMESTAMP') throw IntegrationErrors.expiredTimestamp(300);
+          if (sigResult.error === 'MISSING_SIGNATURE') {
             throw IntegrationErrors.missingSignature('Expected signature header');
-          } else {
-            throw IntegrationErrors.invalidSignature();
           }
+          throw IntegrationErrors.invalidSignature();
         }
 
         let deliveryId = req.headers.get('x-github-delivery') || req.headers.get('x-request-id');
@@ -178,22 +139,20 @@ export function createIntegrationHandler<T>(
             const eventId = (JSON.parse(rawPayload) as { id?: unknown }).id;
             if (typeof eventId === 'string') deliveryId = eventId;
           } catch {
-            // Payload parsing below returns the canonical invalid-payload error.
+            // Canonical payload parsing below owns the user-facing error.
           }
         }
-        if (await rejectWebhookReplay(integration.id, deliveryId)) {
-          throw IntegrationErrors.invalidSignature({ reason: 'Duplicate webhook delivery' });
-        }
+
+        deliveryClaim = await claimWebhookDelivery(integration.id, provider, deliveryId);
+        const claimedResponse = webhookDeliveryResponse(deliveryClaim);
+        if (claimedResponse) return claimedResponse;
       }
 
       let body: unknown;
       try {
-        if (options.parsePayload) {
-          body = options.parsePayload(rawPayload);
-        } else {
-          body = JSON.parse(rawPayload);
-        }
-      } catch {
+        body = options.parsePayload ? options.parsePayload(rawPayload) : JSON.parse(rawPayload);
+      } catch (error) {
+        await failWebhookDelivery(deliveryClaim, error);
         throw IntegrationErrors.invalidPayload('Invalid JSON in request body');
       }
 
@@ -201,12 +160,13 @@ export function createIntegrationHandler<T>(
       if (schema) {
         const validation = validatePayload(schema as any, body); // eslint-disable-line @typescript-eslint/no-explicit-any
         if (!validation.success) {
+          await failWebhookDelivery(deliveryClaim, new Error('Integration payload validation failed'));
           throw IntegrationErrors.validationError(validation.errors);
         }
         body = validation.data;
       }
 
-      const ctx: IntegrationContext<T> = {
+      const result = await processor({
         integration: {
           id: integration.id,
           type: integration.type,
@@ -217,41 +177,24 @@ export function createIntegrationHandler<T>(
         rawPayload,
         headers,
         startTime,
-      };
-
-      const result = await processor(ctx);
+      });
+      await completeWebhookDelivery(deliveryClaim);
 
       recordWebhookReceived(integrationType, integrationId, true, performance.now() - startTime);
-
       return jsonOk({ status: 'success', result }, 202);
     } catch (error) {
+      await failWebhookDelivery(deliveryClaim, error).catch(() => {});
       if (error instanceof IntegrationBodyTooLargeError) {
         return jsonError(
-          new AppError({
-            code: 'PAYLOAD_TOO_LARGE',
-            userMessage: error.message,
-            cause: error,
-          })
+          new AppError({ code: 'PAYLOAD_TOO_LARGE', userMessage: error.message, cause: error })
         );
       }
       const latency = performance.now() - startTime;
-
       if (isIntegrationError(error)) {
-        if (integrationId) {
-          recordWebhookReceived(integrationType, integrationId, false, latency, error.code);
-        }
-
-        logger.warn('integration.webhook_error', {
-          integrationId,
-          code: error.code,
-          message: error.message,
-        });
-
+        if (integrationId) recordWebhookReceived(integrationType, integrationId, false, latency, error.code);
+        logger.warn('integration.webhook_error', { integrationId, code: error.code, message: error.message });
         const appError = integrationErrorToAppError(error);
         if (appError) return jsonError(appError);
-
-        // Preserve legacy behavior for the internal/rate-limited variants that
-        // have dedicated handling or should not expose new semantics here.
         return jsonError(error.message, error.statusCode);
       }
 
@@ -259,11 +202,7 @@ export function createIntegrationHandler<T>(
         integrationId,
         error: error instanceof Error ? error.message : String(error),
       });
-
-      if (integrationId) {
-        recordWebhookReceived(integrationType, integrationId, false, latency, 'INTERNAL_ERROR');
-      }
-
+      if (integrationId) recordWebhookReceived(integrationType, integrationId, false, latency, 'INTERNAL_ERROR');
       return jsonError('Internal Server Error', 500);
     }
   };
@@ -290,15 +229,12 @@ export async function withIntegrationMiddleware(
       })
     );
   }
-
   if (!integrationId) {
     return jsonError(
       new AppError({
         code: 'VALIDATION_FAILED',
         userMessage: LEGACY_REQUIRED_MESSAGE,
-        fields: [
-          { field: 'integrationId', code: 'required', message: 'integrationId is required' },
-        ],
+        fields: [{ field: 'integrationId', code: 'required', message: 'integrationId is required' }],
       })
     );
   }
@@ -307,76 +243,34 @@ export async function withIntegrationMiddleware(
     where: { id: integrationId },
     select: { key: true, enabled: true, type: true },
   });
-
   if (!integration) {
     logger.warn('integration.not_found', { integrationId });
-    recordWebhookReceived(
-      integrationType,
-      integrationId,
-      false,
-      performance.now() - startTime,
-      'NOT_FOUND'
-    );
+    recordWebhookReceived(integrationType, integrationId, false, performance.now() - startTime, 'NOT_FOUND');
     return jsonError(
-      new AppError({
-        code: 'INTEGRATION_NOT_FOUND',
-        userMessage: LEGACY_NOT_FOUND_MESSAGE,
-        details: { integrationId },
-      })
+      new AppError({ code: 'INTEGRATION_NOT_FOUND', userMessage: LEGACY_NOT_FOUND_MESSAGE, details: { integrationId } })
     );
   }
-
   if (!integration.enabled) {
     logger.warn('integration.disabled', { integrationId });
-    recordWebhookReceived(
-      integrationType,
-      integrationId,
-      false,
-      performance.now() - startTime,
-      'DISABLED'
-    );
+    recordWebhookReceived(integrationType, integrationId, false, performance.now() - startTime, 'DISABLED');
     return jsonError(
-      new AppError({
-        code: 'INTEGRATION_DISABLED',
-        userMessage: 'Integration is disabled',
-        details: { integrationId },
-      })
+      new AppError({ code: 'INTEGRATION_DISABLED', userMessage: 'Integration is disabled', details: { integrationId } })
     );
   }
-
-  // A routing key is scoped to one configured provider. Without this check a
-  // key for one integration could be submitted to a different provider route
-  // and handled with that route's parser and signature policy.
   if (integration.type !== integrationType) {
     logger.warn('integration.type_mismatch', {
       integrationId,
       expectedType: integrationType,
       actualType: integration.type,
     });
-    recordWebhookReceived(
-      integrationType,
-      integrationId,
-      false,
-      performance.now() - startTime,
-      'UNAUTHORIZED'
-    );
+    recordWebhookReceived(integrationType, integrationId, false, performance.now() - startTime, 'UNAUTHORIZED');
     return jsonError(
-      new AppError({
-        code: 'INTEGRATION_AUTHENTICATION_FAILED',
-        userMessage: LEGACY_INVALID_INPUT_MESSAGE,
-      })
+      new AppError({ code: 'INTEGRATION_AUTHENTICATION_FAILED', userMessage: LEGACY_INVALID_INPUT_MESSAGE })
     );
   }
-
   if (!isIntegrationAuthorized(req, integration.key)) {
     logger.warn('integration.invalid_key', { integrationId });
-    recordWebhookReceived(
-      integrationType,
-      integrationId,
-      false,
-      performance.now() - startTime,
-      'UNAUTHORIZED'
-    );
+    recordWebhookReceived(integrationType, integrationId, false, performance.now() - startTime, 'UNAUTHORIZED');
     return jsonError(
       new AppError({
         code: 'INTEGRATION_AUTHENTICATION_FAILED',
@@ -389,36 +283,27 @@ export async function withIntegrationMiddleware(
   if (RATE_LIMIT_ENABLED) {
     const rateResult = await checkRateLimit(integrationId);
     if (!rateResult.allowed) {
-      recordWebhookReceived(
-        integrationType,
-        integrationId,
-        false,
-        performance.now() - startTime,
-        'RATE_LIMITED'
-      );
-      return new Response(
-        JSON.stringify({ error: 'RATE_LIMITED', message: 'Rate limit exceeded' }),
-        {
-          status: 429,
-          headers: { 'Content-Type': 'application/json', ...createRateLimitHeaders(rateResult) },
-        }
-      );
+      recordWebhookReceived(integrationType, integrationId, false, performance.now() - startTime, 'RATE_LIMITED');
+      return new Response(JSON.stringify({ error: 'RATE_LIMITED', message: 'Rate limit exceeded' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json', ...createRateLimitHeaders(rateResult) },
+      });
     }
   }
 
   try {
     const response = await handler();
-    const success = response.status >= 200 && response.status < 300;
-    recordWebhookReceived(integrationType, integrationId, success, performance.now() - startTime);
+    recordWebhookReceived(
+      integrationType,
+      integrationId,
+      response.status >= 200 && response.status < 300,
+      performance.now() - startTime
+    );
     return response;
   } catch (error) {
     if (error instanceof IntegrationBodyTooLargeError) {
       return jsonError(
-        new AppError({
-          code: 'PAYLOAD_TOO_LARGE',
-          userMessage: error.message,
-          cause: error,
-        })
+        new AppError({ code: 'PAYLOAD_TOO_LARGE', userMessage: error.message, cause: error })
       );
     }
     logger.error('integration.handler_error', {
@@ -426,13 +311,7 @@ export async function withIntegrationMiddleware(
       integrationType,
       error: error instanceof Error ? error.message : String(error),
     });
-    recordWebhookReceived(
-      integrationType,
-      integrationId,
-      false,
-      performance.now() - startTime,
-      'ERROR'
-    );
+    recordWebhookReceived(integrationType, integrationId, false, performance.now() - startTime, 'ERROR');
     throw error;
   }
 }

--- a/src/lib/integrations/request-security.ts
+++ b/src/lib/integrations/request-security.ts
@@ -3,7 +3,9 @@ import type { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 
 export const MAX_INTEGRATION_BODY_BYTES = 1024 * 1024;
-const REPLAY_WINDOW_MS = 24 * 60 * 60 * 1000;
+const WEBHOOK_DELIVERY_TASK = 'INBOUND_INTEGRATION_DELIVERY';
+const WEBHOOK_DELIVERY_LEASE_MS = 5 * 60 * 1000;
+const MAX_RECORDED_ERROR_LENGTH = 1000;
 
 export class IntegrationBodyTooLargeError extends Error {
   constructor() {
@@ -43,29 +45,154 @@ export async function readIntegrationBody(
   }
 }
 
-export async function rejectWebhookReplay(
+export type WebhookDeliveryClaim =
+  | { tracked: false }
+  | {
+      tracked: true;
+      id: string;
+      state: 'ACQUIRED' | 'SUCCEEDED' | 'IN_PROGRESS';
+    };
+
+function deliveryRecordId(integrationId: string, provider: string, deliveryId: string): string {
+  const fingerprint = createHash('sha256')
+    .update(`${provider}\0${integrationId}\0${deliveryId}`)
+    .digest('hex');
+  return `inbound-delivery:${fingerprint}`;
+}
+
+/**
+ * Claim a provider delivery before business processing.
+ *
+ * Unlike the old replay tombstone, this is a durable inbox lease:
+ * - COMPLETED means the delivery already committed successfully and is a safe no-op.
+ * - PROCESSING with a live lease means another replica owns it.
+ * - FAILED or an expired PROCESSING lease can be reclaimed by a provider retry.
+ *
+ * The provider nonce is hashed before persistence so request identifiers that may
+ * contain sensitive provider metadata are never stored verbatim.
+ */
+export async function claimWebhookDelivery(
   integrationId: string,
+  provider: string,
   deliveryId?: string | null
-): Promise<boolean> {
-  // A body/signature is not a delivery nonce: providers legitimately resend
-  // identical state notifications. Only claim an explicit provider delivery
-  // ID (or a signed timestamp+signature tuple supplied by the caller).
+): Promise<WebhookDeliveryClaim> {
   const nonce = deliveryId?.trim();
-  if (!nonce) return false;
-  const fingerprint = createHash('sha256').update(`${integrationId}\0${nonce}`).digest('hex');
-  const key = `webhook-replay:${fingerprint}`;
+  if (!nonce) return { tracked: false };
+
+  const id = deliveryRecordId(integrationId, provider, nonce);
   const now = new Date();
-  const expiresAt = new Date(now.getTime() + REPLAY_WINDOW_MS);
+  const leaseExpiredBefore = new Date(now.getTime() - WEBHOOK_DELIVERY_LEASE_MS);
+  const deliveryHash = createHash('sha256').update(nonce).digest('hex');
+
   try {
-    await prisma.rateLimit.create({ data: { key, count: 1, expiresAt } });
-    return false;
-  } catch {
-    // Reclaim an expired nonce atomically. If no expired row was reclaimed,
-    // another request owns an unexpired claim and this delivery is a replay.
-    const reclaimed = await prisma.rateLimit.updateMany({
-      where: { key, expiresAt: { lte: now } },
-      data: { count: 1, expiresAt },
+    await prisma.backgroundJob.create({
+      data: {
+        id,
+        type: 'SCHEDULED_TASK',
+        status: 'PROCESSING',
+        scheduledAt: now,
+        startedAt: now,
+        attempts: 1,
+        // Provider retries, not the generic worker, own retry cadence for inbox rows.
+        maxAttempts: 1000,
+        payload: {
+          task: WEBHOOK_DELIVERY_TASK,
+          integrationId,
+          provider,
+          deliveryHash,
+        },
+      },
     });
-    return reclaimed.count === 0;
+    return { tracked: true, id, state: 'ACQUIRED' };
+  } catch {
+    const existing = await prisma.backgroundJob.findUnique({
+      where: { id },
+      select: { status: true },
+    });
+
+    if (existing?.status === 'COMPLETED') {
+      return { tracked: true, id, state: 'SUCCEEDED' };
+    }
+
+    const reclaimed = await prisma.backgroundJob.updateMany({
+      where: {
+        id,
+        OR: [
+          { status: 'FAILED' },
+          { status: 'PROCESSING', startedAt: { lte: leaseExpiredBefore } },
+        ],
+      },
+      data: {
+        status: 'PROCESSING',
+        startedAt: now,
+        completedAt: null,
+        failedAt: null,
+        error: null,
+        attempts: { increment: 1 },
+      },
+    });
+
+    if (reclaimed.count === 1) {
+      return { tracked: true, id, state: 'ACQUIRED' };
+    }
+
+    // Re-read after the conditional update so a concurrent owner that completed
+    // between our first read and reclaim attempt is recognized as a success.
+    const current = await prisma.backgroundJob.findUnique({
+      where: { id },
+      select: { status: true },
+    });
+    if (current?.status === 'COMPLETED') {
+      return { tracked: true, id, state: 'SUCCEEDED' };
+    }
+
+    return { tracked: true, id, state: 'IN_PROGRESS' };
   }
+}
+
+export async function completeWebhookDelivery(claim: WebhookDeliveryClaim): Promise<void> {
+  if (!claim.tracked || claim.state !== 'ACQUIRED') return;
+  await prisma.backgroundJob.updateMany({
+    where: { id: claim.id, status: 'PROCESSING' },
+    data: {
+      status: 'COMPLETED',
+      completedAt: new Date(),
+      failedAt: null,
+      error: null,
+    },
+  });
+}
+
+export async function failWebhookDelivery(
+  claim: WebhookDeliveryClaim,
+  error: unknown
+): Promise<void> {
+  if (!claim.tracked || claim.state !== 'ACQUIRED') return;
+  const message = (error instanceof Error ? error.message : String(error)).slice(
+    0,
+    MAX_RECORDED_ERROR_LENGTH
+  );
+  await prisma.backgroundJob.updateMany({
+    where: { id: claim.id, status: 'PROCESSING' },
+    data: {
+      status: 'FAILED',
+      failedAt: new Date(),
+      completedAt: null,
+      error: message || 'Inbound integration processing failed',
+    },
+  });
+}
+
+export function webhookDeliveryResponse(claim: WebhookDeliveryClaim): Response | null {
+  if (!claim.tracked || claim.state === 'ACQUIRED') return null;
+  if (claim.state === 'SUCCEEDED') {
+    return new Response(JSON.stringify({ status: 'duplicate', processed: true }), {
+      status: 202,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return new Response(JSON.stringify({ status: 'processing', retry: true }), {
+    status: 503,
+    headers: { 'Content-Type': 'application/json', 'Retry-After': '1' },
+  });
 }

--- a/tests/lib/integration-request-security.test.ts
+++ b/tests/lib/integration-request-security.test.ts
@@ -1,44 +1,121 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const rateLimit = vi.hoisted(() => ({
+const backgroundJob = vi.hoisted(() => ({
   create: vi.fn(),
+  findUnique: vi.fn(),
   updateMany: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => ({
-  default: { rateLimit },
+  default: { backgroundJob },
 }));
 
-import { rejectWebhookReplay } from '@/lib/integrations/request-security';
+import {
+  claimWebhookDelivery,
+  completeWebhookDelivery,
+  failWebhookDelivery,
+} from '@/lib/integrations/request-security';
 
-describe('integration replay claims', () => {
+describe('durable inbound integration delivery claims', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    rateLimit.create.mockResolvedValue({});
-    rateLimit.updateMany.mockResolvedValue({ count: 0 });
+    backgroundJob.create.mockResolvedValue({});
+    backgroundJob.findUnique.mockResolvedValue(null);
+    backgroundJob.updateMany.mockResolvedValue({ count: 0 });
   });
 
-  it('does not deduplicate identical bodies when the provider has no nonce', async () => {
-    expect(await rejectWebhookReplay('integration-1', null)).toBe(false);
-    expect(await rejectWebhookReplay('integration-1', null)).toBe(false);
-    expect(rateLimit.create).not.toHaveBeenCalled();
+  it('does not invent deduplication when the provider has no delivery identity', async () => {
+    expect(await claimWebhookDelivery('integration-1', 'provider', null)).toEqual({ tracked: false });
+    expect(backgroundJob.create).not.toHaveBeenCalled();
   });
 
-  it('rejects an unexpired duplicate provider delivery ID', async () => {
-    rateLimit.create.mockRejectedValueOnce(new Error('unique constraint'));
-
-    expect(await rejectWebhookReplay('integration-1', 'delivery-1')).toBe(true);
-    expect(rateLimit.updateMany).toHaveBeenCalledWith(
+  it('acquires a new provider delivery as PROCESSING', async () => {
+    const claim = await claimWebhookDelivery('integration-1', 'github', 'delivery-1');
+    expect(claim).toMatchObject({ tracked: true, state: 'ACQUIRED' });
+    expect(backgroundJob.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ expiresAt: { lte: expect.any(Date) } }),
+        data: expect.objectContaining({ status: 'PROCESSING', type: 'SCHEDULED_TASK' }),
       })
     );
   });
 
-  it('atomically reclaims an expired provider delivery ID', async () => {
-    rateLimit.create.mockRejectedValueOnce(new Error('unique constraint'));
-    rateLimit.updateMany.mockResolvedValueOnce({ count: 1 });
+  it('treats only a successfully completed delivery as a safe duplicate', async () => {
+    backgroundJob.create.mockRejectedValueOnce(new Error('unique constraint'));
+    backgroundJob.findUnique.mockResolvedValueOnce({ status: 'COMPLETED' });
 
-    expect(await rejectWebhookReplay('integration-1', 'delivery-1')).toBe(false);
+    expect(await claimWebhookDelivery('integration-1', 'github', 'delivery-1')).toMatchObject({
+      tracked: true,
+      state: 'SUCCEEDED',
+    });
+    expect(backgroundJob.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('does not allow two replicas to own a live delivery concurrently', async () => {
+    backgroundJob.create.mockRejectedValueOnce(new Error('unique constraint'));
+    backgroundJob.findUnique
+      .mockResolvedValueOnce({ status: 'PROCESSING' })
+      .mockResolvedValueOnce({ status: 'PROCESSING' });
+
+    expect(await claimWebhookDelivery('integration-1', 'github', 'delivery-1')).toMatchObject({
+      tracked: true,
+      state: 'IN_PROGRESS',
+    });
+  });
+
+  it('reclaims a failed delivery so a provider retry can process it', async () => {
+    backgroundJob.create.mockRejectedValueOnce(new Error('unique constraint'));
+    backgroundJob.findUnique.mockResolvedValueOnce({ status: 'FAILED' });
+    backgroundJob.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    expect(await claimWebhookDelivery('integration-1', 'github', 'delivery-1')).toMatchObject({
+      tracked: true,
+      state: 'ACQUIRED',
+    });
+    expect(backgroundJob.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ OR: expect.any(Array) }),
+        data: expect.objectContaining({ status: 'PROCESSING' }),
+      })
+    );
+  });
+
+  it('can reclaim a crashed owner after its PROCESSING lease expires', async () => {
+    backgroundJob.create.mockRejectedValueOnce(new Error('unique constraint'));
+    backgroundJob.findUnique.mockResolvedValueOnce({ status: 'PROCESSING' });
+    backgroundJob.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    const claim = await claimWebhookDelivery('integration-1', 'github', 'delivery-1');
+    expect(claim).toMatchObject({ tracked: true, state: 'ACQUIRED' });
+    expect(backgroundJob.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            expect.objectContaining({ status: 'PROCESSING', startedAt: { lte: expect.any(Date) } }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('marks a delivery completed only after the caller reports business success', async () => {
+    const claim = { tracked: true, id: 'inbound-delivery:test', state: 'ACQUIRED' } as const;
+    backgroundJob.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    await completeWebhookDelivery(claim);
+    expect(backgroundJob.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'COMPLETED' }) })
+    );
+  });
+
+  it('marks a failed processing attempt reclaimable instead of poisoning future retries', async () => {
+    const claim = { tracked: true, id: 'inbound-delivery:test', state: 'ACQUIRED' } as const;
+    backgroundJob.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    await failWebhookDelivery(claim, new Error('temporary database outage'));
+    expect(backgroundJob.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'FAILED', error: 'temporary database outage' }),
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary

Hardens OpsKnight's integration boundary against the highest-risk failure modes identified in the integration robustness audit.

### Included in this PR
- replace tombstone-style inbound replay handling with a durable PostgreSQL-backed delivery inbox lifecycle
- allow failed/expired inbound deliveries to be reclaimed instead of permanently suppressing provider retries
- make successful duplicate deliveries idempotent no-ops
- apply the retry-safe delivery lifecycle to GitHub, Sentry and Grafana webhooks
- harden PagerDuty ingestion with provider-type isolation and stable delivery identity
- replace Slack slash-command fire-and-forget execution with a persisted ChatOps intent before HTTP acknowledgement
- encrypt persisted Slack response capability data rather than storing response URLs in plaintext
- add durable ChatOps processing primitives on the existing PostgreSQL BackgroundJob control plane
- add Slack workspace validation helpers so service-bound actions can reject cross-workspace requests before lifecycle mutation
- bound Slack request payloads and fail closed on malformed input

## Reliability model

The implementation deliberately reuses OpsKnight's existing PostgreSQL control plane rather than adding Redis/Kafka. Delivery ownership and ChatOps intent execution therefore remain durable across process restart and are coordinated across replicas through the database.

## Security

- signature verification remains mandatory where configured
- provider type is validated before processing PagerDuty events
- Slack workspace identity is checked against the service's installed Slack integration
- encrypted-at-rest durable Slack response capability data
- bounded inbound payloads
- no arbitrary Slack response URL reconstruction outside Slack-controlled hosts

## Audit status

This PR targets the P0 integration-loss and ChatOps durability findings first. CI and review should be treated as required before merge. Production-like multi-replica kill/failover/provider-fault tests remain deployment evidence requirements and should not be inferred solely from unit/CI success.

## Commit history

The implementation branch was kept scoped to this hardening effort. Squash merge is recommended to retain a single logical commit on `main`.