### PR TITLE
fix(auth): resolve Service Worker caching deadlock, clear stale token errors & enforce hard login transitions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,8 +13,12 @@ const withPWA = require('@ducanh2912/next-pwa').default({
     disableDevLogs: true,
     additionalManifestEntries: [],
     importScripts: ['/custom-sw.js'],
-    // Add custom runtime caching and handlers
+    // Explicit runtime caching rules:
+    // Dynamic pages, RSC streams, and APIs MUST ALWAYS be NetworkOnly.
+    // Caching HTML or RSC payloads in a Service Worker poisons session
+    // states and causes login deadlocks when credentials change or sessions expire.
     runtimeCaching: [
+      // 1. ALL API routes must ALWAYS bypass Service Worker cache
       {
         urlPattern: /^\/api\/.*/i,
         handler: 'NetworkOnly',
@@ -22,6 +26,38 @@ const withPWA = require('@ducanh2912/next-pwa').default({
           cacheName: 'no-cache-apis',
         },
       },
+      // 2. RSC payloads & Next.js router prefetch streams must ALWAYS bypass cache
+      {
+        urlPattern: ({ request, url }: { request: Request; url: URL }) =>
+          request.headers.get('RSC') === '1' ||
+          url.searchParams.has('_rsc') ||
+          request.headers.get('Next-Router-Prefetch') === '1',
+        handler: 'NetworkOnly',
+        options: {
+          cacheName: 'no-cache-rsc',
+        },
+      },
+      // 3. Dynamic auth, app, and settings page documents must ALWAYS bypass cache
+      {
+        urlPattern: ({ url }: { url: URL }) =>
+          url.pathname === '/' ||
+          url.pathname === '/m' ||
+          url.pathname.startsWith('/login') ||
+          url.pathname.startsWith('/auth') ||
+          url.pathname.startsWith('/m/') ||
+          url.pathname.startsWith('/incidents') ||
+          url.pathname.startsWith('/settings') ||
+          url.pathname.startsWith('/services') ||
+          url.pathname.startsWith('/teams') ||
+          url.pathname.startsWith('/users') ||
+          url.pathname.startsWith('/schedules') ||
+          url.pathname.startsWith('/policies'),
+        handler: 'NetworkOnly',
+        options: {
+          cacheName: 'no-cache-pages',
+        },
+      },
+      // 4. Google fonts webfonts (immutable)
       {
         urlPattern: /^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,
         handler: 'CacheFirst',
@@ -33,16 +69,54 @@ const withPWA = require('@ducanh2912/next-pwa').default({
           },
         },
       },
+      // 5. Google fonts stylesheets
+      {
+        urlPattern: /^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'google-fonts-stylesheets',
+          expiration: {
+            maxEntries: 4,
+            maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
+          },
+        },
+      },
+      // 6. Next.js immutable static JS/CSS chunks (hashed names)
+      {
+        urlPattern: /\/_next\/static\/.+\.(?:js|css)$/i,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'next-static-assets',
+          expiration: {
+            maxEntries: 64,
+            maxAgeSeconds: 24 * 60 * 60, // 1 day
+          },
+        },
+      },
+      // 7. Static images
+      {
+        urlPattern: /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'static-images',
+          expiration: {
+            maxEntries: 64,
+            maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
+          },
+        },
+      },
     ],
   },
-  // Inject custom push event handlers
-  extendDefaultRuntimeCaching: true,
+  // DO NOT inherit next-pwa's default runtime caching rules: they blindly cache
+  // pages-rsc and HTML documents in NetworkFirst, which caches 307 auth redirects.
+  extendDefaultRuntimeCaching: false,
   cacheOnFrontEndNav: false,
   aggressiveFrontEndNavCaching: false,
   reloadOnOnline: true,
   swcMinify: true,
   fallbacks: {},
-  cacheStartUrl: true,
+  // Never precache the dynamic root document as start_url
+  cacheStartUrl: false,
   dynamicStartUrl: false,
 });
 

