### PR TITLE
fix(filters): enforce actor-scoped data reads

### DIFF
--- a/src/app/(app)/action-items/page.tsx
+++ b/src/app/(app)/action-items/page.tsx
@@ -3,7 +3,8 @@ import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import prisma from '@/lib/prisma';
-import { getUserPermissions } from '@/lib/rbac';
+import { getCurrentAuthorizationActor, getUserPermissions } from '@/lib/rbac';
+import { dashboardUserReadWhere, postmortemReadWhere } from '@/lib/authorization-filters';
 import ActionItemsBoard from '@/components/action-items/ActionItemsBoard';
 import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
 import { CheckSquare, Circle, Clock, CheckCircle2, AlertOctagon } from 'lucide-react';
@@ -31,20 +32,29 @@ export default async function ActionItemsPage({
   const owner = params.owner;
   const priority = params.priority as 'HIGH' | 'MEDIUM' | 'LOW' | undefined;
   const view = params.view || 'board';
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
 
   // Get all postmortems with action items
   const postmortems = await prisma.postmortem.findMany({
     where: {
-      OR: [
+      AND: [
+        postmortemReadWhere(actor),
         {
-          actionItems: {
-            not: Prisma.JsonNull,
-          },
-        },
-        {
-          actionItemRecords: {
-            some: {},
-          },
+          OR: [
+            {
+              actionItems: {
+                not: Prisma.JsonNull,
+              },
+            },
+            {
+              actionItemRecords: {
+                some: {},
+              },
+            },
+          ],
         },
       ],
     },
@@ -160,12 +170,11 @@ export default async function ActionItemsPage({
 
   // Get all users for owner filter
   const users = await prisma.user.findMany({
-    where: { status: 'ACTIVE' },
+    where: { AND: [{ status: 'ACTIVE' }, dashboardUserReadWhere(actor)] },
     select: { id: true, name: true, email: true },
     orderBy: { name: 'asc' },
   });
 
-  const permissions = await getUserPermissions();
   const canManage = permissions.isResponderOrAbove;
 
   return (

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -9,6 +9,12 @@ import FilterChips from '@/components/analytics/FilterChips';
 import AnalyticsContent from '@/components/analytics/AnalyticsContent';
 import AnalyticsSkeleton from '@/components/analytics/AnalyticsSkeleton';
 import { buildAnalyticsExportUrl } from '@/lib/analytics-export';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import {
+  dashboardUserReadWhere,
+  serviceReadWhere,
+  teamReadWhere,
+} from '@/lib/authorization-filters';
 import { LayoutDashboard, BarChart3, Repeat } from 'lucide-react';
 
 import './analytics-v2.css';
@@ -39,6 +45,7 @@ export default async function AnalyticsV2Page({
   searchParams?: Promise<SearchParams>;
 }) {
   const session = await getServerSession(await getAuthOptions());
+  const actor = await getCurrentAuthorizationActor();
   const email = session?.user?.email ?? null;
   const user = email
     ? await prisma.user.findUnique({ where: { email }, select: { timeZone: true } })
@@ -66,17 +73,26 @@ export default async function AnalyticsV2Page({
   const windowDays = allowedWindows.has(windowCandidate) ? windowCandidate : 7;
 
   const [teams, services, users] = await Promise.all([
-    prisma.team.findMany({ select: { id: true, name: true } }),
-    prisma.service.findMany({ select: { id: true, name: true, teamId: true } }),
-    prisma.user.findMany({ select: { id: true, name: true, email: true } }),
+    prisma.team.findMany({ where: teamReadWhere(actor), select: { id: true, name: true } }),
+    prisma.service.findMany({
+      where: serviceReadWhere(actor),
+      select: { id: true, name: true, teamId: true },
+    }),
+    prisma.user.findMany({
+      where: dashboardUserReadWhere(actor),
+      select: { id: true, name: true, email: true },
+    }),
   ]);
 
   const servicesForFilter = teamId ? services.filter(s => s.teamId === teamId) : services;
+  const effectiveServiceId = servicesForFilter.some(service => service.id === serviceId)
+    ? serviceId
+    : undefined;
 
   const exportUrl = buildAnalyticsExportUrl({
     windowDays,
     teamId,
-    serviceId,
+    serviceId: effectiveServiceId,
     assigneeId,
     status: statusFilter,
     urgency: urgencyFilter,
@@ -87,7 +103,7 @@ export default async function AnalyticsV2Page({
   // re-query instead of stale content frozen on screen.
   const suspenseKey = [
     teamId ?? 'ALL',
-    serviceId ?? 'ALL',
+    effectiveServiceId ?? 'ALL',
     assigneeId ?? 'ALL',
     statusFilter ?? 'ALL',
     urgencyFilter ?? 'ALL',
@@ -158,7 +174,7 @@ export default async function AnalyticsV2Page({
         users={users}
         currentFilters={{
           team: teamId ?? 'ALL',
-          service: serviceId ?? 'ALL',
+          service: effectiveServiceId ?? 'ALL',
           assignee: assigneeId ?? 'ALL',
           status: statusFilter ?? 'ALL',
           urgency: urgencyFilter ?? 'ALL',
@@ -170,7 +186,7 @@ export default async function AnalyticsV2Page({
         <FilterChips
           filters={{
             team: teamId ?? 'ALL',
-            service: serviceId ?? 'ALL',
+            service: effectiveServiceId ?? 'ALL',
             assignee: assigneeId ?? 'ALL',
             status: statusFilter ?? 'ALL',
             urgency: urgencyFilter ?? 'ALL',
@@ -188,7 +204,8 @@ export default async function AnalyticsV2Page({
       <Suspense key={suspenseKey} fallback={<AnalyticsSkeleton />}>
         <AnalyticsContent
           teamId={teamId}
-          serviceId={serviceId}
+          actor={actor}
+          serviceId={effectiveServiceId}
           assigneeId={assigneeId}
           statusFilter={statusFilter}
           urgencyFilter={urgencyFilter}

--- a/src/app/(app)/incidents/page.tsx
+++ b/src/app/(app)/incidents/page.tsx
@@ -1,6 +1,11 @@
 import prisma from '@/lib/prisma';
 import Link from 'next/link';
-import { getUserPermissions } from '@/lib/rbac';
+import { getCurrentAuthorizationActor, getUserPermissions } from '@/lib/rbac';
+import {
+  dashboardUserReadWhere,
+  incidentReadWhere,
+  teamReadWhere,
+} from '@/lib/authorization-filters';
 import IncidentsListTable from '@/components/incident/IncidentsListTable';
 import IncidentsFilters from '@/components/incident/IncidentsFilters';
 import {
@@ -55,25 +60,18 @@ export default async function IncidentsPage({
   const currentPage = parseInt(params.page || '1', 10);
   const skip = (currentPage - 1) * ITEMS_PER_PAGE;
 
-  const permissions = await getUserPermissions();
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
   const canCreateIncident = permissions.capabilities.some(
     capability => capability === 'incident.create.all' || capability === 'incident.create.scoped'
   );
 
-  const currentUser = await prisma.user.findUnique({
-    where: { id: permissions.id },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      teamMemberships: { select: { teamId: true } },
-    },
-  });
+  const userTeamIds = [...actor.teamIds];
 
-  const userTeamIds = currentUser?.teamMemberships.map(t => t.teamId) || [];
-
-  // FIX: Fetch ALL teams for the filter dropdown, not just teams the user is in
   const allTeams = await prisma.team.findMany({
+    where: teamReadWhere(actor),
     select: { id: true, name: true },
     orderBy: { name: 'asc' },
   });
@@ -83,7 +81,7 @@ export default async function IncidentsPage({
     search: currentSearch,
     priority: currentPriority,
     urgency: currentUrgency,
-    assigneeId: currentUser?.id ?? permissions.id,
+    assigneeId: actor.id,
     assignee: currentAssignee,
     serviceId: currentServiceId,
     status: currentStatus,
@@ -94,6 +92,7 @@ export default async function IncidentsPage({
   if (currentTeamId !== 'all') {
     where.teamId = currentTeamId === 'mine' ? { in: userTeamIds } : currentTeamId;
   }
+  const effectiveWhere = { AND: [incidentReadWhere(actor), where] };
 
   const orderBy = buildIncidentOrderBy(currentSort);
 
@@ -101,7 +100,7 @@ export default async function IncidentsPage({
     search: currentSearch,
     priority: currentPriority,
     urgency: currentUrgency,
-    assigneeId: currentUser?.id ?? permissions.id,
+    assigneeId: actor.id,
     assignee: currentAssignee,
     serviceId: currentServiceId,
     createdAfter: validCreatedAfter,
@@ -113,15 +112,20 @@ export default async function IncidentsPage({
   if (currentTeamId !== 'all') {
     baseWhere.teamId = currentTeamId === 'mine' ? { in: userTeamIds } : currentTeamId;
   }
+  const effectiveBaseWhere = { AND: [incidentReadWhere(actor), baseWhere] };
+  const mineWhere = buildIncidentWhere({ filter: 'mine', ...statsBase });
+  if (currentTeamId !== 'all') {
+    mineWhere.teamId = currentTeamId === 'mine' ? { in: userTeamIds } : currentTeamId;
+  }
   const [statusCounts, mineCount] = await Promise.all([
     // Single groupBy query for all status counts
     prisma.incident.groupBy({
       by: ['status'],
-      where: baseWhere,
+      where: effectiveBaseWhere,
       _count: { _all: true },
     }),
     // Separate query for "mine" since it has additional assigneeId filter
-    prisma.incident.count({ where: buildIncidentWhere({ filter: 'mine', ...statsBase }) }),
+    prisma.incident.count({ where: { AND: [incidentReadWhere(actor), mineWhere] } }),
   ]);
 
   // Aggregate status counts from groupBy result
@@ -131,11 +135,11 @@ export default async function IncidentsPage({
   const snoozedCount = statusCountMap.get('SNOOZED') || 0;
   const suppressedCount = statusCountMap.get('SUPPRESSED') || 0;
 
-  const totalCount = await prisma.incident.count({ where });
+  const totalCount = await prisma.incident.count({ where: effectiveWhere });
   const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
 
   const incidents = await prisma.incident.findMany({
-    where,
+    where: effectiveWhere,
     select: incidentListSelect,
     orderBy,
     skip,
@@ -144,7 +148,7 @@ export default async function IncidentsPage({
 
   const users = canCreateIncident
     ? await prisma.user.findMany({
-        where: { status: 'ACTIVE' },
+        where: { AND: [{ status: 'ACTIVE' }, dashboardUserReadWhere(actor)] },
         select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
         orderBy: { name: 'asc' },
       })

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
 import DashboardRealtimeWrapper from '@/components/DashboardRealtimeWrapper';
 import DashboardCommandCenter from '@/components/dashboard/DashboardCommandCenter';
 import DashboardIncidentFilters from '@/components/dashboard/DashboardIncidentFilters';
@@ -42,7 +42,7 @@ import { IncidentHeatmapWidget } from '@/components/dashboard/widgets/IncidentHe
 import { IncidentStatus, IncidentUrgency } from '@prisma/client';
 import { buildIncidentListHref } from '@/lib/incident-links';
 import {
-  dashboardMetricsScope,
+  actorMetricReadScope,
   dashboardUserReadWhere,
   incidentReadWhere,
   serviceReadWhere,
@@ -133,7 +133,7 @@ export default async function Dashboard({
   const incidentAccess = incidentReadWhere(actor);
   const serviceAccess = serviceReadWhere(actor);
   const userAccess = dashboardUserReadWhere(actor);
-  const metricsScope = dashboardMetricsScope(actor);
+  const metricsScope = actorMetricReadScope(actor);
 
   // Build filters using utility functions
   const filterParams: DashboardFilterParams = {
@@ -227,7 +227,7 @@ export default async function Dashboard({
       orderBy: { name: 'asc' },
     }),
     // Fail-safe wrapper for SLA metrics
-    calculateSLAMetrics({
+    calculateActorSLAMetrics(actor, {
       serviceId: service,
       assigneeId: assigneeFilter,
       urgency: urgency as 'HIGH' | 'MEDIUM' | 'LOW' | undefined,
@@ -238,7 +238,6 @@ export default async function Dashboard({
       includeIncidents: true,
       includeActiveIncidents: true,
       incidentLimit: 5,
-      ...metricsScope,
     }).catch(err => {
       console.error('Failed to load SLA metrics:', err);
       // Return safe default object matching return type

--- a/src/app/(app)/postmortems/[incidentId]/page.tsx
+++ b/src/app/(app)/postmortems/[incidentId]/page.tsx
@@ -5,7 +5,8 @@ import { getPostmortem } from '../actions';
 import { notFound } from 'next/navigation';
 import PostmortemForm from '@/components/PostmortemForm';
 import PostmortemDetailView from '@/components/postmortem/PostmortemDetailView';
-import { getUserPermissions } from '@/lib/rbac';
+import { getCurrentAuthorizationActor, getUserPermissions } from '@/lib/rbac';
+import { dashboardUserReadWhere, incidentReadWhere } from '@/lib/authorization-filters';
 import prisma from '@/lib/prisma';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/shadcn/card';
@@ -30,14 +31,17 @@ export default async function PostmortemPage({
   const editMode = searchParamsData?.edit === 'true';
 
   const postmortem = await getPostmortem(incidentId);
-  const permissions = await getUserPermissions();
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
   const canEdit = permissions.isResponderOrAbove;
   // All users can view published postmortems, but only responders+ can edit
   const canView = postmortem ? postmortem.status === 'PUBLISHED' || canEdit : canEdit;
 
   // Get users for action items assignment
   const users = await prisma.user.findMany({
-    where: { status: 'ACTIVE' },
+    where: { AND: [{ status: 'ACTIVE' }, dashboardUserReadWhere(actor)] },
     select: { id: true, name: true, email: true },
     orderBy: { name: 'asc' },
   });
@@ -45,8 +49,8 @@ export default async function PostmortemPage({
   if (!postmortem) {
     // Check if incident exists and is resolved
     const prisma = (await import('@/lib/prisma')).default;
-    const incident = await prisma.incident.findUnique({
-      where: { id: incidentId },
+    const incident = await prisma.incident.findFirst({
+      where: { AND: [incidentReadWhere(actor), { id: incidentId }] },
       select: { id: true, title: true, status: true },
     });
 

--- a/src/app/(app)/postmortems/actions.ts
+++ b/src/app/(app)/postmortems/actions.ts
@@ -1,8 +1,15 @@
 'use server';
 
 import prisma from '@/lib/prisma';
+import type { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
-import { getCurrentUser, assertResponderOrAbove, getUserPermissions } from '@/lib/rbac';
+import {
+  getCurrentAuthorizationActor,
+  getCurrentUser,
+  assertResponderOrAbove,
+  getUserPermissions,
+} from '@/lib/rbac';
+import { postmortemReadWhere } from '@/lib/authorization-filters';
 import { CAPABILITIES, hasCapability } from '@/lib/authorization';
 import {
   getStoredActionItemId,
@@ -208,11 +215,14 @@ export async function upsertPostmortem(incidentId: string, data: PostmortemData)
  */
 export async function getPostmortem(incidentId: string) {
   const user = await getCurrentUser();
+  const actor = await getCurrentAuthorizationActor();
   const canViewDrafts = hasCapability(user.role, CAPABILITIES.POSTMORTEM_DRAFT_READ);
-  const postmortem = await prisma.postmortem.findUnique({
+  const postmortem = await prisma.postmortem.findFirst({
     where: {
-      incidentId,
-      ...(canViewDrafts ? {} : { status: 'PUBLISHED' }),
+      AND: [
+        postmortemReadWhere(actor),
+        { incidentId, ...(canViewDrafts ? {} : { status: 'PUBLISHED' }) },
+      ],
     },
     include: {
       createdBy: {
@@ -342,30 +352,32 @@ export async function getAllPostmortems(
   const { status, search, serviceId, page = 1, limit = 50 } = options;
   const skip = (page - 1) * limit;
 
-  const permissions = await getUserPermissions();
-  const baseWhere: Record<string, unknown> = permissions.isResponderOrAbove
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
+  const selectedWhere: Prisma.PostmortemWhereInput = permissions.isResponderOrAbove
     ? status
       ? { status }
       : {}
     : { status: 'PUBLISHED' as const };
 
   if (serviceId && serviceId !== 'all') {
-    baseWhere.incident = {
-      ...((baseWhere.incident as Record<string, unknown>) || {}),
-      serviceId,
-    };
+    selectedWhere.incident = { serviceId };
   }
 
   if (search && search.trim()) {
     const q = search.trim();
-    baseWhere.OR = [
+    selectedWhere.OR = [
       { title: { contains: q, mode: 'insensitive' } },
       { incident: { title: { contains: q, mode: 'insensitive' } } },
       { incident: { service: { name: { contains: q, mode: 'insensitive' } } } },
     ];
   }
 
-  const where = baseWhere;
+  const where: Prisma.PostmortemWhereInput = {
+    AND: [postmortemReadWhere(actor), selectedWhere],
+  };
 
   const [postmortems, total] = await Promise.all([
     prisma.postmortem.findMany({

--- a/src/app/(app)/postmortems/create/page.tsx
+++ b/src/app/(app)/postmortems/create/page.tsx
@@ -2,7 +2,8 @@ import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import PostmortemForm from '@/components/PostmortemForm';
-import { getUserPermissions } from '@/lib/rbac';
+import { getCurrentAuthorizationActor, getUserPermissions } from '@/lib/rbac';
+import { dashboardUserReadWhere, incidentReadWhere } from '@/lib/authorization-filters';
 import prisma from '@/lib/prisma';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/shadcn/card';
@@ -16,7 +17,10 @@ export default async function CreatePostmortemPage() {
     redirect('/login');
   }
 
-  const permissions = await getUserPermissions();
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
   const canCreate = permissions.isResponderOrAbove;
 
   if (!canCreate) {
@@ -33,8 +37,7 @@ export default async function CreatePostmortemPage() {
   // Get all resolved incidents without postmortems
   const resolvedIncidents = await prisma.incident.findMany({
     where: {
-      status: 'RESOLVED',
-      postmortem: null,
+      AND: [incidentReadWhere(actor), { status: 'RESOLVED', postmortem: null }],
     },
     include: {
       service: {
@@ -49,7 +52,7 @@ export default async function CreatePostmortemPage() {
 
   // Get users for action items assignment
   const users = await prisma.user.findMany({
-    where: { status: 'ACTIVE' },
+    where: { AND: [{ status: 'ACTIVE' }, dashboardUserReadWhere(actor)] },
     select: { id: true, name: true, email: true },
     orderBy: { name: 'asc' },
   });

--- a/src/app/(app)/postmortems/page.tsx
+++ b/src/app/(app)/postmortems/page.tsx
@@ -2,7 +2,12 @@ import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { getAllPostmortems } from './actions';
-import { getUserPermissions } from '@/lib/rbac';
+import { getCurrentAuthorizationActor, getUserPermissions } from '@/lib/rbac';
+import {
+  incidentReadWhere,
+  postmortemReadWhere,
+  serviceReadWhere,
+} from '@/lib/authorization-filters';
 import prisma from '@/lib/prisma';
 import Link from 'next/link';
 import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
@@ -29,15 +34,19 @@ export default async function PostmortemsPage({
   const search = params.search;
   const serviceId = params.serviceId;
   const page = params.page ? parseInt(params.page) : 1;
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
 
   const [{ postmortems, pagination }, services] = await Promise.all([
     getAllPostmortems({ status, search, serviceId, page }),
     prisma.service.findMany({
+      where: serviceReadWhere(actor),
       select: { id: true, name: true },
       orderBy: { name: 'asc' },
     }),
   ]);
-  const permissions = await getUserPermissions();
   const canCreate = permissions.isResponderOrAbove;
 
   // Get user timezone for date formatting
@@ -54,8 +63,7 @@ export default async function PostmortemsPage({
   const resolvedIncidentsWithoutPostmortems = canCreate
     ? await prisma.incident.findMany({
         where: {
-          status: 'RESOLVED',
-          postmortem: null,
+          AND: [incidentReadWhere(actor), { status: 'RESOLVED', postmortem: null }],
         },
         select: {
           id: true,
@@ -68,11 +76,12 @@ export default async function PostmortemsPage({
     : [];
 
   // Fetch counts for metrics
+  const postmortemAccess = postmortemReadWhere(actor);
   const [totalCount, publishedCount, draftCount, archivedCount] = await Promise.all([
-    prisma.postmortem.count(),
-    prisma.postmortem.count({ where: { status: 'PUBLISHED' } }),
-    prisma.postmortem.count({ where: { status: 'DRAFT' } }),
-    prisma.postmortem.count({ where: { status: 'ARCHIVED' } }),
+    prisma.postmortem.count({ where: postmortemAccess }),
+    prisma.postmortem.count({ where: { AND: [postmortemAccess, { status: 'PUBLISHED' }] } }),
+    prisma.postmortem.count({ where: { AND: [postmortemAccess, { status: 'DRAFT' }] } }),
+    prisma.postmortem.count({ where: { AND: [postmortemAccess, { status: 'ARCHIVED' }] } }),
   ]);
 
   return (

--- a/src/app/(app)/reports/executive/[id]/page.tsx
+++ b/src/app/(app)/reports/executive/[id]/page.tsx
@@ -3,7 +3,9 @@ import { redirect, notFound } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import prisma from '@/lib/prisma';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { serviceReadWhere, teamReadWhere } from '@/lib/authorization-filters';
 import { serializeSlaMetrics } from '@/lib/sla';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { DASHBOARD_TEMPLATES } from '@/lib/reports/dashboard-templates';
@@ -55,6 +57,7 @@ export default async function SavedDashboardPage({ params, searchParams }: PageP
   }
 
   const userTimeZone = getUserTimeZone(user);
+  const actor = await getCurrentAuthorizationActor();
 
   // Parse filters
   const windowDays = Number(queryParams?.window || 7);
@@ -62,7 +65,7 @@ export default async function SavedDashboardPage({ params, searchParams }: PageP
   const serviceId = queryParams?.serviceId || undefined;
 
   // Fetch metrics
-  const metrics = await calculateSLAMetrics({
+  const metrics = await calculateActorSLAMetrics(actor, {
     windowDays,
     teamId,
     serviceId,
@@ -74,8 +77,13 @@ export default async function SavedDashboardPage({ params, searchParams }: PageP
 
   // Fetch filter options
   const [teams, services] = await Promise.all([
-    prisma.team.findMany({ select: { id: true, name: true }, orderBy: { name: 'asc' } }),
+    prisma.team.findMany({
+      where: teamReadWhere(actor),
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    }),
     prisma.service.findMany({
+      where: serviceReadWhere(actor),
       select: { id: true, name: true, teamId: true },
       orderBy: { name: 'asc' },
     }),

--- a/src/app/(app)/reports/executive/page.tsx
+++ b/src/app/(app)/reports/executive/page.tsx
@@ -3,7 +3,9 @@ import { redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import prisma from '@/lib/prisma';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { serviceReadWhere, teamReadWhere } from '@/lib/authorization-filters';
 import { serializeSlaMetrics } from '@/lib/sla';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { getTemplateById, DASHBOARD_TEMPLATES } from '@/lib/reports/dashboard-templates';
@@ -43,6 +45,7 @@ export default async function ExecutiveDashboardPage({
   }
 
   const userTimeZone = getUserTimeZone(user);
+  const actor = await getCurrentAuthorizationActor();
   const params = await searchParams;
 
   // Parse filters
@@ -84,7 +87,7 @@ export default async function ExecutiveDashboardPage({
   }
 
   // Fetch metrics
-  const metrics = await calculateSLAMetrics({
+  const metrics = await calculateActorSLAMetrics(actor, {
     windowDays,
     teamId,
     serviceId,
@@ -96,8 +99,13 @@ export default async function ExecutiveDashboardPage({
 
   // Fetch filter options
   const [teams, services] = await Promise.all([
-    prisma.team.findMany({ select: { id: true, name: true }, orderBy: { name: 'asc' } }),
+    prisma.team.findMany({
+      where: teamReadWhere(actor),
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    }),
     prisma.service.findMany({
+      where: serviceReadWhere(actor),
       select: { id: true, name: true, teamId: true },
       orderBy: { name: 'asc' },
     }),

--- a/src/app/(app)/schedules/page.tsx
+++ b/src/app/(app)/schedules/page.tsx
@@ -1,5 +1,6 @@
 import prisma from '@/lib/prisma';
-import { getUserPermissions } from '@/lib/rbac';
+import { getCurrentAuthorizationActor, getUserPermissions } from '@/lib/rbac';
+import { scheduleReadWhere } from '@/lib/authorization-filters';
 import { createSchedule } from './actions';
 import ScheduleDirectoryList from '@/components/schedules/ScheduleDirectoryList';
 import ScheduleCreateForm from '@/components/ScheduleCreateForm';
@@ -17,9 +18,13 @@ import {
 import Link from 'next/link';
 
 export default async function SchedulesPage() {
-  const permissions = await getUserPermissions();
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
 
   const schedules = await prisma.onCallSchedule.findMany({
+    where: scheduleReadWhere(actor),
     include: {
       layers: {
         include: {

--- a/src/app/(app)/services/[id]/page.tsx
+++ b/src/app/(app)/services/[id]/page.tsx
@@ -2,7 +2,12 @@ import prisma from '@/lib/prisma';
 import type { WebhookIntegration } from '@prisma/client';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { assertCanModifyService, assertCanViewService } from '@/lib/rbac';
+import {
+  assertCanModifyService,
+  assertCanViewService,
+  getCurrentAuthorizationActor,
+} from '@/lib/rbac';
+import { incidentReadWhere } from '@/lib/authorization-filters';
 import { deleteService, updateService, deleteIntegration } from '../actions';
 
 // UI Components
@@ -153,6 +158,8 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
   } catch {
     notFound();
   }
+  const actor = await getCurrentAuthorizationActor();
+  const incidentAccess = incidentReadWhere(actor);
 
   let canManageService = false;
   try {
@@ -162,7 +169,10 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
     // The service is viewable but this user cannot change its configuration.
   }
 
-  const { calculateSLAMetrics, calculateMultiServiceUptime } = await import('@/lib/sla-server');
+  const [{ calculateActorSLAMetrics }, { calculateMultiServiceUptime }] = await Promise.all([
+    import('@/lib/actor-metrics'),
+    import('@/lib/sla-server'),
+  ]);
   const slaWindowDays = 30;
   const now = new Date();
   const thirtyDaysAgo = new Date(now.getTime() - slaWindowDays * 24 * 60 * 60 * 1000);
@@ -206,6 +216,7 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
         },
         jiraServiceMapping: true,
         incidents: {
+          where: incidentAccess,
           include: {
             assignee: {
               select: { id: true, name: true, email: true, avatarUrl: true, gender: true },
@@ -226,8 +237,8 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
         },
       },
     }),
-    prisma.incident.count({ where: { serviceId: id } }),
-    calculateSLAMetrics({
+    prisma.incident.count({ where: { AND: [incidentAccess, { serviceId: id }] } }),
+    calculateActorSLAMetrics(actor, {
       serviceId: id,
       windowDays: slaWindowDays,
       includeActiveIncidents: true,

--- a/src/app/(app)/services/[id]/page.tsx
+++ b/src/app/(app)/services/[id]/page.tsx
@@ -7,7 +7,7 @@ import {
   assertCanViewService,
   getCurrentAuthorizationActor,
 } from '@/lib/rbac';
-import { incidentReadWhere } from '@/lib/authorization-filters';
+import { incidentReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
 import { deleteService, updateService, deleteIntegration } from '../actions';
 
 // UI Components
@@ -169,10 +169,9 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
     // The service is viewable but this user cannot change its configuration.
   }
 
-  const [{ calculateActorSLAMetrics }, { calculateMultiServiceUptime }] = await Promise.all([
-    import('@/lib/actor-metrics'),
-    import('@/lib/sla-server'),
-  ]);
+  const { calculateActorSLAMetrics, calculateActorMultiServiceUptime } = await import(
+    '@/lib/actor-metrics'
+  );
   const slaWindowDays = 30;
   const now = new Date();
   const thirtyDaysAgo = new Date(now.getTime() - slaWindowDays * 24 * 60 * 60 * 1000);
@@ -188,8 +187,8 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
     jiraConfig,
     chatOpsConfig,
   ] = await Promise.all([
-    prisma.service.findUnique({
-      where: { id },
+    prisma.service.findFirst({
+      where: { AND: [serviceReadWhere(actor), { id }] },
       include: {
         team: {
           select: { id: true, name: true, description: true },
@@ -229,12 +228,7 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
           skip,
           take: INCIDENTS_PER_PAGE,
         },
-        _count: {
-          select: {
-            incidents: true,
-            integrations: true,
-          },
-        },
+        _count: { select: { integrations: true } },
       },
     }),
     prisma.incident.count({ where: { AND: [incidentAccess, { serviceId: id }] } }),
@@ -243,7 +237,7 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
       windowDays: slaWindowDays,
       includeActiveIncidents: true,
     }),
-    calculateMultiServiceUptime([id], thirtyDaysAgo, now),
+    calculateActorMultiServiceUptime(actor, [id], thirtyDaysAgo, now),
     canManageService ? prisma.team.findMany({ orderBy: { name: 'asc' } }) : Promise.resolve([]),
     canManageService
       ? prisma.escalationPolicy.findMany({
@@ -293,7 +287,7 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
     effectiveDurationDays > 0 ? (windowTotalIncidents / effectiveDurationDays) * 30 : 0;
   const availability = Math.max(0, Math.min(100, uptimeByService[id] ?? 100));
 
-  const totalIncidents = service._count.incidents;
+  const totalIncidents = totalIncidentCount;
   const totalPages = Math.ceil(totalIncidents / INCIDENTS_PER_PAGE);
 
   const boundUpdateService = updateService.bind(null, service.id);

--- a/src/app/(app)/services/page.tsx
+++ b/src/app/(app)/services/page.tsx
@@ -3,7 +3,12 @@ import { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { logAudit } from '@/lib/audit';
-import { getUserPermissions, assertAdminOrResponder } from '@/lib/rbac';
+import {
+  getCurrentAuthorizationActor,
+  getUserPermissions,
+  assertAdminOrResponder,
+} from '@/lib/rbac';
+import { incidentReadWhere, serviceReadWhere, teamReadWhere } from '@/lib/authorization-filters';
 import { assertServiceNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
 import ServicesListTable from '@/components/service/ServicesListTable';
 import ServicesFilters from '@/components/service/ServicesFilters';
@@ -92,12 +97,22 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
     parseInt(typeof params?.page === 'string' ? params.page : '1', 10)
   );
 
+  const [permissions, actor] = await Promise.all([
+    getUserPermissions(),
+    getCurrentAuthorizationActor(),
+  ]);
+  const serviceAccess = serviceReadWhere(actor);
+  const incidentAccess = incidentReadWhere(actor);
+  const canCreateService = permissions.isAdminOrResponder;
+
   const [teams, policies] = await Promise.all([
-    prisma.team.findMany({ orderBy: { name: 'asc' } }),
-    prisma.escalationPolicy.findMany({
-      select: { id: true, name: true },
-      orderBy: { name: 'asc' },
-    }),
+    prisma.team.findMany({ where: teamReadWhere(actor), orderBy: { name: 'asc' } }),
+    canCreateService
+      ? prisma.escalationPolicy.findMany({
+          select: { id: true, name: true },
+          orderBy: { name: 'asc' },
+        })
+      : Promise.resolve([]),
   ]);
 
   // Build where clause for filtering
@@ -116,19 +131,23 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
       status: { in: activeIncidentStatuses() },
     };
     if (statusFilter === 'CRITICAL') {
-      andConditions.push({ incidents: { some: { ...active, urgency: 'HIGH' } } });
+      andConditions.push({
+        incidents: { some: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } },
+      });
     } else if (statusFilter === 'DEGRADED') {
       andConditions.push({
         AND: [
-          { incidents: { some: active } },
-          { incidents: { none: { ...active, urgency: 'HIGH' } } },
+          { incidents: { some: { AND: [incidentAccess, active] } } },
+          { incidents: { none: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } } },
         ],
       });
     } else if (statusFilter === 'OPERATIONAL') {
-      andConditions.push({ incidents: { none: active } });
+      andConditions.push({ incidents: { none: { AND: [incidentAccess, active] } } });
     }
   }
-  const where: Prisma.ServiceWhereInput = andConditions.length > 0 ? { AND: andConditions } : {};
+  const selectedWhere: Prisma.ServiceWhereInput =
+    andConditions.length > 0 ? { AND: andConditions } : {};
+  const where: Prisma.ServiceWhereInput = { AND: [serviceAccess, selectedWhere] };
 
   // Build orderBy clause
   let orderBy: Prisma.ServiceOrderByWithRelationInput = { name: 'asc' };
@@ -137,9 +156,9 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
   } else if (sortBy === 'status') {
     orderBy = { status: 'asc' };
   } else if (sortBy === 'incidents_desc') {
-    orderBy = { incidents: { _count: 'desc' } };
+    orderBy = { name: 'asc' };
   } else if (sortBy === 'incidents_asc') {
-    orderBy = { incidents: { _count: 'asc' } };
+    orderBy = { name: 'asc' };
   }
 
   const totalFilteredItems = await prisma.service.count({ where });
@@ -165,10 +184,10 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
     orderBy,
   });
 
-  const { calculateSLAMetrics } = await import('@/lib/sla-server');
+  const { calculateActorSLAMetrics } = await import('@/lib/actor-metrics');
   const slaWindowDays = 30;
   // SLA server is the source of truth for service metrics/status
-  const slaMetrics = await calculateSLAMetrics({
+  const slaMetrics = await calculateActorSLAMetrics(actor, {
     windowDays: slaWindowDays,
     includeActiveIncidents: true,
     serviceId: services.map(s => s.id),
@@ -206,22 +225,27 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
     status: { in: activeIncidentStatuses() },
   };
   const [operationalCount, degradedCount, criticalCount] = await Promise.all([
-    prisma.service.count({ where: { incidents: { none: active } } }),
+    prisma.service.count({
+      where: { AND: [serviceAccess, { incidents: { none: { AND: [incidentAccess, active] } } }] },
+    }),
     prisma.service.count({
       where: {
         AND: [
-          { incidents: { some: active } },
-          { incidents: { none: { ...active, urgency: 'HIGH' } } },
+          serviceAccess,
+          { incidents: { some: { AND: [incidentAccess, active] } } },
+          { incidents: { none: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } } },
         ],
       },
     }),
     prisma.service.count({
-      where: { incidents: { some: { ...active, urgency: 'HIGH' } } },
+      where: {
+        AND: [
+          serviceAccess,
+          { incidents: { some: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } } },
+        ],
+      },
     }),
   ]);
-
-  const permissions = await getUserPermissions();
-  const canCreateService = permissions.isAdminOrResponder;
 
   return (
     <div className="mx-auto w-full max-w-[1600px] space-y-6 px-4 py-6 md:px-6 md:py-8">

--- a/src/app/(app)/services/page.tsx
+++ b/src/app/(app)/services/page.tsx
@@ -116,37 +116,43 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
   ]);
 
   // Build where clause for filtering
-  const andConditions: Prisma.ServiceWhereInput[] = [];
+  const nonStatusConditions: Prisma.ServiceWhereInput[] = [];
   if (searchQuery) {
-    andConditions.push({
+    nonStatusConditions.push({
       OR: [
         { name: { contains: searchQuery, mode: 'insensitive' as const } },
         { description: { contains: searchQuery, mode: 'insensitive' as const } },
       ],
     });
   }
-  if (teamFilter) andConditions.push({ teamId: teamFilter });
+  if (teamFilter) nonStatusConditions.push({ teamId: teamFilter });
+  const selectedNonStatusWhere: Prisma.ServiceWhereInput =
+    nonStatusConditions.length > 0 ? { AND: nonStatusConditions } : {};
+  const baseWhere: Prisma.ServiceWhereInput = {
+    AND: [serviceAccess, selectedNonStatusWhere],
+  };
+  const statusConditions: Prisma.ServiceWhereInput[] = [];
   if (statusFilter !== 'all') {
     const active = {
       status: { in: activeIncidentStatuses() },
     };
     if (statusFilter === 'CRITICAL') {
-      andConditions.push({
+      statusConditions.push({
         incidents: { some: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } },
       });
     } else if (statusFilter === 'DEGRADED') {
-      andConditions.push({
+      statusConditions.push({
         AND: [
           { incidents: { some: { AND: [incidentAccess, active] } } },
           { incidents: { none: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } } },
         ],
       });
     } else if (statusFilter === 'OPERATIONAL') {
-      andConditions.push({ incidents: { none: { AND: [incidentAccess, active] } } });
+      statusConditions.push({ incidents: { none: { AND: [incidentAccess, active] } } });
     }
   }
   const selectedWhere: Prisma.ServiceWhereInput =
-    andConditions.length > 0 ? { AND: andConditions } : {};
+    statusConditions.length > 0 ? { AND: [selectedNonStatusWhere, ...statusConditions] } : selectedNonStatusWhere;
   const where: Prisma.ServiceWhereInput = { AND: [serviceAccess, selectedWhere] };
 
   // Build orderBy clause
@@ -155,34 +161,66 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
     orderBy = { name: 'desc' };
   } else if (sortBy === 'status') {
     orderBy = { status: 'asc' };
-  } else if (sortBy === 'incidents_desc') {
-    orderBy = { name: 'asc' };
-  } else if (sortBy === 'incidents_asc') {
-    orderBy = { name: 'asc' };
   }
 
-  const totalFilteredItems = await prisma.service.count({ where });
+  const isIncidentCountSort = sortBy === 'incidents_desc' || sortBy === 'incidents_asc';
+  const [totalFilteredItems, countSortServices] = await Promise.all([
+    prisma.service.count({ where }),
+    isIncidentCountSort
+      ? prisma.service.findMany({ where, select: { id: true, name: true } })
+      : Promise.resolve([]),
+  ]);
   const totalPages = Math.ceil(totalFilteredItems / ITEMS_PER_PAGE);
   const startIdx = (currentPage - 1) * ITEMS_PER_PAGE;
 
-  const services = await prisma.service.findMany({
-    where,
-    skip: startIdx,
-    take: ITEMS_PER_PAGE,
-    select: {
-      id: true,
-      name: true,
-      description: true,
-      region: true,
-      slaTier: true,
-      status: true,
-      team: true,
-      policy: {
-        select: { id: true, name: true },
-      },
-    },
-    orderBy,
-  });
+  const serviceSelect = {
+    id: true,
+    name: true,
+    description: true,
+    region: true,
+    slaTier: true,
+    status: true,
+    team: true,
+    policy: { select: { id: true, name: true } },
+  } as const;
+  const countSortActiveCounts = isIncidentCountSort
+    ? await prisma.incident.groupBy({
+        by: ['serviceId'],
+        where: {
+          AND: [
+            incidentAccess,
+            { status: { in: activeIncidentStatuses() } },
+            { serviceId: { in: countSortServices.map(service => service.id) } },
+          ],
+        },
+        _count: { _all: true },
+      })
+    : [];
+  const countByServiceId = new Map(
+    countSortActiveCounts.map(count => [count.serviceId, count._count._all])
+  );
+  const orderedCountSortIds = isIncidentCountSort
+    ? countSortServices
+        .sort((left, right) => {
+          const difference = (countByServiceId.get(left.id) ?? 0) - (countByServiceId.get(right.id) ?? 0);
+          return (sortBy === 'incidents_desc' ? -difference : difference) || left.name.localeCompare(right.name);
+        })
+        .map(service => service.id)
+    : [];
+  const pageServiceIds = orderedCountSortIds.slice(startIdx, startIdx + ITEMS_PER_PAGE);
+  const services = isIncidentCountSort
+    ? await prisma.service.findMany({ where: { id: { in: pageServiceIds } }, select: serviceSelect })
+    : await prisma.service.findMany({
+        where,
+        skip: startIdx,
+        take: ITEMS_PER_PAGE,
+        select: serviceSelect,
+        orderBy,
+      });
+  if (isIncidentCountSort) {
+    const position = new Map(pageServiceIds.map((id, index) => [id, index]));
+    services.sort((left, right) => (position.get(left.id) ?? 0) - (position.get(right.id) ?? 0));
+  }
 
   const { calculateActorSLAMetrics } = await import('@/lib/actor-metrics');
   const slaWindowDays = 30;
@@ -218,20 +256,18 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
     };
   });
 
-  // Calculate high-level stats (just for the page, or maybe we need total stats?)
-  // If we need total stats, we can't get it without fetching all. Let's just keep stats based on what we have, or leave it. Wait, the user didn't mention stats, but they said "Remove the in-memory .filter(), .sort(), .slice() operations".
   const totalServices = totalFilteredItems;
   const active = {
     status: { in: activeIncidentStatuses() },
   };
   const [operationalCount, degradedCount, criticalCount] = await Promise.all([
     prisma.service.count({
-      where: { AND: [serviceAccess, { incidents: { none: { AND: [incidentAccess, active] } } }] },
+      where: { AND: [baseWhere, { incidents: { none: { AND: [incidentAccess, active] } } }] },
     }),
     prisma.service.count({
       where: {
         AND: [
-          serviceAccess,
+          baseWhere,
           { incidents: { some: { AND: [incidentAccess, active] } } },
           { incidents: { none: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } } },
         ],
@@ -240,7 +276,7 @@ export default async function ServicesPage({ searchParams }: ServicesPageProps) 
     prisma.service.count({
       where: {
         AND: [
-          serviceAccess,
+          baseWhere,
           { incidents: { some: { AND: [incidentAccess, { ...active, urgency: 'HIGH' }] } } },
         ],
       },

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -9,7 +9,8 @@ import ProfileDetailTabs from '@/components/settings/ProfileDetailTabs';
 import ProfileHeroBanner from '@/components/settings/ProfileHeroBanner';
 import { SettingsSection } from '@/components/settings/layout/SettingsSection';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
 import { Users, Calendar, Flame, ShieldCheck } from 'lucide-react';
 
 export const revalidate = 0;
@@ -116,8 +117,9 @@ export default async function ProfileSettingsPage({ searchParams }: ProfileSetti
   const localTimeStr = formatLocalTimeInTz(timeZone);
 
   // Centralized SLA Metrics Calculation for Current User (Last 30 Days)
-  const slaMetrics = user?.id
-    ? await calculateSLAMetrics({
+  const actor = user?.id ? await getCurrentAuthorizationActor() : null;
+  const slaMetrics = user?.id && actor
+    ? await calculateActorSLAMetrics(actor, {
         assigneeId: user.id,
         userTimeZone: timeZone,
         windowDays: 30,

--- a/src/app/(mobile)/m/analytics/page.tsx
+++ b/src/app/(mobile)/m/analytics/page.tsx
@@ -12,10 +12,14 @@ import { INCIDENT_METRIC_DEFINITIONS, metricDefinitionTooltip } from '@/lib/metr
 export const dynamic = 'force-dynamic';
 
 export default async function MobileAnalyticsPage() {
-  const { calculateSLAMetrics } = await import('@/lib/sla-server');
+  const [{ calculateActorSLAMetrics }, { getCurrentAuthorizationActor }] = await Promise.all([
+    import('@/lib/actor-metrics'),
+    import('@/lib/rbac'),
+  ]);
+  const actor = await getCurrentAuthorizationActor();
   const metricsWindowDays = 90;
   const lastUpdated = new Date();
-  const slaMetrics = await calculateSLAMetrics({
+  const slaMetrics = await calculateActorSLAMetrics(actor, {
     windowDays: metricsWindowDays,
     includeAllTime: false,
     includeIncidents: true,

--- a/src/app/(mobile)/m/incidents/[id]/page.tsx
+++ b/src/app/(mobile)/m/incidents/[id]/page.tsx
@@ -6,6 +6,12 @@ import { MobileAvatar } from '@/components/mobile/MobileUtils';
 import { getDefaultAvatar } from '@/lib/avatar';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import {
+  dashboardUserReadWhere,
+  incidentReadWhere,
+  teamReadWhere,
+} from '@/lib/authorization-filters';
 import MobileTime from '@/components/mobile/MobileTime';
 import type { ReactNode } from 'react';
 import {
@@ -59,9 +65,10 @@ export default async function MobileIncidentDetailPage({ params }: PageProps) {
   const authOptions = await getAuthOptions();
   const session = await getServerSession(authOptions);
   const currentUserId = session?.user?.id || null;
+  const actor = await getCurrentAuthorizationActor();
 
-  const incident = await prisma.incident.findUnique({
-    where: { id },
+  const incident = await prisma.incident.findFirst({
+    where: { AND: [incidentReadWhere(actor), { id }] },
     include: {
       service: { select: { id: true, name: true } },
       assignee: { select: { id: true, name: true, email: true, avatarUrl: true, gender: true } },
@@ -100,11 +107,12 @@ export default async function MobileIncidentDetailPage({ params }: PageProps) {
 
   const [users, teams] = await Promise.all([
     prisma.user.findMany({
-      where: { status: 'ACTIVE' },
+      where: { AND: [{ status: 'ACTIVE' }, dashboardUserReadWhere(actor)] },
       select: { id: true, name: true, email: true },
       orderBy: { name: 'asc' },
     }),
     prisma.team.findMany({
+      where: teamReadWhere(actor),
       select: { id: true, name: true },
       orderBy: { name: 'asc' },
     }),

--- a/src/app/(mobile)/m/incidents/page.tsx
+++ b/src/app/(mobile)/m/incidents/page.tsx
@@ -5,6 +5,8 @@ import type { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { activeIncidentStatuses, mutedIncidentStatuses } from '@/lib/incident-status';
 import { normalizeIncidentStatus } from '@/lib/incidents-query';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { incidentReadWhere } from '@/lib/authorization-filters';
 import { AlertTriangle, Plus, ChevronLeft, ChevronRight, SearchX } from 'lucide-react';
 
 export const dynamic = 'force-dynamic';
@@ -68,36 +70,36 @@ export default async function MobileIncidentsPage(props: {
   const createdBefore = createdBeforeValue ? new Date(createdBeforeValue) : undefined;
   const page = Math.max(1, parseInt(searchParams?.page || '1', 10));
 
-  const where: Prisma.IncidentWhereInput = {};
+  const selectedWhere: Prisma.IncidentWhereInput = {};
 
   if (query) {
-    where.title = { contains: query, mode: 'insensitive' };
+    selectedWhere.title = { contains: query, mode: 'insensitive' };
   }
 
   if (filter === 'all_open') {
-    where.status = { in: activeIncidentStatuses() };
+    selectedWhere.status = { in: activeIncidentStatuses() };
   } else if (filter === 'muted') {
-    where.status = { in: mutedIncidentStatuses() };
+    selectedWhere.status = { in: mutedIncidentStatuses() };
   } else if (filter === 'open') {
-    where.status = 'OPEN';
+    selectedWhere.status = 'OPEN';
   } else if (filter === 'acknowledged') {
-    where.status = 'ACKNOWLEDGED';
+    selectedWhere.status = 'ACKNOWLEDGED';
   } else if (filter === 'resolved') {
-    where.status = 'RESOLVED';
+    selectedWhere.status = 'RESOLVED';
   }
 
-  if (status) where.status = status;
-  if (assignee) where.assigneeId = assignee.toLowerCase() === 'unassigned' ? null : assignee;
-  if (serviceId) where.serviceId = serviceId;
-  if (urgency) where.urgency = urgency;
+  if (status) selectedWhere.status = status;
+  if (assignee) selectedWhere.assigneeId = assignee.toLowerCase() === 'unassigned' ? null : assignee;
+  if (serviceId) selectedWhere.serviceId = serviceId;
+  if (urgency) selectedWhere.urgency = urgency;
   if (resolvedAfter && !Number.isNaN(resolvedAfter.getTime())) {
-    where.resolvedAt = { gte: resolvedAfter };
+    selectedWhere.resolvedAt = { gte: resolvedAfter };
   }
   if (createdAfter && !Number.isNaN(createdAfter.getTime())) {
-    where.createdAt = { ...(where.createdAt as Prisma.DateTimeFilter), gte: createdAfter };
+    selectedWhere.createdAt = { ...(selectedWhere.createdAt as Prisma.DateTimeFilter), gte: createdAfter };
   }
   if (createdBefore && !Number.isNaN(createdBefore.getTime())) {
-    where.createdAt = { ...(where.createdAt as Prisma.DateTimeFilter), lte: createdBefore };
+    selectedWhere.createdAt = { ...(selectedWhere.createdAt as Prisma.DateTimeFilter), lte: createdBefore };
   }
 
   const orderBy: Prisma.IncidentOrderByWithRelationInput[] =
@@ -106,6 +108,11 @@ export default async function MobileIncidentsPage(props: {
       : sort === 'urgency'
         ? [{ urgency: 'desc' }, { createdAt: 'desc' }]
         : [{ createdAt: 'desc' }];
+
+  const actor = await getCurrentAuthorizationActor();
+  const where: Prisma.IncidentWhereInput = {
+    AND: [incidentReadWhere(actor), selectedWhere],
+  };
 
   const [incidents, totalCount] = await Promise.all([
     prisma.incident.findMany({

--- a/src/app/(mobile)/m/layout.tsx
+++ b/src/app/(mobile)/m/layout.tsx
@@ -16,6 +16,8 @@ import { UserAvatarProvider } from '@/contexts/UserAvatarContext';
 import { ThemeProvider } from '@/components/providers/ThemeProvider';
 import MobileBiometricGuard from '@/components/mobile/MobileBiometricGuard';
 import { activeIncidentStatuses } from '@/lib/incident-status';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { incidentReadWhere } from '@/lib/authorization-filters';
 
 // Force all app routes to be dynamic
 export const dynamic = 'force-dynamic';
@@ -51,10 +53,11 @@ export default async function MobileLayout({ children }: { children: React.React
   let systemStatus: 'ok' | 'warning' | 'danger' = 'ok';
 
   try {
+    const actor = await getCurrentAuthorizationActor();
     const openUrgencyCounts = await prisma.incident.groupBy({
       by: ['urgency'],
       where: {
-        status: { in: activeIncidentStatuses() },
+        AND: [incidentReadWhere(actor), { status: { in: activeIncidentStatuses() } }],
       },
       _count: { _all: true },
     });

--- a/src/app/(mobile)/m/page.tsx
+++ b/src/app/(mobile)/m/page.tsx
@@ -17,8 +17,12 @@ export default async function MobileDashboard() {
 
   // Fetch key metrics and on-call status
   const metricsWindowDays = 90;
-  const { calculateSLAMetrics } = await import('@/lib/sla-server');
-  const slaMetrics = await calculateSLAMetrics({
+  const [{ calculateActorSLAMetrics }, { getCurrentAuthorizationActor }] = await Promise.all([
+    import('@/lib/actor-metrics'),
+    import('@/lib/rbac'),
+  ]);
+  const actor = await getCurrentAuthorizationActor();
+  const slaMetrics = await calculateActorSLAMetrics(actor, {
     windowDays: metricsWindowDays,
     includeAllTime: false,
     includeActiveIncidents: true,

--- a/src/app/(mobile)/m/services/[id]/page.tsx
+++ b/src/app/(mobile)/m/services/[id]/page.tsx
@@ -7,6 +7,8 @@ import MobileTime from '@/components/mobile/MobileTime';
 import type { ReactNode } from 'react';
 import { activeIncidentStatuses } from '@/lib/incident-status';
 import { buildIncidentListHref } from '@/lib/incident-links';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { incidentReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,13 +18,17 @@ type PageProps = {
 
 export default async function MobileServiceDetailPage({ params }: PageProps) {
   const { id } = await params;
+  const actor = await getCurrentAuthorizationActor();
+  const incidentAccess = incidentReadWhere(actor);
 
-  const service = await prisma.service.findUnique({
-    where: { id },
+  const service = await prisma.service.findFirst({
+    where: { AND: [serviceReadWhere(actor), { id }] },
     include: {
       policy: true,
       incidents: {
-        where: { status: { in: activeIncidentStatuses() } },
+        where: {
+          AND: [incidentAccess, { status: { in: activeIncidentStatuses() } }],
+        },
         orderBy: { createdAt: 'desc' },
         take: 5,
         select: {
@@ -36,7 +42,9 @@ export default async function MobileServiceDetailPage({ params }: PageProps) {
       _count: {
         select: {
           incidents: {
-            where: { status: { in: activeIncidentStatuses() } },
+            where: {
+              AND: [incidentAccess, { status: { in: activeIncidentStatuses() } }],
+            },
           },
         },
       },

--- a/src/app/(mobile)/m/services/page.tsx
+++ b/src/app/(mobile)/m/services/page.tsx
@@ -1,6 +1,8 @@
 import prisma from '@/lib/prisma';
 import { activeIncidentStatuses } from '@/lib/incident-status';
 import MobileServicesClient from '@/components/mobile/MobileServicesClient';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { incidentReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,19 +13,22 @@ export default async function MobileServicesPage({
 }) {
   const params = await searchParams;
   const query = params.q || '';
+  const actor = await getCurrentAuthorizationActor();
+  const incidentAccess = incidentReadWhere(actor);
+  const serviceWhere = query
+    ? { name: { contains: query, mode: 'insensitive' as const } }
+    : {};
 
   const services = await prisma.service.findMany({
-    where: query
-      ? {
-          name: { contains: query, mode: 'insensitive' },
-        }
-      : undefined,
+    where: { AND: [serviceReadWhere(actor), serviceWhere] },
     orderBy: { name: 'asc' },
     include: {
       _count: {
         select: {
           incidents: {
-            where: { status: { in: activeIncidentStatuses() } },
+            where: {
+              AND: [incidentAccess, { status: { in: activeIncidentStatuses() } }],
+            },
           },
         },
       },

--- a/src/app/(mobile)/m/status/page.tsx
+++ b/src/app/(mobile)/m/status/page.tsx
@@ -3,6 +3,8 @@ import MobileCard from '@/components/mobile/MobileCard';
 import Link from 'next/link';
 import MobileTime from '@/components/mobile/MobileTime';
 import { activeIncidentStatuses } from '@/lib/incident-status';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { incidentReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
 
 export const dynamic = 'force-dynamic';
 
@@ -35,6 +37,7 @@ type Announcement = {
 export default async function MobileStatusPage() {
   const now = new Date();
   const metricsWindowDays = 90;
+  const actor = await getCurrentAuthorizationActor();
 
   // Get status page config
   // Get status page config (optional for internal view)
@@ -54,6 +57,7 @@ export default async function MobileStatusPage() {
 
   // Fetch ALL services for internal dashboard view
   const services = await prisma.service.findMany({
+    where: serviceReadWhere(actor),
     orderBy: { name: 'asc' },
     select: { id: true, name: true, targetAckMinutes: true, targetResolveMinutes: true },
   });
@@ -62,7 +66,7 @@ export default async function MobileStatusPage() {
   const activeIncidentCounts = await prisma.incident.groupBy({
     by: ['serviceId', 'urgency'],
     where: {
-      status: { in: activeIncidentStatuses() },
+      AND: [incidentReadWhere(actor), { status: { in: activeIncidentStatuses() } }],
     },
     _count: { id: true },
   });
@@ -75,12 +79,15 @@ export default async function MobileStatusPage() {
     verifiedCounts.set(group.serviceId, current);
   }
 
-  const { calculateSLAMetrics, getExternalStatusLabel } = await import('@/lib/sla-server');
+  const [{ calculateActorSLAMetrics }, { getExternalStatusLabel }] = await Promise.all([
+    import('@/lib/actor-metrics'),
+    import('@/lib/sla-server'),
+  ]);
   const { getServiceDynamicStatus } = await import('@/lib/service-status');
 
   // Use all services for metrics
   const serviceIds = services.map(s => s.id);
-  const metrics = await calculateSLAMetrics({
+  const metrics = await calculateActorSLAMetrics(actor, {
     serviceId: serviceIds,
     windowDays: metricsWindowDays,
     includeActiveIncidents: true,

--- a/src/app/(mobile)/m/teams/page.tsx
+++ b/src/app/(mobile)/m/teams/page.tsx
@@ -1,6 +1,8 @@
 import prisma from '@/lib/prisma';
 import { activeIncidentStatuses } from '@/lib/incident-status';
 import MobileTeamsClient from '@/components/mobile/MobileTeamsClient';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
+import { incidentReadWhere, teamReadWhere } from '@/lib/authorization-filters';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,20 +13,23 @@ export default async function MobileTeamsPage({
 }) {
   const params = await searchParams;
   const query = params.q || '';
+  const actor = await getCurrentAuthorizationActor();
+  const incidentAccess = incidentReadWhere(actor);
+  const selectedWhere = query
+    ? { name: { contains: query, mode: 'insensitive' as const } }
+    : {};
 
   const teams = await prisma.team.findMany({
-    where: query
-      ? {
-          name: { contains: query, mode: 'insensitive' },
-        }
-      : undefined,
+    where: { AND: [teamReadWhere(actor), selectedWhere] },
     orderBy: { name: 'asc' },
     include: {
       _count: {
         select: {
           members: true,
           incidents: {
-            where: { status: { in: activeIncidentStatuses() } },
+            where: {
+              AND: [incidentAccess, { status: { in: activeIncidentStatuses() } }],
+            },
           },
         },
       },

--- a/src/app/api/analytics/export/route.ts
+++ b/src/app/api/analytics/export/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
-import { assertResponderOrAbove } from '@/lib/rbac';
+import { assertResponderOrAbove, getCurrentAuthorizationActor } from '@/lib/rbac';
+import {
+  dashboardUserReadWhere,
+  incidentReadWhere,
+  serviceReadWhere,
+  teamReadWhere,
+} from '@/lib/authorization-filters';
 import prisma from '@/lib/prisma';
 import { jsonError } from '@/lib/api-response';
 import { logger } from '@/lib/logger';
@@ -12,7 +18,7 @@ import {
 import type { IncidentStatus, IncidentUrgency } from '@prisma/client';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { getReportingWindowForDays } from '@/lib/retention-policy';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
 import { INCIDENT_METRIC_DEFINITIONS, metricScopeLabel } from '@/lib/metric-contract';
 import { incidentStatusLabel } from '@/lib/incident-status';
 
@@ -76,6 +82,7 @@ export async function GET(req: NextRequest) {
     } catch (error) {
       return jsonError(error instanceof Error ? error.message : 'Unauthorized', 403);
     }
+    const actor = await getCurrentAuthorizationActor();
 
     // Get user timezone for date formatting
     const email = session?.user?.email ?? null;
@@ -129,7 +136,7 @@ export async function GET(req: NextRequest) {
 
     // Fetch data with limits to prevent memory issues on large datasets
     const [metrics, recentIncidents, services, teams, users] = await Promise.all([
-      calculateSLAMetrics({
+      calculateActorSLAMetrics(actor, {
         startDate: effectiveStart,
         endDate: effectiveEnd,
         teamId: teamId || undefined,
@@ -140,7 +147,7 @@ export async function GET(req: NextRequest) {
         userTimeZone,
       }),
       prisma.incident.findMany({
-        where: recentIncidentWhere,
+        where: { AND: [incidentReadWhere(actor), recentIncidentWhere] },
         include: {
           service: true,
           assignee: true,
@@ -149,15 +156,17 @@ export async function GET(req: NextRequest) {
         take: 10000, // Limit to prevent OOM on large datasets
       }),
       prisma.service.findMany({
-        where: teamId ? { teamId } : undefined,
+        where: { AND: [serviceReadWhere(actor), teamId ? { teamId } : {}] },
         select: { id: true, name: true, teamId: true },
         take: 500, // Reasonable limit for services
       }),
       prisma.team.findMany({
+        where: teamReadWhere(actor),
         select: { id: true, name: true },
         take: 200, // Reasonable limit for teams
       }),
       prisma.user.findMany({
+        where: dashboardUserReadWhere(actor),
         select: { id: true, name: true, email: true },
         take: 2000, // Reasonable limit for users
       }),

--- a/src/app/api/reports/metrics/route.ts
+++ b/src/app/api/reports/metrics/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from 'next/server';
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
 import { serializeSlaMetrics } from '@/lib/sla';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
-import { assertCanReadServiceMetrics } from '@/lib/rbac';
+import { assertCanReadServiceMetrics, getCurrentAuthorizationActor } from '@/lib/rbac';
 import { logger } from '@/lib/logger';
 import { CAPABILITIES, hasCapability } from '@/lib/authorization';
 import { jsonError, jsonOk } from '@/lib/api-response';
@@ -85,7 +85,8 @@ export async function GET(request: NextRequest) {
       includeDescription && hasCapability(user.role, CAPABILITIES.INCIDENT_SENSITIVE_READ);
 
     // Calculate metrics using the centralized SLA server
-    const metrics = await calculateSLAMetrics({
+    const actor = await getCurrentAuthorizationActor();
+    const metrics = await calculateActorSLAMetrics(actor, {
       windowDays,
       teamId,
       serviceId,

--- a/src/app/api/sla/compliance/route.ts
+++ b/src/app/api/sla/compliance/route.ts
@@ -2,7 +2,9 @@ import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import prisma from '@/lib/prisma';
-import { calculateSLAMetrics, calculateMultiServiceUptime } from '@/lib/sla-server';
+import { calculateMultiServiceUptime } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
+import { getCurrentAuthorizationActor } from '@/lib/rbac';
 import { logger } from '@/lib/logger';
 import { CAPABILITIES, hasCapability, isAppRole } from '@/lib/authorization';
 import { jsonError, jsonOk } from '@/lib/api-response';
@@ -60,6 +62,7 @@ export async function GET(_request: NextRequest) {
     }
 
     const whereClause = await getDefinitionWhereForUser(sessionUser.id, sessionUser.role);
+    const actor = await getCurrentAuthorizationActor();
 
     const definitions = await prisma.sLADefinition.findMany({
       where: whereClause,
@@ -94,7 +97,7 @@ export async function GET(_request: NextRequest) {
           }
 
           // Get SLA metrics for this service
-          const metrics = await calculateSLAMetrics({
+          const metrics = await calculateActorSLAMetrics(actor, {
             serviceId: def.serviceId || undefined,
             priority: (def as any).priority || undefined,
             windowDays,

--- a/src/app/api/sla/compliance/route.ts
+++ b/src/app/api/sla/compliance/route.ts
@@ -2,8 +2,7 @@ import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import prisma from '@/lib/prisma';
-import { calculateMultiServiceUptime } from '@/lib/sla-server';
-import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
+import { calculateActorMultiServiceUptime, calculateActorSLAMetrics } from '@/lib/actor-metrics';
 import { getCurrentAuthorizationActor } from '@/lib/rbac';
 import { logger } from '@/lib/logger';
 import { CAPABILITIES, hasCapability, isAppRole } from '@/lib/authorization';
@@ -114,14 +113,16 @@ export async function GET(_request: NextRequest) {
               if (def.serviceId) {
                 const now = new Date();
                 const startDate = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
-                const uptimeMap = await calculateMultiServiceUptime(
+                const uptimeMap = await calculateActorMultiServiceUptime(
+                  actor,
                   [def.serviceId],
                   startDate,
                   now
                 );
                 currentValue = uptimeMap[def.serviceId] ?? null;
                 const previousStart = new Date(startDate.getTime() - windowDays * 86400000);
-                const previousMap = await calculateMultiServiceUptime(
+                const previousMap = await calculateActorMultiServiceUptime(
+                  actor,
                   [def.serviceId],
                   previousStart,
                   startDate

--- a/src/components/analytics/AnalyticsContent.tsx
+++ b/src/components/analytics/AnalyticsContent.tsx
@@ -1,10 +1,11 @@
-import { calculateSLAMetrics } from '@/lib/sla-server';
+import { calculateActorSLAMetrics } from '@/lib/actor-metrics';
 import { formatTimeMinutesMs } from '@/lib/time-format';
 import { smoothSeries } from '@/lib/analytics-metrics';
 import { formatDateTime } from '@/lib/timezone';
 import { buildIncidentListHref } from '@/lib/incident-links';
 import { INCIDENT_METRIC_DEFINITIONS, metricDefinitionTooltip } from '@/lib/metric-contract';
 import { logger } from '@/lib/logger';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
 import MetricCard from '@/components/analytics/MetricCard';
 import MetricIcon from '@/components/analytics/MetricIcon';
 import GaugeChart from '@/components/analytics/GaugeChart';
@@ -32,6 +33,7 @@ type AllowedStatus = 'OPEN' | 'ACKNOWLEDGED' | 'SNOOZED' | 'SUPPRESSED' | 'RESOL
 type AllowedUrgency = 'HIGH' | 'MEDIUM' | 'LOW';
 
 interface Props {
+  actor: AuthorizationActor;
   teamId?: string;
   serviceId?: string;
   assigneeId?: string;
@@ -80,6 +82,7 @@ function buildSparklineAreaPath(values: number[], width: number = 72, height: nu
 }
 
 export default async function AnalyticsContent({
+  actor,
   teamId,
   serviceId,
   assigneeId,
@@ -88,7 +91,7 @@ export default async function AnalyticsContent({
   windowDays,
   userTimeZone,
 }: Props) {
-  const metrics = await calculateSLAMetrics({
+  const metrics = await calculateActorSLAMetrics(actor, {
     teamId,
     serviceId,
     assigneeId,
@@ -349,8 +352,8 @@ export default async function AnalyticsContent({
           <AlertCircle className="w-4 h-4" />
           <span>
             <strong>Detail coverage:</strong> Detail charts cover{' '}
-            {formatDate(metrics.detailCoverage.start)} -{' '}
-            {formatDate(metrics.detailCoverage.end)}, using{' '}
+            {formatDate(metrics.detailCoverage.start)} - {formatDate(metrics.detailCoverage.end)},
+            using{' '}
             {(
               metrics.detailCoverage.sampledIncidents ?? metrics.detailCoverage.totalIncidents
             ).toLocaleString()}{' '}

--- a/src/lib/actor-metrics.ts
+++ b/src/lib/actor-metrics.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+
+import type { AuthorizationActor } from '@/lib/authorization-policy';
+import { actorMetricReadScope } from '@/lib/authorization-filters';
+import { calculateSLAMetrics, type SLAMetricsFilter } from '@/lib/sla-server';
+import type { SLAMetrics } from '@/lib/sla';
+
+/**
+ * User-facing metrics boundary. It is deliberately actor-first so callers
+ * cannot execute analytics and then attempt to filter unauthorized rows.
+ */
+export function calculateActorSLAMetrics(
+  actor: AuthorizationActor,
+  filters: SLAMetricsFilter = {}
+): Promise<SLAMetrics> {
+  return calculateSLAMetrics({ ...filters, ...actorMetricReadScope(actor) });
+}

--- a/src/lib/actor-metrics.ts
+++ b/src/lib/actor-metrics.ts
@@ -1,8 +1,12 @@
 import 'server-only';
 
 import type { AuthorizationActor } from '@/lib/authorization-policy';
-import { actorMetricReadScope } from '@/lib/authorization-filters';
-import { calculateSLAMetrics, type SLAMetricsFilter } from '@/lib/sla-server';
+import { actorMetricReadScope, incidentReadWhere } from '@/lib/authorization-filters';
+import {
+  calculateMultiServiceUptime,
+  calculateSLAMetrics,
+  type SLAMetricsFilter,
+} from '@/lib/sla-server';
 import type { SLAMetrics } from '@/lib/sla';
 
 /**
@@ -14,4 +18,16 @@ export function calculateActorSLAMetrics(
   filters: SLAMetricsFilter = {}
 ): Promise<SLAMetrics> {
   return calculateSLAMetrics({ ...filters, ...actorMetricReadScope(actor) });
+}
+
+/** Authenticated uptime boundary; public status pages use the unscoped helper. */
+export function calculateActorMultiServiceUptime(
+  actor: AuthorizationActor,
+  serviceIds: string[],
+  startDate: Date,
+  endDate: Date = new Date()
+): Promise<Record<string, number>> {
+  return calculateMultiServiceUptime(serviceIds, startDate, endDate, {
+    incidentWhere: incidentReadWhere(actor),
+  });
 }

--- a/src/lib/authorization-filters.ts
+++ b/src/lib/authorization-filters.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from '@prisma/client';
+import type { IncidentMetricFilter } from '@/lib/metrics/domain/filter';
 import { AuthorizationError, CAPABILITIES } from '@/lib/authorization';
 import {
   AUTHORIZATION_ACTIONS,
@@ -45,6 +46,68 @@ export function serviceReadWhere(actor: AuthorizationActor): Prisma.ServiceWhere
   return decision.scope === 'global' ? {} : { teamId: { in: [...actor.teamIds] } };
 }
 
+export function teamReadWhere(actor: AuthorizationActor): Prisma.TeamWhereInput {
+  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.SERVICE_READ });
+  if (!decision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Team access denied.',
+      CAPABILITIES.SERVICE_READ_SCOPED
+    );
+  }
+  return decision.scope === 'global' ? {} : { id: { in: [...actor.teamIds] } };
+}
+
+export function scheduleReadWhere(actor: AuthorizationActor): Prisma.OnCallScheduleWhereInput {
+  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.SCHEDULE_READ });
+  if (!decision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Schedule access denied.',
+      CAPABILITIES.SCHEDULE_READ_SCOPED
+    );
+  }
+  if (decision.scope === 'global') return {};
+  return {
+    OR: [
+      { layers: { some: { users: { some: { userId: actor.id } } } } },
+      { overrides: { some: { OR: [{ userId: actor.id }, { replacesUserId: actor.id }] } } },
+      {
+        escalationRules: {
+          some: {
+            policy: {
+              services: {
+                some: { team: { members: { some: { userId: actor.id, role: 'OWNER' } } } },
+              },
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+export function actorMetricReadScope(
+  actor: AuthorizationActor
+): Pick<IncidentMetricFilter, 'authorizationScope'> {
+  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ });
+  if (!decision.allowed) {
+    throw new AuthorizationError(
+      'Forbidden. Analytics access denied.',
+      CAPABILITIES.INCIDENT_READ_SCOPED
+    );
+  }
+  return decision.scope === 'global'
+    ? {}
+    : { authorizationScope: { actorId: actor.id, teamIds: [...actor.teamIds] } };
+}
+
+export function actionItemReadWhere(actor: AuthorizationActor): Prisma.ActionItemWhereInput {
+  return { incident: incidentReadWhere(actor) };
+}
+
+export function postmortemReadWhere(actor: AuthorizationActor): Prisma.PostmortemWhereInput {
+  return { incident: incidentReadWhere(actor) };
+}
+
 export function dashboardUserReadWhere(actor: AuthorizationActor): Prisma.UserWhereInput {
   const incidentDecision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ });
   if (!incidentDecision.allowed) {
@@ -55,25 +118,12 @@ export function dashboardUserReadWhere(actor: AuthorizationActor): Prisma.UserWh
   }
   if (incidentDecision.scope === 'global') return {};
   return {
-    OR: [
-      { id: actor.id },
-      { teamMemberships: { some: { teamId: { in: [...actor.teamIds] } } } },
-    ],
+    OR: [{ id: actor.id }, { teamMemberships: { some: { teamId: { in: [...actor.teamIds] } } } }],
   };
 }
 
-export function dashboardMetricsScope(actor: AuthorizationActor): {
-  teamId?: string[];
-  useOrScope?: boolean;
-} {
-  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.INCIDENT_READ });
-  if (!decision.allowed) {
-    throw new AuthorizationError(
-      'Forbidden. Dashboard metrics access denied.',
-      CAPABILITIES.INCIDENT_READ_SCOPED
-    );
-  }
-  return decision.scope === 'global'
-    ? {}
-    : { teamId: [...actor.teamIds], useOrScope: true };
+export function dashboardMetricsScope(
+  actor: AuthorizationActor
+): Pick<IncidentMetricFilter, 'authorizationScope'> {
+  return actorMetricReadScope(actor);
 }

--- a/src/lib/metrics/domain/filter.ts
+++ b/src/lib/metrics/domain/filter.ts
@@ -10,6 +10,15 @@ export type IncidentMetricFilter = {
   status?: 'ACTIVE' | 'OPEN' | 'ACKNOWLEDGED' | 'SNOOZED' | 'SUPPRESSED' | 'RESOLVED';
   visibility?: 'PUBLIC' | 'PRIVATE' | 'ALL';
   useOrScope?: boolean;
+  /**
+   * Mandatory row-level authorization scope for user-facing metric reads.
+   * Internal/system callers may omit it, but UI/API boundaries must obtain it
+   * from the centralized authorization layer rather than constructing it.
+   */
+  authorizationScope?: {
+    actorId: string;
+    teamIds: readonly string[];
+  };
 };
 
 export type MetricFilterIdentity = {
@@ -21,10 +30,11 @@ export type MetricFilterIdentity = {
   status: string | null;
   visibility: string | null;
   scope: 'and' | 'or';
+  authorization: string | null;
 };
 
-const values = (value?: string | string[]): string[] =>
-  value ? (Array.isArray(value) ? [...new Set(value)].sort() : [value]) : [];
+const values = (value?: string | readonly string[]): string[] =>
+  value ? (typeof value === 'string' ? [value] : [...new Set(value)].sort()) : [];
 
 export function compileIncidentMetricFilter(
   filter: IncidentMetricFilter,
@@ -36,11 +46,43 @@ export function compileIncidentMetricFilter(
   const services = values(filter.serviceId);
   const teams = values(filter.teamId);
   const priorities = values(filter.priority);
+  const authorizationTeamIds = values(filter.authorizationScope?.teamIds);
   const prisma: Prisma.IncidentWhereInput = {};
+  const prismaPredicates: Prisma.IncidentWhereInput[] = [];
   const sqlPredicates: Prisma.Sql[] = [];
   const prismaScopes: Prisma.IncidentWhereInput[] = [];
   const sqlScopes: Prisma.Sql[] = [];
   const column = (name: string) => Prisma.raw(`${tableAlias ? `${tableAlias}.` : ''}"${name}"`);
+
+  if (filter.authorizationScope) {
+    const { actorId } = filter.authorizationScope;
+    const teamScope: Prisma.IncidentWhereInput = {
+      AND: [
+        { visibility: 'PUBLIC' },
+        {
+          OR: [
+            { teamId: { in: authorizationTeamIds } },
+            { service: { teamId: { in: authorizationTeamIds } } },
+          ],
+        },
+      ],
+    };
+    prismaPredicates.push({
+      OR: [
+        { assigneeId: actorId },
+        { watchers: { some: { userId: actorId } } },
+        ...(authorizationTeamIds.length > 0 ? [teamScope] : []),
+      ],
+    });
+
+    const teamSql =
+      authorizationTeamIds.length > 0
+        ? Prisma.sql` OR (${column('visibility')} = 'PUBLIC'::"IncidentVisibility" AND (${column('teamId')} = ANY(${authorizationTeamIds}::text[]) OR ${column('serviceId')} IN (SELECT id FROM "Service" WHERE "teamId" = ANY(${authorizationTeamIds}::text[]))))`
+        : Prisma.empty;
+    sqlPredicates.push(
+      Prisma.sql`(${column('assigneeId')} = ${actorId} OR EXISTS (SELECT 1 FROM "IncidentWatcher" iw WHERE iw."incidentId" = ${column('id')} AND iw."userId" = ${actorId})${teamSql})`
+    );
+  }
 
   if (services.length) {
     prismaScopes.push({ serviceId: { in: services } });
@@ -93,9 +135,14 @@ export function compileIncidentMetricFilter(
     );
   }
   if (prismaScopes.length) {
-    if (filter.useOrScope) prisma.OR = prismaScopes;
-    else prisma.AND = prismaScopes;
+    if (!filter.authorizationScope) {
+      if (filter.useOrScope) prisma.OR = prismaScopes;
+      else prisma.AND = prismaScopes;
+    } else {
+      prismaPredicates.push(filter.useOrScope ? { OR: prismaScopes } : { AND: prismaScopes });
+    }
   }
+  if (prismaPredicates.length) prisma.AND = prismaPredicates;
   if (sqlScopes.length) {
     sqlPredicates.push(
       filter.useOrScope
@@ -118,6 +165,9 @@ export function compileIncidentMetricFilter(
       status: filter.status ?? null,
       visibility: filter.visibility === 'ALL' ? null : (filter.visibility ?? null),
       scope: filter.useOrScope ? 'or' : 'and',
+      authorization: filter.authorizationScope
+        ? `${filter.authorizationScope.actorId}:${authorizationTeamIds.join(',')}`
+        : null,
     },
   };
 }

--- a/src/lib/metrics/domain/rollup-eligibility.ts
+++ b/src/lib/metrics/domain/rollup-eligibility.ts
@@ -9,6 +9,7 @@ import type { IncidentMetricFilter } from './filter';
 export function isRollupCompatibleIncidentFilter(filter: IncidentMetricFilter): boolean {
   return !(
     filter.teamId !== undefined ||
+    filter.authorizationScope !== undefined ||
     filter.priority !== undefined ||
     filter.urgency !== undefined ||
     filter.assigneeId !== undefined ||

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -10,11 +10,12 @@ import {
   CAPABILITIES,
   getRoleCapabilities,
   hasCapability,
+  isAppRole,
   type AppRole,
   type Capability,
 } from '@/lib/authorization';
 import { resolveUserActor } from '@/lib/authorization-actors';
-import { serviceReadWhere } from '@/lib/authorization-filters';
+import { scheduleReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
 import { AUTHORIZATION_ACTIONS, authorize } from '@/lib/authorization-policy';
 import {
   deriveScheduleUICapabilities,
@@ -82,6 +83,15 @@ export async function getCurrentUser() {
     });
   }
   return user;
+}
+
+export async function getCurrentAuthorizationActor() {
+  const user = await getCurrentUser();
+  const actor = await resolveUserActor(user.id);
+  if (!actor || !isAppRole(user.role) || actor.status !== 'ACTIVE') {
+    throw appError('AUTHORIZATION_DENIED', 'Unauthorized. Invalid application role.');
+  }
+  return actor;
 }
 
 export async function assertAdmin() {
@@ -482,26 +492,7 @@ export async function assertCanViewSchedule(scheduleId: string) {
 }
 
 export async function getViewableScheduleWhere(): Promise<Prisma.OnCallScheduleWhereInput> {
-  const user = await getCurrentUser();
-  if (hasCapability(user.role as AppRole, CAPABILITIES.SCHEDULE_READ_ALL)) return {};
-
-  return {
-    OR: [
-      { layers: { some: { users: { some: { userId: user.id } } } } },
-      { overrides: { some: { OR: [{ userId: user.id }, { replacesUserId: user.id }] } } },
-      {
-        escalationRules: {
-          some: {
-            policy: {
-              services: {
-                some: { team: { members: { some: { userId: user.id, role: 'OWNER' } } } },
-              },
-            },
-          },
-        },
-      },
-    ],
-  };
+  return scheduleReadWhere(await getCurrentAuthorizationActor());
 }
 
 async function resolveScheduleUICapabilities(

--- a/src/lib/schedule-api-auth.ts
+++ b/src/lib/schedule-api-auth.ts
@@ -1,35 +1,7 @@
-import { Prisma } from '@prisma/client';
-import { AuthorizationError, CAPABILITIES } from '@/lib/authorization';
-import {
-  AUTHORIZATION_ACTIONS,
-  authorize,
-  type AuthorizationActor,
-} from '@/lib/authorization-policy';
+import type { Prisma } from '@prisma/client';
+import type { AuthorizationActor } from '@/lib/authorization-policy';
+import { scheduleReadWhere } from '@/lib/authorization-filters';
 
 export function getScheduleApiScope(actor: AuthorizationActor): Prisma.OnCallScheduleWhereInput {
-  const decision = authorize({ actor, action: AUTHORIZATION_ACTIONS.SCHEDULE_READ });
-  if (!decision.allowed) {
-    throw new AuthorizationError(
-      'Forbidden. Schedule access denied.',
-      CAPABILITIES.SCHEDULE_READ_SCOPED
-    );
-  }
-  if (decision.scope === 'global') return {};
-
-  return {
-    OR: [
-      { layers: { some: { users: { some: { userId: actor.id } } } } },
-      {
-        escalationRules: {
-          some: {
-            policy: {
-              services: {
-                some: { team: { members: { some: { userId: actor.id } } } },
-              },
-            },
-          },
-        },
-      },
-    ],
-  };
+  return scheduleReadWhere(actor);
 }

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -2707,7 +2707,10 @@ export async function calculateMultiServiceUptime(
   serviceIds: string[],
   startDate: Date,
   endDate: Date = new Date(),
-  visibility?: 'PUBLIC' | 'PRIVATE' | 'ALL'
+  options: 'PUBLIC' | 'PRIVATE' | 'ALL' | {
+    visibility?: 'PUBLIC' | 'PRIVATE' | 'ALL';
+    incidentWhere?: import('@prisma/client').Prisma.IncidentWhereInput;
+  } = {}
 ): Promise<Record<string, number>> {
   const { default: prisma } = await import('./prisma');
 
@@ -2717,13 +2720,20 @@ export async function calculateMultiServiceUptime(
     'incident'
   );
 
-  const visibilityFilter = visibility && visibility !== 'ALL' ? { visibility } : {};
+  // Keep the legacy visibility argument for public-status callers while allowing
+  // authenticated callers to add their actor-derived incident read predicate.
+  const normalizedOptions = typeof options === 'string' ? { visibility: options } : options;
+  const visibilityFilter =
+    normalizedOptions.visibility && normalizedOptions.visibility !== 'ALL'
+      ? { visibility: normalizedOptions.visibility }
+      : {};
 
   const incidents = await prisma.incident.findMany({
     where: {
       serviceId: { in: serviceIds },
       ...visibilityFilter,
       AND: [
+        normalizedOptions.incidentWhere ?? {},
         { createdAt: { lt: effectiveEnd } },
         {
           OR: [

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -122,33 +122,10 @@ const allowedStatus = ['OPEN', 'ACKNOWLEDGED', 'SNOOZED', 'SUPPRESSED', 'RESOLVE
 
 async function getCurrentIncidentSnapshot(filters: SLAMetricsFilter) {
   const { default: prisma } = await import('./prisma');
-  const scopeWhere: Prisma.IncidentWhereInput = {};
-
-  if (filters.serviceId) {
-    scopeWhere.serviceId = Array.isArray(filters.serviceId)
-      ? { in: filters.serviceId }
-      : filters.serviceId;
-  }
-  if (filters.teamId) {
-    const teamIds = Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId];
-    if (filters.useOrScope) {
-      scopeWhere.OR = [{ teamId: { in: teamIds } }, { service: { teamId: { in: teamIds } } }];
-    } else {
-      scopeWhere.service = { teamId: { in: teamIds } };
-    }
-  }
-  if (filters.priority) {
-    scopeWhere.priority = Array.isArray(filters.priority)
-      ? { in: filters.priority }
-      : filters.priority;
-  }
-  if (filters.visibility && filters.visibility !== 'ALL') {
-    scopeWhere.visibility = filters.visibility;
-  }
+  const scopeWhere = compileIncidentMetricFilter({ ...filters, status: undefined }).prisma;
 
   const activeWhere: Prisma.IncidentWhereInput = {
-    ...scopeWhere,
-    status: { in: activeIncidentStatuses() },
+    AND: [scopeWhere, { status: { in: activeIncidentStatuses() } }],
   };
   const [statusCounts, urgencyCounts, unassignedActive, mutedCounts] = await Promise.all([
     prisma.incident.groupBy({
@@ -161,10 +138,10 @@ async function getCurrentIncidentSnapshot(filters: SLAMetricsFilter) {
       where: activeWhere,
       _count: { _all: true },
     }),
-    prisma.incident.count({ where: { ...activeWhere, assigneeId: null } }),
+    prisma.incident.count({ where: { AND: [activeWhere, { assigneeId: null }] } }),
     prisma.incident.groupBy({
       by: ['status'],
-      where: { ...scopeWhere, status: { in: ['SNOOZED', 'SUPPRESSED'] } },
+      where: { AND: [scopeWhere, { status: { in: ['SNOOZED', 'SUPPRESSED'] } }] },
       _count: { _all: true },
     }),
   ]);
@@ -874,107 +851,47 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
   const pageSize = filters.pageSize || DEFAULT_PAGE_SIZE;
   const page = Math.max(1, filters.page || 1);
 
-  // 2. Build Where Clauses
-  const serviceWhere = filters.serviceId
-    ? {
-        serviceId: Array.isArray(filters.serviceId) ? { in: filters.serviceId } : filters.serviceId,
-      }
-    : {};
-
-  const teamWhere = filters.teamId
-    ? filters.useOrScope
-      ? {
-          OR: [
-            { teamId: Array.isArray(filters.teamId) ? { in: filters.teamId } : filters.teamId },
-            {
-              service: {
-                teamId: Array.isArray(filters.teamId) ? { in: filters.teamId } : filters.teamId,
-              },
-            },
-          ],
-        }
-      : { teamId: Array.isArray(filters.teamId) ? { in: filters.teamId } : filters.teamId }
-    : {};
-
-  const assigneeWhere =
-    filters.assigneeId !== undefined ? { assigneeId: filters.assigneeId } : null;
-  const statusWhere = filters.status
-    ? filters.status === 'ACTIVE'
-      ? { status: { in: activeIncidentStatuses() } }
-      : { status: filters.status }
-    : null;
-  const urgencyWhere = filters.urgency ? { urgency: filters.urgency } : null;
-  const priorityWhere = filters.priority
-    ? {
-        priority: Array.isArray(filters.priority) ? { in: filters.priority } : filters.priority,
-      }
-    : {};
-  const visibilityWhere =
-    filters.visibility && filters.visibility !== 'ALL'
-      ? { visibility: filters.visibility as any } // Cast to any to avoid type errors until client updates
-      : {};
-
+  // 2. Build Where Clauses. Selection and authorization are compiled once,
+  // then ANDed with snapshot-specific status predicates.
   const mutedStatusList = ['SNOOZED', 'SUPPRESSED'] as const;
   const activeStatusWhere = { status: { in: activeIncidentStatusesForFilter(filters.status) } };
-
-  let activeWhere: Prisma.IncidentWhereInput = {
-    ...activeStatusWhere,
-    ...(urgencyWhere ?? {}),
-    ...priorityWhere,
-    ...(visibilityWhere ?? {}),
-  } as any;
-
-  const hasServiceFilter = Object.keys(serviceWhere).length > 0;
-  const hasTeamFilter = Object.keys(teamWhere).length > 0;
-
-  if (filters.useOrScope && (hasServiceFilter || hasTeamFilter || assigneeWhere)) {
-    activeWhere.OR = [
-      ...(hasServiceFilter ? [serviceWhere] : []),
-      ...(hasTeamFilter ? [{ service: teamWhere }] : []),
-      ...(assigneeWhere ? [assigneeWhere] : []),
-    ];
-  } else {
-    activeWhere = {
-      ...activeWhere,
-      ...(hasServiceFilter ? serviceWhere : {}),
-      ...(hasTeamFilter ? { service: teamWhere } : {}),
-      ...(assigneeWhere ?? {}),
-    };
-  }
+  const snapshotScope = compileIncidentMetricFilter({ ...filters, status: undefined }).prisma;
+  const activeWhere: Prisma.IncidentWhereInput = { AND: [snapshotScope, activeStatusWhere] };
 
   const shouldIncludeMutedCounts =
-    !filters.status || mutedStatusList.includes(filters.status as any);
+    !filters.status || filters.status === 'SNOOZED' || filters.status === 'SUPPRESSED';
   const mutedStatusFilter =
-    filters.status && mutedStatusList.includes(filters.status as any)
+    filters.status === 'SNOOZED' || filters.status === 'SUPPRESSED'
       ? [filters.status]
-      : mutedStatusList;
-  let mutedWhere: Prisma.IncidentWhereInput = {
-    status: { in: mutedStatusFilter },
-    ...(urgencyWhere ?? {}),
-    ...priorityWhere,
-    ...(visibilityWhere ?? {}),
-  } as any;
-
-  if (filters.useOrScope && (hasServiceFilter || hasTeamFilter || assigneeWhere)) {
-    mutedWhere.OR = [
-      ...(hasServiceFilter ? [serviceWhere] : []),
-      ...(hasTeamFilter ? [{ service: teamWhere }] : []),
-      ...(assigneeWhere ? [assigneeWhere] : []),
-    ];
-  } else {
-    mutedWhere = {
-      ...mutedWhere,
-      ...(hasServiceFilter ? serviceWhere : {}),
-      ...(hasTeamFilter ? { service: teamWhere } : {}),
-      ...(assigneeWhere ?? {}),
-    };
-  }
+      : [...mutedStatusList];
+  const mutedWhere: Prisma.IncidentWhereInput = {
+    AND: [snapshotScope, { status: { in: mutedStatusFilter } }],
+  };
 
   const compiledMetricFilter = compileIncidentMetricFilter(filters);
   const recentIncidentWhere: Prisma.IncidentWhereInput = {
     ...compiledMetricFilter.prisma,
     createdAt: { gte: finalStart, lte: finalEnd },
   };
+  const selectedServiceWhere: Prisma.ServiceWhereInput = filters.serviceId
+    ? { id: Array.isArray(filters.serviceId) ? { in: filters.serviceId } : filters.serviceId }
+    : filters.teamId
+      ? { teamId: Array.isArray(filters.teamId) ? { in: filters.teamId } : filters.teamId }
+      : {};
+  const serviceTargetWhere: Prisma.ServiceWhereInput = filters.authorizationScope
+    ? {
+        AND: [
+          selectedServiceWhere,
+          {
+            incidents: {
+              some: compileIncidentMetricFilter({
+                authorizationScope: filters.authorizationScope,
+              }).prisma,
+            },
+          },
+        ],
+      }
+    : selectedServiceWhere;
 
   // Heatmap query (last 365 days, clipped to retention policy).
   // Filter set is applied via `fullIncidentFilterSql` in the raw SQL below
@@ -1126,11 +1043,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     // instead of the configured per-service targets, silently producing
     // wrong SLA compliance numbers for team-scoped dashboards.
     prisma.service.findMany({
-      where: filters.serviceId
-        ? { id: Array.isArray(filters.serviceId) ? { in: filters.serviceId } : filters.serviceId }
-        : filters.teamId
-          ? { teamId: Array.isArray(filters.teamId) ? { in: filters.teamId } : filters.teamId }
-          : {},
+      where: serviceTargetWhere,
       select: { id: true, name: true, targetAckMinutes: true, targetResolveMinutes: true },
     }),
     prisma.incident.groupBy({

--- a/tests/api/reports-metrics-response.test.ts
+++ b/tests/api/reports-metrics-response.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server';
 import { GET } from '@/app/api/reports/metrics/route';
 
 const mocks = vi.hoisted(() => ({
-  calculateSLAMetrics: vi.fn(),
+  calculateActorSLAMetrics: vi.fn(),
   serializeSlaMetrics: vi.fn(),
 }));
 
@@ -13,12 +13,20 @@ vi.mock('next-auth', () => ({
 vi.mock('@/lib/auth', () => ({ getAuthOptions: vi.fn().mockResolvedValue({}) }));
 vi.mock('@/lib/rbac', () => ({
   assertCanReadServiceMetrics: vi.fn().mockResolvedValue({ role: 'ADMIN' }),
+  getCurrentAuthorizationActor: vi.fn().mockResolvedValue({
+    id: 'admin-1',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    teamIds: [],
+  }),
 }));
 vi.mock('@/lib/authorization', () => ({
   CAPABILITIES: { INCIDENT_SENSITIVE_READ: 'incident.sensitive.read' },
   hasCapability: vi.fn().mockReturnValue(true),
 }));
-vi.mock('@/lib/sla-server', () => ({ calculateSLAMetrics: mocks.calculateSLAMetrics }));
+vi.mock('@/lib/actor-metrics', () => ({
+  calculateActorSLAMetrics: mocks.calculateActorSLAMetrics,
+}));
 vi.mock('@/lib/sla', () => ({ serializeSlaMetrics: mocks.serializeSlaMetrics }));
 vi.mock('@/lib/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -27,7 +35,7 @@ vi.mock('@/lib/logger', () => ({
 describe('GET /api/reports/metrics response contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.calculateSLAMetrics.mockResolvedValue({ dataSource: 'live' });
+    mocks.calculateActorSLAMetrics.mockResolvedValue({ dataSource: 'live' });
     mocks.serializeSlaMetrics.mockReturnValue({ mtta: 12, mttr: 34 });
   });
 
@@ -45,5 +53,9 @@ describe('GET /api/reports/metrics response contract', () => {
     expect(body).toMatchObject({ success: true, dataState: 'available' });
     expect(body.requestId).toBeTypeOf('string');
     expect(body.timestamp).toBeTypeOf('string');
+    expect(mocks.calculateActorSLAMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'admin-1' }),
+      expect.objectContaining({ serviceId: 'svc-1', windowDays: 7 })
+    );
   });
 });

--- a/tests/architecture/actor-scoped-pages-contract.test.ts
+++ b/tests/architecture/actor-scoped-pages-contract.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pages = {
+  incidents: readFileSync('src/app/(app)/incidents/page.tsx', 'utf8'),
+  services: readFileSync('src/app/(app)/services/page.tsx', 'utf8'),
+  analytics: readFileSync('src/app/(app)/analytics/page.tsx', 'utf8'),
+  schedules: readFileSync('src/app/(app)/schedules/page.tsx', 'utf8'),
+  actionItems: readFileSync('src/app/(app)/action-items/page.tsx', 'utf8'),
+  postmortems: readFileSync('src/app/(app)/postmortems/page.tsx', 'utf8'),
+  analyticsContent: readFileSync('src/components/analytics/AnalyticsContent.tsx', 'utf8'),
+  dashboard: readFileSync('src/app/(app)/page.tsx', 'utf8'),
+  mobileAnalytics: readFileSync('src/app/(mobile)/m/analytics/page.tsx', 'utf8'),
+  mobileDashboard: readFileSync('src/app/(mobile)/m/page.tsx', 'utf8'),
+  executiveReport: readFileSync('src/app/(app)/reports/executive/page.tsx', 'utf8'),
+};
+
+describe('actor-scoped page read contract', () => {
+  it.each([
+    ['incidents', pages.incidents, 'incidentReadWhere(actor)'],
+    ['services', pages.services, 'serviceReadWhere(actor)'],
+    ['analytics', pages.analytics, 'serviceReadWhere(actor)'],
+    ['schedules', pages.schedules, 'scheduleReadWhere(actor)'],
+    ['action items', pages.actionItems, 'postmortemReadWhere(actor)'],
+    ['postmortems', pages.postmortems, 'postmortemReadWhere(actor)'],
+  ])('%s composes centralized authorization before querying', (_name, page, predicate) => {
+    expect(page).toContain('getCurrentAuthorizationActor()');
+    expect(page).toContain(predicate);
+  });
+
+  it('routes user-facing analytics through the actor-first metrics boundary', () => {
+    for (const page of [
+      pages.analyticsContent,
+      pages.dashboard,
+      pages.mobileAnalytics,
+      pages.mobileDashboard,
+      pages.executiveReport,
+    ]) {
+      expect(page).toContain('calculateActorSLAMetrics(');
+    }
+  });
+});

--- a/tests/architecture/actor-scoped-pages-contract.test.ts
+++ b/tests/architecture/actor-scoped-pages-contract.test.ts
@@ -12,6 +12,13 @@ const pages = {
   dashboard: readFileSync('src/app/(app)/page.tsx', 'utf8'),
   mobileAnalytics: readFileSync('src/app/(mobile)/m/analytics/page.tsx', 'utf8'),
   mobileDashboard: readFileSync('src/app/(mobile)/m/page.tsx', 'utf8'),
+  mobileIncidents: readFileSync('src/app/(mobile)/m/incidents/page.tsx', 'utf8'),
+  mobileIncidentDetail: readFileSync('src/app/(mobile)/m/incidents/[id]/page.tsx', 'utf8'),
+  mobileServices: readFileSync('src/app/(mobile)/m/services/page.tsx', 'utf8'),
+  mobileServiceDetail: readFileSync('src/app/(mobile)/m/services/[id]/page.tsx', 'utf8'),
+  mobileTeams: readFileSync('src/app/(mobile)/m/teams/page.tsx', 'utf8'),
+  mobileLayout: readFileSync('src/app/(mobile)/m/layout.tsx', 'utf8'),
+  serviceDetail: readFileSync('src/app/(app)/services/[id]/page.tsx', 'utf8'),
   executiveReport: readFileSync('src/app/(app)/reports/executive/page.tsx', 'utf8'),
 };
 
@@ -38,5 +45,22 @@ describe('actor-scoped page read contract', () => {
     ]) {
       expect(page).toContain('calculateActorSLAMetrics(');
     }
+  });
+
+  it.each([
+    ['mobile incidents', pages.mobileIncidents, ['incidentReadWhere(actor)']],
+    ['mobile incident detail', pages.mobileIncidentDetail, ['incidentReadWhere(actor)']],
+    ['mobile services', pages.mobileServices, ['serviceReadWhere(actor)', 'incidentReadWhere(actor)']],
+    ['mobile service detail', pages.mobileServiceDetail, ['serviceReadWhere(actor)', 'incidentReadWhere(actor)']],
+    ['mobile teams', pages.mobileTeams, ['teamReadWhere(actor)', 'incidentReadWhere(actor)']],
+    ['mobile layout', pages.mobileLayout, ['incidentReadWhere(actor)']],
+    ['service detail', pages.serviceDetail, ['serviceReadWhere(actor)', 'incidentReadWhere(actor)']],
+  ])('%s uses centralized actor scope for rows and counts', (_name, page, predicates) => {
+    expect(page).toContain('getCurrentAuthorizationActor()');
+    for (const predicate of predicates) expect(page).toContain(predicate);
+  });
+
+  it('keeps authenticated uptime behind the actor-aware boundary', () => {
+    expect(pages.serviceDetail).toContain('calculateActorMultiServiceUptime(');
   });
 });

--- a/tests/architecture/dashboard-authorization-contract.test.ts
+++ b/tests/architecture/dashboard-authorization-contract.test.ts
@@ -10,7 +10,7 @@ describe('dashboard authorization contract', () => {
     expect(page).toContain('incidentReadWhere(actor)');
     expect(page).toContain('serviceReadWhere(actor)');
     expect(page).toContain('dashboardUserReadWhere(actor)');
-    expect(page).toContain('dashboardMetricsScope(actor)');
+    expect(page).toContain('calculateActorSLAMetrics(actor');
     expect(dataRoute).toContain('dashboardMetricsScope(actor)');
     expect(streamRoute).toContain('dashboardMetricsScope(actor)');
   });

--- a/tests/lib/authorization-filters.test.ts
+++ b/tests/lib/authorization-filters.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { incidentReadWhere, serviceReadWhere } from '@/lib/authorization-filters';
+import {
+  actionItemReadWhere,
+  actorMetricReadScope,
+  incidentReadWhere,
+  postmortemReadWhere,
+  scheduleReadWhere,
+  serviceReadWhere,
+  teamReadWhere,
+} from '@/lib/authorization-filters';
 import type { AuthorizationActor } from '@/lib/authorization-policy';
 import { getScheduleApiScope } from '@/lib/schedule-api-auth';
 
@@ -33,6 +41,26 @@ describe('authorization query filters', () => {
     expect(serviceReadWhere({ ...user, role: 'RESPONDER', teamIds: [] })).toEqual({});
   });
 
+  it('scopes every related directory through the same actor policy', () => {
+    expect(serviceReadWhere(user)).toEqual({ teamId: { in: ['team-1'] } });
+    expect(teamReadWhere(user)).toEqual({ id: { in: ['team-1'] } });
+    expect(actionItemReadWhere(user)).toEqual({ incident: incidentReadWhere(user) });
+    expect(postmortemReadWhere(user)).toEqual({ incident: incidentReadWhere(user) });
+    expect(scheduleReadWhere(user)).toMatchObject({
+      OR: expect.arrayContaining([
+        { layers: { some: { users: { some: { userId: 'user-1' } } } } },
+        { overrides: { some: { OR: [{ userId: 'user-1' }, { replacesUserId: 'user-1' }] } } },
+      ]),
+    });
+  });
+
+  it('creates an explicit metrics authorization scope for scoped readers', () => {
+    expect(actorMetricReadScope(user)).toEqual({
+      authorizationScope: { actorId: 'user-1', teamIds: ['team-1'] },
+    });
+    expect(actorMetricReadScope({ ...user, role: 'ADMIN' })).toEqual({});
+  });
+
   it('fails closed when an API key lacks its required scope', () => {
     expect(() =>
       serviceReadWhere({ ...user, apiKey: { id: 'key-1', scopes: ['incidents:read'] } })
@@ -48,11 +76,18 @@ describe('authorization query filters', () => {
       OR: [
         { layers: { some: { users: { some: { userId: 'user-1' } } } } },
         {
+          overrides: {
+            some: { OR: [{ userId: 'user-1' }, { replacesUserId: 'user-1' }] },
+          },
+        },
+        {
           escalationRules: {
             some: {
               policy: {
                 services: {
-                  some: { team: { members: { some: { userId: 'user-1' } } } },
+                  some: {
+                    team: { members: { some: { userId: 'user-1', role: 'OWNER' } } },
+                  },
                 },
               },
             },

--- a/tests/lib/dashboard-authorization-filters.test.ts
+++ b/tests/lib/dashboard-authorization-filters.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  dashboardMetricsScope,
-  dashboardUserReadWhere,
-} from '@/lib/authorization-filters';
+import { dashboardMetricsScope, dashboardUserReadWhere } from '@/lib/authorization-filters';
 import type { AuthorizationActor } from '@/lib/authorization-policy';
 import { buildWidgetActivityIncidentWhere } from '@/lib/widget-data-provider';
 
@@ -15,15 +12,14 @@ const user: AuthorizationActor = {
 
 describe('dashboard authorization filters', () => {
   it('limits regular-user metric calculations to their teams', () => {
-    expect(dashboardMetricsScope(user)).toEqual({ teamId: ['team-1'], useOrScope: true });
+    expect(dashboardMetricsScope(user)).toEqual({
+      authorizationScope: { actorId: 'user-1', teamIds: ['team-1'] },
+    });
   });
 
   it('limits the dashboard user picker to self and teammates', () => {
     expect(dashboardUserReadWhere(user)).toEqual({
-      OR: [
-        { id: 'user-1' },
-        { teamMemberships: { some: { teamId: { in: ['team-1'] } } } },
-      ],
+      OR: [{ id: 'user-1' }, { teamMemberships: { some: { teamId: { in: ['team-1'] } } } }],
     });
   });
 
@@ -50,10 +46,7 @@ describe('dashboard authorization filters', () => {
       AND: [
         { serviceId: 'service-outside-team' },
         {
-          OR: [
-            { teamId: { in: ['team-1'] } },
-            { service: { teamId: { in: ['team-1'] } } },
-          ],
+          OR: [{ teamId: { in: ['team-1'] } }, { service: { teamId: { in: ['team-1'] } } }],
         },
       ],
     });

--- a/tests/lib/metric-filter.test.ts
+++ b/tests/lib/metric-filter.test.ts
@@ -29,4 +29,34 @@ describe('canonical incident metric filter', () => {
     expect(compiled.sql.strings.join(' ')).toContain('i."assigneeId" IS NULL');
     expect(compiled.identity).toMatchObject({ scope: 'or', assignee: null });
   });
+
+  it('ANDs immutable actor authorization with user-selected filters in Prisma and SQL', () => {
+    const compiled = compileIncidentMetricFilter({
+      serviceId: 'selected-service',
+      status: 'OPEN',
+      authorizationScope: { actorId: 'actor-1', teamIds: ['team-2', 'team-1'] },
+    });
+
+    expect(compiled.prisma.AND).toHaveLength(2);
+    expect(compiled.prisma.AND).toContainEqual({
+      OR: [
+        { assigneeId: 'actor-1' },
+        { watchers: { some: { userId: 'actor-1' } } },
+        {
+          AND: [
+            { visibility: 'PUBLIC' },
+            {
+              OR: [
+                { teamId: { in: ['team-1', 'team-2'] } },
+                { service: { teamId: { in: ['team-1', 'team-2'] } } },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(compiled.sql.strings.join(' ')).toContain('"IncidentWatcher"');
+    expect(compiled.sql.values).toContain('actor-1');
+    expect(compiled.identity.authorization).toBe('actor-1:team-1,team-2');
+  });
 });

--- a/tests/lib/sla-server.test.ts
+++ b/tests/lib/sla-server.test.ts
@@ -105,6 +105,26 @@ describe('calculateMultiServiceUptime visibility', () => {
       })
     );
   });
+
+  it('composes an authenticated incident predicate with uptime dates', async () => {
+    prismaMock.incident.findMany.mockResolvedValueOnce([]);
+    const incidentWhere = { assigneeId: 'user-1' };
+
+    await calculateMultiServiceUptime(
+      ['service-1'],
+      new Date('2026-01-01T00:00:00.000Z'),
+      new Date('2026-01-02T00:00:00.000Z'),
+      { incidentWhere }
+    );
+
+    expect(prismaMock.incident.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: expect.arrayContaining([incidentWhere]),
+        }),
+      })
+    );
+  });
 });
 
 // Initialize the new mock functions


### PR DESCRIPTION
## Summary

Implements the P0 security and data-correctness slice from the product-wide filter audit.

## What changed

- Enforces actor-scoped reads for Incidents, Services, Analytics, Schedules, Postmortems, and Action Items.
- Adds an actor-first `calculateActorSLAMetrics` boundary for dashboards, mobile analytics, executive reports, and SLA compliance.
- Compiles actor authorization into both Prisma and parameterized SQL paths (assignee, watcher, and public team/service visibility).
- Prevents actor-scoped queries from using unscoped historical rollups and includes authorization scope in metric identity.
- Fixes current snapshot counts, service metric hydration, and alert/trend data to use the canonical scope.
- Fixes analytics export leakage and Services status/count side channels identified by Bugbot.
- Centralizes schedule visibility and constrains user/team/service/postmortem options before sending data to the browser.

## Validation

- TypeScript: passed
- Production build: passed
- Full unit suite: 2,073 passed, 4 skipped
- Focused regression/security tests after Bugbot fixes: 17 passed
- Security review: no actionable findings
- Changed core files: ESLint passes with zero warnings

This PR intentionally focuses on the P0 authorization boundary. Runtime parsing, URL state, and performance follow-ups remain separate reviewable phases.
