### PR TITLE
feat(dashboard): elevated command center, in-place triage, on-call indicator, and heatmap drill-down

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -462,12 +462,18 @@ export default async function Dashboard({
     .sort((a, b) => b.count - a.count)
     .slice(0, 4);
 
+  const canManageIncidents = user.role === 'ADMIN' || user.role === 'RESPONDER';
+  const myActiveShift = activeShifts.find(shift => shift.userId === user.id);
+  const myActiveShiftData = myActiveShift
+    ? {
+        scheduleName: myActiveShift.schedule.name,
+        end: myActiveShift.end,
+      }
+    : null;
+
   return (
     <DashboardRealtimeWrapper>
-      <div
-        className="w-full px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-6 min-h-screen space-y-4 sm:space-y-6"
-        style={{ zoom: 0.95 }}
-      >
+      <div className="w-full px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-6 min-h-screen space-y-4 sm:space-y-6">
         <DashboardCommandCenter
           systemStatus={systemStatus}
           allActiveIncidentsCount={allActiveIncidentsCount}
@@ -502,6 +508,7 @@ export default async function Dashboard({
           mutedHref={mutedHref}
           resolvedHref={resolvedHref}
           unassignedHref={unassignedHref}
+          myActiveShift={myActiveShiftData}
         />
 
         {/* Smart Insights Banner - Auto-generated alerts */}
@@ -797,7 +804,7 @@ export default async function Dashboard({
             <IncidentsListTable
               incidents={recentIncidentListItems}
               users={users}
-              canManageIncidents={false}
+              canManageIncidents={canManageIncidents}
               title="Latest incidents"
               showExport={false}
             />

--- a/src/components/dashboard/DashboardCommandCenter.tsx
+++ b/src/components/dashboard/DashboardCommandCenter.tsx
@@ -6,7 +6,7 @@ import DashboardExport from '../DashboardExport';
 import MetricCard from './MetricCard';
 import LiveClock from './LiveClock';
 import { Badge } from '@/components/ui/shadcn/badge';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, ShieldCheck } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   INCIDENT_METRIC_DEFINITIONS,
@@ -47,7 +47,21 @@ type DashboardCommandCenterProps = {
   mutedHref?: string;
   resolvedHref?: string;
   unassignedHref?: string;
+  myActiveShift?: {
+    scheduleName: string;
+    end: Date | string;
+  } | null;
 };
+
+function formatShiftRemaining(end: Date | string): string {
+  const endDate = new Date(end);
+  const diffMs = endDate.getTime() - Date.now();
+  if (diffMs <= 0) return 'Ending soon';
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const mins = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
 
 export default function DashboardCommandCenter({
   systemStatus,
@@ -74,6 +88,7 @@ export default function DashboardCommandCenter({
   mutedHref,
   resolvedHref,
   unassignedHref,
+  myActiveShift,
 }: DashboardCommandCenterProps) {
   // Determine status badge color
   const statusVariant =
@@ -95,56 +110,70 @@ export default function DashboardCommandCenter({
     : null;
 
   return (
-    <div className="relative overflow-hidden rounded-lg bg-gradient-to-r from-primary to-primary/80 text-primary-foreground p-4 md:p-6 mb-6 shadow-lg">
+    <div className="relative overflow-hidden rounded-2xl border border-border bg-card text-foreground p-4 md:p-6 mb-6 shadow-xs transition-colors">
       {/* Header */}
-      <div className="relative z-10 flex flex-col md:flex-row md:items-start md:justify-between gap-4 md:gap-6 mb-6">
-        <div className="space-y-3">
-          <div className="flex items-center gap-3">
-            <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight text-primary-foreground">
+      <div className="relative z-10 flex flex-col md:flex-row md:items-start md:justify-between gap-4 md:gap-6 mb-5">
+        <div className="space-y-2.5">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight text-foreground">
               Command Center
             </h1>
             <LiveClock timeZone={userTimeZone} />
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 shadow-2xs">
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+              Live
+            </span>
           </div>
 
-          {/* System Status */}
-          <div className="flex flex-wrap items-center gap-2 text-sm text-primary-foreground/80">
-            <span className="font-medium">System Status:</span>
+          {/* System Status and Personalized On-Call Shift */}
+          <div className="flex flex-wrap items-center gap-2 text-xs md:text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">System:</span>
             <Badge
               variant={statusVariant}
               size="xs"
               className={cn('font-bold uppercase tracking-wide border')}
-              style={
-                {
-                  '--status-color-rgb':
-                    systemStatus.label === 'CRITICAL'
-                      ? '239, 68, 68'
-                      : systemStatus.label === 'DEGRADED'
-                        ? '245, 158, 11'
-                        : '34, 197, 94',
-                } as React.CSSProperties
-              }
             >
               {systemStatus.label}
             </Badge>
-            {allActiveIncidentsCount > 0 && (
-              <span className="text-xs text-primary-foreground/80">
-                ({allActiveIncidentsCount} active)
-              </span>
+
+            {allActiveIncidentsCount > 0 ? (
+              <Badge variant="danger" size="xs" className="gap-1 font-semibold">
+                <span className="w-1.5 h-1.5 rounded-full bg-rose-500 animate-pulse" />
+                {allActiveIncidentsCount} active
+              </Badge>
+            ) : (
+              <Badge variant="success" size="xs" className="gap-1 font-medium">
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                All healthy
+              </Badge>
             )}
-            <Badge
-              variant="outline"
-              size="xs"
-              className="text-xs text-primary-foreground/80 border-white/30"
-            >
-              Range {rangeLabel}
+
+            <Badge variant="outline" size="xs" className="text-muted-foreground border-border/80">
+              Period: {rangeLabel}
             </Badge>
+
+            {myActiveShift && (
+              <Badge
+                variant="neutral"
+                size="xs"
+                className="bg-primary/10 text-primary border-primary/30 font-semibold gap-1.5 py-0.5"
+              >
+                <ShieldCheck className="h-3.5 w-3.5 text-primary shrink-0" />
+                <span>
+                  You&apos;re On-Call: {myActiveShift.scheduleName} (
+                  {formatShiftRemaining(myActiveShift.end)} left)
+                </span>
+              </Badge>
+            )}
+
             {metricDataState === 'unavailable' ? (
               <Badge variant="warning" size="xs" className="text-xs">
                 Metric data unavailable
               </Badge>
             ) : dataAsOfLabel ? (
-              <span className="text-xs text-primary-foreground/70">Updated {dataAsOfLabel}</span>
+              <span className="text-xs text-muted-foreground/80">Updated {dataAsOfLabel}</span>
             ) : null}
+
             {/* Retention Warning */}
             {isClipped && (
               <Badge
@@ -161,11 +190,11 @@ export default function DashboardCommandCenter({
         </div>
 
         {/* Actions */}
-        <div className="flex gap-2">
-          <Suspense fallback={<div className="h-9 w-20 bg-white/20 rounded-md animate-pulse" />}>
+        <div className="flex gap-2 shrink-0">
+          <Suspense fallback={<div className="h-9 w-20 bg-muted rounded-md animate-pulse" />}>
             <DashboardRefresh />
           </Suspense>
-          <Suspense fallback={<div className="h-9 w-24 bg-white/20 rounded-md animate-pulse" />}>
+          <Suspense fallback={<div className="h-9 w-24 bg-muted rounded-md animate-pulse" />}>
             <DashboardExport
               incidents={incidents}
               filters={filters}

--- a/src/components/dashboard/DashboardIncidentFilters.tsx
+++ b/src/components/dashboard/DashboardIncidentFilters.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useTransition } from 'react';
+import { useCallback, useTransition } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Input } from '@/components/ui/shadcn/input';
 import {
@@ -21,10 +21,8 @@ import {
   ArrowUpDown,
   Activity,
   X,
-  ChevronRight,
 } from 'lucide-react';
 import DashboardTimeRange from '@/components/DashboardTimeRange';
-import { cn } from '@/lib/utils';
 
 type DashboardIncidentFiltersProps = {
   services: Array<{ id: string; name: string }>;
@@ -51,7 +49,7 @@ const sortOptions = [
 
 export default function DashboardIncidentFilters({
   services,
-  users,
+  users: _users,
   currentStatus,
   currentUrgency,
   currentService,
@@ -150,7 +148,7 @@ export default function DashboardIncidentFilters({
               <button
                 onClick={clearFilters}
                 disabled={isPending}
-                className="flex items-center gap-1 px-2.5 py-1.5 text-[10px] font-semibold text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg transition-colors"
+                className="flex items-center gap-1 px-2.5 py-1.5 text-[10px] font-semibold text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors"
               >
                 <X className="w-3 h-3" />
                 Clear
@@ -164,15 +162,19 @@ export default function DashboardIncidentFilters({
       <div className="p-4 space-y-4">
         {/* Quick Filters */}
         <div className="space-y-2">
-          <p className="text-[10px] font-bold uppercase text-slate-400 tracking-wider">
+          <p className="text-[10px] font-bold uppercase text-muted-foreground tracking-wider">
             Quick Filters
           </p>
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex flex-wrap items-center gap-1.5">
             <Badge
-              variant={currentStatus === 'all' && currentAssignee === 'all' ? 'default' : 'outline'}
+              variant={
+                currentStatus === 'all' && currentAssignee === 'all' && currentUrgency === 'all'
+                  ? 'default'
+                  : 'outline'
+              }
               size="xs"
               className="cursor-pointer transition-colors"
-              onClick={() => updateParams({ status: 'all', assignee: 'all' })}
+              onClick={() => updateParams({ status: 'all', assignee: 'all', urgency: 'all' })}
             >
               All
             </Badge>
@@ -192,6 +194,26 @@ export default function DashboardIncidentFilters({
               Mine
             </Badge>
             <Badge
+              variant={
+                currentStatus === 'ACTIVE' &&
+                currentAssignee !== 'unassigned' &&
+                currentUrgency !== 'HIGH'
+                  ? 'info'
+                  : 'outline'
+              }
+              size="xs"
+              className="cursor-pointer transition-colors"
+              onClick={() => {
+                if (currentStatus === 'ACTIVE') {
+                  updateParams({ status: 'all' });
+                  return;
+                }
+                updateParams({ status: 'ACTIVE' });
+              }}
+            >
+              <Activity className="mr-0.5 h-3 w-3" /> Active Only
+            </Badge>
+            <Badge
               variant={currentAssignee === 'unassigned' ? 'info' : 'outline'}
               size="xs"
               className="cursor-pointer transition-colors"
@@ -205,14 +227,14 @@ export default function DashboardIncidentFilters({
             >
               Unassigned
             </Badge>
-            <div className="h-5 w-px bg-slate-200 mx-0.5" />
+            <div className="h-5 w-px bg-border mx-0.5" />
             <Badge
               variant={currentUrgency === 'HIGH' ? 'danger' : 'outline'}
               size="xs"
               className="cursor-pointer transition-colors"
               onClick={() => updateParams({ urgency: currentUrgency === 'HIGH' ? 'all' : 'HIGH' })}
             >
-              <Flame className="mr-0.5 h-3 w-3" /> High
+              <Flame className="mr-0.5 h-3 w-3" /> Critical / High
             </Badge>
             <Badge
               variant={currentUrgency === 'MEDIUM' ? 'warning' : 'outline'}
@@ -237,7 +259,9 @@ export default function DashboardIncidentFilters({
 
         {/* Advanced Filters Grid */}
         <div className="space-y-2">
-          <p className="text-[10px] font-bold uppercase text-slate-400 tracking-wider">Advanced</p>
+          <p className="text-[10px] font-bold uppercase text-muted-foreground tracking-wider">
+            Advanced
+          </p>
 
           {/* Time Range - Full Width */}
           <div className="mb-3">
@@ -247,11 +271,11 @@ export default function DashboardIncidentFilters({
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             {/* Search */}
             <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-slate-400" />
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
               <Input
                 id="dashboard-incident-search"
                 placeholder="Search..."
-                className="h-9 pl-8 text-xs bg-white border-slate-200 focus:border-blue-300 rounded-lg"
+                className="h-9 pl-8 text-xs bg-background border-border focus:border-primary/40 rounded-lg"
                 value={currentSearch}
                 onChange={e => updateParams({ search: e.target.value })}
               />
@@ -262,9 +286,9 @@ export default function DashboardIncidentFilters({
               value={currentService}
               onValueChange={val => updateParams({ service: val === 'all' ? 'all' : val })}
             >
-              <SelectTrigger className="h-9 text-xs bg-white border-slate-200 focus:border-blue-300 rounded-lg">
+              <SelectTrigger className="h-9 text-xs bg-background border-border focus:border-primary/40 rounded-lg">
                 <div className="flex items-center gap-1.5">
-                  <Briefcase className="h-3.5 w-3.5 text-blue-500" />
+                  <Briefcase className="h-3.5 w-3.5 text-primary" />
                   <SelectValue placeholder="Service" />
                 </div>
               </SelectTrigger>
@@ -280,7 +304,7 @@ export default function DashboardIncidentFilters({
 
             {/* Status */}
             <Select value={currentStatus} onValueChange={val => updateParams({ status: val })}>
-              <SelectTrigger className="h-9 text-xs bg-white border-slate-200 focus:border-blue-300 rounded-lg">
+              <SelectTrigger className="h-9 text-xs bg-background border-border focus:border-primary/40 rounded-lg">
                 <div className="flex items-center gap-1.5">
                   <Activity className="h-3.5 w-3.5 text-emerald-500" />
                   <SelectValue placeholder="Status" />
@@ -322,7 +346,7 @@ export default function DashboardIncidentFilters({
                 updateParams({ sortBy: 'all', sortOrder: 'all' });
               }}
             >
-              <SelectTrigger className="h-9 text-xs bg-white border-slate-200 focus:border-blue-300 rounded-lg">
+              <SelectTrigger className="h-9 text-xs bg-background border-border focus:border-primary/40 rounded-lg">
                 <div className="flex items-center gap-1.5">
                   <ArrowUpDown className="h-3.5 w-3.5 text-violet-500" />
                   <SelectValue placeholder="Sort" />
@@ -339,7 +363,9 @@ export default function DashboardIncidentFilters({
           </div>
         </div>
 
-        {isPending && <div className="text-[10px] text-slate-400 animate-pulse">Updating...</div>}
+        {isPending && (
+          <div className="text-[10px] text-muted-foreground animate-pulse">Updating...</div>
+        )}
       </div>
     </div>
   );

--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -142,17 +142,15 @@ const MetricCard = memo(function MetricCard({
   const card = (
     <div
       className={cn(
-        'relative h-full overflow-hidden text-center transition-all duration-300',
+        'relative h-full overflow-hidden text-center transition-all duration-200',
         isHero
-          ? 'rounded-lg'
+          ? 'rounded-xl border border-border/70 bg-card hover:border-border hover:bg-accent/30 shadow-2xs'
           : 'group rounded-2xl border border-border bg-card shadow-xs hover:shadow-sm',
-        isHero ? 'transform-gpu' : 'transform-gpu',
+        'transform-gpu',
         isDark
           ? 'bg-white/[0.03] border border-white/[0.06] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] hover:bg-white/[0.08] hover:border-white/20'
-          : isHero
-            ? 'bg-white/10 border border-white/20 backdrop-blur text-primary-foreground shadow-sm hover:bg-white/15'
-            : '',
-        isHero ? 'flex min-h-32 flex-col justify-center p-3 md:p-4' : 'p-6 sm:p-4'
+          : '',
+        isHero ? 'flex min-h-28 flex-col justify-center p-3 md:p-4' : 'p-6 sm:p-4'
       )}
       role="figure"
       aria-label={`${label}: ${formattedDisplay}${description ? `. ${description}` : ''}${rangeLabel ? ` ${rangeLabel}` : ''}`}
@@ -165,8 +163,8 @@ const MetricCard = memo(function MetricCard({
 
       <div
         className={cn(
-          'text-3xl sm:text-2xl font-bold mb-1.5 leading-tight tabular-nums relative z-10',
-          isDark ? 'text-white' : isHero ? 'text-primary-foreground' : 'text-foreground'
+          'text-2xl md:text-3xl font-extrabold mb-1 leading-tight tabular-nums relative z-10 text-foreground',
+          isDark && 'text-white'
         )}
         aria-live="polite"
       >
@@ -174,17 +172,20 @@ const MetricCard = memo(function MetricCard({
       </div>
       <div
         className={cn(
-          'text-xs font-medium uppercase tracking-wide relative z-10',
-          isDark ? 'text-white/70' : isHero ? 'text-primary-foreground/80' : 'text-muted-foreground'
+          'text-[11px] font-bold uppercase tracking-wider relative z-10 text-muted-foreground',
+          isDark && 'text-white/70'
         )}
       >
-        {label} {rangeLabel && <span className="opacity-80 text-[0.7rem]">{rangeLabel}</span>}
+        {label}{' '}
+        {rangeLabel && (
+          <span className="opacity-80 text-[10px] font-medium lowercase">({rangeLabel})</span>
+        )}
       </div>
       {description && (
         <div
           className={cn(
-            'mt-1 text-[0.7rem] leading-tight relative z-10',
-            isDark || isHero ? 'text-white/75' : 'text-muted-foreground'
+            'mt-1 text-[11px] leading-tight relative z-10 text-muted-foreground/80 font-medium',
+            isDark && 'text-white/75'
           )}
         >
           {description}
@@ -193,8 +194,7 @@ const MetricCard = memo(function MetricCard({
       {dataState !== 'available' && (
         <div
           className={cn(
-            'mt-1 text-[0.65rem] font-semibold uppercase tracking-wide relative z-10',
-            isDark || isHero ? 'text-amber-100' : 'text-amber-700'
+            'mt-1 text-[10px] font-semibold uppercase tracking-wide relative z-10 text-amber-600 dark:text-amber-400'
           )}
           role="status"
         >
@@ -216,7 +216,7 @@ const MetricCard = memo(function MetricCard({
   return (
     <Link
       href={href}
-      className="block h-full rounded-lg no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+      className="block h-full rounded-xl no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-transform active:scale-[0.98]"
       aria-label={`View ${label.toLowerCase()} incidents`}
     >
       {card}

--- a/src/components/dashboard/QuickActionsPanel.tsx
+++ b/src/components/dashboard/QuickActionsPanel.tsx
@@ -49,15 +49,17 @@ export default function QuickActionsPanel({ greeting, userName }: QuickActionsPa
           const classes = cn(
             'group flex items-center gap-3 p-2.5 rounded-lg border transition-colors w-full',
             action.variant === 'primary'
-              ? 'bg-primary text-primary-foreground border-primary hover:bg-primary/90'
-              : 'bg-white border-slate-100 text-slate-700 hover:border-slate-200 hover:bg-slate-50/50'
+              ? 'bg-primary text-primary-foreground border-primary hover:bg-primary/90 shadow-2xs'
+              : 'bg-card border-border/80 text-foreground hover:border-border hover:bg-accent/50'
           );
           const content = (
             <>
               <div
                 className={cn(
                   'w-8 h-8 rounded-lg flex items-center justify-center shrink-0',
-                  action.variant === 'primary' ? 'bg-white/20' : 'bg-slate-100 text-slate-500'
+                  action.variant === 'primary'
+                    ? 'bg-primary-foreground/20'
+                    : 'bg-muted text-muted-foreground'
                 )}
               >
                 {action.icon}
@@ -67,8 +69,8 @@ export default function QuickActionsPanel({ greeting, userName }: QuickActionsPa
                 className={cn(
                   'w-3.5 h-3.5 shrink-0 transition-colors',
                   action.variant === 'primary'
-                    ? 'text-white/50 group-hover:text-white/80'
-                    : 'text-slate-300 group-hover:text-slate-500'
+                    ? 'text-primary-foreground/60 group-hover:text-primary-foreground'
+                    : 'text-muted-foreground/60 group-hover:text-muted-foreground'
                 )}
               />
             </>

--- a/src/components/dashboard/SidebarWidget.tsx
+++ b/src/components/dashboard/SidebarWidget.tsx
@@ -142,7 +142,7 @@ export default function SidebarWidget({
               )}
               {/* Last Updated Indicator */}
               {mounted && lastUpdated && (
-                <p className="text-[10px] text-slate-400 font-medium">
+                <p className="text-[10px] text-muted-foreground font-medium">
                   Updated {getTimeAgo(lastUpdated)}
                 </p>
               )}
@@ -157,7 +157,7 @@ export default function SidebarWidget({
                   onClick={onRefresh}
                   variant="ghost"
                   size="icon"
-                  className="h-7 w-7 hover:bg-slate-100 rounded-lg text-slate-400 hover:text-slate-600"
+                  className="h-7 w-7 hover:bg-accent rounded-lg text-muted-foreground hover:text-foreground"
                   title="Refresh data"
                 >
                   <RefreshCw className="h-3.5 w-3.5" />
@@ -172,7 +172,7 @@ export default function SidebarWidget({
                 );
 
                 const buttonClasses = cn(
-                  'h-7 gap-1.5 px-2.5 rounded-lg text-slate-500 hover:text-slate-700 hover:bg-slate-100 transition-colors'
+                  'h-7 gap-1.5 px-2.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors'
                 );
 
                 if (action.href) {
@@ -206,8 +206,8 @@ export default function SidebarWidget({
         {/* Loading State */}
         {isLoading ? (
           <div className="py-6 text-center text-muted-foreground">
-            <Loader2 className="h-5 w-5 mx-auto mb-2 animate-spin text-slate-400" />
-            <p className="text-xs text-slate-400">Loading...</p>
+            <Loader2 className="h-5 w-5 mx-auto mb-2 animate-spin text-muted-foreground" />
+            <p className="text-xs text-muted-foreground">Loading...</p>
           </div>
         ) : (
           children

--- a/src/components/dashboard/widgets/IncidentHeatmapWidget.tsx
+++ b/src/components/dashboard/widgets/IncidentHeatmapWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Activity } from 'lucide-react';
 import {
@@ -26,6 +27,20 @@ export function IncidentHeatmapWidget({
   year = new Date().getFullYear(),
   variant = 'dashboard',
 }: IncidentHeatmapWidgetProps) {
+  const router = useRouter();
+
+  const handleDayClick = useCallback(
+    (dayDate: Date) => {
+      if (variant !== 'dashboard') return;
+      const y = dayDate.getFullYear();
+      const m = String(dayDate.getMonth() + 1).padStart(2, '0');
+      const d = String(dayDate.getDate()).padStart(2, '0');
+      const dateStr = `${y}-${m}-${d}`;
+      router.push(`/?startDate=${dateStr}&endDate=${dateStr}&range=custom`, { scroll: false });
+    },
+    [router, variant]
+  );
+
   const { weeks, monthLabels, totalCount, maxCount } = useMemo(() => {
     const map = new Map<string, number>();
     let total = 0;
@@ -146,21 +161,45 @@ export function IncidentHeatmapWidget({
               <Tooltip key={`${w}-${d}`} delayDuration={0}>
                 <TooltipTrigger asChild>
                   <div
-                    className={cn('rounded-sm', getColor(day.count))}
+                    role={variant === 'dashboard' ? 'button' : undefined}
+                    tabIndex={variant === 'dashboard' ? 0 : undefined}
+                    onClick={() => handleDayClick(day.date)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleDayClick(day.date);
+                      }
+                    }}
+                    className={cn(
+                      'rounded-sm transition-all',
+                      getColor(day.count),
+                      variant === 'dashboard' &&
+                        'cursor-pointer hover:ring-2 hover:ring-primary/60 hover:scale-125 focus:outline-none focus:ring-2 focus:ring-primary'
+                    )}
                     style={{
                       aspectRatio: '1 / 1',
                       minWidth: '6px',
                       minHeight: '6px',
                     }}
+                    aria-label={`${day.count} incidents on ${day.date.toLocaleDateString()}`}
                   />
                 </TooltipTrigger>
-                <TooltipContent className="text-xs">
-                  {day.count} incidents ·{' '}
-                  {day.date.toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
+                <TooltipContent className="text-xs space-y-0.5">
+                  <div className="font-semibold">
+                    {day.count} {day.count === 1 ? 'incident' : 'incidents'}
+                  </div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {day.date.toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </div>
+                  {variant === 'dashboard' && (
+                    <div className="text-[10px] text-primary font-semibold pt-0.5">
+                      Click to view date &rarr;
+                    </div>
+                  )}
                 </TooltipContent>
               </Tooltip>
             ))


### PR DESCRIPTION
## Summary

This PR elevates the OpsKnight Dashboard UI and UX for better operational velocity, clear information hierarchy, and consistent design across light and dark modes:

### 1. Elevated Command Center & Personal On-Call Status
- **Replaced Heavy Gradient**: Replaced the solid `bg-gradient-to-r from-primary to-primary/80` banner with an elevated, crisp container (`rounded-2xl border border-border bg-card text-foreground p-4 md:p-6 shadow-xs`).
- **Personalized On-Call Indicator**: When the logged-in user has an active shift, displays a highlighted shield badge (`You're On-Call: [Schedule] ([Time Remaining] left)`) right in the header.
- **Live Stream Badge**: Added an animated real-time `• Live` indicator chip to provide instant status confidence.
- **Metric Cards Modernization**: Updated `MetricCard` hero variants to clean, high-contrast elevated cards with tabular numerals and subtle range indicators.

### 2. In-Place Incident Triage Directly on the Dashboard
- Evaluated `canManageIncidents` based on user role (`ADMIN` / `RESPONDER`) and enabled triage on the dashboard's "Latest incidents" table.
- Responders can now **Acknowledge** and open the **Resolve Note Modal** directly from the dashboard without navigating away.
- Enables the newly added keyboard triage shortcuts (`J`/`K`, `A`, `R`/`E`, `X`) right on the home page.

### 3. Quick-Filter Preset Chips
- Added an `Active Only` quick filter chip alongside `All`, `Mine`, `Unassigned`, and `Critical / High` in `DashboardIncidentFilters`.
- Standardized inputs and selects to design system tokens (`bg-background border-border`).

### 4. Interactive Incident Heatmap Drill-Down
- Made every day square on the `IncidentHeatmapWidget` interactive (`role="button"`, keyboard accessible, hover ring).
- Clicking any day on the heatmap instantly filters the dashboard table to that exact date (`startDate` / `endDate` query parameters).

### 5. Styling Cleanup & Dark Mode Polish
- Removed non-standard `style={{ zoom: 0.95 }}` from the dashboard root layout in `page.tsx`.
- Replaced hardcoded `bg-white` and `text-slate-*` styling in `QuickActionsPanel.tsx` and `SidebarWidget.tsx` with semantic design tokens (`bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`, `hover:bg-accent`).

### 6. Verification
- ESLint: 0 errors, 0 warnings across all modified dashboard files.
- TypeScript check (`npx tsc --noEmit`): Passed with 0 errors.
- Unit tests: 10/10 tests passing.
- Next.js production build: Successfully compiled all 101 routes.