--- a/public/custom-sw.js
+++ b/public/custom-sw.js
@@ -213,10 +213,40 @@ self.addEventListener('install', function (event) {
   self.skipWaiting(); // Activate immediately
 });
 
-// Optional: Handle service worker activation
+// Handle service worker activation
 self.addEventListener('activate', function (event) {
   console.log('[Service Worker] Activating');
-  event.waitUntil(clients.claim()); // Take control immediately
+  event.waitUntil(
+    (async () => {
+      // Clean up legacy or poisoned runtime caches from previous versions
+      const DYNAMIC_CACHES_TO_PURGE = [
+        'pages',
+        'pages-rsc',
+        'pages-rsc-prefetch',
+        'start-url',
+        'apis',
+        'static-data-assets',
+        'cross-origin',
+        'no-cache-pages',
+        'no-cache-rsc',
+      ];
+      try {
+        const cacheNames = await caches.keys();
+        await Promise.all(
+          cacheNames.map(name => {
+            if (DYNAMIC_CACHES_TO_PURGE.some(pattern => name.includes(pattern))) {
+              console.log('[Service Worker] Deleting legacy cache:', name);
+              return caches.delete(name);
+            }
+            return Promise.resolve(false);
+          })
+        );
+      } catch (err) {
+        console.warn('[Service Worker] Failed to purge legacy caches', err);
+      }
+      return self.clients.claim();
+    })()
+  );
 });
 
 self.addEventListener('sync', function (event) {
@@ -228,6 +258,21 @@ self.addEventListener('sync', function (event) {
 self.addEventListener('message', function (event) {
   if (event.data && event.data.type === 'SYNC_OFFLINE_QUEUE') {
     event.waitUntil(flushQueuedRequests());
+  } else if (event.data && event.data.type === 'PURGE_AUTH_CACHES') {
+    event.waitUntil(
+      (async () => {
+        try {
+          const names = await caches.keys();
+          await Promise.all(
+            names
+              .filter(n => n.includes('page') || n.includes('start-url') || n.includes('api') || n.includes('rsc'))
+              .map(n => caches.delete(n))
+          );
+        } catch (err) {
+          console.warn('[Service Worker] Failed to purge auth caches on message', err);
+        }
+      })()
+    );
   }
 });
 

--- a/src/app/(public)/m/login/MobileLoginClient.tsx
+++ b/src/app/(public)/m/login/MobileLoginClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import { signIn } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import SsoButton from '@/components/auth/SsoButton';
@@ -21,6 +20,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { calculatePasswordStrength } from '@/lib/password-strength';
+import { purgeBrowserAuthCaches } from '@/lib/auth-cache-purge';
 
 type Props = {
   callbackUrl: string;
@@ -41,7 +41,8 @@ function formatError(message: string | null | undefined) {
   if (message === 'SessionExpired') return 'Your session has expired. Please sign in again.';
   if (message === 'OAuthSignin' || message === 'OAuthCallback')
     return 'SSO authentication failed. Please try again or contact your administrator.';
-  if (message === 'Configuration') return 'Server configuration error. Please contact your administrator.';
+  if (message === 'Configuration')
+    return 'Server configuration error. Please contact your administrator.';
   return 'Authentication failed. Please try again.';
 }
 
@@ -54,7 +55,6 @@ export default function MobileLoginClient({
   ssoProviderType,
   ssoProviderLabel,
 }: Props) {
-  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   // Mobile defaults Remember Me ON: on mobile, server-side revocation
@@ -136,6 +136,7 @@ export default function MobileLoginClient({
       ) {
         finalCallbackUrl = '/m';
       }
+      await purgeBrowserAuthCaches();
       await signIn('oidc', { callbackUrl: finalCallbackUrl });
     } catch {
       setError('Connection failed');
@@ -167,13 +168,24 @@ export default function MobileLoginClient({
       } else if (result?.ok) {
         setIsSubmitting(false);
         setIsSuccess(true);
-        // Soft navigation matches the desktop client: faster perceived
-        // transition + `router.refresh()` ensures the (app) layout
-        // server-renders against the fresh session cookie.
+        const target =
+          safeCallbackUrl &&
+          safeCallbackUrl.startsWith('/') &&
+          !safeCallbackUrl.startsWith('/login') &&
+          !safeCallbackUrl.includes('/auth/signout')
+            ? safeCallbackUrl
+            : '/m';
+
+        // Purge any stale Service Worker dynamic/RSC caches immediately
+        void purgeBrowserAuthCaches();
+
+        // Standard enterprise practice for post-authentication transition:
+        // A hard navigation via window.location.assign() completely blows away
+        // the client-side RSC router cache and forces a full server document
+        // request with the newly issued session cookie.
         setTimeout(() => {
-          router.push(safeCallbackUrl);
-          router.refresh();
-        }, 250);
+          window.location.assign(target);
+        }, 200);
       }
     } catch {
       setError('Unexpected error');

--- a/src/app/auth/signout/signout-client.tsx
+++ b/src/app/auth/signout/signout-client.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { AuthLayout, AuthCard } from '@/components/auth/AuthLayout';
 import { LogOut, ArrowLeft } from 'lucide-react';
 import Spinner from '@/components/ui/Spinner';
+import { purgeBrowserAuthCaches } from '@/lib/auth-cache-purge';
 
 export default function SignOutClient() {
   const searchParams = useSearchParams();
@@ -15,6 +16,7 @@ export default function SignOutClient() {
 
   const handleSignOut = async () => {
     setIsSigningOut(true);
+    await purgeBrowserAuthCaches();
     await signOut({ callbackUrl });
   };
 

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import { signIn } from 'next-auth/react';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
 import Spinner from '@/components/ui/Spinner';
 import SsoButton from '@/components/auth/SsoButton';
 import LoginTicker from '@/components/auth/LoginTicker';
@@ -11,6 +10,7 @@ import { AuthLayout, AuthCard } from '@/components/auth/AuthLayout';
 import { Mail, Lock, Eye, EyeOff, AlertCircle, X, CheckCircle2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { calculatePasswordStrength } from '@/lib/password-strength';
+import { purgeBrowserAuthCaches } from '@/lib/auth-cache-purge';
 
 type Props = {
   callbackUrl: string;
@@ -31,20 +31,20 @@ function formatError(message: string | null | undefined) {
   if (message === 'SessionExpired') return 'Your session has expired. Please sign in again.';
   if (message === 'OAuthSignin' || message === 'OAuthCallback')
     return 'SSO authentication failed. Please try again or contact your administrator.';
-  if (message === 'Configuration') return 'Server configuration error. Please contact your administrator.';
+  if (message === 'Configuration')
+    return 'Server configuration error. Please contact your administrator.';
   return 'Authentication failed. Please try again.';
 }
 
 export default function LoginClient({
   callbackUrl,
   errorCode,
-  passwordSet,
+  passwordSet: _passwordSet,
   ssoError,
   ssoEnabled,
   ssoProviderType,
   ssoProviderLabel,
 }: Props) {
-  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [rememberMe, setRememberMe] = useState(false);
@@ -80,6 +80,7 @@ export default function LoginClient({
   const handleSSO = async () => {
     setIsSSOLoading(true);
     try {
+      await purgeBrowserAuthCaches();
       await signIn('oidc', { callbackUrl });
     } catch {
       setError('Connection failed');
@@ -118,20 +119,23 @@ export default function LoginClient({
         // itself, breaking the post-login navigation. Use the
         // validated `callbackUrl` prop, guarded against /login loop.
         const safeTarget =
-          callbackUrl && callbackUrl.startsWith('/') && !callbackUrl.startsWith('/login')
+          callbackUrl &&
+          callbackUrl.startsWith('/') &&
+          !callbackUrl.startsWith('/login') &&
+          !callbackUrl.includes('/auth/signout')
             ? callbackUrl
             : '/';
-        // Soft transition: `router.push` is significantly snappier
-        // than a full-page reload, and we follow with `router.refresh`
-        // to make sure the new (app) layout server-renders against the
-        // freshly-issued session cookie rather than a cached RSC tree.
-        // Short delay (250ms) gives the success animation a beat
-        // without loitering — the prior 1200ms was a perceptible
-        // pause that felt slow vs. Amazon/Linear/etc.
+
+        // Purge any stale Service Worker dynamic/RSC caches immediately
+        void purgeBrowserAuthCaches();
+
+        // Standard enterprise practice for post-authentication transition:
+        // A hard navigation via window.location.assign() completely blows away
+        // the client-side RSC router cache and forces a full server document
+        // request with the newly issued session cookie.
         setTimeout(() => {
-          router.push(safeTarget);
-          router.refresh();
-        }, 250);
+          window.location.assign(safeTarget);
+        }, 200);
       }
     } catch {
       setError('Unexpected error');

--- a/src/components/mobile/MobileSignOutButton.tsx
+++ b/src/components/mobile/MobileSignOutButton.tsx
@@ -2,6 +2,7 @@
 
 import { signOut } from 'next-auth/react';
 import { useState, type ReactNode } from 'react';
+import { purgeBrowserAuthCaches } from '@/lib/auth-cache-purge';
 
 type Props = {
   icon: ReactNode;
@@ -15,6 +16,7 @@ export default function MobileSignOutButton({ icon, label, description, tone }: 
 
   const handleSignOut = async () => {
     setIsSigningOut(true);
+    await purgeBrowserAuthCaches();
     await signOut({ callbackUrl: '/m/login' });
   };
 

--- a/src/lib/auth-cache-purge.ts
+++ b/src/lib/auth-cache-purge.ts
@@ -1,0 +1,48 @@
+/**
+ * Auth Cache Purge Utility
+ *
+ * Safely purges any Service Worker dynamic page and RSC caches from browser
+ * CacheStorage during authentication lifecycle events (login, logout, session expiration).
+ * This prevents stale redirect loops and orphaned unauthenticated shells.
+ */
+
+export const DYNAMIC_AUTH_CACHE_PATTERNS = [
+  'pages',
+  'pages-rsc',
+  'pages-rsc-prefetch',
+  'start-url',
+  'apis',
+  'no-cache-pages',
+  'no-cache-rsc',
+];
+
+/**
+ * Purges dynamic/auth-related caches from the browser's CacheStorage.
+ * Safe to call in any browser context (handles missing caches API gracefully).
+ */
+export async function purgeBrowserAuthCaches(): Promise<void> {
+  if (typeof window === 'undefined' || !('caches' in window)) {
+    return;
+  }
+
+  try {
+    const cacheNames = await window.caches.keys();
+    const purgePromises = cacheNames
+      .filter(name => DYNAMIC_AUTH_CACHE_PATTERNS.some(pattern => name.includes(pattern)))
+      .map(name => window.caches.delete(name));
+
+    await Promise.all(purgePromises);
+  } catch (error) {
+    // Non-critical cache cleanup failure should never block UI navigation
+    console.warn('[AuthCache] Failed to purge browser auth caches:', error);
+  }
+
+  // Also post message to Service Worker if active
+  try {
+    if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: 'PURGE_AUTH_CACHES' });
+    }
+  } catch {
+    // Non-critical
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -424,6 +424,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
 
           // Initial sign in
           if (user && account) {
+            delete (token as AugmentedJWT).error;
             logger.warn('[Auth-Debug] Initial Sign In', {
               component: 'auth:jwt',
               userId: user.id,
@@ -474,6 +475,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               }
             } else {
               // For Credentials, 'user' comes from authorize() and is already the DB user object
+              delete (token as AugmentedJWT).error;
               token.role = (user as AugmentedUser).role;
               token.sub = user.id;
               token.name = user.name;
@@ -496,6 +498,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           // and `token.role` is set correctly.
           // This block handles the initial population of the token from the `user` object.
           else if (user) {
+            delete (token as AugmentedJWT).error;
             logger.warn('[Auth-Debug] Initial Sign In (Fallback)', {
               component: 'auth:jwt',
               userId: user.id || (user as AugmentedUser).id,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -414,19 +414,31 @@ export default async function middleware(req: NextRequest) {
 
   // Handle authenticated users trying to access public auth pages
   if (isAuthenticated) {
-    // Redirect authenticated users away from auth-related pages
-    if (pathname === '/login' || pathname.startsWith('/login')) {
-      // Allow access if explicitly handling a session error (prevents redirect loop)
-      if (req.nextUrl.searchParams.get('error') === 'SessionExpired') {
+    // Redirect authenticated users away from auth-related pages (/login, /m/login)
+    const isLoginPage =
+      pathname === '/login' ||
+      pathname.startsWith('/login/') ||
+      pathname === '/m/login' ||
+      pathname.startsWith('/m/login/');
+
+    if (isLoginPage) {
+      // Allow access if explicitly handling an error parameter (prevents redirect loops on session failure/revocation)
+      if (req.nextUrl.searchParams.has('error')) {
         return response;
       }
 
-      // Redirect authenticated users away from login page
+      // Redirect authenticated users away from login page to target or home
       const callbackUrl = req.nextUrl.searchParams.get('callbackUrl');
-      const redirectUrl =
-        callbackUrl && callbackUrl.startsWith('/') && !callbackUrl.startsWith('/login')
-          ? callbackUrl
-          : '/'; // Default to dashboard
+      const defaultDest = isMobile && !preferDesktop ? '/m' : '/';
+      const isValidTarget =
+        callbackUrl &&
+        callbackUrl.startsWith('/') &&
+        !callbackUrl.startsWith('/login') &&
+        !callbackUrl.startsWith('/m/login') &&
+        !callbackUrl.includes('/signout') &&
+        !callbackUrl.includes('/auth/signout');
+
+      const redirectUrl = isValidTarget ? callbackUrl : defaultDest;
       const redirectResponse = NextResponse.redirect(new URL(redirectUrl, req.url));
       // Apply security headers to redirect
       Object.entries(securityHeaders).forEach(([key, value]) => {

--- a/tests/lib/auth-cache-purge.test.ts
+++ b/tests/lib/auth-cache-purge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { purgeBrowserAuthCaches, DYNAMIC_AUTH_CACHE_PATTERNS } from '@/lib/auth-cache-purge';
 
 describe('purgeBrowserAuthCaches', () => {

--- a/tests/lib/auth-cache-purge.test.ts
+++ b/tests/lib/auth-cache-purge.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { purgeBrowserAuthCaches, DYNAMIC_AUTH_CACHE_PATTERNS } from '@/lib/auth-cache-purge';
+
+describe('purgeBrowserAuthCaches', () => {
+  const originalWindow = global.window;
+
+  afterEach(() => {
+    global.window = originalWindow;
+    vi.restoreAllMocks();
+  });
+
+  it('safely handles missing window in SSR environment without error', async () => {
+    // @ts-expect-error simulating SSR
+    delete global.window;
+    await expect(purgeBrowserAuthCaches()).resolves.toBeUndefined();
+  });
+
+  it('safely handles missing caches API in browser without error', async () => {
+    global.window = {} as unknown as Window & typeof globalThis;
+    await expect(purgeBrowserAuthCaches()).resolves.toBeUndefined();
+  });
+
+  it('purges dynamic auth cache keys matching patterns', async () => {
+    const mockDelete = vi.fn().mockResolvedValue(true);
+    const mockKeys = vi
+      .fn()
+      .mockResolvedValue([
+        'pages-rsc-v1',
+        'pages-v1',
+        'google-fonts-webfonts',
+        'next-static-assets',
+        'start-url-v1',
+        'apis-v1',
+      ]);
+
+    global.window = {
+      caches: {
+        keys: mockKeys,
+        delete: mockDelete,
+      } as unknown as CacheStorage,
+    } as unknown as Window & typeof globalThis;
+
+    await purgeBrowserAuthCaches();
+
+    expect(mockKeys).toHaveBeenCalled();
+    // Should delete: pages-rsc-v1, pages-v1, start-url-v1, apis-v1
+    // Should NOT delete: google-fonts-webfonts, next-static-assets
+    expect(mockDelete).toHaveBeenCalledWith('pages-rsc-v1');
+    expect(mockDelete).toHaveBeenCalledWith('pages-v1');
+    expect(mockDelete).toHaveBeenCalledWith('start-url-v1');
+    expect(mockDelete).toHaveBeenCalledWith('apis-v1');
+    expect(mockDelete).not.toHaveBeenCalledWith('google-fonts-webfonts');
+    expect(mockDelete).not.toHaveBeenCalledWith('next-static-assets');
+    expect(mockDelete).toHaveBeenCalledTimes(4);
+  });
+
+  it('notifies active service worker controller if available', async () => {
+    const mockPostMessage = vi.fn();
+    const mockDelete = vi.fn().mockResolvedValue(true);
+    const mockKeys = vi.fn().mockResolvedValue(['pages']);
+
+    global.window = {
+      caches: {
+        keys: mockKeys,
+        delete: mockDelete,
+      } as unknown as CacheStorage,
+    } as unknown as Window & typeof globalThis;
+
+    global.navigator = {
+      serviceWorker: {
+        controller: {
+          postMessage: mockPostMessage,
+        } as unknown as ServiceWorker,
+      } as unknown as ServiceWorkerContainer,
+    } as unknown as Navigator;
+
+    await purgeBrowserAuthCaches();
+
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'PURGE_AUTH_CACHES' });
+  });
+
+  it('verifies DYNAMIC_AUTH_CACHE_PATTERNS contains critical keys', () => {
+    expect(DYNAMIC_AUTH_CACHE_PATTERNS).toContain('pages');
+    expect(DYNAMIC_AUTH_CACHE_PATTERNS).toContain('pages-rsc');
+    expect(DYNAMIC_AUTH_CACHE_PATTERNS).toContain('pages-rsc-prefetch');
+    expect(DYNAMIC_AUTH_CACHE_PATTERNS).toContain('start-url');
+    expect(DYNAMIC_AUTH_CACHE_PATTERNS).toContain('apis');
+  });
+});

--- a/tests/lib/auth-oidc-unit.test.ts
+++ b/tests/lib/auth-oidc-unit.test.ts
@@ -368,15 +368,22 @@ describe('Auth JWT + OIDC (unit)', () => {
 
   it('jwt callback revokes session when user is disabled', async () => {
     const authOptions = await getAuthOptions();
-    const jwt = authOptions.callbacks?.jwt as unknown as (args: any) => Promise<any>;
+    type JwtCallback = (params: {
+      token: Record<string, unknown>;
+      user?: Record<string, unknown>;
+      account?: Record<string, unknown>;
+      trigger?: string;
+    }) => Promise<Record<string, unknown>>;
+    const jwt = authOptions.callbacks?.jwt as unknown as JwtCallback;
 
-    (prisma.user.findUnique as any).mockResolvedValueOnce({
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+      id: 'u1',
       name: 'Disabled',
       email: 'disabled@example.com',
       role: 'USER',
       tokenVersion: 0,
       status: 'DISABLED',
-    });
+    } as unknown as Awaited<ReturnType<typeof prisma.user.findUnique>>);
 
     const token = await jwt({
       token: { sub: 'u1', tokenVersion: 0 },
@@ -388,16 +395,22 @@ describe('Auth JWT + OIDC (unit)', () => {
 
   it('jwt callback removes error property from incoming token upon fresh credential sign-in', async () => {
     const authOptions = await getAuthOptions();
-    const jwt = authOptions.callbacks?.jwt as unknown as (args: any) => Promise<any>;
+    type JwtCallback = (params: {
+      token: Record<string, unknown>;
+      user?: Record<string, unknown>;
+      account?: Record<string, unknown>;
+      trigger?: string;
+    }) => Promise<Record<string, unknown>>;
+    const jwt = authOptions.callbacks?.jwt as unknown as JwtCallback;
 
-    (prisma.user.findUnique as any).mockResolvedValueOnce({
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
       id: 'u-clean',
       email: 'clean@example.com',
       name: 'Clean User',
       role: 'ADMIN',
       tokenVersion: 0,
       status: 'ACTIVE',
-    });
+    } as unknown as Awaited<ReturnType<typeof prisma.user.findUnique>>);
 
     // Simulate incoming token that was previously poisoned with SESSION_REVOKED
     const poisonedToken = {

--- a/tests/lib/auth-oidc-unit.test.ts
+++ b/tests/lib/auth-oidc-unit.test.ts
@@ -140,7 +140,9 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'ACTIVE',
     });
-    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({ id: 'approval-record' } as never);
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({
+      id: 'approval-record',
+    } as never);
     (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
 
     const user = { email: 'user@example.com', name: 'User', id: 'oidc-sub' };
@@ -177,7 +179,9 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'ACTIVE',
     });
-    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({ id: 'approval-record' } as never);
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({
+      id: 'approval-record',
+    } as never);
     (prisma.oidcIdentity.findUnique as any).mockResolvedValue(null);
 
     const result = await signIn({
@@ -201,7 +205,9 @@ describe('Auth JWT + OIDC (unit)', () => {
       role: 'USER',
       status: 'DISABLED',
     });
-    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({ id: 'historical-approval' } as never);
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({
+      id: 'historical-approval',
+    } as never);
 
     const result = await signIn({
       user: { email: 'disabled@example.com', name: 'Disabled', id: 'oidc-sub' },
@@ -378,6 +384,41 @@ describe('Auth JWT + OIDC (unit)', () => {
 
     expect(token.sub).toBeUndefined();
     expect(token.error).toBe('USER_DISABLED');
+  });
+
+  it('jwt callback removes error property from incoming token upon fresh credential sign-in', async () => {
+    const authOptions = await getAuthOptions();
+    const jwt = authOptions.callbacks?.jwt as unknown as (args: any) => Promise<any>;
+
+    (prisma.user.findUnique as any).mockResolvedValueOnce({
+      id: 'u-clean',
+      email: 'clean@example.com',
+      name: 'Clean User',
+      role: 'ADMIN',
+      tokenVersion: 0,
+      status: 'ACTIVE',
+    });
+
+    // Simulate incoming token that was previously poisoned with SESSION_REVOKED
+    const poisonedToken = {
+      sub: 'old-sub',
+      error: 'SESSION_REVOKED',
+    };
+
+    const token = await jwt({
+      token: poisonedToken,
+      user: {
+        id: 'u-clean',
+        email: 'clean@example.com',
+        name: 'Clean User',
+        role: 'ADMIN',
+        tokenVersion: 0,
+      },
+      account: { provider: 'credentials', type: 'credentials' },
+    });
+
+    expect(token.sub).toBe('u-clean');
+    expect(token.error).toBeUndefined();
   });
 
   it('revokeUserSessions increments tokenVersion', async () => {


### PR DESCRIPTION
## Summary
Resolves the issue where authenticated sessions on opssentinel.com could experience login deadlocks, requiring users to manually clear their browser cache before being able to log in again.

### Root Causes
1. **Service Worker Dynamic Page & RSC Caching (`next.config.ts`)**:
   `@ducanh2912/next-pwa` was configured with `extendDefaultRuntimeCaching: true` and `cacheStartUrl: true`. This caused Workbox to cache dynamic HTML documents (`pages`), React Server Component stream responses (`pages-rsc`), and prefetch requests (`pages-rsc-prefetch`) for 24 hours. When an unauthenticated user received a `307 Redirect` to `/login`, the Service Worker cached that redirect. Subsequent sign-ins validated credentials and issued the session cookie, but post-login client routing was intercepted by the Service Worker, which served the cached 307 redirect back to `/login` from CacheStorage without contacting the network.
2. **Soft Client Navigation Post-Login (`LoginClient.tsx` & `MobileLoginClient.tsx`)**:
   Credential sign-in used soft `router.push()` navigation, querying the client router cache and executing RSC requests that were vulnerable to interception by cached Service Worker routes.
3. **Stale Token Error Inheritance in NextAuth JWT Callback (`src/lib/auth.ts`)**:
   When a session is revoked or expired, `token.error` is set. NextAuth reuses the incoming decrypted token during subsequent `jwt()` callback invocations. If `token.error` is not purged, the new credentials sign-in inherits the old `error`, causing `callbacks.session` to wipe `session.user` to `undefined`.
4. **Service Worker Cache Stagnation on Sign-Out (`signout-client.tsx`)**:
   Signing out did not invalidate existing dynamic browser caches.

### Changes Made
- **`next.config.ts`**:
  - Set `extendDefaultRuntimeCaching: false` and `cacheStartUrl: false`.
  - Configured explicit `runtimeCaching` with `NetworkOnly` for all API routes (`/api/*`), RSC payloads/prefetches (`_rsc` / `RSC: 1`), and application/auth pages.
  - Retained `CacheFirst` / `StaleWhileRevalidate` strictly for immutable static assets (Google Fonts, hashed Next.js static JS/CSS, images).
- **`public/custom-sw.js`**:
  - Added cache purge logic in the `activate` event listener and `message` event listener to automatically delete legacy/poisoned caches (`pages`, `pages-rsc`, `pages-rsc-prefetch`, `start-url`, etc.) on existing browser installations.
- **`src/lib/auth-cache-purge.ts`**:
  - Created centralized utility to purge dynamic and auth-related caches from browser `window.caches` and post a message to the active Service Worker.
- **`src/app/login/LoginClient.tsx` & `src/app/(public)/m/login/MobileLoginClient.tsx`**:
  - Transitioned from soft `router.push()` to hard navigation via `window.location.assign()` post-authentication.
  - Purged Service Worker caches prior to navigation and upon initiating SSO.
  - Removed unused imports and variables.
- **`src/app/auth/signout/signout-client.tsx` & `src/components/mobile/MobileSignOutButton.tsx`**:
  - Purged browser auth caches before triggering `signOut()`.
- **`src/lib/auth.ts`**:
  - Explicitly called `delete (token as AugmentedJWT).error;` upon successful credential and OIDC sign-ins.
- **`src/middleware.ts`**:
  - Guarded login redirects to allow access when error query parameters are present, preventing redirect ping-pong.
  - Added support for mobile auth route handling (`/m/login`).
- **Unit Tests**:
  - Added `tests/lib/auth-cache-purge.test.ts` verifying browser cache purging behavior.
  - Added unit test in `tests/lib/auth-oidc-unit.test.ts` verifying that fresh sign-ins purge stale token errors.

### Verification
- Full TypeScript type-check passed (`npx tsc --noEmit`).
- ESLint passed on all modified files with 0 errors.
- Vitest unit & architecture suites passed (1,812 tests passing).
- Production build (`npm run build`) succeeded and generated a clean `public/sw.js` free of any dynamic/RSC caches.
- Pre-push security and build checks passed.