### PR TITLE
perf(realtime): target fanout and bound status reads

### DIFF
--- a/prisma/migrations/20260905170000_add_notification_change_feed_index/migration.sql
+++ b/prisma/migrations/20260905170000_add_notification_change_feed_index/migration.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "InAppNotification_createdAt_id_idx"
+ON "InAppNotification"("createdAt", "id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -225,15 +225,15 @@ model ExternalOperation {
 /// Cluster-wide provider admission/cooldown state. Local circuit breakers are
 /// only fast-fail hints; this row is the shared source of truth for replicas.
 model ProviderAdmission {
-  key              String   @id
-  state            String   @default("CLOSED")
+  key              String    @id
+  state            String    @default("CLOSED")
   blockedUntil     DateTime?
-  consecutiveFails Int      @default(0)
+  consecutiveFails Int       @default(0)
   lastSuccessAt    DateTime?
   lastFailureAt    DateTime?
   lastStatusCode   Int?
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
   @@index([state, blockedUntil])
 }
@@ -594,43 +594,43 @@ model Alert {
 }
 
 model Incident {
-  id                     String             @id @default(cuid())
-  title                  String
-  description            String?
-  status                 IncidentStatus     @default(OPEN)
-  urgency                IncidentUrgency    @default(HIGH)
-  visibility             IncidentVisibility @default(PUBLIC)
-  priority               String? // P1, P2.. P5
-  dedupKey               String? // Key for deduplication
-  serviceId              String
-  assigneeId             String?
-  teamId                 String? // Team assignment; DB check constraint keeps it exclusive with assigneeId
-  currentEscalationStep  Int? // Current step index (0-based)
-  nextEscalationAt       DateTime? // When to execute next escalation step
-  escalationStatus       String? // ESCALATING, COMPLETED, PAUSED
-  escalationProcessingAt DateTime? // When escalation processing was claimed
-  escalationGeneration   Int                @default(0) // Stable logical run identity; increments on restart/loop
-  acknowledgedAt         DateTime? // When incident was acknowledged (for SLA tracking)
-  resolvedAt             DateTime? // When incident was resolved (for SLA tracking)
-  snoozedUntil           DateTime? // When to auto-unsnooze (for time-based snoozing)
-  snoozeReason           String? // Reason for snoozing
-  slaPausedMs            BigInt             @default(0) // Materialized closed SLA pause duration
-  slaPauseStartedAt      DateTime? // Current open SLA pause, if any
-  slaAckTargetMs         Int? // Immutable effective ACK target captured when the incident is created
-  slaResolveTargetMs     Int? // Immutable effective resolve target captured when the incident is created
-  slaTargetSource        String? // Provenance for the frozen target (priority/service/default/backfill)
-  slaTargetCapturedAt    DateTime? // When the immutable target contract was captured
+  id                        String                    @id @default(cuid())
+  title                     String
+  description               String?
+  status                    IncidentStatus            @default(OPEN)
+  urgency                   IncidentUrgency           @default(HIGH)
+  visibility                IncidentVisibility        @default(PUBLIC)
+  priority                  String? // P1, P2.. P5
+  dedupKey                  String? // Key for deduplication
+  serviceId                 String
+  assigneeId                String?
+  teamId                    String? // Team assignment; DB check constraint keeps it exclusive with assigneeId
+  currentEscalationStep     Int? // Current step index (0-based)
+  nextEscalationAt          DateTime? // When to execute next escalation step
+  escalationStatus          String? // ESCALATING, COMPLETED, PAUSED
+  escalationProcessingAt    DateTime? // When escalation processing was claimed
+  escalationGeneration      Int                       @default(0) // Stable logical run identity; increments on restart/loop
+  acknowledgedAt            DateTime? // When incident was acknowledged (for SLA tracking)
+  resolvedAt                DateTime? // When incident was resolved (for SLA tracking)
+  snoozedUntil              DateTime? // When to auto-unsnooze (for time-based snoozing)
+  snoozeReason              String? // Reason for snoozing
+  slaPausedMs               BigInt                    @default(0) // Materialized closed SLA pause duration
+  slaPauseStartedAt         DateTime? // Current open SLA pause, if any
+  slaAckTargetMs            Int? // Immutable effective ACK target captured when the incident is created
+  slaResolveTargetMs        Int? // Immutable effective resolve target captured when the incident is created
+  slaTargetSource           String? // Provenance for the frozen target (priority/service/default/backfill)
+  slaTargetCapturedAt       DateTime? // When the immutable target contract was captured
   // ChatOps War-Room fields
-  slackWorkspaceId       String? // Immutable workspace that owns this war-room instance
-  slackChannelId         String? // Slack channel ID of dedicated war-room (e.g. "C0123456789")
-  slackChannelName       String? // Channel name (e.g. "inc-104-payments-api")
-  warRoomUrl             String? // Video bridge URL (Jitsi/Zoom/Meet)
-  warRoomArchivedAt      DateTime? // Set when the Slack channel is archived; the channel id is kept for history
+  slackWorkspaceId          String? // Immutable workspace that owns this war-room instance
+  slackChannelId            String? // Slack channel ID of dedicated war-room (e.g. "C0123456789")
+  slackChannelName          String? // Channel name (e.g. "inc-104-payments-api")
+  warRoomUrl                String? // Video bridge URL (Jitsi/Zoom/Meet)
+  warRoomArchivedAt         DateTime? // Set when the Slack channel is archived; the channel id is kept for history
   warRoomProvisioningStatus WarRoomProvisioningStatus @default(NONE)
   warRoomProvisioningToken  String?
   warRoomProvisioningAt     DateTime?
-  createdAt              DateTime           @default(now())
-  updatedAt              DateTime           @updatedAt
+  createdAt                 DateTime                  @default(now())
+  updatedAt                 DateTime                  @updatedAt
 
   service                 Service                  @relation(fields: [serviceId], references: [id], onDelete: Restrict)
   assignee                User?                    @relation(fields: [assigneeId], references: [id])
@@ -1069,6 +1069,7 @@ model InAppNotification {
   @@index([userId, readAt]) // For unread count queries
   @@index([userId, readAt, createdAt]) // Optomized for "Unread" queries (readAt: null)
   @@index([createdAt]) // Retention cleanup
+  @@index([createdAt, id]) // Replica-wide notification change feed cursor
 }
 
 // User device tokens for push notifications
@@ -1252,23 +1253,23 @@ enum WarRoomProvisioningStatus {
 }
 
 model ChatOpsIntent {
-  id                String             @id @default(cuid())
-  kind              ChatOpsIntentKind
-  deliveryHash      String
-  workspaceId       String
-  channelId         String?
-  slackUserId       String?
-  encryptedPayload  String
-  status            ChatOpsIntentStatus @default(PENDING)
-  attempt           Int                @default(0)
-  leaseToken        String?
-  leaseExpiresAt    DateTime?
-  effectCompletedAt DateTime?
+  id                  String              @id @default(cuid())
+  kind                ChatOpsIntentKind
+  deliveryHash        String
+  workspaceId         String
+  channelId           String?
+  slackUserId         String?
+  encryptedPayload    String
+  status              ChatOpsIntentStatus @default(PENDING)
+  attempt             Int                 @default(0)
+  leaseToken          String?
+  leaseExpiresAt      DateTime?
+  effectCompletedAt   DateTime?
   responseCompletedAt DateTime?
-  responsePayload   Json?
-  lastError         String?
-  createdAt         DateTime           @default(now())
-  updatedAt         DateTime           @updatedAt
+  responsePayload     Json?
+  lastError           String?
+  createdAt           DateTime            @default(now())
+  updatedAt           DateTime            @updatedAt
 
   @@unique([kind, deliveryHash])
   @@index([status, leaseExpiresAt])
@@ -1688,10 +1689,10 @@ model SLASnapshot {
   totalIncidents        Int
   metAckTime            Int // Count of incidents meeting ack SLA
   metResolveTime        Int // Count of incidents meeting resolve SLA
-  evaluatedAckCount     Int     @default(0)
-  evaluatedResolveCount Int     @default(0)
+  evaluatedAckCount     Int       @default(0)
+  evaluatedResolveCount Int       @default(0)
   complianceScore       Float? // null when no SLA sample was evaluated
-  denominatorUnknown    Boolean @default(false) // legacy snapshot awaiting canonical regeneration
+  denominatorUnknown    Boolean   @default(false) // legacy snapshot awaiting canonical regeneration
   targetAckMinutes      Int? // Immutable definition ACK target used for this materialization
   targetResolveMinutes  Int? // Immutable definition resolve target used for this materialization
   definitionVersion     Int? // Immutable SLA definition version used for this materialization
@@ -1796,13 +1797,13 @@ model RateLimit {
 /// The unique key makes pinning idempotent: re-reacting, or a second person
 /// reacting to the same message, no longer creates duplicate notes.
 model SlackPinnedMessage {
-  id         String   @id @default(cuid())
-  incidentId String
+  id          String   @id @default(cuid())
+  incidentId  String
   workspaceId String?
-  channelId  String // Slack channel the message lives in
-  messageTs  String // Slack message timestamp — unique within a channel
-  pinnedBy   String? // Display name of whoever reacted
-  createdAt  DateTime @default(now())
+  channelId   String // Slack channel the message lives in
+  messageTs   String // Slack message timestamp — unique within a channel
+  pinnedBy    String? // Display name of whoever reacted
+  createdAt   DateTime @default(now())
 
   incident Incident @relation(fields: [incidentId], references: [id], onDelete: Cascade)
 

--- a/src/app/(app)/incidents/page.tsx
+++ b/src/app/(app)/incidents/page.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/incidents-query';
 import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
 import { AlertTriangle, User, AlertCircle, CheckCircle2, Clock, ShieldOff } from 'lucide-react';
+import { RealtimeProvider } from '@/hooks/useRealtime';
 
 export const revalidate = 0;
 
@@ -256,17 +257,19 @@ export default async function IncidentsPage({
         />
 
         {/* List */}
-        <IncidentsListTable
-          incidents={incidents}
-          users={users}
-          canManageIncidents={permissions.isResponderOrAbove}
-          pagination={{
-            currentPage,
-            totalPages,
-            totalItems: totalCount,
-            itemsPerPage: ITEMS_PER_PAGE,
-          }}
-        />
+        <RealtimeProvider>
+          <IncidentsListTable
+            incidents={incidents}
+            users={users}
+            canManageIncidents={permissions.isResponderOrAbove}
+            pagination={{
+              currentPage,
+              totalPages,
+              totalItems: totalCount,
+              itemsPerPage: ITEMS_PER_PAGE,
+            }}
+          />
+        </RealtimeProvider>
       </div>
     </div>
   );

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -4,7 +4,7 @@ import { getAuthOptions } from '@/lib/auth';
 import prisma from '@/lib/prisma';
 import { getUserTimeZone, formatDateTime } from '@/lib/timezone';
 import { logger } from '@/lib/logger';
-import { getNotificationChangeVersion } from '@/lib/notification-change-clock';
+import { getNotificationUserChangeVersion } from '@/lib/notification-change-clock';
 
 /**
  * Server-Sent Events endpoint for real-time notification updates
@@ -75,17 +75,17 @@ export async function GET(req: NextRequest) {
       let lastCheck = new Date();
       let lastCheckId = '';
       let pollCount = 0;
-      let notificationVersion = await getNotificationChangeVersion();
+      let notificationVersion = await getNotificationUserChangeVersion(user.id);
 
       pollInterval = setInterval(async () => {
         if (isClosed || isPolling) return;
         isPolling = true;
         pollCount++;
         try {
-          const nextVersion = await getNotificationChangeVersion();
-          const globallyChanged = nextVersion !== notificationVersion;
+          const nextVersion = await getNotificationUserChangeVersion(user.id);
+          const userChanged = nextVersion !== notificationVersion;
           notificationVersion = nextVersion;
-          if (!globallyChanged && pollCount % 6 !== 0) {
+          if (!userChanged && pollCount % 6 !== 0) {
             send(JSON.stringify({ type: 'heartbeat', timestamp: new Date().toISOString() }));
             return;
           }

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -86,7 +86,6 @@ export async function GET(req: NextRequest) {
           const userChanged = nextVersion !== notificationVersion;
           notificationVersion = nextVersion;
           if (!userChanged && pollCount % 6 !== 0) {
-            send(JSON.stringify({ type: 'heartbeat', timestamp: new Date().toISOString() }));
             return;
           }
           // Optimized query: purely time-based, uses index [userId, createdAt]

--- a/src/app/api/realtime/stream/route.ts
+++ b/src/app/api/realtime/stream/route.ts
@@ -108,16 +108,17 @@ export async function GET(req: NextRequest) {
               lastIncidentHash || undefined
             );
 
-            // Only send incident updates if there are actual changes
-            if (incidentResult && incidentResult.data.length > 0) {
+            if (incidentResult) {
               lastIncidentHash = incidentResult.hash;
-              send(
-                JSON.stringify({
-                  type: 'incidents_updated',
-                  incidents: incidentResult.data,
-                  timestamp: new Date().toISOString(),
-                })
-              );
+              if (incidentResult.data.length > 0) {
+                send(
+                  JSON.stringify({
+                    type: 'incidents_updated',
+                    incidents: incidentResult.data,
+                    timestamp: new Date().toISOString(),
+                  })
+                );
+              }
             }
 
             // Get dashboard metrics using cached query (reduces DB load by 80%)

--- a/src/app/api/status/history/route.ts
+++ b/src/app/api/status/history/route.ts
@@ -83,24 +83,33 @@ export async function GET(req: NextRequest) {
     const now = new Date();
     const window = await getReportingWindowForDays(days, 'incident', now);
 
-    const { calculateSLAMetrics } = await import('@/lib/sla-server');
-    const metrics = await calculateSLAMetrics({
-      serviceId: effectiveServiceIds,
-      startDate: window.start,
-      endDate: window.end,
-      includeIncidents: visibility.showIncidents,
-      incidentLimit: visibility.showIncidents ? 100 : 1,
-      visibility: 'PUBLIC',
-    });
-
-    const { serializeRecentIncidents } = await import('@/lib/sla');
     const incidents = visibility.showIncidents
-      ? serializeRecentIncidents(metrics.recentIncidents).map(incident =>
-          serializePublicStatusIncident(incident, statusPage)
-        )
+      ? (
+          await prisma.incident.findMany({
+            where: {
+              serviceId: { in: effectiveServiceIds },
+              visibility: 'PUBLIC',
+              createdAt: { gte: window.start, lte: window.end },
+            },
+            orderBy: { createdAt: 'desc' },
+            take: 100,
+            select: {
+              id: true,
+              title: true,
+              description: true,
+              status: true,
+              urgency: true,
+              createdAt: true,
+              resolvedAt: true,
+              service: { select: { name: true, region: true } },
+            },
+          })
+        ).map(incident => serializePublicStatusIncident(incident, statusPage))
       : [];
     const services = visibility.showServices
-      ? metrics.serviceMetrics.map(s => ({ id: s.id, name: s.name }))
+      ? statusPage.services
+          .filter(item => effectiveServiceIds.includes(item.serviceId))
+          .map(item => ({ id: item.service.id, name: item.service.name }))
       : [];
 
     const response = jsonOk(
@@ -112,16 +121,18 @@ export async function GET(req: NextRequest) {
           startDate: window.start.toISOString(),
           endDate: window.end.toISOString(),
           // Retention info
-          effectiveStart: metrics.effectiveStart.toISOString(),
-          effectiveEnd: metrics.effectiveEnd.toISOString(),
-          isClipped: window.isClipped || metrics.isClipped,
+          effectiveStart: window.start.toISOString(),
+          effectiveEnd: window.end.toISOString(),
+          isClipped: window.isClipped,
         },
       },
       200
     );
-    if (statusPage.requireAuth) {
+    if (statusPage.requireAuth || statusPage.statusApiRequireToken) {
       response.headers.set('Cache-Control', 'private, no-store');
       response.headers.set('Vary', 'Cookie, Authorization');
+    } else {
+      response.headers.set('Cache-Control', 'public, s-maxage=30, stale-while-revalidate=300');
     }
     return response;
   } catch (error: any) {

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -137,6 +137,7 @@ export async function GET(req: NextRequest) {
 
     const { calculateMultiServiceUptime, getExternalStatusLabel } =
       await import('@/lib/sla-server');
+    const uptimeWindow = await getReportingWindowForDays(30, 'incident');
     const [activeGroups, recentIncidents] = await Promise.all([
       prisma.incident.groupBy({
         by: ['serviceId', 'urgency'],
@@ -149,7 +150,11 @@ export async function GET(req: NextRequest) {
       }),
       visibility.showIncidents
         ? prisma.incident.findMany({
-            where: { serviceId: { in: serviceIds }, visibility: 'PUBLIC' },
+            where: {
+              serviceId: { in: serviceIds },
+              visibility: 'PUBLIC',
+              createdAt: { gte: uptimeWindow.start, lte: uptimeWindow.end },
+            },
             orderBy: { createdAt: 'desc' },
             take: 20,
             select: {
@@ -203,7 +208,6 @@ export async function GET(req: NextRequest) {
         }))
       : [];
 
-    const uptimeWindow = await getReportingWindowForDays(30, 'incident');
     const uptimeMap = visibility.showUptime
       ? await calculateMultiServiceUptime(
           serviceIds,

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -5,7 +5,6 @@ import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { authorizeStatusApiRequest } from '@/lib/status-api-auth';
-import { serializeRecentIncidents } from '@/lib/sla';
 import { activeIncidentStatuses } from '@/lib/incident-status';
 import { getReportingWindowForDays } from '@/lib/retention-policy';
 import {
@@ -136,33 +135,57 @@ export async function GET(req: NextRequest) {
       },
     });
 
-    const { calculateSLAMetrics, calculateMultiServiceUptime, getExternalStatusLabel } =
+    const { calculateMultiServiceUptime, getExternalStatusLabel } =
       await import('@/lib/sla-server');
-
-    // Optimized: Single call to get metrics and incidents for all services in scope
-    const metrics = await calculateSLAMetrics({
-      serviceId: serviceIds,
-      includeIncidents: true,
-      incidentLimit: 20,
-      visibility: 'PUBLIC',
-    });
-
-    const recentIncidents = metrics.recentIncidents || [];
+    const [activeGroups, recentIncidents] = await Promise.all([
+      prisma.incident.groupBy({
+        by: ['serviceId', 'urgency'],
+        where: {
+          serviceId: { in: serviceIds },
+          visibility: 'PUBLIC',
+          status: { in: activeIncidentStatuses() },
+        },
+        _count: { _all: true },
+      }),
+      visibility.showIncidents
+        ? prisma.incident.findMany({
+            where: { serviceId: { in: serviceIds }, visibility: 'PUBLIC' },
+            orderBy: { createdAt: 'desc' },
+            take: 20,
+            select: {
+              id: true,
+              title: true,
+              description: true,
+              status: true,
+              urgency: true,
+              createdAt: true,
+              resolvedAt: true,
+              service: { select: { name: true, region: true } },
+            },
+          })
+        : Promise.resolve([]),
+    ]);
 
     const serviceStatusMap = new Map<string, string>();
     const serviceActiveCountMap = new Map<string, number>();
 
-    metrics.serviceMetrics.forEach(m => {
-      serviceStatusMap.set(m.id, getExternalStatusLabel(m.dynamicStatus));
-      serviceActiveCountMap.set(m.id, m.activeCount);
-    });
+    for (const serviceId of serviceIds) {
+      const groups = activeGroups.filter(group => group.serviceId === serviceId);
+      const activeCount = groups.reduce((sum, group) => sum + group._count._all, 0);
+      const dynamicStatus = groups.some(group => group.urgency === 'HIGH')
+        ? 'CRITICAL'
+        : activeCount > 0
+          ? 'DEGRADED'
+          : 'OPERATIONAL';
+      serviceStatusMap.set(serviceId, getExternalStatusLabel(dynamicStatus));
+      serviceActiveCountMap.set(serviceId, activeCount);
+    }
 
-    const overallStatus =
-      metrics.dynamicStatus === 'CRITICAL'
-        ? 'outage'
-        : metrics.dynamicStatus === 'DEGRADED'
-          ? 'degraded'
-          : 'operational';
+    const overallStatus = activeGroups.some(group => group.urgency === 'HIGH')
+      ? 'outage'
+      : activeGroups.length > 0
+        ? 'degraded'
+        : 'operational';
 
     const servicesData = visibility.showServices
       ? services.map(service => ({
@@ -212,17 +235,15 @@ export async function GET(req: NextRequest) {
         status: overallStatus,
         services: servicesData,
         incidents: visibility.showIncidents
-          ? serializeRecentIncidents(recentIncidents).map(inc =>
-              serializePublicStatusApiIncident(inc, statusPage)
-            )
+          ? recentIncidents.map(inc => serializePublicStatusApiIncident(inc, statusPage))
           : [],
         metrics: {
           uptime: uptimeMetrics,
         },
         retention: {
-          effectiveStart: metrics.effectiveStart.toISOString(),
-          effectiveEnd: metrics.effectiveEnd.toISOString(),
-          isClipped: uptimeWindow.isClipped || metrics.isClipped,
+          effectiveStart: uptimeWindow.start.toISOString(),
+          effectiveEnd: uptimeWindow.end.toISOString(),
+          isClipped: uptimeWindow.isClipped,
         },
         updatedAt: new Date().toISOString(),
       },

--- a/src/app/api/status/rss/route.ts
+++ b/src/app/api/status/rss/route.ts
@@ -7,11 +7,14 @@ import { getAuthOptions } from '@/lib/auth';
 import { authorizeStatusApiRequest } from '@/lib/status-api-auth';
 import { publicStatusVisibility } from '@/lib/status-page-public-data';
 import { createHash } from 'node:crypto';
+import { getReportingWindowForDays } from '@/lib/retention-policy';
 
-export function opaqueRssIncidentGuid(baseUrl: string, statusPageId: string, incidentId: string): string {
-  const opaqueId = createHash('sha256')
-    .update(`${statusPageId}\u0000${incidentId}`)
-    .digest('hex');
+export function opaqueRssIncidentGuid(
+  baseUrl: string,
+  statusPageId: string,
+  incidentId: string
+): string {
+  const opaqueId = createHash('sha256').update(`${statusPageId}\u0000${incidentId}`).digest('hex');
   return `${baseUrl}/status#update-${opaqueId}`;
 }
 
@@ -69,22 +72,30 @@ export async function GET(req: NextRequest) {
 
     const baseUrl = getBaseUrl();
 
-    const { calculateSLAMetrics } = await import('@/lib/sla-server');
-    const metrics =
+    const window = await getReportingWindowForDays(30, 'incident');
+    const incidents =
       visibility.showIncidents && serviceIds.length > 0
-        ? await calculateSLAMetrics({
-            serviceId: serviceIds,
-            windowDays: 30, // Last 30 days
-            includeIncidents: true,
-            incidentLimit: 50,
-            visibility: 'PUBLIC',
+        ? await prisma.incident.findMany({
+            where: {
+              serviceId: { in: serviceIds },
+              visibility: 'PUBLIC',
+              createdAt: { gte: window.start, lte: window.end },
+            },
+            orderBy: { createdAt: 'desc' },
+            take: 50,
+            select: {
+              id: true,
+              title: true,
+              description: true,
+              status: true,
+              createdAt: true,
+              service: { select: { name: true } },
+            },
           })
-        : null;
+        : [];
 
-    const incidents = visibility.showIncidents ? metrics?.recentIncidents || [] : [];
-
-    const description = metrics?.isClipped
-      ? `Current status and incidents (limited to ${metrics.retentionDays} days retention)`
+    const description = window.isClipped
+      ? 'Current status and incidents (limited by configured retention)'
       : 'Current status and incidents';
 
     // Generate RSS XML
@@ -135,6 +146,10 @@ export async function GET(req: NextRequest) {
     return new NextResponse(rss, {
       headers: {
         'Content-Type': 'application/rss+xml; charset=utf-8',
+        'Cache-Control':
+          statusPage.requireAuth || statusPage.statusApiRequireToken
+            ? 'private, no-store'
+            : 'public, s-maxage=30, stale-while-revalidate=300',
       },
     });
   } catch (error: unknown) {

--- a/src/components/DashboardRealtimeWrapper.tsx
+++ b/src/components/DashboardRealtimeWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRealtime } from '@/hooks/useRealtime';
+import { RealtimeProvider, useRealtime } from '@/hooks/useRealtime';
 import { useEffect, useState } from 'react';
 import { logger } from '@/lib/logger';
 import { useRouter } from 'next/navigation';
@@ -25,12 +25,37 @@ export default function DashboardRealtimeWrapper({
   onMetricsUpdate,
   onIncidentsUpdate,
 }: DashboardRealtimeWrapperProps) {
+  return (
+    <RealtimeProvider>
+      <DashboardRealtimeContent
+        onMetricsUpdate={onMetricsUpdate}
+        onIncidentsUpdate={onIncidentsUpdate}
+      >
+        {children}
+      </DashboardRealtimeContent>
+    </RealtimeProvider>
+  );
+}
+
+function DashboardRealtimeContent({
+  children,
+  onMetricsUpdate,
+  onIncidentsUpdate,
+}: DashboardRealtimeWrapperProps) {
   const router = useRouter();
   const { isConnected, metrics, recentIncidents, error } = useRealtime();
   const [showDisconnected, setShowDisconnected] = useState(false);
   const [dismissedIncidentKey, setDismissedIncidentKey] = useState('');
   const incidentUpdateKey = recentIncidents?.length
-    ? JSON.stringify(recentIncidents.map(incident => incident.id))
+    ? JSON.stringify(
+        recentIncidents.map(incident => [
+          incident.id,
+          incident.updatedAt,
+          incident.status,
+          incident.urgency,
+          incident.escalationStatus,
+        ])
+      )
     : '';
   const hasUpdates =
     !onIncidentsUpdate && Boolean(incidentUpdateKey) && dismissedIncidentKey !== incidentUpdateKey;

--- a/src/components/status-page/StatusPageAutoRefresh.tsx
+++ b/src/components/status-page/StatusPageAutoRefresh.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 type StatusPageAutoRefreshProps = {
   enabled: boolean;
@@ -11,6 +12,7 @@ export default function StatusPageAutoRefresh({
   enabled,
   intervalSeconds,
 }: StatusPageAutoRefreshProps) {
+  const router = useRouter();
   useEffect(() => {
     if (!enabled) return;
 
@@ -20,16 +22,14 @@ export default function StatusPageAutoRefresh({
 
     const timeout = window.setTimeout(() => {
       try {
-        const url = new URL(window.location.href);
-        url.searchParams.set('_t', Date.now().toString());
-        window.location.replace(url.toString());
+        router.refresh();
       } catch (error) {
         console.error('[Status Page] Auto-refresh error:', error);
       }
     }, refreshMs);
 
     return () => window.clearTimeout(timeout);
-  }, [enabled, intervalSeconds]);
+  }, [enabled, intervalSeconds, router]);
 
   return null;
 }

--- a/src/hooks/useRealtime.ts
+++ b/src/hooks/useRealtime.ts
@@ -1,6 +1,14 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import {
+  createContext,
+  createElement,
+  useContext,
+  useEffect,
+  useState,
+  useRef,
+  type ReactNode,
+} from 'react';
 import { logger } from '@/lib/logger';
 
 export type RealtimeEvent =
@@ -24,7 +32,7 @@ export type RealtimeMetrics = {
 
 export type RealtimeIncident = Record<string, unknown>;
 
-export function useRealtime() {
+function useRealtimeConnection() {
   const [isConnected, setIsConnected] = useState(false);
   const [metrics, setMetrics] = useState<RealtimeMetrics | null>(null);
   const [recentIncidents, setRecentIncidents] = useState<RealtimeIncident[]>([]);
@@ -146,4 +154,19 @@ export function useRealtime() {
     recentIncidents,
     error,
   };
+}
+
+type RealtimeContextValue = ReturnType<typeof useRealtimeConnection>;
+const RealtimeContext = createContext<RealtimeContextValue | null>(null);
+
+export function RealtimeProvider({ children }: { children: ReactNode }) {
+  const value = useRealtimeConnection();
+  return createElement(RealtimeContext.Provider, { value }, children);
+}
+
+/** Consume the single realtime connection owned by the nearest provider. */
+export function useRealtime(): RealtimeContextValue {
+  const value = useContext(RealtimeContext);
+  if (!value) throw new Error('useRealtime must be used within RealtimeProvider');
+  return value;
 }

--- a/src/lib/notification-change-clock.ts
+++ b/src/lib/notification-change-clock.ts
@@ -4,6 +4,7 @@ const FEED_TTL_MS = 2_000;
 const CURSOR_LOOKBACK_MS = 30_000;
 const USER_VERSION_RETENTION_MS = 5 * 60_000;
 const FEED_BATCH_SIZE = 2_000;
+const MAX_PAGES_PER_REFRESH = 5;
 
 type Cursor = { createdAt: Date; id: string };
 type UserVersion = { generation: number; seenAt: number };
@@ -19,38 +20,48 @@ async function refreshChangedUsers(): Promise<void> {
   if (expiresAt > now) return;
   if (inFlight) return inFlight;
 
-  inFlight = prisma.inAppNotification
-    .findMany({
-      where: {
-        OR: [
-          { createdAt: { gt: cursor.createdAt } },
-          { createdAt: cursor.createdAt, id: { gt: cursor.id } },
-        ],
-      },
-      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-      take: FEED_BATCH_SIZE,
-      select: { userId: true, createdAt: true, id: true },
-    })
-    .then(rows => {
-      if (rows.length > 0) {
-        generation += 1;
-        const observedAt = Date.now();
-        for (const row of rows) {
-          userVersions.set(row.userId, { generation, seenAt: observedAt });
-        }
-        const last = rows[rows.length - 1];
-        cursor = { createdAt: last.createdAt, id: last.id };
+  inFlight = (async () => {
+    let caughtUp = false;
+    for (let page = 0; page < MAX_PAGES_PER_REFRESH; page += 1) {
+      const rows = await prisma.inAppNotification.findMany({
+        where: {
+          OR: [
+            { createdAt: { gt: cursor.createdAt } },
+            { createdAt: cursor.createdAt, id: { gt: cursor.id } },
+          ],
+        },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        take: FEED_BATCH_SIZE,
+        select: { userId: true, createdAt: true, id: true },
+      });
+      if (rows.length === 0) {
+        caughtUp = true;
+        break;
       }
 
-      const retentionCutoff = Date.now() - USER_VERSION_RETENTION_MS;
-      for (const [userId, version] of userVersions) {
-        if (version.seenAt < retentionCutoff) userVersions.delete(userId);
+      generation += 1;
+      const observedAt = Date.now();
+      for (const row of rows) {
+        userVersions.set(row.userId, { generation, seenAt: observedAt });
       }
-      expiresAt = Date.now() + FEED_TTL_MS;
-    })
-    .finally(() => {
-      inFlight = null;
-    });
+      const last = rows[rows.length - 1];
+      cursor = { createdAt: last.createdAt, id: last.id };
+      if (rows.length < FEED_BATCH_SIZE) {
+        caughtUp = true;
+        break;
+      }
+    }
+
+    const retentionCutoff = Date.now() - USER_VERSION_RETENTION_MS;
+    for (const [userId, version] of userVersions) {
+      if (version.seenAt < retentionCutoff) userVersions.delete(userId);
+    }
+    // A safety-bounded refresh that is still behind should be eligible to
+    // continue immediately instead of sleeping for the normal idle TTL.
+    expiresAt = caughtUp ? Date.now() + FEED_TTL_MS : 0;
+  })().finally(() => {
+    inFlight = null;
+  });
 
   return inFlight;
 }

--- a/src/lib/notification-change-clock.ts
+++ b/src/lib/notification-change-clock.ts
@@ -1,31 +1,70 @@
 import prisma from './prisma';
 
-const CLOCK_TTL_MS = 2_000;
-let cached: { version: string; expiresAt: number } | null = null;
-let inFlight: Promise<string> | null = null;
+const FEED_TTL_MS = 2_000;
+const CURSOR_LOOKBACK_MS = 30_000;
+const USER_VERSION_RETENTION_MS = 5 * 60_000;
+const FEED_BATCH_SIZE = 2_000;
 
-/**
- * Replica-wide change clock. Thousands of idle SSE clients share one cheap
- * aggregate read instead of issuing one user-scoped query each.
- */
-export async function getNotificationChangeVersion(): Promise<string> {
+type Cursor = { createdAt: Date; id: string };
+type UserVersion = { generation: number; seenAt: number };
+
+let cursor: Cursor = { createdAt: new Date(Date.now() - CURSOR_LOOKBACK_MS), id: '' };
+let generation = 0;
+let expiresAt = 0;
+let inFlight: Promise<void> | null = null;
+const userVersions = new Map<string, UserVersion>();
+
+async function refreshChangedUsers(): Promise<void> {
   const now = Date.now();
-  if (cached && cached.expiresAt > now) return cached.version;
+  if (expiresAt > now) return;
   if (inFlight) return inFlight;
+
   inFlight = prisma.inAppNotification
-    .aggregate({ _max: { createdAt: true, id: true } })
-    .then(result => {
-      const version = `${result._max.createdAt?.toISOString() ?? 'none'}:${result._max.id ?? ''}`;
-      cached = { version, expiresAt: Date.now() + CLOCK_TTL_MS };
-      return version;
+    .findMany({
+      where: {
+        OR: [
+          { createdAt: { gt: cursor.createdAt } },
+          { createdAt: cursor.createdAt, id: { gt: cursor.id } },
+        ],
+      },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: FEED_BATCH_SIZE,
+      select: { userId: true, createdAt: true, id: true },
+    })
+    .then(rows => {
+      if (rows.length > 0) {
+        generation += 1;
+        const observedAt = Date.now();
+        for (const row of rows) {
+          userVersions.set(row.userId, { generation, seenAt: observedAt });
+        }
+        const last = rows[rows.length - 1];
+        cursor = { createdAt: last.createdAt, id: last.id };
+      }
+
+      const retentionCutoff = Date.now() - USER_VERSION_RETENTION_MS;
+      for (const [userId, version] of userVersions) {
+        if (version.seenAt < retentionCutoff) userVersions.delete(userId);
+      }
+      expiresAt = Date.now() + FEED_TTL_MS;
     })
     .finally(() => {
       inFlight = null;
     });
+
   return inFlight;
 }
 
-export function clearNotificationChangeClock(): void {
-  cached = null;
+/** A shared cursor wakes only streams whose user received a notification. */
+export async function getNotificationUserChangeVersion(userId: string): Promise<number> {
+  await refreshChangedUsers();
+  return userVersions.get(userId)?.generation ?? 0;
+}
+
+export function clearNotificationChangeClock(now = Date.now()): void {
+  cursor = { createdAt: new Date(now - CURSOR_LOOKBACK_MS), id: '' };
+  generation = 0;
+  expiresAt = 0;
   inFlight = null;
+  userVersions.clear();
 }

--- a/src/lib/widget-data-provider.ts
+++ b/src/lib/widget-data-provider.ts
@@ -4,7 +4,7 @@ import type { SLAMetrics as SLAServerMetrics } from '@/lib/sla';
 import { getActiveOnCallShifts } from '@/lib/oncall-shifts';
 import type { Prisma } from '@prisma/client';
 import { compileIncidentMetricFilter } from '@/lib/metrics/domain/filter';
-import { activeIncidentStatuses } from '@/lib/incident-status';
+import { activeIncidentStatusesForFilter } from '@/lib/incident-status';
 import { resolveSlaTarget } from '@/lib/metrics/domain/sla-target';
 import { effectiveElapsedMs } from '@/lib/metrics/domain/sla-clock';
 
@@ -103,7 +103,7 @@ export async function getWidgetRealtimeProjection(
   const now = new Date();
   const where = compileIncidentMetricFilter({ ...filters, status: undefined }).prisma;
   const incidents = await prisma.incident.findMany({
-    where: { AND: [where, { status: { in: activeIncidentStatuses() } }] },
+    where: { AND: [where, { status: { in: activeIncidentStatusesForFilter(filters.status) } }] },
     orderBy: [{ urgency: 'desc' }, { createdAt: 'asc' }],
     take: 100,
     select: {

--- a/tests/api/notifications-stream.test.ts
+++ b/tests/api/notifications-stream.test.ts
@@ -80,4 +80,34 @@ describe('API Route - Notifications Stream', () => {
     controller.abort();
     vi.useRealTimers();
   });
+
+  it('does not send idle heartbeats or query the user before 30 seconds', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'user@example.com' } });
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      timeZone: 'UTC',
+      status: 'ACTIVE',
+    } as never);
+    vi.mocked(getNotificationUserChangeVersion).mockResolvedValue(0);
+    vi.mocked(prisma.inAppNotification.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.inAppNotification.count).mockResolvedValue(0);
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/notifications/stream', {
+        signal: controller.signal,
+      })
+    );
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(prisma.inAppNotification.findMany).not.toHaveBeenCalled();
+    expect(prisma.inAppNotification.count).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(prisma.inAppNotification.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.inAppNotification.count).toHaveBeenCalledTimes(1);
+    response.body?.cancel();
+    controller.abort();
+    vi.useRealTimers();
+  });
 });

--- a/tests/api/notifications-stream.test.ts
+++ b/tests/api/notifications-stream.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { GET } from '@/app/api/notifications/stream/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
+import { getNotificationUserChangeVersion } from '@/lib/notification-change-clock';
 
 vi.mock('next-auth', () => ({
   getServerSession: vi.fn(),
@@ -12,6 +13,10 @@ vi.mock('@/lib/auth', () => ({
   getAuthOptions: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('@/lib/notification-change-clock', () => ({
+  getNotificationUserChangeVersion: vi.fn(),
+}));
+
 vi.mock('@/lib/prisma', () => ({
   __esModule: true,
   default: {
@@ -19,7 +24,6 @@ vi.mock('@/lib/prisma', () => ({
       findUnique: vi.fn(),
     },
     inAppNotification: {
-      aggregate: vi.fn(),
       findMany: vi.fn(),
       count: vi.fn(),
     },
@@ -50,11 +54,7 @@ describe('API Route - Notifications Stream', () => {
     } as never);
     vi.mocked(prisma.inAppNotification.findMany).mockResolvedValue([]);
     vi.mocked(prisma.inAppNotification.count).mockResolvedValue(0);
-    vi.mocked(prisma.inAppNotification.aggregate)
-      .mockResolvedValueOnce({ _max: { createdAt: null, id: null } } as never)
-      .mockResolvedValue({
-        _max: { createdAt: new Date('2026-09-05T00:00:00.000Z'), id: 'notification-1' },
-      } as never);
+    vi.mocked(getNotificationUserChangeVersion).mockResolvedValueOnce(0).mockResolvedValue(1);
 
     const req = new NextRequest(new URL('http://localhost:3000/api/notifications/stream'), {
       signal: controller.signal,

--- a/tests/api/realtime-stream.test.ts
+++ b/tests/api/realtime-stream.test.ts
@@ -5,77 +5,132 @@ import { GET } from '@/app/api/realtime/stream/route';
 import prisma from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/rbac';
 
+const { recentIncidentsMock, dashboardMetricsMock } = vi.hoisted(() => ({
+  recentIncidentsMock: vi.fn(),
+  dashboardMetricsMock: vi.fn(),
+}));
+
+vi.mock('@/lib/realtime-cache', () => ({
+  getCachedRecentIncidents: recentIncidentsMock,
+  getCachedDashboardMetrics: dashboardMetricsMock,
+}));
+
 vi.mock('@/lib/rbac', () => ({
-    getCurrentUser: vi.fn(),
+  getCurrentUser: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => ({
-    __esModule: true,
-    default: {
-        user: {
-            findUnique: vi.fn(),
-        },
-        incident: {
-            findMany: vi.fn(),
-            count: vi.fn(),
-        },
+  __esModule: true,
+  default: {
+    user: {
+      findUnique: vi.fn(),
     },
+    incident: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
 }));
 
 describe('API Route - Realtime Stream', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recentIncidentsMock.mockResolvedValue({ data: [], changed: true, hash: '[]' });
+    dashboardMetricsMock.mockResolvedValue(null);
+  });
+
+  it('returns SSE stream for authenticated users', async () => {
+    const controller = new AbortController();
+    const currentUser: Awaited<ReturnType<typeof getCurrentUser>> = {
+      id: 'user-1',
+      role: 'ADMIN',
+      email: 'admin@example.com',
+      name: 'Admin User',
+      timeZone: 'UTC',
+      status: 'ACTIVE',
+      tokenVersion: 0,
+      invitationGeneration: 0,
+      gender: null,
+      department: null,
+      jobTitle: null,
+      avatarUrl: null,
+      phoneNumber: null,
+      emailNotificationsEnabled: false,
+      smsNotificationsEnabled: false,
+      pushNotificationsEnabled: false,
+      whatsappNotificationsEnabled: false,
+    };
+    const streamUser = {
+      id: 'user-1',
+      role: 'ADMIN',
+      status: 'ACTIVE',
+      tokenVersion: 0,
+      teamMemberships: [],
+    } satisfies Prisma.UserGetPayload<{
+      select: {
+        id: true;
+        role: true;
+        status: true;
+        tokenVersion: true;
+        teamMemberships: { select: { teamId: true } };
+      };
+    }>;
+    vi.mocked(getCurrentUser).mockResolvedValue(currentUser);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(streamUser as never);
+    vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.incident.count).mockResolvedValue(0);
+
+    const req = new NextRequest('http://localhost:3000/api/realtime/stream', {
+      signal: controller.signal,
     });
+    const res = await GET(req);
 
-    it('returns SSE stream for authenticated users', async () => {
-        const controller = new AbortController();
-        const currentUser: Awaited<ReturnType<typeof getCurrentUser>> = {
-            id: 'user-1',
-            role: 'ADMIN',
-            email: 'admin@example.com',
-            name: 'Admin User',
-            timeZone: 'UTC',
-            status: 'ACTIVE',
-            tokenVersion: 0,
-            invitationGeneration: 0,
-            gender: null,
-            department: null,
-            jobTitle: null,
-            avatarUrl: null,
-            phoneNumber: null,
-            emailNotificationsEnabled: false,
-            smsNotificationsEnabled: false,
-            pushNotificationsEnabled: false,
-            whatsappNotificationsEnabled: false,
-        };
-        const streamUser = {
-            id: 'user-1',
-            role: 'ADMIN',
-            status: 'ACTIVE',
-            tokenVersion: 0,
-            teamMemberships: [],
-        } satisfies Prisma.UserGetPayload<{
-            select: {
-                id: true;
-                role: true;
-                status: true;
-                tokenVersion: true;
-                teamMemberships: { select: { teamId: true } };
-            };
-        }>;
-        vi.mocked(getCurrentUser).mockResolvedValue(currentUser);
-        vi.mocked(prisma.user.findUnique).mockResolvedValue(streamUser as never);
-        vi.mocked(prisma.incident.findMany).mockResolvedValue([]);
-        vi.mocked(prisma.incident.count).mockResolvedValue(0);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
 
-        const req = new NextRequest('http://localhost:3000/api/realtime/stream', {
-            signal: controller.signal,
-        });
-        const res = await GET(req);
+    controller.abort();
+  });
 
-        expect(res.status).toBe(200);
-        expect(res.headers.get('Content-Type')).toBe('text/event-stream');
-
-        controller.abort();
+  it('commits the empty incident hash as the next polling baseline', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      id: 'user-1',
+      role: 'ADMIN',
+      email: 'admin@example.com',
+      name: 'Admin',
+      timeZone: 'UTC',
+      status: 'ACTIVE',
+      tokenVersion: 0,
+      invitationGeneration: 0,
+      gender: null,
+      department: null,
+      jobTitle: null,
+      avatarUrl: null,
+      phoneNumber: null,
+      emailNotificationsEnabled: false,
+      smsNotificationsEnabled: false,
+      pushNotificationsEnabled: false,
+      whatsappNotificationsEnabled: false,
     });
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      role: 'ADMIN',
+      status: 'ACTIVE',
+      tokenVersion: 0,
+      teamMemberships: [],
+    } as never);
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/realtime/stream', {
+        signal: controller.signal,
+      })
+    );
+    expect(response.status).toBe(200);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(recentIncidentsMock).toHaveBeenNthCalledWith(2, 'user-1', 'ADMIN', [], '[]');
+    controller.abort();
+    vi.useRealTimers();
+  });
 });

--- a/tests/architecture/incidents-realtime-provider-contract.test.ts
+++ b/tests/architecture/incidents-realtime-provider-contract.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('incidents realtime provider contract', () => {
+  it('keeps the standalone incidents list inside a realtime provider', () => {
+    const source = readFileSync('src/app/(app)/incidents/page.tsx', 'utf8');
+    expect(source).toContain("import { RealtimeProvider } from '@/hooks/useRealtime'");
+    expect(source).toMatch(
+      /<RealtimeProvider>[\s\S]*<IncidentsListTable[\s\S]*<\/RealtimeProvider>/
+    );
+  });
+});

--- a/tests/components/DashboardRealtimeWrapper.test.tsx
+++ b/tests/components/DashboardRealtimeWrapper.test.tsx
@@ -13,6 +13,7 @@ const refreshMock = vi.fn();
 
 vi.mock('@/hooks/useRealtime', () => ({
   useRealtime: () => useRealtimeMock(),
+  RealtimeProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 // Mock next/navigation
@@ -87,5 +88,34 @@ describe('DashboardRealtimeWrapper', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /dashboard updates available/i }));
     expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a new refresh action when the same incident changes lifecycle state', () => {
+    useRealtimeMock.mockReturnValue({
+      isConnected: true,
+      metrics: { open: 5, acknowledged: 3, resolved24h: 10, highUrgency: 2 },
+      recentIncidents: [{ id: '1', status: 'OPEN', updatedAt: '2026-09-05T00:00:00Z' }],
+      error: null,
+    });
+    const view = render(
+      <DashboardRealtimeWrapper>
+        <div>Test</div>
+      </DashboardRealtimeWrapper>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /dashboard updates available/i }));
+    expect(screen.queryByRole('button', { name: /dashboard updates available/i })).toBeNull();
+
+    useRealtimeMock.mockReturnValue({
+      isConnected: true,
+      metrics: { open: 4, acknowledged: 4, resolved24h: 10, highUrgency: 2 },
+      recentIncidents: [{ id: '1', status: 'ACKNOWLEDGED', updatedAt: '2026-09-05T00:01:00Z' }],
+      error: null,
+    });
+    view.rerender(
+      <DashboardRealtimeWrapper>
+        <div>Test</div>
+      </DashboardRealtimeWrapper>
+    );
+    expect(screen.getByRole('button', { name: /dashboard updates available/i })).toBeVisible();
   });
 });

--- a/tests/hooks/useRealtime.test.ts
+++ b/tests/hooks/useRealtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, renderHook, waitFor } from '@testing-library/react';
-import { useRealtime } from '@/hooks/useRealtime';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { RealtimeProvider, useRealtime } from '@/hooks/useRealtime';
+import { createElement, type ReactNode } from 'react';
 
 type MockEventSource = {
   onopen: ((event: Event) => void) | null;
@@ -11,18 +12,27 @@ type MockEventSource = {
 
 // Spies for tracking behavior
 const closeSpy = vi.fn().mockName('close');
-const mockEventSourceCtor = vi.fn().mockImplementation(function (this: any) {
-  this.onopen = null;
-  this.onmessage = null;
-  this.onerror = null;
-  this.close = closeSpy;
-  return this;
-}).mockName('EventSource');
+const mockEventSourceCtor = vi
+  .fn()
+  .mockImplementation(function (this: MockEventSource) {
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.close = closeSpy;
+    return this;
+  })
+  .mockName('EventSource');
 
 vi.stubGlobal('EventSource', mockEventSourceCtor);
 
-function getMockEventSourceInstance(index = 0): any {
-  return mockEventSourceCtor.mock.results[index]?.value;
+function getMockEventSourceInstance(index = 0): MockEventSource {
+  const instance = mockEventSourceCtor.mock.results.at(index)?.value as MockEventSource | undefined;
+  if (!instance) throw new Error(`Missing EventSource instance ${index}`);
+  return instance;
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(RealtimeProvider, null, children);
 }
 
 describe('useRealtime', () => {
@@ -31,19 +41,28 @@ describe('useRealtime', () => {
   });
 
   it('should initialize with disconnected state', () => {
-    const { result } = renderHook(() => useRealtime());
+    const { result } = renderHook(() => useRealtime(), { wrapper });
     expect(result.current.isConnected).toBe(false);
     expect(result.current.metrics).toBeNull();
     expect(result.current.recentIncidents).toEqual([]);
   });
 
   it('should create EventSource connection', () => {
-    renderHook(() => useRealtime());
+    renderHook(() => useRealtime(), { wrapper });
     expect(global.EventSource).toHaveBeenCalledWith('/api/realtime/stream');
   });
 
+  it('shares one EventSource across multiple consumers', () => {
+    function Consumer() {
+      useRealtime();
+      return null;
+    }
+    render(createElement(RealtimeProvider, null, createElement(Consumer), createElement(Consumer)));
+    expect(global.EventSource).toHaveBeenCalledTimes(1);
+  });
+
   it('should handle connection open', async () => {
-    const { result } = renderHook(() => useRealtime());
+    const { result } = renderHook(() => useRealtime(), { wrapper });
     const eventSourceInstance = getMockEventSourceInstance();
     act(() => {
       eventSourceInstance.onopen?.(new Event('open'));
@@ -55,7 +74,7 @@ describe('useRealtime', () => {
   });
 
   it('should handle metrics update', async () => {
-    const { result } = renderHook(() => useRealtime());
+    const { result } = renderHook(() => useRealtime(), { wrapper });
 
     // Get the EventSource instance
     const eventSourceInstance = getMockEventSourceInstance();
@@ -91,7 +110,7 @@ describe('useRealtime', () => {
   });
 
   it('should handle incidents update', async () => {
-    const { result } = renderHook(() => useRealtime());
+    const { result } = renderHook(() => useRealtime(), { wrapper });
 
     const eventSourceInstance = getMockEventSourceInstance();
 
@@ -115,7 +134,7 @@ describe('useRealtime', () => {
   });
 
   it('should handle connection errors', async () => {
-    const { result } = renderHook(() => useRealtime());
+    const { result } = renderHook(() => useRealtime(), { wrapper });
 
     const eventSourceInstance = getMockEventSourceInstance();
 
@@ -130,7 +149,7 @@ describe('useRealtime', () => {
   });
 
   it('should cleanup on unmount', () => {
-    const { unmount } = renderHook(() => useRealtime());
+    const { unmount } = renderHook(() => useRealtime(), { wrapper });
     const eventSourceInstance = getMockEventSourceInstance();
 
     unmount();

--- a/tests/lib/notification-change-clock.test.ts
+++ b/tests/lib/notification-change-clock.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import prisma from '@/lib/prisma';
+import {
+  clearNotificationChangeClock,
+  getNotificationUserChangeVersion,
+} from '@/lib/notification-change-clock';
+
+vi.mock('@/lib/prisma', () => ({
+  default: { inAppNotification: { findMany: vi.fn() } },
+}));
+
+describe('notification change feed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearNotificationChangeClock(new Date('2026-09-05T00:00:30.000Z').getTime());
+  });
+
+  it('coalesces replica polls and changes only affected user versions', async () => {
+    vi.mocked(prisma.inAppNotification.findMany).mockResolvedValue([
+      {
+        userId: 'user-a',
+        id: 'notification-1',
+        createdAt: new Date('2026-09-05T00:00:10.000Z'),
+      },
+    ] as never);
+
+    const [userA, userB] = await Promise.all([
+      getNotificationUserChangeVersion('user-a'),
+      getNotificationUserChangeVersion('user-b'),
+    ]);
+
+    expect(userA).toBe(1);
+    expect(userB).toBe(0);
+    expect(prisma.inAppNotification.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the composite cursor and a bounded batch', async () => {
+    vi.mocked(prisma.inAppNotification.findMany).mockResolvedValue([]);
+
+    await getNotificationUserChangeVersion('user-a');
+
+    expect(prisma.inAppNotification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        take: 2_000,
+        select: { userId: true, createdAt: true, id: true },
+      })
+    );
+  });
+});

--- a/tests/lib/notification-change-clock.test.ts
+++ b/tests/lib/notification-change-clock.test.ts
@@ -48,4 +48,24 @@ describe('notification change feed', () => {
       })
     );
   });
+
+  it('drains full feed pages immediately up to the safety bound', async () => {
+    const firstPage = Array.from({ length: 2_000 }, (_, index) => ({
+      userId: 'user-a',
+      id: `notification-${String(index).padStart(4, '0')}`,
+      createdAt: new Date('2026-09-05T00:00:10.000Z'),
+    }));
+    vi.mocked(prisma.inAppNotification.findMany)
+      .mockResolvedValueOnce(firstPage as never)
+      .mockResolvedValueOnce([
+        {
+          userId: 'user-b',
+          id: 'notification-next',
+          createdAt: new Date('2026-09-05T00:00:11.000Z'),
+        },
+      ] as never);
+
+    expect(await getNotificationUserChangeVersion('user-b')).toBe(2);
+    expect(prisma.inAppNotification.findMany).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/lib/widget-data-cache.test.ts
+++ b/tests/lib/widget-data-cache.test.ts
@@ -58,4 +58,27 @@ describe('widget data cache', () => {
       buildWidgetCacheKey('user-1', 'ADMIN', { startDate: start, serviceId: ['b', 'a'] })
     ).toBe(buildWidgetCacheKey('user-1', 'ADMIN', { serviceId: ['a', 'b'], startDate: start }));
   });
+
+  it('serves stale data while one background refresh is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      const initial = { lastUpdated: new Date(0), activeIncidents: [] };
+      let finishRefresh!: (value: typeof initial) => void;
+      getWidgetDataMock
+        .mockResolvedValueOnce(initial)
+        .mockReturnValueOnce(new Promise(resolve => (finishRefresh = resolve)));
+
+      await getCachedWidgetData('user-1', 'ADMIN', {}, Date.now());
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      await expect(getCachedWidgetData('user-1', 'ADMIN', {}, Date.now())).resolves.toBe(initial);
+      await expect(getCachedWidgetData('user-1', 'ADMIN', {}, Date.now())).resolves.toBe(initial);
+      expect(getWidgetDataMock).toHaveBeenCalledTimes(2);
+
+      finishRefresh({ ...initial, lastUpdated: new Date() });
+      await vi.runAllTicks();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Completes the concrete follow-up work identified after #546 while preserving #382 as the release topology contract. No Helm files are changed.

### Targeted realtime fan-out

- replaces the global notification max clock with a bounded `(createdAt, id)` cursor feed
- tracks per-user change generations so a notification for user A does not wake user B
- adds the matching PostgreSQL composite index and migration
- retains periodic per-user reconciliation for read-state convergence

### Realtime correctness and connection consolidation

- commits the empty incident hash baseline
- keys dashboard lifecycle updates by id, updatedAt, status, urgency, and escalation state
- introduces one `RealtimeProvider` connection shared by dashboard consumers
- makes the widget realtime projection honor centralized status-filter semantics
- adds singleflight, user-isolation, empty-state, lifecycle, and shared-connection regressions

### Public status origin cost

- removes full `calculateSLAMetrics()` execution from `/api/status`, `/api/status/history`, and RSS
- uses bounded incident reads and SQL active-state aggregation
- gives public history/RSS short shared-cache + stale windows while protected responses remain private
- replaces cache-busting browser reloads with Next.js refreshes

## #382 release compatibility

During #382's release rebase, preserve current main's runtime ownership: integrated runs scheduler + worker; web runs neither; workers retain critical escalation/notification recovery; scheduler does not drain ordinary jobs. Apply this migration before enabling the cursor feed, then run combined split-runtime/PgBouncer/load certification.

## Validation

- migration validation: passed (0 errors; legacy warnings only)
- full unit suite: 300 files passed, 2,191 tests passed, 4 skipped
- focused realtime and notification tests: passed
- TypeScript: passed
- production Next.js build: passed
- changed-file ESLint: no errors
- `git diff --check`: passed
