### PR TITLE
fix: prevent sidebar navigation freeze, unstyled layout, and idle session failure

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -88,8 +88,8 @@ const withPWA = require('@ducanh2912/next-pwa').default({
         options: {
           cacheName: 'next-static-assets',
           expiration: {
-            maxEntries: 64,
-            maxAgeSeconds: 24 * 60 * 60, // 1 day
+            maxEntries: 500,
+            maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
           },
         },
       },
@@ -100,7 +100,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
         options: {
           cacheName: 'static-images',
           expiration: {
-            maxEntries: 64,
+            maxEntries: 200,
             maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
           },
         },

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { Toaster } from '@/components/ui/shadcn/sonner';
 import { TimezoneProvider } from '@/contexts/TimezoneContext';
 import { KeyboardShortcutsProvider } from '@/components/KeyboardShortcutsProvider';
+import ChunkLoadErrorHandler from '@/components/ChunkLoadErrorHandler';
 
 function AppThemeProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -28,7 +29,8 @@ function AppThemeProvider({ children }: { children: React.ReactNode }) {
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SessionProvider>
+    <SessionProvider refetchInterval={300} refetchOnWindowFocus={true}>
+      <ChunkLoadErrorHandler />
       <AppThemeProvider>
         <TimezoneProvider>
           <KeyboardShortcutsProvider>{children}</KeyboardShortcutsProvider>

--- a/src/components/ChunkLoadErrorHandler.tsx
+++ b/src/components/ChunkLoadErrorHandler.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect } from 'react';
+import { logger } from '@/lib/logger';
+
+const RELOAD_THROTTLE_MS = 15000;
+const STORAGE_KEY = 'opsknight_chunk_reload_timestamp';
+
+function isChunkOrStyleError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('loading chunk') ||
+    normalized.includes('chunkloaderror') ||
+    normalized.includes('failed to fetch dynamically imported module') ||
+    normalized.includes('error loading dynamically imported module') ||
+    normalized.includes('css chunk load failed') ||
+    normalized.includes('loading css chunk') ||
+    normalized.includes('importing a module script failed')
+  );
+}
+
+function handleAutoReload(reason: string) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const lastReload = Number.parseInt(sessionStorage.getItem(STORAGE_KEY) || '0', 10);
+    const now = Date.now();
+
+    if (Number.isFinite(lastReload) && now - lastReload < RELOAD_THROTTLE_MS) {
+      logger.warn('[ChunkRecovery] Throttling chunk reload to prevent infinite loop', {
+        reason,
+        timeSinceLastReload: now - lastReload,
+      });
+      return;
+    }
+
+    sessionStorage.setItem(STORAGE_KEY, String(now));
+    logger.warn('[ChunkRecovery] Detected chunk/stylesheet mismatch. Reloading application...', {
+      reason,
+    });
+
+    // Hard reload from server to fetch latest build HTML and chunks
+    window.location.reload();
+  } catch (err) {
+    logger.error('[ChunkRecovery] Failed to execute auto-reload', { error: err });
+    window.location.reload();
+  }
+}
+
+export default function ChunkLoadErrorHandler() {
+  useEffect(() => {
+    // 1. Listen for unhandled runtime errors & resource loading failures (capturing phase)
+    const handleError = (event: ErrorEvent) => {
+      // Check for Error message
+      if (event?.message && isChunkOrStyleError(event.message)) {
+        handleAutoReload(`Runtime Error: ${event.message}`);
+        return;
+      }
+
+      if (event?.error?.message && isChunkOrStyleError(event.error.message)) {
+        handleAutoReload(`Runtime Error: ${event.error.message}`);
+        return;
+      }
+
+      // Check for failed <link rel="stylesheet"> or <script> element
+      const target = event.target as HTMLElement | null;
+      if (target && target.nodeName) {
+        const tagName = target.nodeName.toLowerCase();
+        if (tagName === 'link' && (target as HTMLLinkElement).rel === 'stylesheet') {
+          const href = (target as HTMLLinkElement).href || '';
+          if (href.includes('/_next/static/')) {
+            handleAutoReload(`Stylesheet load failure: ${href}`);
+          }
+        } else if (tagName === 'script') {
+          const src = (target as HTMLScriptElement).src || '';
+          if (src.includes('/_next/static/')) {
+            handleAutoReload(`Script chunk load failure: ${src}`);
+          }
+        }
+      }
+    };
+
+    // 2. Listen for unhandled promise rejections (dynamic imports)
+    const handleRejection = (event: PromiseRejectionEvent) => {
+      const reason = event?.reason;
+      const message =
+        reason instanceof Error
+          ? reason.message
+          : typeof reason === 'string'
+            ? reason
+            : reason?.message || '';
+
+      if (message && isChunkOrStyleError(message)) {
+        handleAutoReload(`Promise Rejection: ${message}`);
+      }
+    };
+
+    window.addEventListener('error', handleError, true);
+    window.addEventListener('unhandledrejection', handleRejection);
+
+    return () => {
+      window.removeEventListener('error', handleError, true);
+      window.removeEventListener('unhandledrejection', handleRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -79,12 +79,30 @@ export default class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback;
       }
 
+      const rawMessage = this.state.error?.message?.toLowerCase() || '';
+      const isChunkError =
+        rawMessage.includes('loading chunk') ||
+        rawMessage.includes('chunkloaderror') ||
+        rawMessage.includes('failed to fetch dynamically imported module') ||
+        rawMessage.includes('error loading dynamically imported module');
+
       return (
         <ErrorState
-          title="Something went wrong"
-          message={this.state.error ? getUserFacingErrorMessage(this.state.error) : 'An unexpected error occurred'}
+          title={isChunkError ? 'Application Update Available' : 'Something went wrong'}
+          message={
+            isChunkError
+              ? 'A new version of OpsKnight has been deployed. Please reload the page to get the latest updates.'
+              : this.state.error
+                ? getUserFacingErrorMessage(this.state.error)
+                : 'An unexpected error occurred'
+          }
+          retryText={isChunkError ? 'Reload Application' : 'Try Again'}
           onRetry={() => {
-            this.setState({ hasError: false, error: null });
+            if (isChunkError && typeof window !== 'undefined') {
+              window.location.reload();
+            } else {
+              this.setState({ hasError: false, error: null });
+            }
           }}
         />
       );

--- a/src/components/ui/ErrorState.tsx
+++ b/src/components/ui/ErrorState.tsx
@@ -5,10 +5,11 @@ import { AlertCircle, RefreshCw, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/shadcn/button';
 import { cn } from '@/lib/utils';
 
-interface ErrorStateProps {
+export interface ErrorStateProps {
   title?: string;
   message?: string;
   errorCode?: string;
+  retryText?: string;
   onRetry?: () => void;
   onGoBack?: () => void;
   showDetails?: boolean;
@@ -30,6 +31,7 @@ export default function ErrorState({
   title = 'Something went wrong',
   message = 'An error occurred while processing your request.',
   errorCode,
+  retryText = 'Try Again',
   onRetry,
   onGoBack,
   showDetails = false,
@@ -64,7 +66,7 @@ export default function ErrorState({
           {onRetry && (
             <Button onClick={onRetry} className="flex items-center gap-2">
               <RefreshCw className="w-4 h-4" />
-              Try Again
+              {retryText}
             </Button>
           )}
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -462,6 +462,9 @@ export default async function middleware(req: NextRequest) {
   url.pathname = isMobile && !preferDesktop ? '/m/login' : '/login';
   url.searchParams.set('callbackUrl', req.nextUrl.pathname + req.nextUrl.search);
   const redirectResponse = NextResponse.redirect(url);
+  // Ensure redirects are never cached by browser or service worker
+  redirectResponse.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+  redirectResponse.headers.set('Pragma', 'no-cache');
   // Apply security headers to redirect
   Object.entries(securityHeaders).forEach(([key, value]) => {
     redirectResponse.headers.set(key, value);

--- a/tests/components/ChunkLoadErrorHandler.test.tsx
+++ b/tests/components/ChunkLoadErrorHandler.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import ChunkLoadErrorHandler from '@/components/ChunkLoadErrorHandler';
+
+describe('ChunkLoadErrorHandler', () => {
+  const originalLocation = window.location;
+  const reloadMock = vi.fn();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadMock.mockClear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        reload: reloadMock,
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('should reload when ChunkLoadError occurs', () => {
+    render(<ChunkLoadErrorHandler />);
+
+    const errorEvent = new ErrorEvent('error', {
+      message: 'Loading chunk 842 failed. (missing: /_next/static/chunks/842.js)',
+    });
+    window.dispatchEvent(errorEvent);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem('opsknight_chunk_reload_timestamp')).toBeTruthy();
+  });
+
+  it('should reload when dynamic import rejection occurs', () => {
+    render(<ChunkLoadErrorHandler />);
+
+    const rejectionEvent = new PromiseRejectionEvent('unhandledrejection', {
+      promise: Promise.resolve(),
+      reason: new Error('Failed to fetch dynamically imported module: /_next/static/chunks/pages/users.js'),
+    });
+    window.dispatchEvent(rejectionEvent);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reload when stylesheet fails to load', () => {
+    render(<ChunkLoadErrorHandler />);
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://opsknight.com/_next/static/css/abc123.css';
+
+    const errorEvent = new Event('error', { bubbles: true });
+    Object.defineProperty(errorEvent, 'target', { value: link, enumerable: true });
+    window.dispatchEvent(errorEvent);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throttle reloads within 15 seconds to prevent reload loops', () => {
+    sessionStorage.setItem('opsknight_chunk_reload_timestamp', String(Date.now()));
+    render(<ChunkLoadErrorHandler />);
+
+    const errorEvent = new ErrorEvent('error', {
+      message: 'ChunkLoadError: Loading chunk 123 failed',
+    });
+    window.dispatchEvent(errorEvent);
+
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('should ignore unrelated runtime errors', () => {
+    render(<ChunkLoadErrorHandler />);
+
+    const errorEvent = new ErrorEvent('error', {
+      message: 'TypeError: Cannot read property of undefined',
+    });
+    window.dispatchEvent(errorEvent);
+
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem
When users stay on `opsknight.com` for some time without navigating:
1. **Deployment Version Skew & Deleted Static Chunks**: When a new deployment occurs or Workbox evicts cached static assets, Next.js chunk hashes change. Subsequent client-side navigation or CSS evaluations fail with `404 Not Found`, stripping styles and causing the React App Router to deadlock silently.
2. **Session / JWT Expiration on Idle RSC Navigation**: When a user's session expires during inactivity, Next.js `<Link>` background RSC requests (`RSC: 1`) receive a `307 Redirect` to `/login`, returning login HTML instead of the expected binary RSC flight stream. The client router cannot parse HTML as flight stream and aborts navigation without user feedback.
3. **PWA / Workbox Cache Eviction**: `maxEntries: 64` in `next.config.ts` evicted stylesheets and chunks while browsing.

## Solution
1. **ChunkLoadErrorHandler Component**: Created a resilient global error listener that catches unhandled chunk loading failures, dynamic import failures, and failed CSS `<link rel="stylesheet">` elements, automatically reloading the application with loop protection (max 1 reload per 15s).
2. **Background Session Keep-Alive**: Configured `SessionProvider` with `refetchInterval={300}` (5 minutes) and `refetchOnWindowFocus={true}` to keep sessions active and refreshed.
3. **ErrorBoundary Recovery**: Added chunk load detection to `ErrorBoundary` with a clear update message and instant reload action.
4. **Workbox Static Assets Cache**: Increased `next-static-assets` cache limit from 64 to 500 in `next.config.ts`.
5. **Middleware No-Store Redirects**: Added `no-store, no-cache` headers on unauthenticated redirects to avoid stale cached redirect bodies.
6. **Unit Tests**: Added automated unit tests covering all chunk and dynamic import error recovery scenarios.

## Verification
- Unit test suite: 295 test files passed (2162 tests passed).
- `ChunkLoadErrorHandler.test.tsx` verified all reload and throttle scenarios.