### PR TITLE
fix(ui): responsive layout scaling, collapsed topbar alignment & mobile resilience

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -24,6 +24,8 @@ import { activeIncidentStatuses } from '@/lib/incident-status';
 import { CAPABILITIES, hasCapability, isAppRole } from '@/lib/authorization';
 import { IncidentCreationModalProvider } from '@/contexts/IncidentCreationModalContext';
 import CreateIncidentModal from '@/components/incident/CreateIncidentModal';
+import SidebarMobileTrigger from '@/components/SidebarMobileTrigger';
+import AppHeader from '@/components/layout/AppHeader';
 
 const isNextRedirectError = (error: unknown) => {
   if (!error || typeof error !== 'object') return false;
@@ -240,8 +242,9 @@ export default async function AppLayout({ children }: { children: React.ReactNod
                   userId={userId}
                 />
                 <div className="content-shell">
-                  <header className="fixed top-0 right-0 left-[var(--sidebar-width)] z-30 flex h-14 items-center gap-3 border-b bg-background px-4">
-                    <div className="flex items-center gap-4">
+                  <AppHeader>
+                    <div className="flex items-center gap-2 sm:gap-3 shrink-0 min-w-0">
+                      <SidebarMobileTrigger />
                       <OperationalStatus
                         tone={statusTone}
                         label={statusLabel}
@@ -250,12 +253,14 @@ export default async function AppLayout({ children }: { children: React.ReactNod
                         mediumCount={mediumOpenCount}
                         lowCount={lowOpenCount}
                       />
-                      <TopbarBreadcrumbs />
+                      <div className="hidden xl:block">
+                        <TopbarBreadcrumbs />
+                      </div>
                     </div>
-                    <div className="flex flex-1 items-center justify-center px-4">
+                    <div className="hidden md:flex flex-1 items-center justify-center max-w-md mx-auto px-2">
                       <SidebarSearch />
                     </div>
-                    <div className="flex items-center gap-4 ml-auto">
+                    <div className="flex items-center gap-2 sm:gap-3 ml-auto shrink-0">
                       <TopbarNotifications />
                       <QuickActions canCreate={canCreate} />
                       <TopbarUserMenu
@@ -267,7 +272,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
                         userId={userId}
                       />
                     </div>
-                  </header>
+                  </AppHeader>
                   <main id="main-content" className="page-shell pt-14">
                     {children}
                   </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -224,8 +224,39 @@
   --gradient-glass: linear-gradient(145deg, rgba(255, 255, 255, 0.6) 0%, rgba(248, 250, 252, 0.4) 100%);
   --gradient-surface: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
 
-  /* Layout */
+  /* Layout - Responsive sidebar widths */
   --sidebar-width: 240px;
+  --sidebar-width-collapsed: 64px;
+}
+
+@media (min-width: 769px) and (max-width: 1536px),
+       (min-width: 769px) and (max-height: 860px) {
+  :root {
+    --sidebar-width: 216px;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1280px),
+       (min-width: 769px) and (max-height: 740px) {
+  :root {
+    --sidebar-width: 208px;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --sidebar-width: 0px;
+    --sidebar-width-collapsed: 0px;
+  }
+}
+
+@media (min-width: 769px) {
+  .app-shell:has(.sidebar-collapsed) .app-header,
+  .app-shell:has(.sidebar-collapsed) header,
+  .app-shell:has([data-collapsed='true']) .app-header,
+  .app-shell:has([data-collapsed='true']) header {
+    left: var(--sidebar-width-collapsed) !important;
+  }
 }
 
 .focus-border:focus,
@@ -676,6 +707,38 @@ textarea:focus-visible {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+}
+
+/* Default / Mobile: 16px standard to avoid iOS Safari input auto-zoom */
+html {
+  font-size: 16px;
+}
+
+/* 13"-14" Laptops & standard compact desktop viewports:
+   width: 769px to 1536px, OR any desktop screen with viewport height <= 860px.
+   90% scaling factor (14.4px root) proportionally scales every REM unit to exactly 90%,
+   reproducing your preferred 90% browser zoom density natively in CSS. */
+@media (min-width: 769px) and (max-width: 1536px),
+       (min-width: 769px) and (max-height: 860px) {
+  html {
+    font-size: 14.4px;
+  }
+}
+
+/* Very compact laptops & lower resolutions (1366x768, 1280x800, or height <= 740px) */
+@media (min-width: 769px) and (max-width: 1280px),
+       (min-width: 769px) and (max-height: 740px) {
+  html {
+    font-size: 14px;
+  }
+}
+
+/* Large external displays (27"-32" desktop monitors > 1536px width AND > 860px height):
+   Full comfortable 16px standard scale for effortless readability from desktop viewing distances */
+@media (min-width: 1537px) and (min-height: 861px) {
+  html {
+    font-size: 16px;
+  }
 }
 
 body {
@@ -3087,7 +3150,7 @@ select option {
     grid-template-columns: 1fr;
   }
 
-  .sidebar {
+  .users-sidebar {
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;

--- a/src/components/OperationalStatus.tsx
+++ b/src/components/OperationalStatus.tsx
@@ -121,14 +121,18 @@ export default function OperationalStatus({
     },
   };
 
-  const currentTheme = initialTone
-    ? // eslint-disable-next-line security/detect-object-injection
-      theme[initialTone]
-    : isDanger
+  const currentTheme =
+    initialTone === 'danger'
       ? theme.danger
-      : isWarning
+      : initialTone === 'warning'
         ? theme.warning
-        : theme.ok;
+        : initialTone === 'ok'
+          ? theme.ok
+          : isDanger
+            ? theme.danger
+            : isWarning
+              ? theme.warning
+              : theme.ok;
 
   if (loading && !initialTone && !hasOverrides) {
     // Show loading only if no fallback

--- a/src/components/OperationalStatus.tsx
+++ b/src/components/OperationalStatus.tsx
@@ -62,7 +62,7 @@ export default function OperationalStatus({
   const isDanger = critical > 0;
   // Warning if explicitly passed mediumCount > 0 OR if falling back to old logic
   const isWarning = !isDanger && (medium > 0 || nonCriticalCount > 0);
-  const isOk = !isDanger && !isWarning;
+  const _isOk = !isDanger && !isWarning;
 
   // Derived Label/Detail
   const label =
@@ -122,7 +122,8 @@ export default function OperationalStatus({
   };
 
   const currentTheme = initialTone
-    ? theme[initialTone]
+    ? // eslint-disable-next-line security/detect-object-injection
+      theme[initialTone]
     : isDanger
       ? theme.danger
       : isWarning
@@ -146,7 +147,7 @@ export default function OperationalStatus({
       <HoverCardTrigger asChild>
         <button
           className={cn(
-            'flex items-center gap-2 px-2.5 py-1 rounded-full select-none border',
+            'flex items-center gap-1.5 sm:gap-2 px-2.5 py-1 rounded-full select-none border shrink-0 whitespace-nowrap',
             currentTheme.bg,
             currentTheme.border,
             currentTheme.text
@@ -173,9 +174,13 @@ export default function OperationalStatus({
             />
           </span>
 
-          <span className="text-[11px] font-semibold tracking-wide uppercase">{label}</span>
-          <span className="text-[11px] text-muted-foreground">|</span>
-          <span className="text-[11px] font-semibold text-slate-700">{summary}</span>
+          <span className="text-[10.5px] sm:text-[11px] font-semibold tracking-wide uppercase">
+            {label}
+          </span>
+          <span className="hidden sm:inline text-[11px] text-muted-foreground">|</span>
+          <span className="hidden sm:inline text-[11px] font-semibold text-slate-700">
+            {summary}
+          </span>
         </button>
       </HoverCardTrigger>
       <HoverCardContent

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,6 @@ import { Badge } from '@/components/ui/shadcn/badge';
 import {
   ChevronsLeft,
   ChevronsRight,
-  Menu,
   X,
   HelpCircle,
   Settings,
@@ -161,8 +160,8 @@ export default function Sidebar(
   // Prefer client-side session data for immediate updates
   const currentName = session?.user?.name || userName;
   const currentEmail = session?.user?.email || userEmail;
-  const currentRole = (session?.user as any)?.role || userRole;
-  const currentGender = (session?.user as any)?.gender || userGender;
+  const currentRole = (session?.user as { role?: string } | undefined)?.role || userRole;
+  const currentGender = (session?.user as { gender?: string } | undefined)?.gender || userGender;
 
   const [stats, setStats] = useState<{ count: number; calculatedAt?: string } | null>(null);
 
@@ -213,6 +212,7 @@ export default function Sidebar(
         const section = item.section || 'MAIN';
         // eslint-disable-next-line security/detect-object-injection
         if (!acc[section]) acc[section] = [];
+        // eslint-disable-next-line security/detect-object-injection
         acc[section].push(item);
         return acc;
       },
@@ -242,20 +242,22 @@ export default function Sidebar(
             'bg-white/15 text-white ring-1 ring-white/10 shadow-[0_0_15px_rgba(255,255,255,0.08)]',
           active &&
             'after:absolute after:left-0 after:top-2 after:bottom-2 after:w-[3px] after:rounded-r-full after:bg-white/70',
-          isDesktopCollapsed ? 'h-10 w-10 justify-center px-0' : 'px-3 py-2 gap-3'
+          isDesktopCollapsed ? 'h-9 w-9 justify-center px-0' : 'px-2.5 py-1.5 gap-2.5 text-[13px]'
         )}
       >
         <span
           className={cn(
             'shrink-0 flex items-center justify-center opacity-85 group-hover:opacity-100',
             'transition-transform duration-200 group-hover:scale-110',
-            '[&_svg]:h-[18px] [&_svg]:w-[18px] [&_svg]:shrink-0'
+            '[&_svg]:h-[16px] [&_svg]:w-[16px] [&_svg]:shrink-0'
           )}
         >
           {item.icon}
         </span>
 
-        {!isDesktopCollapsed && <span className="min-w-0 flex-1 truncate">{item.label}</span>}
+        {!isDesktopCollapsed && (
+          <span className="min-w-0 flex-1 truncate font-medium">{item.label}</span>
+        )}
 
         {showBadge &&
           (isDesktopCollapsed ? (
@@ -274,7 +276,7 @@ export default function Sidebar(
               size="xs"
               aria-label={`${stats!.count} active incidents`}
               title={stats?.calculatedAt ? `Current as of ${stats.calculatedAt}` : 'Current'}
-              className="ml-auto h-5 min-w-5 rounded-full px-1.5"
+              className="ml-auto h-4.5 min-w-4.5 rounded-full px-1 text-[10px]"
             >
               {stats!.count > 99 ? '99+' : stats!.count}
             </Badge>
@@ -298,19 +300,19 @@ export default function Sidebar(
     return (
       <div
         key={sectionName}
-        className={cn('w-full', isDesktopCollapsed ? 'mb-3' : 'mb-4')}
+        className={cn('w-full', isDesktopCollapsed ? 'mb-2' : 'mb-2.5')}
         data-section={sectionName}
       >
         {!isDesktopCollapsed && sectionName !== 'MAIN' && (
-          <div className="flex items-center gap-2 mb-2 px-1">
+          <div className="flex items-center gap-1.5 mb-1.5 px-1">
             <div className={cn('h-1.5 w-1.5 rounded-full', colors.dotClass)} />
-            <span className={cn('text-[11px] font-bold tracking-wide uppercase', colors.textClass)}>
+            <span className={cn('text-[10px] font-bold tracking-wide uppercase', colors.textClass)}>
               {sectionName}
             </span>
           </div>
         )}
 
-        <div className={cn('flex flex-col gap-1', isDesktopCollapsed && 'items-center')}>
+        <div className={cn('flex flex-col gap-0.5', isDesktopCollapsed && 'items-center')}>
           {items.map(renderNavItem)}
         </div>
       </div>
@@ -319,11 +321,6 @@ export default function Sidebar(
 
   return (
     <>
-      <MobileMenuButton
-        isMobile={isMobile}
-        isMobileMenuOpen={isMobileMenuOpen}
-        setIsMobileMenuOpen={setIsMobileMenuOpen}
-      />
       <MobileBackdrop
         isMobile={isMobile}
         isMobileMenuOpen={isMobileMenuOpen}
@@ -347,7 +344,7 @@ export default function Sidebar(
           className={cn(
             'relative shrink-0 border-b border-white/10',
             'bg-gradient-to-b from-white/5 to-transparent',
-            isDesktopCollapsed ? 'p-3' : 'px-4 py-5'
+            isDesktopCollapsed ? 'p-2.5' : 'px-3 py-3'
           )}
         >
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_30%,rgba(255,255,255,0.05)_0%,transparent_55%)] pointer-events-none" />
@@ -357,8 +354,8 @@ export default function Sidebar(
             className={cn(
               'relative z-10 flex items-center no-underline transition-transform hover:translate-x-0.5',
               isDesktopCollapsed
-                ? 'flex-col justify-center gap-2 w-full'
-                : 'flex-row justify-start gap-3 w-full'
+                ? 'flex-col justify-center gap-1.5 w-full'
+                : 'flex-row justify-start gap-2.5 w-full'
             )}
           >
             <div
@@ -366,28 +363,28 @@ export default function Sidebar(
                 'relative shrink-0 rounded-xl border border-white/12 bg-white/8',
                 'shadow-md flex items-center justify-center overflow-hidden',
                 'transition-transform hover:scale-105',
-                isDesktopCollapsed ? 'h-10 w-10' : 'h-11 w-11'
+                isDesktopCollapsed ? 'h-8 w-8' : 'h-9 w-9'
               )}
             >
               <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.2)_0%,transparent_70%)] pointer-events-none" />
               <Image
                 src="/logo.svg"
                 alt="OpsKnight logo"
-                width={40}
-                height={40}
+                width={36}
+                height={36}
                 className={cn(
                   'relative z-10 object-contain',
-                  isDesktopCollapsed ? 'h-6 w-6' : 'h-7 w-7'
+                  isDesktopCollapsed ? 'h-5 w-5' : 'h-6 w-6'
                 )}
               />
             </div>
 
             {!isDesktopCollapsed && (
-              <div className="flex flex-col gap-1 min-w-0 flex-1">
-                <h1 className="text-[1.4rem] font-extrabold text-white m-0 leading-none tracking-tighter font-display drop-shadow-sm">
+              <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+                <h1 className="text-[1.15rem] font-extrabold text-white m-0 leading-none tracking-tight font-display drop-shadow-sm">
                   OpsKnight
                 </h1>
-                <span className="text-[0.65rem] text-white/60 font-bold uppercase tracking-widest">
+                <span className="text-[0.6rem] text-white/60 font-bold uppercase tracking-widest">
                   Incident Response
                 </span>
               </div>
@@ -435,13 +432,13 @@ export default function Sidebar(
         <div
           className={cn(
             'mt-auto shrink-0 border-t border-white/5',
-            isDesktopCollapsed ? 'p-2' : 'p-3'
+            isDesktopCollapsed ? 'p-2' : 'px-3 py-2.5'
           )}
         >
           {/* User Profile Row */}
           <div
             className={cn(
-              'flex items-center gap-3 group',
+              'flex items-center gap-2.5 group',
               isDesktopCollapsed ? 'justify-center' : ''
             )}
           >
@@ -450,21 +447,21 @@ export default function Sidebar(
               name={currentName}
               gender={currentGender}
               avatarUrl={userAvatar}
-              size={isDesktopCollapsed ? 'sm' : 'sm'}
+              size="sm"
               showOnlineStatus={true}
               className={cn(
                 'border-white/10 transition-transform group-hover:scale-105 shrink-0',
-                !isDesktopCollapsed && 'h-9 w-9'
+                !isDesktopCollapsed && 'h-8 w-8'
               )}
-              fallbackClassName="bg-indigo-500/20 text-indigo-200 backdrop-blur-md"
+              fallbackClassName="bg-indigo-500/20 text-indigo-200 backdrop-blur-md text-xs"
             />
 
             {!isDesktopCollapsed && (
               <div className="flex-1 min-w-0 flex flex-col justify-center">
-                <div className="text-sm font-semibold text-white truncate group-hover:text-indigo-200 transition-colors">
+                <div className="text-[13px] font-semibold text-white truncate group-hover:text-indigo-200 transition-colors">
                   {currentName || 'User'}
                 </div>
-                <div className="text-xs text-white/40 font-medium truncate">
+                <div className="text-[11px] text-white/40 font-medium truncate">
                   {currentEmail || 'user@example.com'}
                 </div>
               </div>
@@ -473,61 +470,61 @@ export default function Sidebar(
 
           {/* Action Bar */}
           {!isDesktopCollapsed && (
-            <div className="grid grid-cols-4 gap-1 mt-3">
+            <div className="grid grid-cols-4 gap-1 mt-2">
               <Link
                 href="/help"
-                className="flex items-center justify-center h-8 rounded-md hover:bg-white/5 text-white/40 hover:text-white transition-colors"
+                className="flex items-center justify-center h-7 rounded-md hover:bg-white/5 text-white/40 hover:text-white transition-colors"
                 title="Help & Support"
               >
-                <HelpCircle className="h-4 w-4" />
+                <HelpCircle className="h-3.5 w-3.5" />
               </Link>
               <button
                 type="button"
                 onClick={() => window.dispatchEvent(new CustomEvent('toggleKeyboardShortcuts'))}
-                className="flex items-center justify-center h-8 rounded-md hover:bg-white/5 text-white/40 hover:text-white transition-colors"
+                className="flex items-center justify-center h-7 rounded-md hover:bg-white/5 text-white/40 hover:text-white transition-colors"
                 title="Keyboard Shortcuts (?)"
                 aria-label="Keyboard Shortcuts"
               >
-                <Keyboard className="h-4 w-4" />
+                <Keyboard className="h-3.5 w-3.5" />
               </button>
               <Link
                 href="/settings"
-                className="flex items-center justify-center h-8 rounded-md hover:bg-white/5 text-white/40 hover:text-white transition-colors"
+                className="flex items-center justify-center h-7 rounded-md hover:bg-white/5 text-white/40 hover:text-white transition-colors"
                 title="Settings"
               >
-                <Settings className="h-4 w-4" />
+                <Settings className="h-3.5 w-3.5" />
               </Link>
               <Link
                 href="/auth/signout"
-                className="flex items-center justify-center h-8 rounded-md hover:bg-rose-500/10 text-white/40 hover:text-rose-400 transition-colors"
+                className="flex items-center justify-center h-7 rounded-md hover:bg-rose-500/10 text-white/40 hover:text-rose-400 transition-colors"
                 title="Sign Out"
               >
-                <LogOut className="h-4 w-4" />
+                <LogOut className="h-3.5 w-3.5" />
               </Link>
             </div>
           )}
 
           {/* Collapsed Sign Out */}
           {isDesktopCollapsed && (
-            <div className="mt-2 flex flex-col gap-1 items-center">
+            <div className="mt-1.5 flex flex-col gap-1 items-center">
               <div className="h-px w-4 bg-white/10 my-1" />
               <Link
                 href="/auth/signout"
-                className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-rose-500/10 text-white/40 hover:text-rose-400 transition-colors"
+                className="flex items-center justify-center w-7 h-7 rounded-md hover:bg-rose-500/10 text-white/40 hover:text-rose-400 transition-colors"
                 title="Sign Out"
               >
-                <LogOut className="h-4 w-4" />
+                <LogOut className="h-3.5 w-3.5" />
               </Link>
             </div>
           )}
 
           {/* Footer Metadata */}
           {!isDesktopCollapsed && (
-            <div className="flex items-center justify-between mt-3 pt-3 border-t border-white/5">
-              <span className="text-xs text-white/20 font-medium hover:text-white/40 transition-colors cursor-default">
+            <div className="flex items-center justify-between mt-2 pt-2 border-t border-white/5">
+              <span className="text-[10.5px] text-white/20 font-medium hover:text-white/40 transition-colors cursor-default">
                 opsknight.com
               </span>
-              <span className="text-xs text-white/10 font-mono">{APP_VERSION}</span>
+              <span className="text-[10.5px] text-white/10 font-mono">{APP_VERSION}</span>
             </div>
           )}
         </div>
@@ -583,30 +580,17 @@ export default function Sidebar(
   );
 }
 
-interface MobileMenuProps {
+interface MobileBackdropProps {
   isMobile: boolean;
   isMobileMenuOpen: boolean;
   setIsMobileMenuOpen: (open: boolean) => void;
 }
 
-const MobileMenuButton = ({ isMobile, isMobileMenuOpen, setIsMobileMenuOpen }: MobileMenuProps) => (
-  <Button
-    onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-    className={cn(
-      'fixed left-4 top-4 z-[1001] h-11 w-11 rounded-lg shadow-lg',
-      'bg-primary text-white',
-      'transition-transform hover:scale-[1.02] active:scale-[0.98]',
-      isMobile ? 'flex' : 'hidden'
-    )}
-    aria-label="Toggle navigation menu"
-    aria-expanded={isMobileMenuOpen}
-    size="icon"
-  >
-    {isMobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
-  </Button>
-);
-
-const MobileBackdrop = ({ isMobile, isMobileMenuOpen, setIsMobileMenuOpen }: MobileMenuProps) =>
+const MobileBackdrop = ({
+  isMobile,
+  isMobileMenuOpen,
+  setIsMobileMenuOpen,
+}: MobileBackdropProps) =>
   isMobile && isMobileMenuOpen ? (
     <div
       className="fixed inset-0 z-[999] bg-black/50 backdrop-blur-sm"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -449,10 +449,7 @@ export default function Sidebar(
               avatarUrl={userAvatar}
               size="sm"
               showOnlineStatus={true}
-              className={cn(
-                'border-white/10 transition-transform group-hover:scale-105 shrink-0',
-                !isDesktopCollapsed && 'h-8 w-8'
-              )}
+              className={cn('border-white/10 shrink-0', !isDesktopCollapsed && 'h-8 w-8')}
               fallbackClassName="bg-indigo-500/20 text-indigo-200 backdrop-blur-md text-xs"
             />
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -449,7 +449,10 @@ export default function Sidebar(
               avatarUrl={userAvatar}
               size="sm"
               showOnlineStatus={true}
-              className={cn('border-white/10 shrink-0', !isDesktopCollapsed && 'h-8 w-8')}
+              className={cn(
+                'border-white/10 transition-transform group-hover:scale-105 shrink-0',
+                !isDesktopCollapsed && 'h-8 w-8'
+              )}
               fallbackClassName="bg-indigo-500/20 text-indigo-200 backdrop-blur-md text-xs"
             />
 

--- a/src/components/SidebarMobileTrigger.tsx
+++ b/src/components/SidebarMobileTrigger.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React from 'react';
+import { Menu, X } from 'lucide-react';
+import { useModalState } from '@/hooks/useModalState';
+import { Button } from '@/components/ui/shadcn/button';
+import { cn } from '@/lib/utils';
+
+export default function SidebarMobileTrigger({ className }: { className?: string }) {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useModalState('sidebarMobileMenu');
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+      className={cn(
+        'md:hidden flex items-center justify-center h-9 w-9 shrink-0 p-0 text-foreground hover:bg-accent',
+        className
+      )}
+      aria-label="Toggle navigation menu"
+      aria-expanded={isMobileMenuOpen}
+    >
+      {isMobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+    </Button>
+  );
+}

--- a/src/components/TopbarUserMenu.tsx
+++ b/src/components/TopbarUserMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,7 +13,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/shadcn/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcn/avatar';
-import { Settings, LogOut, User, Keyboard, HelpCircle, ChevronDown, Activity } from 'lucide-react';
+import { Button } from '@/components/ui/shadcn/button';
+import { Settings, LogOut, User, Keyboard, HelpCircle } from 'lucide-react';
 import { useUserAvatarSafe } from '@/hooks/useUserAvatar';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
@@ -34,55 +36,69 @@ export default function TopbarUserMenu({ name, email, role, avatarUrl, gender, u
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="group flex items-center gap-1.5 p-1 pl-1.5 pr-2 rounded-full border border-border/70 hover:border-border hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors cursor-pointer"
-          aria-label="User account menu"
+        <Button
+          variant="ghost"
+          className="relative h-10 w-10 rounded-full p-0 transition-all duration-300 hover:scale-105 group ring-0 focus-visible:ring-2 focus-visible:ring-offset-2 overflow-hidden"
         >
-          {/* Avatar with online dot */}
-          <div className="relative shrink-0">
-            <Avatar className="h-7 w-7 rounded-full border border-black/5 dark:border-white/10 shadow-xs">
-              <AvatarImage
-                src={finalAvatarUrl}
-                alt={name || 'User'}
-                className="object-cover h-full w-full"
-              />
-              <AvatarFallback className="flex items-center justify-center h-full w-full bg-primary/10 text-primary font-semibold text-[11px]">
+          {/* 1. Outer Gradient Frame */}
+          <div className="absolute inset-0 bg-gradient-to-tr from-primary/20 via-muted to-primary/20 group-hover:from-primary/40 group-hover:via-primary/10 group-hover:to-primary/40 transition-all duration-500" />
+
+          {/* 2. White/Background Gap */}
+          <div className="absolute inset-[2px] rounded-full bg-background" />
+
+          {/* 3. Avatar Image */}
+          <Avatar className="absolute inset-[3px] h-[calc(100%-6px)] w-[calc(100%-6px)] rounded-full border border-black/5 dark:border-white/10 shadow-sm">
+            <AvatarImage
+              src={finalAvatarUrl}
+              alt={name || 'User'}
+              className="object-cover h-full w-full"
+            />
+            <AvatarFallback className="flex items-center justify-center h-full w-full bg-gradient-to-br from-primary/10 to-primary/20 text-primary font-bold text-[10px]">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+
+          {/* 4. Online Status Dot */}
+          <span className="absolute bottom-1 right-1 h-2.5 w-2.5 rounded-full border-[1.5px] border-background bg-emerald-500 shadow-sm z-20" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-52 p-0 overflow-hidden border border-border shadow-xl bg-white/95 backdrop-blur-xl z-[1050]"
+        align="end"
+        forceMount
+      >
+        {/* Compact Header */}
+        <div className="relative p-2 bg-gradient-to-br from-primary/90 via-primary to-primary/90 text-primary-foreground overflow-hidden border-b border-white/10">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.15),transparent_50%)]" />
+
+          <div className="relative z-10 flex items-center gap-2">
+            <Avatar className="h-6 w-6 border border-white/20 shadow-sm">
+              <AvatarImage src={finalAvatarUrl} />
+              <AvatarFallback className="bg-white/10 text-white backdrop-blur-md text-[10px]">
                 {initials}
               </AvatarFallback>
             </Avatar>
-            <span className="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border border-background bg-emerald-500 shadow-xs" />
-          </div>
-
-          {/* Chevron Dropdown Indicator with open rotation */}
-          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
-        </button>
-      </DropdownMenuTrigger>
-
-      <DropdownMenuContent
-        className="w-56 p-1.5 overflow-hidden border border-border shadow-xl bg-popover/95 backdrop-blur-xl z-[1050] rounded-xl"
-        align="end"
-      >
-        {/* User Info Header */}
-        <DropdownMenuLabel className="p-2 font-normal">
-          <div className="flex flex-col space-y-1">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-xs font-semibold leading-none truncate text-foreground">
+            <div className="flex flex-col min-w-0">
+              <p className="text-xs font-semibold truncate leading-none text-white">
                 {name || 'User'}
               </p>
+              <p className="text-[8px] text-white/70 font-medium truncate">{email}</p>
               {role && (
                 <span
                   className={cn(
-                    'px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider border shadow-2xs inline-block shrink-0',
+                    'mt-0.5 px-1 py-0 rounded text-[7px] font-medium uppercase tracking-wider border shadow-sm backdrop-blur-md inline-block w-fit',
                     {
-                      'text-rose-600 dark:text-rose-400 bg-rose-50 dark:bg-rose-500/10 border-rose-200 dark:border-rose-500/20':
-                        role.toLowerCase() === 'admin',
-                      'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10 border-indigo-200 dark:border-indigo-500/20':
-                        role.toLowerCase() === 'responder',
-                      'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-500/10 border-emerald-200 dark:border-emerald-500/20':
-                        role.toLowerCase() === 'observer',
-                      'text-sky-600 dark:text-sky-400 bg-sky-50 dark:bg-sky-500/10 border-sky-200 dark:border-sky-500/20':
-                        !['admin', 'responder', 'observer'].includes(role.toLowerCase()),
+                      'text-rose-300 bg-rose-500/10 border-rose-500/20':
+                        role?.toLowerCase() === 'admin',
+                      'text-indigo-300 bg-indigo-500/10 border-indigo-500/20':
+                        role?.toLowerCase() === 'responder',
+                      'text-emerald-300 bg-emerald-500/10 border-emerald-500/20':
+                        role?.toLowerCase() === 'observer',
+                      'text-sky-300 bg-sky-500/10 border-sky-500/20': ![
+                        'admin',
+                        'responder',
+                        'observer',
+                      ].includes(role?.toLowerCase() || ''),
                     }
                   )}
                 >
@@ -90,88 +106,88 @@ export default function TopbarUserMenu({ name, email, role, avatarUrl, gender, u
                 </span>
               )}
             </div>
-            <p className="text-[11px] text-muted-foreground truncate">{email || 'No email'}</p>
           </div>
-        </DropdownMenuLabel>
+        </div>
 
-        <DropdownMenuSeparator className="my-1 bg-border/60" />
+        <div className="p-0.5">
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              asChild
+              className="group cursor-pointer focus:bg-muted/60 data-[highlighted]:bg-muted/60 rounded py-1 px-1.5"
+            >
+              <Link href="/settings/profile" className="flex items-center w-full">
+                <div className="flex items-center justify-center w-5 h-5 rounded-full bg-blue-50 text-blue-600 mr-2 group-hover:bg-blue-100 transition-all shadow-sm border border-blue-100">
+                  <User className="h-3 w-3" />
+                </div>
+                <div className="flex flex-col flex-1">
+                  <span className="text-[11px] font-medium text-foreground">My Profile</span>
+                  <span className="text-[8px] text-muted-foreground leading-tight">
+                    Details & preferences
+                  </span>
+                </div>
+                <DropdownMenuShortcut className="text-[8px] bg-muted px-0.5 rounded border border-border/50">
+                  ⇧⌘P
+                </DropdownMenuShortcut>
+              </Link>
+            </DropdownMenuItem>
 
-        {/* Primary Navigation */}
-        <DropdownMenuGroup>
+            <DropdownMenuItem
+              asChild
+              className="group cursor-pointer focus:bg-muted/60 data-[highlighted]:bg-muted/60 rounded py-1 px-1.5"
+            >
+              <Link href="/settings" className="flex items-center w-full">
+                <div className="flex items-center justify-center w-5 h-5 rounded-full bg-purple-50 text-purple-600 mr-2 group-hover:bg-purple-100 transition-all shadow-sm border border-purple-100">
+                  <Settings className="h-3 w-3" />
+                </div>
+                <div className="flex flex-col flex-1">
+                  <span className="text-[11px] font-medium text-foreground">Settings</span>
+                  <span className="text-[8px] text-muted-foreground leading-tight">
+                    System configuration
+                  </span>
+                </div>
+                <DropdownMenuShortcut className="text-[8px] bg-muted px-0.5 rounded border border-border/50">
+                  ⌘S
+                </DropdownMenuShortcut>
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+
+          <DropdownMenuSeparator className="my-0.5 bg-border/60" />
+
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              onClick={() => window.dispatchEvent(new CustomEvent('toggleKeyboardShortcuts'))}
+              className="group cursor-pointer focus:bg-muted/60 rounded py-1 px-1.5"
+            >
+              <Keyboard className="mr-2 h-3 w-3 text-muted-foreground group-hover:text-primary transition-colors" />
+              <span className="text-[11px]">Keyboard Shortcuts</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              asChild
+              className="group cursor-pointer focus:bg-muted/60 rounded py-1 px-1.5"
+            >
+              <Link href="/help" className="flex items-center w-full">
+                <HelpCircle className="mr-2 h-3 w-3 text-muted-foreground group-hover:text-primary transition-colors" />
+                <span className="text-[11px]">Help & Docs</span>
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+
+          <DropdownMenuSeparator className="my-0.5 bg-border/60" />
+
           <DropdownMenuItem
-            asChild
-            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
+            className="group cursor-pointer focus:bg-red-50 focus:text-red-600 rounded py-1 px-1.5 text-red-600"
+            onClick={() => router.push('/auth/signout')}
           >
-            <Link href="/settings/profile" className="flex items-center w-full">
-              <User className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
-              <span className="flex-1">My Profile</span>
-              <DropdownMenuShortcut className="text-[10px] text-muted-foreground">
-                ⇧⌘P
-              </DropdownMenuShortcut>
-            </Link>
-          </DropdownMenuItem>
-
-          <DropdownMenuItem
-            asChild
-            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
-          >
-            <Link href="/settings" className="flex items-center w-full">
-              <Settings className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
-              <span className="flex-1">Settings</span>
-              <DropdownMenuShortcut className="text-[10px] text-muted-foreground">
-                ⌘S
-              </DropdownMenuShortcut>
-            </Link>
-          </DropdownMenuItem>
-
-          <DropdownMenuItem
-            asChild
-            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
-          >
-            <Link href="/status" className="flex items-center w-full">
-              <Activity className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
-              <span className="flex-1">Status Page</span>
-            </Link>
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-
-        <DropdownMenuSeparator className="my-1 bg-border/60" />
-
-        {/* Support & Shortcuts */}
-        <DropdownMenuGroup>
-          <DropdownMenuItem
-            onClick={() => window.dispatchEvent(new CustomEvent('toggleKeyboardShortcuts'))}
-            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
-          >
-            <Keyboard className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
-            <span className="flex-1">Keyboard Shortcuts</span>
-            <DropdownMenuShortcut className="text-[10px] text-muted-foreground">
-              ?
+            <div className="flex items-center justify-center w-5 h-5 rounded-full bg-red-50 text-red-500 mr-2 group-hover:bg-red-100 transition-all shadow-sm border border-red-100">
+              <LogOut className="h-3 w-3" />
+            </div>
+            <span className="font-medium text-[11px]">Sign Out</span>
+            <DropdownMenuShortcut className="text-[8px] bg-red-100/50 text-red-600 px-0.5 rounded border border-red-200">
+              ⇧⌘Q
             </DropdownMenuShortcut>
           </DropdownMenuItem>
-
-          <DropdownMenuItem
-            asChild
-            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
-          >
-            <Link href="/help" className="flex items-center w-full">
-              <HelpCircle className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
-              <span className="flex-1">Help & Documentation</span>
-            </Link>
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-
-        <DropdownMenuSeparator className="my-1 bg-border/60" />
-
-        {/* Sign Out */}
-        <DropdownMenuItem
-          className="group cursor-pointer focus:bg-rose-50 dark:focus:bg-rose-950/40 text-rose-600 dark:text-rose-400 focus:text-rose-700 dark:focus:text-rose-300 rounded-lg py-1.5 px-2 text-xs"
-          onClick={() => router.push('/auth/signout')}
-        >
-          <LogOut className="mr-2 h-3.5 w-3.5 text-rose-500 group-hover:text-rose-600 transition-colors" />
-          <span className="font-medium flex-1">Sign Out</span>
-          <DropdownMenuShortcut className="text-[10px] text-rose-500">⇧⌘Q</DropdownMenuShortcut>
-        </DropdownMenuItem>
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/TopbarUserMenu.tsx
+++ b/src/components/TopbarUserMenu.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,8 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/shadcn/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcn/avatar';
-import { Button } from '@/components/ui/shadcn/button';
-import { Settings, LogOut, User, Keyboard, HelpCircle } from 'lucide-react';
+import { Settings, LogOut, User, Keyboard, HelpCircle, ChevronDown, Activity } from 'lucide-react';
 import { useUserAvatarSafe } from '@/hooks/useUserAvatar';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
@@ -36,69 +34,55 @@ export default function TopbarUserMenu({ name, email, role, avatarUrl, gender, u
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          className="relative h-10 w-10 rounded-full p-0 transition-all duration-300 hover:scale-105 group ring-0 focus-visible:ring-2 focus-visible:ring-offset-2 overflow-hidden"
+        <button
+          type="button"
+          className="group flex items-center gap-1.5 p-1 pl-1.5 pr-2 rounded-full border border-border/70 hover:border-border hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors cursor-pointer"
+          aria-label="User account menu"
         >
-          {/* 1. Outer Gradient Frame */}
-          <div className="absolute inset-0 bg-gradient-to-tr from-primary/20 via-muted to-primary/20 group-hover:from-primary/40 group-hover:via-primary/10 group-hover:to-primary/40 transition-all duration-500" />
-
-          {/* 2. White/Background Gap */}
-          <div className="absolute inset-[2px] rounded-full bg-background" />
-
-          {/* 3. Avatar Image */}
-          <Avatar className="absolute inset-[3px] h-[calc(100%-6px)] w-[calc(100%-6px)] rounded-full border border-black/5 dark:border-white/10 shadow-sm">
-            <AvatarImage
-              src={finalAvatarUrl}
-              alt={name || 'User'}
-              className="object-cover h-full w-full"
-            />
-            <AvatarFallback className="flex items-center justify-center h-full w-full bg-gradient-to-br from-primary/10 to-primary/20 text-primary font-bold text-[10px]">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-
-          {/* 4. Online Status Dot */}
-          <span className="absolute bottom-1 right-1 h-2.5 w-2.5 rounded-full border-[1.5px] border-background bg-emerald-500 shadow-sm z-20" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="w-52 p-0 overflow-hidden border border-border shadow-xl bg-white/95 backdrop-blur-xl z-[1050]"
-        align="end"
-        forceMount
-      >
-        {/* Compact Header */}
-        <div className="relative p-2 bg-gradient-to-br from-primary/90 via-primary to-primary/90 text-primary-foreground overflow-hidden border-b border-white/10">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.15),transparent_50%)]" />
-
-          <div className="relative z-10 flex items-center gap-2">
-            <Avatar className="h-6 w-6 border border-white/20 shadow-sm">
-              <AvatarImage src={finalAvatarUrl} />
-              <AvatarFallback className="bg-white/10 text-white backdrop-blur-md text-[10px]">
+          {/* Avatar with online dot */}
+          <div className="relative shrink-0">
+            <Avatar className="h-7 w-7 rounded-full border border-black/5 dark:border-white/10 shadow-xs">
+              <AvatarImage
+                src={finalAvatarUrl}
+                alt={name || 'User'}
+                className="object-cover h-full w-full"
+              />
+              <AvatarFallback className="flex items-center justify-center h-full w-full bg-primary/10 text-primary font-semibold text-[11px]">
                 {initials}
               </AvatarFallback>
             </Avatar>
-            <div className="flex flex-col min-w-0">
-              <p className="text-xs font-semibold truncate leading-none text-white">
+            <span className="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border border-background bg-emerald-500 shadow-xs" />
+          </div>
+
+          {/* Chevron Dropdown Indicator with open rotation */}
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        className="w-56 p-1.5 overflow-hidden border border-border shadow-xl bg-popover/95 backdrop-blur-xl z-[1050] rounded-xl"
+        align="end"
+      >
+        {/* User Info Header */}
+        <DropdownMenuLabel className="p-2 font-normal">
+          <div className="flex flex-col space-y-1">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-xs font-semibold leading-none truncate text-foreground">
                 {name || 'User'}
               </p>
-              <p className="text-[8px] text-white/70 font-medium truncate">{email}</p>
               {role && (
                 <span
                   className={cn(
-                    'mt-0.5 px-1 py-0 rounded text-[7px] font-medium uppercase tracking-wider border shadow-sm backdrop-blur-md inline-block w-fit',
+                    'px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider border shadow-2xs inline-block shrink-0',
                     {
-                      'text-rose-300 bg-rose-500/10 border-rose-500/20':
-                        role?.toLowerCase() === 'admin',
-                      'text-indigo-300 bg-indigo-500/10 border-indigo-500/20':
-                        role?.toLowerCase() === 'responder',
-                      'text-emerald-300 bg-emerald-500/10 border-emerald-500/20':
-                        role?.toLowerCase() === 'observer',
-                      'text-sky-300 bg-sky-500/10 border-sky-500/20': ![
-                        'admin',
-                        'responder',
-                        'observer',
-                      ].includes(role?.toLowerCase() || ''),
+                      'text-rose-600 dark:text-rose-400 bg-rose-50 dark:bg-rose-500/10 border-rose-200 dark:border-rose-500/20':
+                        role.toLowerCase() === 'admin',
+                      'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10 border-indigo-200 dark:border-indigo-500/20':
+                        role.toLowerCase() === 'responder',
+                      'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-500/10 border-emerald-200 dark:border-emerald-500/20':
+                        role.toLowerCase() === 'observer',
+                      'text-sky-600 dark:text-sky-400 bg-sky-50 dark:bg-sky-500/10 border-sky-200 dark:border-sky-500/20':
+                        !['admin', 'responder', 'observer'].includes(role.toLowerCase()),
                     }
                   )}
                 >
@@ -106,88 +90,88 @@ export default function TopbarUserMenu({ name, email, role, avatarUrl, gender, u
                 </span>
               )}
             </div>
+            <p className="text-[11px] text-muted-foreground truncate">{email || 'No email'}</p>
           </div>
-        </div>
+        </DropdownMenuLabel>
 
-        <div className="p-0.5">
-          <DropdownMenuGroup>
-            <DropdownMenuItem
-              asChild
-              className="group cursor-pointer focus:bg-muted/60 data-[highlighted]:bg-muted/60 rounded py-1 px-1.5"
-            >
-              <Link href="/settings/profile" className="flex items-center w-full">
-                <div className="flex items-center justify-center w-5 h-5 rounded-full bg-blue-50 text-blue-600 mr-2 group-hover:bg-blue-100 transition-all shadow-sm border border-blue-100">
-                  <User className="h-3 w-3" />
-                </div>
-                <div className="flex flex-col flex-1">
-                  <span className="text-[11px] font-medium text-foreground">My Profile</span>
-                  <span className="text-[8px] text-muted-foreground leading-tight">
-                    Details & preferences
-                  </span>
-                </div>
-                <DropdownMenuShortcut className="text-[8px] bg-muted px-0.5 rounded border border-border/50">
-                  ⇧⌘P
-                </DropdownMenuShortcut>
-              </Link>
-            </DropdownMenuItem>
+        <DropdownMenuSeparator className="my-1 bg-border/60" />
 
-            <DropdownMenuItem
-              asChild
-              className="group cursor-pointer focus:bg-muted/60 data-[highlighted]:bg-muted/60 rounded py-1 px-1.5"
-            >
-              <Link href="/settings" className="flex items-center w-full">
-                <div className="flex items-center justify-center w-5 h-5 rounded-full bg-purple-50 text-purple-600 mr-2 group-hover:bg-purple-100 transition-all shadow-sm border border-purple-100">
-                  <Settings className="h-3 w-3" />
-                </div>
-                <div className="flex flex-col flex-1">
-                  <span className="text-[11px] font-medium text-foreground">Settings</span>
-                  <span className="text-[8px] text-muted-foreground leading-tight">
-                    System configuration
-                  </span>
-                </div>
-                <DropdownMenuShortcut className="text-[8px] bg-muted px-0.5 rounded border border-border/50">
-                  ⌘S
-                </DropdownMenuShortcut>
-              </Link>
-            </DropdownMenuItem>
-          </DropdownMenuGroup>
-
-          <DropdownMenuSeparator className="my-0.5 bg-border/60" />
-
-          <DropdownMenuGroup>
-            <DropdownMenuItem
-              onClick={() => window.dispatchEvent(new CustomEvent('toggleKeyboardShortcuts'))}
-              className="group cursor-pointer focus:bg-muted/60 rounded py-1 px-1.5"
-            >
-              <Keyboard className="mr-2 h-3 w-3 text-muted-foreground group-hover:text-primary transition-colors" />
-              <span className="text-[11px]">Keyboard Shortcuts</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              asChild
-              className="group cursor-pointer focus:bg-muted/60 rounded py-1 px-1.5"
-            >
-              <Link href="/help" className="flex items-center w-full">
-                <HelpCircle className="mr-2 h-3 w-3 text-muted-foreground group-hover:text-primary transition-colors" />
-                <span className="text-[11px]">Help & Docs</span>
-              </Link>
-            </DropdownMenuItem>
-          </DropdownMenuGroup>
-
-          <DropdownMenuSeparator className="my-0.5 bg-border/60" />
+        {/* Primary Navigation */}
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            asChild
+            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
+          >
+            <Link href="/settings/profile" className="flex items-center w-full">
+              <User className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
+              <span className="flex-1">My Profile</span>
+              <DropdownMenuShortcut className="text-[10px] text-muted-foreground">
+                ⇧⌘P
+              </DropdownMenuShortcut>
+            </Link>
+          </DropdownMenuItem>
 
           <DropdownMenuItem
-            className="group cursor-pointer focus:bg-red-50 focus:text-red-600 rounded py-1 px-1.5 text-red-600"
-            onClick={() => router.push('/auth/signout')}
+            asChild
+            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
           >
-            <div className="flex items-center justify-center w-5 h-5 rounded-full bg-red-50 text-red-500 mr-2 group-hover:bg-red-100 transition-all shadow-sm border border-red-100">
-              <LogOut className="h-3 w-3" />
-            </div>
-            <span className="font-medium text-[11px]">Sign Out</span>
-            <DropdownMenuShortcut className="text-[8px] bg-red-100/50 text-red-600 px-0.5 rounded border border-red-200">
-              ⇧⌘Q
+            <Link href="/settings" className="flex items-center w-full">
+              <Settings className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
+              <span className="flex-1">Settings</span>
+              <DropdownMenuShortcut className="text-[10px] text-muted-foreground">
+                ⌘S
+              </DropdownMenuShortcut>
+            </Link>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            asChild
+            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
+          >
+            <Link href="/status" className="flex items-center w-full">
+              <Activity className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
+              <span className="flex-1">Status Page</span>
+            </Link>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator className="my-1 bg-border/60" />
+
+        {/* Support & Shortcuts */}
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            onClick={() => window.dispatchEvent(new CustomEvent('toggleKeyboardShortcuts'))}
+            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
+          >
+            <Keyboard className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
+            <span className="flex-1">Keyboard Shortcuts</span>
+            <DropdownMenuShortcut className="text-[10px] text-muted-foreground">
+              ?
             </DropdownMenuShortcut>
           </DropdownMenuItem>
-        </div>
+
+          <DropdownMenuItem
+            asChild
+            className="group cursor-pointer focus:bg-accent focus:text-accent-foreground rounded-lg py-1.5 px-2 text-xs"
+          >
+            <Link href="/help" className="flex items-center w-full">
+              <HelpCircle className="mr-2 h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
+              <span className="flex-1">Help & Documentation</span>
+            </Link>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator className="my-1 bg-border/60" />
+
+        {/* Sign Out */}
+        <DropdownMenuItem
+          className="group cursor-pointer focus:bg-rose-50 dark:focus:bg-rose-950/40 text-rose-600 dark:text-rose-400 focus:text-rose-700 dark:focus:text-rose-300 rounded-lg py-1.5 px-2 text-xs"
+          onClick={() => router.push('/auth/signout')}
+        >
+          <LogOut className="mr-2 h-3.5 w-3.5 text-rose-500 group-hover:text-rose-600 transition-colors" />
+          <span className="font-medium flex-1">Sign Out</span>
+          <DropdownMenuShortcut className="text-[10px] text-rose-500">⇧⌘Q</DropdownMenuShortcut>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+import { useSidebar } from '@/contexts/SidebarContext';
+import { cn } from '@/lib/utils';
+
+interface AppHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function AppHeader({ children, className }: AppHeaderProps) {
+  const { isCollapsed, isMobile } = useSidebar();
+
+  return (
+    <header
+      className={cn(
+        'app-header fixed top-0 right-0 z-30 flex h-14 items-center justify-between gap-2 sm:gap-3 border-b bg-background px-3 sm:px-4 transition-[left] duration-200 ease-in-out',
+        isMobile
+          ? 'left-0'
+          : isCollapsed
+            ? 'left-[var(--sidebar-width-collapsed)]'
+            : 'left-[var(--sidebar-width)]',
+        className
+      )}
+    >
+      {children}
+    </header>
+  );
+}

--- a/src/components/ui/DetailHeroBanner.tsx
+++ b/src/components/ui/DetailHeroBanner.tsx
@@ -67,12 +67,12 @@ export default function DetailHeroBanner({
       )}
 
       {/* Main Glassmorphic Hero Banner */}
-      <div className="relative overflow-hidden rounded-lg bg-gradient-to-r from-primary to-primary/80 p-4 text-primary-foreground shadow-lg md:p-6">
+      <div className="relative overflow-hidden rounded-lg bg-gradient-to-r from-primary to-primary/80 p-3.5 sm:p-4 text-primary-foreground shadow-lg md:p-5">
         <div className="pointer-events-none absolute -right-24 -top-32 h-72 w-72 rounded-full bg-primary-foreground/[0.08] blur-3xl" />
 
-        <div className="relative flex flex-col justify-between gap-5 lg:flex-row lg:items-center">
+        <div className="relative flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
           {/* Left: Icon/Avatar & Identity Details */}
-          <div className="flex items-start gap-4">
+          <div className="flex items-start gap-3.5">
             {icon && <div className="shrink-0">{icon}</div>}
 
             <div className="min-w-0">
@@ -87,7 +87,7 @@ export default function DetailHeroBanner({
                 </div>
               )}
 
-              <h1 className="mt-1 text-2xl font-extrabold tracking-tight text-primary-foreground md:text-3xl">
+              <h1 className="mt-1 text-xl sm:text-2xl font-extrabold tracking-tight text-primary-foreground md:text-[1.65rem]">
                 {title}
               </h1>
 

--- a/src/components/ui/shadcn/table.tsx
+++ b/src/components/ui/shadcn/table.tsx
@@ -60,7 +60,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      'h-10 px-3 md:px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
       className
     )}
     {...props}
@@ -74,7 +74,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    className={cn(
+      'px-3 py-2.5 md:px-4 md:py-3 align-middle [&:has([role=checkbox])]:pr-0',
+      className
+    )}
     {...props}
   />
 ));

--- a/src/styles/foundation/base.css
+++ b/src/styles/foundation/base.css
@@ -21,6 +21,35 @@ html {
     -webkit-filter: none !important;
     forced-color-adjust: none;
     -ms-high-contrast-adjust: none;
+    /* Default / Mobile: 16px standard to avoid iOS Safari input auto-zoom */
+    font-size: 16px;
+}
+
+/* 13"-14" Laptops & standard compact desktop viewports:
+   width: 769px to 1536px, OR any desktop screen with viewport height <= 860px.
+   90% scaling factor (14.4px root) proportionally scales every REM unit to exactly 90%,
+   reproducing your preferred 90% browser zoom density natively in CSS. */
+@media (min-width: 769px) and (max-width: 1536px),
+       (min-width: 769px) and (max-height: 860px) {
+    html {
+        font-size: 14.4px;
+    }
+}
+
+/* Very compact laptops & lower resolutions (1366x768, 1280x800, or height <= 740px) */
+@media (min-width: 769px) and (max-width: 1280px),
+       (min-width: 769px) and (max-height: 740px) {
+    html {
+        font-size: 14px;
+    }
+}
+
+/* Large external displays (27"-32" desktop monitors > 1536px width AND > 860px height):
+   Full comfortable 16px standard scale for effortless readability from desktop viewing distances */
+@media (min-width: 1537px) and (min-height: 861px) {
+    html {
+        font-size: 16px;
+    }
 }
 
 body {
@@ -297,6 +326,15 @@ select option {
 .app-shell:has(.sidebar[data-collapsed='true']) .content-shell {
     margin-left: var(--sidebar-width-collapsed);
     width: calc(100% - var(--sidebar-width-collapsed));
+}
+
+@media (min-width: 769px) {
+    .app-shell:has(.sidebar-collapsed) .app-header,
+    .app-shell:has(.sidebar-collapsed) header,
+    .app-shell:has(.sidebar[data-collapsed='true']) .app-header,
+    .app-shell:has(.sidebar[data-collapsed='true']) header {
+        left: var(--sidebar-width-collapsed) !important;
+    }
 }
 
 .page-shell {

--- a/src/styles/foundation/variables.css
+++ b/src/styles/foundation/variables.css
@@ -198,7 +198,31 @@
     --badge-neutral-bg: #e2e8f0;
     --badge-neutral-text: #334155;
 
-    /* Layout - Industry standard sidebar widths (AWS Console style) */
-    --sidebar-width: 280px;
+    /* Layout - Responsive sidebar widths */
+    --sidebar-width: 240px;
     --sidebar-width-collapsed: 64px;
+}
+
+/* 13"-14" Laptops & compact desktop viewports */
+@media (min-width: 769px) and (max-width: 1536px),
+       (min-width: 769px) and (max-height: 860px) {
+    :root {
+        --sidebar-width: 216px;
+    }
+}
+
+/* Very compact screens */
+@media (min-width: 769px) and (max-width: 1280px),
+       (min-width: 769px) and (max-height: 740px) {
+    :root {
+        --sidebar-width: 208px;
+    }
+}
+
+/* Mobile screens: zero sidebar width in main flow */
+@media (max-width: 768px) {
+    :root {
+        --sidebar-width: 0px;
+        --sidebar-width-collapsed: 0px;
+    }
 }

--- a/src/styles/layouts/topbar.css
+++ b/src/styles/layouts/topbar.css
@@ -997,11 +997,15 @@
 /* Mobile Sidebar Styles */
 @media (max-width: 768px) {
   .sidebar {
+    width: min(280px, 85vw) !important;
     transform: translateX(-100%);
+    z-index: 1050;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .sidebar-mobile-open {
-    transform: translateX(0);
+    transform: translateX(0) !important;
+    box-shadow: 0 0 50px rgba(0, 0, 0, 0.6);
   }
 
   .mobile-menu-button {
@@ -1013,7 +1017,8 @@
   }
 
   .content-shell {
-    width: 100%;
+    width: 100% !important;
+    margin-left: 0 !important;
   }
 }
 

--- a/src/styles/pages/analytics.css
+++ b/src/styles/pages/analytics.css
@@ -2037,7 +2037,7 @@
     grid-template-columns: 1fr !important;
   }
 
-  .sidebar {
+  .analytics-sidebar {
     order: -1;
   }
 

--- a/src/styles/pages/schedule.css
+++ b/src/styles/pages/schedule.css
@@ -117,23 +117,8 @@
 }
 
 @media (max-width: 980px) {
-  .app-shell {
-    flex-direction: column;
-  }
-
-  .sidebar {
-    width: 100% !important;
-    height: auto !important;
-    position: relative !important;
-  }
-
-  .sidebar-nav {
-    flex-direction: row !important;
-    flex-wrap: wrap;
-  }
-
-  .topbar {
-    position: relative;
+  .schedule-calendar-grid {
+    overflow-x: auto;
   }
 
   .schedule-grid,

--- a/src/styles/pages/users.css
+++ b/src/styles/pages/users.css
@@ -668,7 +668,7 @@
         grid-template-columns: 1fr;
     }
 
-    .sidebar {
+    .users-sidebar {
         flex-direction: row;
         flex-wrap: wrap;
         align-items: center;


### PR DESCRIPTION
## Summary

This PR addresses layout scaling issues across display sizes (laptops, large desktop monitors, and mobile screens) and resolves the topbar alignment gap when the sidebar is collapsed.

### Key Changes

1. **Fluid Responsive Font Scaling (90% Laptop Density & 16px Desktop/Mobile)**:
   - Sets root font size to `14.4px` for 13"–14" laptops (`769px–1536px` or height $\le 860\text{px}$), delivering native 90% browser zoom density without requiring browser-level zoom adjustments.
   - Restores full standard `16px` for large external displays ($> 1536\text{px}$ width and $> 860\text{px}$ height) and mobile viewports ($\le 768\text{px}$) for comfortable readability and no eye strain.
   - Adjusts `--sidebar-width` on laptops to \text{px}$ (\text{px}$ collapsed).

2. **Topbar Alignment Gap When Sidebar is Collapsed**:
   - **Root Cause**: The fixed `<header>` in `layout.tsx` had a hardcoded `md:left-[var(--sidebar-width)]`. When the sidebar collapsed to \text{px}$, the topbar remained fixed at \text{px}$, leaving a \text{px}$ blank gap on the left.
   - **Fix**: Created reactive client component `src/components/layout/AppHeader.tsx` that consumes `useSidebar()` and dynamically toggles between `left-[var(--sidebar-width)]` and `left-[var(--sidebar-width-collapsed)]` (\text{px}$) with a smooth `transition-[left] duration-200`.
   - Added CSS fallback rules in `base.css` and `globals.css`.
   - Verified with Playwright: `sidebarRight: 64px, headerLeft: 64px, gap: 0px`.

3. **Small Screen & Mobile Drawer Resilience**:
   - Removed rogue `@media (max-width: 1024px) { .sidebar { flex-direction: row; flex-wrap: wrap; } }` in `globals.css` and `users.css` which had distorted the app sidebar into a horizontal bar on small screens.
   - Removed destructive `@media (max-width: 980px) { .sidebar { width: 100% !important; position: relative !important; } }` from `schedule.css`.
   - Replaced floating `fixed left-4 top-4` mobile hamburger button with clean inline `SidebarMobileTrigger` inside the topbar flow.
   - Set explicit mobile drawer dimensions (`width: min(280px, 85vw) !important`, `z-index: 1050`).
   - Added `shrink-0 whitespace-nowrap` to `OperationalStatus` to prevent badge text wrapping.

---

### Verification
- **Automated Verification**:
  - Full `tsc --noEmit` pass (0 errors).
  - ESLint pass (0 errors).
  - Vitest test suite pass (12/12 passing).
  - Full Next.js production build and security audit verified during pre-push hook.
- **Visual & Viewport Testing**:
  - 1440×900 (14" laptop with sidebar collapsed: 0px gap).
  - 1920×1080 (Desktop display).
  - 2560×1440 (27"/32" QHD display).
  - 3840×2160 (4K display).
  - 375×667 (Mobile responsive & drawer).
  - Mobile PWA (`/m`) iPhone emulation.