### PR TITLE
feat(health): make system diagnostics truthful and load-safe

### DIFF
--- a/src/app/(app)/settings/system/actions.ts
+++ b/src/app/(app)/settings/system/actions.ts
@@ -643,7 +643,7 @@ export async function refreshAdminHealthAction(): Promise<{
 }> {
   await assertAdmin();
   const { collectAdminHealth } = await import('@/lib/admin-health');
-  const report = await collectAdminHealth();
+  const report = await collectAdminHealth({ force: true });
   return { report };
 }
 
@@ -652,10 +652,11 @@ export async function refreshAdminHealthAction(): Promise<{
  */
 export async function refreshSingleHealthCheckAction(checkId: string): Promise<{
   check: import('@/lib/admin-health').AdminHealthCheck | null;
+  report: import('@/lib/admin-health').AdminHealthReport;
 }> {
   await assertAdmin();
   const { collectAdminHealth } = await import('@/lib/admin-health');
-  const report = await collectAdminHealth();
+  const report = await collectAdminHealth({ force: true });
   const check = report.checks.find(c => c.id === checkId) || null;
-  return { check };
+  return { check, report };
 }

--- a/src/components/settings/SystemHealthCenter.tsx
+++ b/src/components/settings/SystemHealthCenter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useTransition, useMemo, useCallback } from 'react';
+import { useState, useEffect, useTransition, useMemo, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
 import DetailTabs from '@/components/ui/DetailTabs';
@@ -153,39 +153,52 @@ export default function SystemHealthCenter({ initialReport }: Props) {
   const [countdown, setCountdown] = useState<number>(30);
   const [retestingId, setRetestingId] = useState<string | null>(null);
   const [inspectingCheck, setInspectingCheck] = useState<AdminHealthCheck | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
   const [lastRefreshedAt, setLastRefreshedAt] = useState<Date>(
     () => new Date(initialReport.generatedAt)
   );
+  const refreshInFlight = useRef(false);
 
   const handleRefresh = useCallback(() => {
+    if (refreshInFlight.current) return;
+    refreshInFlight.current = true;
     startTransition(async () => {
       try {
         const { report: freshReport } = await refreshAdminHealthAction();
         setReport(freshReport);
         setLastRefreshedAt(new Date(freshReport.generatedAt));
+        setRefreshError(null);
         setCountdown(30);
         toast.success('System diagnostics refreshed');
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to refresh diagnostics');
+        const message = err instanceof Error ? err.message : 'Failed to refresh diagnostics';
+        setRefreshError(message);
+        toast.error(message);
+      } finally {
+        refreshInFlight.current = false;
       }
     });
   }, []);
 
   const handleRetestCheck = useCallback(async (checkId: string) => {
+    if (refreshInFlight.current) return;
+    refreshInFlight.current = true;
     setRetestingId(checkId);
     try {
-      const { check: updatedCheck } = await refreshSingleHealthCheckAction(checkId);
+      const { check: updatedCheck, report: freshReport } =
+        await refreshSingleHealthCheckAction(checkId);
       if (updatedCheck) {
-        setReport(prev => ({
-          ...prev,
-          checks: prev.checks.map(c => (c.id === checkId ? updatedCheck : c)),
-        }));
+        setReport(freshReport);
+        setLastRefreshedAt(new Date(freshReport.generatedAt));
+        setRefreshError(null);
+        setInspectingCheck(previous => (previous?.id === checkId ? updatedCheck : previous));
         toast.success(`"${updatedCheck.label}" re-tested`);
       }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to re-test signal');
     } finally {
       setRetestingId(null);
+      refreshInFlight.current = false;
     }
   }, []);
 
@@ -196,6 +209,7 @@ export default function SystemHealthCenter({ initialReport }: Props) {
       return;
     }
     const interval = setInterval(() => {
+      if (document.visibilityState !== 'visible' || !navigator.onLine) return;
       setCountdown(prev => {
         if (prev <= 1) {
           handleRefresh();
@@ -220,7 +234,11 @@ export default function SystemHealthCenter({ initialReport }: Props) {
     () => report.checks.filter(c => c.status === 'unhealthy').length,
     [report.checks]
   );
-  const attentionCount = degradedCount + unhealthyCount;
+  const unknownCount = useMemo(
+    () => report.checks.filter(c => c.status === 'unknown').length,
+    [report.checks]
+  );
+  const attentionCount = degradedCount + unhealthyCount + unknownCount;
 
   // Category counts
   const categoryCounts = useMemo(() => {
@@ -237,7 +255,7 @@ export default function SystemHealthCenter({ initialReport }: Props) {
       if (activeTab !== 'all' && check.category !== activeTab) {
         return false;
       }
-      if (onlyAttention && check.status !== 'degraded' && check.status !== 'unhealthy') {
+      if (onlyAttention && check.status === 'healthy') {
         return false;
       }
       return true;
@@ -312,7 +330,9 @@ export default function SystemHealthCenter({ initialReport }: Props) {
                   ? 'bg-emerald-500/20 text-emerald-100 border-emerald-400/30'
                   : report.overall === 'degraded'
                     ? 'bg-amber-500/20 text-amber-100 border-amber-400/30'
-                    : 'bg-rose-500/20 text-rose-100 border-rose-400/30'
+                    : report.overall === 'unhealthy'
+                      ? 'bg-rose-500/20 text-rose-100 border-rose-400/30'
+                      : 'bg-primary-foreground/10 text-primary-foreground border-primary-foreground/20'
               )}
             >
               {overallConfig.label}
@@ -326,7 +346,9 @@ export default function SystemHealthCenter({ initialReport }: Props) {
                 ? 'All Core Systems Operational'
                 : report.overall === 'degraded'
                   ? 'Operational with Warnings'
-                  : 'Critical Attention Required'}
+                  : report.overall === 'unhealthy'
+                    ? 'Critical Attention Required'
+                    : 'Insufficient Diagnostic Evidence'}
             </Badge>
           </>
         }
@@ -337,16 +359,19 @@ export default function SystemHealthCenter({ initialReport }: Props) {
               integrations.
             </span>
             <span className="opacity-40">•</span>
-            <span>Last verified at {lastRefreshedAt.toLocaleTimeString()}</span>
+            <span>
+              Last verified at {lastRefreshedAt.toLocaleTimeString()}
+              {report.durationMs !== undefined ? ` in ${report.durationMs} ms` : ''}
+            </span>
           </div>
         }
         statsPlacement="bottom"
         stats={[
           {
-            label: 'Total Signals',
-            value: report.checks.length,
+            label: 'Health Score',
+            value: report.scorePercent !== undefined ? `${report.scorePercent}%` : '—',
             icon: <Layers className="h-4 w-4 opacity-80" />,
-            subtext: 'Operational checks',
+            subtext: `${report.knownSignalPercent ?? 100}% evidence coverage`,
           },
           {
             label: 'Healthy',
@@ -361,10 +386,10 @@ export default function SystemHealthCenter({ initialReport }: Props) {
             subtext: 'Sub-optimal latency/retries',
           },
           {
-            label: 'Action Required',
-            value: unhealthyCount,
+            label: 'Action / Unknown',
+            value: `${unhealthyCount} / ${unknownCount}`,
             icon: <XCircle className="h-4 w-4 text-rose-300" />,
-            subtext: 'Needs intervention',
+            subtext: 'Failures / missing evidence',
           },
         ]}
         actions={
@@ -414,6 +439,23 @@ export default function SystemHealthCenter({ initialReport }: Props) {
       {/* 24-Hour Diagnostic History Sparkline (Service Health Trend) */}
       <HealthHistoryRibbon history={report.history} overall={report.overall} />
 
+      <OperationalBrief checks={report.checks} />
+
+      {refreshError && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-800 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <p className="font-semibold">
+              Latest refresh failed; showing the last successful report.
+            </p>
+            <p className="mt-0.5 opacity-90">{refreshError}</p>
+          </div>
+        </div>
+      )}
+
       {/* Centralized DetailTabs Navigation Header */}
       <DetailTabs
         tabs={tabItems}
@@ -450,8 +492,8 @@ export default function SystemHealthCenter({ initialReport }: Props) {
         {filteredChecks.length === 0 ? (
           <EmptyState
             icon={<CheckCircle2 className="h-6 w-6 text-emerald-500" />}
-            title="All Signals Healthy"
-            description="No signals in this category currently require operational attention."
+            title="No Signals Need Attention"
+            description="No degraded, unhealthy, or unreported signals match this filter."
             action={
               <Button
                 variant="outline"
@@ -514,6 +556,76 @@ export default function SystemHealthCenter({ initialReport }: Props) {
   );
 }
 
+function OperationalBrief({ checks }: { checks: AdminHealthCheck[] }) {
+  const attention = useMemo(() => {
+    const rank: Record<HealthLevel, number> = {
+      unhealthy: 0,
+      degraded: 1,
+      unknown: 2,
+      healthy: 3,
+    };
+    return checks
+      .filter(check => check.status !== 'healthy' && check.required !== false)
+      .sort((left, right) => rank[left.status] - rank[right.status])
+      .slice(0, 5);
+  }, [checks]);
+
+  if (attention.length === 0) return null;
+
+  return (
+    <Card className="border-border/80 shadow-2xs">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <AlertTriangle className="h-4 w-4 text-amber-500" />
+          Operational priorities
+        </CardTitle>
+        <CardDescription>
+          Highest-impact failures, warnings, and evidence gaps from this diagnostic run.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {attention.map(check => {
+          const config = STATUS_CONFIG[check.status];
+          const StatusIcon = config.icon;
+          return (
+            <div
+              key={check.id}
+              className="flex flex-col gap-2 rounded-lg border border-border/70 bg-muted/15 p-3 sm:flex-row sm:items-start sm:justify-between"
+            >
+              <div className="flex min-w-0 items-start gap-2.5">
+                <StatusIcon className={cn('mt-0.5 h-4 w-4 shrink-0', config.iconText)} />
+                <div className="min-w-0">
+                  <p className="text-xs font-bold text-foreground">{check.label}</p>
+                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                    {check.summary}
+                  </p>
+                  {check.impact && (
+                    <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                      <span className="font-semibold text-foreground">Impact:</span> {check.impact}
+                    </p>
+                  )}
+                </div>
+              </div>
+              {check.action && (
+                <Button variant="outline" size="sm" asChild className="h-7 shrink-0 text-[11px]">
+                  <Link
+                    href={check.action.href}
+                    target={check.action.href.startsWith('http') ? '_blank' : undefined}
+                    rel={check.action.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+                  >
+                    {check.action.label}
+                    <ChevronRight className="ml-1 h-3 w-3" />
+                  </Link>
+                </Button>
+              )}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
 /**
  * 24-Hour Diagnostic History Ribbon (Service Health Trend)
  */
@@ -550,10 +662,10 @@ function HealthHistoryRibbon({
         <div className="flex items-center gap-2">
           <Activity className="h-3.5 w-3.5 text-muted-foreground" />
           <span className="font-bold text-foreground text-xs tracking-tight">
-            24-Hour System Health Trend
+            24-Hour Recorded Signal Trend
           </span>
           <span className={cn('text-[11px] font-mono font-semibold', percentColorClass)}>
-            • {uptimePercent}% Operational
+            • {uptimePercent}% Signal Score
           </span>
         </div>
         <div className="hidden sm:flex items-center gap-2.5 text-[10px] text-muted-foreground font-mono">
@@ -659,6 +771,10 @@ function HealthHistoryRibbon({
         <span className="hidden sm:inline text-muted-foreground/60">12 hours ago</span>
         <span>Now</span>
       </div>
+      <p className="pt-2 text-[10px] leading-relaxed text-muted-foreground">
+        Derived from recorded incidents and durable delivery/job failures. This is diagnostic
+        context, not an uptime SLO or proof that unobserved periods were available.
+      </p>
     </div>
   );
 }
@@ -888,6 +1004,12 @@ function HealthCheckCard({
 
           {/* Details Bullet List */}
           <div className="space-y-1.5">
+            {check.scope && (
+              <div className="flex items-center justify-between rounded-md bg-muted/30 px-2 py-1 text-[10px] text-muted-foreground">
+                <span>Evidence scope</span>
+                <span className="font-mono font-semibold uppercase">{check.scope}</span>
+              </div>
+            )}
             {check.details.map((detail, idx) => (
               <div key={idx} className="flex items-start gap-2 text-xs text-muted-foreground">
                 <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40 mt-1.5 shrink-0" />
@@ -897,6 +1019,13 @@ function HealthCheckCard({
               </div>
             ))}
           </div>
+
+          {check.impact && (
+            <div className="rounded-md border border-amber-500/20 bg-amber-500/5 px-2.5 py-2 text-[11px] leading-relaxed text-muted-foreground">
+              <span className="font-semibold text-foreground">Operational impact: </span>
+              {check.impact}
+            </div>
+          )}
 
           {/* Database Migrations / Remediation Command Box with (i) Popover */}
           {check.commandSnippet && (
@@ -1043,7 +1172,10 @@ function DiagnosticInspectorModal({
       label: check.label,
       category: check.category,
       status: check.status,
+      evidenceScope: check.scope || 'unspecified',
+      observedAt: check.observedAt || null,
       summary: check.summary,
+      operationalImpact: check.impact || null,
       details: check.details,
       commandSnippet: check.commandSnippet || null,
       telemetry: check.telemetry?.rawPayload || check.telemetry || {},
@@ -1086,7 +1218,8 @@ function DiagnosticInspectorModal({
                 </Badge>
               </div>
               <DialogDescription className="text-xs text-muted-foreground font-mono">
-                Signal ID: {check.id} • Category: {check.category.toUpperCase()}
+                Signal ID: {check.id} • Category: {check.category.toUpperCase()} • Scope:{' '}
+                {(check.scope || 'unspecified').toUpperCase()}
               </DialogDescription>
             </div>
           </div>
@@ -1105,6 +1238,17 @@ function DiagnosticInspectorModal({
                 {check.summary}
               </p>
             </div>
+
+            {check.impact && (
+              <div className="space-y-1.5">
+                <span className="text-[11px] font-bold uppercase tracking-wider text-foreground">
+                  Operational Impact
+                </span>
+                <p className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-2.5 text-xs leading-relaxed text-muted-foreground">
+                  {check.impact}
+                </p>
+              </div>
+            )}
 
             {/* Diagnostic Facts */}
             <div className="space-y-2">

--- a/src/lib/admin-health.ts
+++ b/src/lib/admin-health.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 import prisma from '@/lib/prisma';
 import { APP_VERSION } from '@/lib/version';
 import { getMetricsByIntegration, getMetricsSummary } from '@/lib/integrations/metrics';
+import { getJobWorkerStatus } from '@/lib/job-worker';
+import { getRealtimeControlPlaneStatus } from '@/lib/realtime-change-control-plane';
 
 export type HealthLevel = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
 export type HealthCategory = 'database' | 'workers' | 'alerting' | 'security' | 'platform';
@@ -50,6 +52,12 @@ export type AdminHealthCheck = {
     steps?: string[];
   };
   telemetry?: CheckTelemetry;
+  /** Where the evidence originates. Prevents replica-local state being mistaken for cluster truth. */
+  scope?: 'cluster' | 'replica' | 'configuration' | 'external';
+  observedAt?: string;
+  impact?: string;
+  /** False for informative signals that are not expected on every deployment role. */
+  required?: boolean;
 };
 
 export type HealthHistorySample = {
@@ -63,7 +71,10 @@ export type HealthHistorySample = {
 
 export type AdminHealthReport = {
   generatedAt: string;
+  durationMs?: number;
   overall: HealthLevel;
+  scorePercent?: number;
+  knownSignalPercent?: number;
   checks: AdminHealthCheck[];
   history?: HealthHistorySample[];
 };
@@ -130,6 +141,15 @@ function byteLabel(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
 }
 
+/** Keep diagnostics actionable without reflecting credentials, URLs, or driver internals. */
+function safeErrorKind(error: unknown): string {
+  if (!(error instanceof Error)) return 'Unexpected database error';
+  const name = error.name.replace(/[^a-zA-Z0-9 _-]/g, '').slice(0, 80);
+  return name
+    ? `${name} (see restricted server logs)`
+    : 'Database error (see restricted server logs)';
+}
+
 async function latestRelease(): Promise<string | null> {
   try {
     const response = await fetch(
@@ -157,6 +177,10 @@ export const CHECK_WEIGHTS: Record<string, number> = {
   jobs: 5,
   escalations: 5,
   'database-capacity': 5,
+  rollups: 5,
+  'integration-control-plane': 5,
+  'worker-replica': 3,
+  realtime: 3,
   // Auxiliary & Delivery Services (Weight 3)
   notifications: 3,
   integrations: 3,
@@ -202,8 +226,13 @@ export function calculateOperationalScore(checks: AdminHealthCheck[]): Operation
     } else if (check.status === 'healthy') {
       weightedScore += weight * 1.0;
     } else {
-      // 'unknown' is neutral, treated as passing
-      weightedScore += weight * 1.0;
+      // Unknown evidence must never inflate health. It is uncertainty, not success.
+      if (check.required === false) {
+        weightedScore += weight;
+      } else {
+        warningIssues.push(check);
+        weightedScore += weight * 0.5;
+      }
     }
   }
 
@@ -231,95 +260,55 @@ export async function generate24HourHistory(
 ): Promise<HealthHistorySample[]> {
   const since = new Date(now.getTime() - 24 * HOUR);
 
-  let incidents: Array<{
-    id: string;
-    title: string;
-    priority: string | null;
-    status: string;
-    createdAt: Date;
-    resolvedAt: Date | null;
-  }> = [];
-
-  let failedJobs: Array<{
+  type FailedJob = {
     id: string;
     createdAt: Date;
-  }> = [];
-
-  let failedDeliveries: Array<{
+  };
+  type FailedDelivery = {
     id: string;
     createdAt: Date;
-  }> = [];
-
-  let failedNotifications: Array<{
+  };
+  type FailedNotification = {
     id: string;
     startedAt: Date;
-  }> = [];
+  };
 
-  try {
-    incidents = await prisma.incident.findMany({
-      where: {
-        createdAt: { gte: since },
-      },
-      select: {
-        id: true,
-        title: true,
-        priority: true,
-        status: true,
-        createdAt: true,
-        resolvedAt: true,
-      },
-    });
-  } catch {
-    // Graceful fallback if database query is restricted
-  }
-
-  try {
-    failedJobs = await prisma.backgroundJob.findMany({
+  const historyResults = await Promise.allSettled([
+    prisma.backgroundJob.findMany({
       where: {
         createdAt: { gte: since },
         status: 'FAILED',
       },
-      select: {
-        id: true,
-        createdAt: true,
-      },
-    });
-  } catch {
-    // Graceful fallback
-  }
-
-  try {
-    failedDeliveries = await prisma.inboundDelivery.findMany({
+      select: { id: true, createdAt: true },
+    }),
+    prisma.inboundDelivery.findMany({
       where: {
         createdAt: { gte: since },
         status: 'FAILED',
       },
-      select: {
-        id: true,
-        createdAt: true,
-      },
-    });
-  } catch {
-    // Graceful fallback
-  }
-
-  try {
-    failedNotifications = await prisma.notificationDeliveryAttempt.findMany({
+      select: { id: true, createdAt: true },
+    }),
+    prisma.notificationDeliveryAttempt.findMany({
       where: {
         startedAt: { gte: since },
         outcome: 'FAILED',
       },
-      select: {
-        id: true,
-        startedAt: true,
-      },
-    });
-  } catch {
-    // Graceful fallback
-  }
+      select: { id: true, startedAt: true },
+    }),
+  ]);
+  const [jobResult, deliveryResult, notificationResult] = historyResults;
+  const failedJobs: FailedJob[] = jobResult.status === 'fulfilled' ? jobResult.value : [];
+  const failedDeliveries: FailedDelivery[] =
+    deliveryResult.status === 'fulfilled' ? deliveryResult.value : [];
+  const failedNotifications: FailedNotification[] =
+    notificationResult.status === 'fulfilled' ? notificationResult.value : [];
+  const unavailableSources = historyResults.filter(result => result.status === 'rejected').length;
 
-  const { scorePercent: liveScorePercent, criticalIssues, warningIssues } =
-    calculateOperationalScore(checks);
+  const {
+    scorePercent: liveScorePercent,
+    criticalIssues,
+    warningIssues,
+  } = calculateOperationalScore(checks);
 
   const topCriticalIssue = criticalIssues[0]?.summary;
   const topWarningIssue = warningIssues[0]?.summary;
@@ -332,28 +321,20 @@ export async function generate24HourHistory(
     const hour = d.getHours();
     const hourLabel = `${hour.toString().padStart(2, '0')}:00`;
 
-    // 1. Incidents active in this hourly bucket
-    const activeIncidents = incidents.filter(inc => {
-      const incStart = inc.createdAt.getTime();
-      const incEnd = inc.resolvedAt ? inc.resolvedAt.getTime() : now.getTime();
-      return incStart <= windowEnd.getTime() && incEnd >= windowStart.getTime();
-    });
-
-    // 2. Failed jobs in this hourly bucket
+    // Customer/service incidents are intentionally excluded: they describe the
+    // monitored estate, not whether OpsKnight itself was available.
     const hourlyFailedJobs = failedJobs.filter(
       j =>
         j.createdAt.getTime() >= windowStart.getTime() &&
         j.createdAt.getTime() < windowEnd.getTime()
     );
 
-    // 3. Failed webhook deliveries in this hourly bucket
     const hourlyFailedDeliveries = failedDeliveries.filter(
       del =>
         del.createdAt.getTime() >= windowStart.getTime() &&
         del.createdAt.getTime() < windowEnd.getTime()
     );
 
-    // 4. Failed notification attempts in this hourly bucket
     const hourlyFailedNotifications = failedNotifications.filter(
       notif =>
         notif.startedAt.getTime() >= windowStart.getTime() &&
@@ -364,22 +345,7 @@ export async function generate24HourHistory(
     let scorePercent = 100;
     let reason = 'All systems operating normally';
 
-    const criticalInc = activeIncidents.find(
-      inc => inc.priority === 'P1' || inc.priority === 'P2'
-    );
-    const warningInc = activeIncidents.find(
-      inc => inc.priority === 'P3' || inc.priority === 'P4'
-    );
-
-    if (criticalInc) {
-      status = 'unhealthy';
-      scorePercent = 40;
-      reason = `Critical incident (${criticalInc.priority || 'P1'}): ${criticalInc.title}`;
-    } else if (warningInc) {
-      status = 'degraded';
-      scorePercent = 75;
-      reason = `Active incident (${warningInc.priority || 'P3'}): ${warningInc.title}`;
-    } else if (hourlyFailedJobs.length > 0) {
+    if (hourlyFailedJobs.length > 0) {
       status = 'degraded';
       scorePercent = Math.max(70, 100 - hourlyFailedJobs.length * 10);
       reason = `${hourlyFailedJobs.length} background job failure(s)`;
@@ -397,19 +363,15 @@ export async function generate24HourHistory(
           ? 'All diagnostic signals passing'
           : topCriticalIssue ||
             topWarningIssue ||
-            (overall === 'degraded'
-              ? 'Operational with warnings'
-              : 'Critical diagnostic error');
-    } else if (criticalIssues.length > 0) {
-      // ONLY if persistent CRITICAL infrastructure is failing (e.g. DB connection broken)
-      status = 'unhealthy';
-      scorePercent = Math.min(50, liveScorePercent);
-      reason = topCriticalIssue || 'Critical diagnostic error';
+            (overall === 'degraded' ? 'Operational with warnings' : 'Critical diagnostic error');
+    } else if (unavailableSources > 0) {
+      status = 'unknown';
+      scorePercent = 0;
+      reason = `${unavailableSources} historical evidence source(s) unavailable`;
     } else {
-      // Normal peaceful historical hour
       status = 'healthy';
       scorePercent = 100;
-      reason = 'All systems operating normally';
+      reason = 'No durable job or delivery failures recorded';
     }
 
     samples.push({
@@ -424,7 +386,12 @@ export async function generate24HourHistory(
   return samples;
 }
 
-export async function collectAdminHealth(): Promise<AdminHealthReport> {
+const HEALTH_CACHE_TTL_MS = 15_000;
+let cachedHealthReport: { report: AdminHealthReport; expiresAt: number } | null = null;
+let healthCollectionInFlight: Promise<AdminHealthReport> | null = null;
+
+async function collectAdminHealthUncached(): Promise<AdminHealthReport> {
+  const collectionStartedAt = Date.now();
   const now = new Date();
   const checks: AdminHealthCheck[] = [];
 
@@ -470,11 +437,11 @@ export async function collectAdminHealth(): Promise<AdminHealthReport> {
       summary: 'PostgreSQL is unavailable to this application instance.',
       details: [
         'Check DATABASE_URL, network policy, credentials, TLS, capacity, and PostgreSQL logs.',
-        `Error: ${error instanceof Error ? error.message : 'Unknown connection error'}`,
+        `Error class: ${safeErrorKind(error)}`,
       ],
       telemetry: {
         rawPayload: {
-          error: error instanceof Error ? error.message : 'Unknown connection error',
+          errorClass: safeErrorKind(error),
         },
       },
     });
@@ -506,6 +473,8 @@ export async function collectAdminHealth(): Promise<AdminHealthReport> {
         id: 'database-capacity',
         label: 'Database capacity',
         category: 'database',
+        scope: 'cluster',
+        observedAt: now.toISOString(),
         status: !capacity
           ? 'unknown'
           : utilization >= 95 || capacity.longTransactions > 0
@@ -1072,6 +1041,8 @@ export async function collectAdminHealth(): Promise<AdminHealthReport> {
     id: 'encryption',
     label: 'Encryption configuration',
     category: 'security',
+    scope: 'configuration',
+    observedAt: now.toISOString(),
     status: encryptionValid
       ? 'healthy'
       : process.env.NODE_ENV === 'development'
@@ -1111,6 +1082,8 @@ export async function collectAdminHealth(): Promise<AdminHealthReport> {
     id: 'version',
     label: 'Version and upgrades',
     category: 'platform',
+    scope: 'external',
+    observedAt: now.toISOString(),
     status: !latest ? 'unknown' : comparison < 0 ? 'degraded' : 'healthy',
     summary: !latest
       ? `Running ${APP_VERSION}; the latest release could not be checked.`
@@ -1133,8 +1106,232 @@ export async function collectAdminHealth(): Promise<AdminHealthReport> {
     },
   });
 
-  const overall = overallStatus(checks);
-  const history = await generate24HourHistory(checks, overall, now);
+  // These signals close important blind spots in the durable control planes. They are
+  // deliberately collected after the baseline checks so a single optional subsystem
+  // can report "unknown" without preventing the rest of the page from rendering.
+  if (databaseAvailable) {
+    try {
+      const [rollup, staleExternalOperations, failedExternalOperations, staleInbound] =
+        await Promise.all([
+          prisma.incidentMetricRollup.findFirst({
+            where: { granularity: 'daily', serviceId: null, teamId: null },
+            orderBy: { date: 'desc' },
+            select: { date: true, updatedAt: true },
+          }),
+          prisma.externalOperation.count({
+            where: {
+              status: { in: ['PENDING', 'PROCESSING', 'AMBIGUOUS'] },
+              updatedAt: { lt: new Date(now.getTime() - 15 * MINUTE) },
+            },
+          }),
+          prisma.externalOperation.count({
+            where: { status: 'FAILED', updatedAt: { gte: new Date(now.getTime() - 24 * HOUR) } },
+          }),
+          prisma.inboundDelivery.count({
+            where: {
+              status: 'PROCESSING',
+              updatedAt: { lt: new Date(now.getTime() - 10 * MINUTE) },
+            },
+          }),
+        ]);
+      const expectedLatestDay = new Date(now);
+      expectedLatestDay.setUTCHours(0, 0, 0, 0);
+      expectedLatestDay.setUTCDate(expectedLatestDay.getUTCDate() - 1);
+      const rollupLagDays = rollup
+        ? Math.max(
+            0,
+            Math.floor((expectedLatestDay.getTime() - rollup.date.getTime()) / (24 * HOUR))
+          )
+        : null;
+      checks.push({
+        id: 'rollups',
+        label: 'Analytics rollup freshness',
+        category: 'workers',
+        scope: 'cluster',
+        observedAt: now.toISOString(),
+        status:
+          rollupLagDays === null
+            ? 'unknown'
+            : rollupLagDays > 1
+              ? 'unhealthy'
+              : rollupLagDays > 0
+                ? 'degraded'
+                : 'healthy',
+        summary: rollup
+          ? `Latest complete daily rollup is ${rollupLagDays} day(s) behind.`
+          : 'No complete daily analytics rollup was found.',
+        details: [
+          `Latest rollup day: ${rollup?.date.toISOString() || 'none'}`,
+          `Last materialized: ${rollup?.updatedAt.toISOString() || 'never'}`,
+        ],
+        impact: 'Stale rollups can make historical reports and executive dashboards incomplete.',
+        telemetry: {
+          rawPayload: { rollupLagDays, latestDate: rollup?.date.toISOString() || null },
+        },
+      });
+      checks.push({
+        id: 'integration-control-plane',
+        label: 'Integration delivery control plane',
+        category: 'alerting',
+        scope: 'cluster',
+        observedAt: now.toISOString(),
+        status:
+          staleExternalOperations > 0 || staleInbound > 0
+            ? 'unhealthy'
+            : failedExternalOperations > 0
+              ? 'degraded'
+              : 'healthy',
+        summary: `${staleExternalOperations} stale external operation(s), ${staleInbound} stale inbound delivery lease(s).`,
+        details: [
+          `Terminal external failures in 24 hours: ${failedExternalOperations}`,
+          'Durable database state is cluster-wide and survives replica restarts.',
+        ],
+        impact:
+          'Stale work delays inbound alerts, ChatOps responses, or external issue synchronization.',
+        telemetry: {
+          rawPayload: {
+            staleExternalOperations,
+            failedExternalOperations24h: failedExternalOperations,
+            staleInboundDeliveries: staleInbound,
+          },
+        },
+      });
+    } catch {
+      checks.push({
+        id: 'control-plane-storage',
+        label: 'Durable control-plane telemetry',
+        category: 'workers',
+        scope: 'cluster',
+        observedAt: now.toISOString(),
+        status: 'unknown',
+        summary: 'Durable rollup and integration state could not be inspected.',
+        details: ['Verify migrations and database permissions for control-plane tables.'],
+      });
+    }
+  }
 
-  return { generatedAt: now.toISOString(), overall, checks, history };
+  const worker = getJobWorkerStatus();
+  const workerSuccessAgeMs = worker.lastSuccessAt
+    ? now.getTime() - worker.lastSuccessAt.getTime()
+    : null;
+  checks.push({
+    id: 'worker-replica',
+    label: 'Local durable-job worker',
+    category: 'workers',
+    scope: 'replica',
+    required: false,
+    observedAt: now.toISOString(),
+    status: !worker.running
+      ? 'unknown'
+      : worker.lastError || workerSuccessAgeMs === null || workerSuccessAgeMs > 5 * MINUTE
+        ? 'degraded'
+        : 'healthy',
+    summary: !worker.running
+      ? 'This web replica does not run the durable-job worker.'
+      : workerSuccessAgeMs === null
+        ? 'The local worker has not completed a successful cycle.'
+        : `The local worker last succeeded ${ageLabel(worker.lastSuccessAt)}.`,
+    details: [
+      `Running on this replica: ${worker.running ? 'yes' : 'no'}`,
+      `In flight: ${worker.inFlight ? 'yes' : 'no'}`,
+      'A non-running local worker is informational when dedicated worker replicas are deployed.',
+    ],
+    impact:
+      'Use cluster queue age together with this replica signal to determine actual delivery health.',
+    telemetry: {
+      rawPayload: {
+        running: worker.running,
+        inFlight: worker.inFlight,
+        lastRunAt: worker.lastRunAt?.toISOString() || null,
+        lastSuccessAt: worker.lastSuccessAt?.toISOString() || null,
+        hasLastError: Boolean(worker.lastError),
+      },
+    },
+  });
+
+  const realtime = getRealtimeControlPlaneStatus();
+  checks.push({
+    id: 'realtime',
+    label: 'Realtime event control plane',
+    category: 'workers',
+    scope: 'replica',
+    observedAt: now.toISOString(),
+    status:
+      realtime.consecutiveFailures > 2
+        ? 'unhealthy'
+        : realtime.consecutiveFailures > 0
+          ? 'degraded'
+          : 'healthy',
+    summary:
+      realtime.consecutiveFailures > 0
+        ? `${realtime.consecutiveFailures} consecutive change-feed polling failure(s) on this replica.`
+        : 'The local realtime change feed has no recorded polling failures.',
+    details: [
+      `Connected subscribers on this replica: ${realtime.subscribers}`,
+      `Observed generation: ${realtime.observedGeneration || 'not yet observed'}`,
+      `Last temporal reconciliation: ${realtime.lastReconciliationAt || 'not started'}`,
+    ],
+    impact:
+      'Repeated failures delay dashboard and widget refreshes; durable data remains authoritative.',
+    telemetry: { rawPayload: realtime },
+  });
+
+  for (const check of checks) {
+    check.observedAt ??= now.toISOString();
+    check.scope ??=
+      check.id === 'version'
+        ? 'external'
+        : check.id === 'integrations'
+          ? 'replica'
+          : check.id === 'public-url' || check.id === 'encryption'
+            ? 'configuration'
+            : 'cluster';
+  }
+
+  const score = calculateOperationalScore(checks);
+  const overall = score.overall;
+  const history = await generate24HourHistory(checks, overall, now);
+  const requiredChecks = checks.filter(check => check.required !== false);
+  const knownChecks = requiredChecks.filter(check => check.status !== 'unknown').length;
+
+  return {
+    generatedAt: now.toISOString(),
+    durationMs: Date.now() - collectionStartedAt,
+    overall,
+    scorePercent: score.scorePercent,
+    knownSignalPercent: Math.round((knownChecks / Math.max(1, requiredChecks.length)) * 1000) / 10,
+    checks,
+    history,
+  };
+}
+
+/**
+ * A health page must not become a database load generator. One collection may
+ * contain several independent diagnostics, so requests on a replica share a
+ * short-lived snapshot and a single in-flight collection. `force` bypasses an
+ * existing snapshot but still joins an already-running collection.
+ */
+export async function collectAdminHealth(options?: {
+  force?: boolean;
+}): Promise<AdminHealthReport> {
+  const now = Date.now();
+  if (!options?.force && cachedHealthReport && cachedHealthReport.expiresAt > now) {
+    return cachedHealthReport.report;
+  }
+  if (healthCollectionInFlight) return healthCollectionInFlight;
+
+  healthCollectionInFlight = collectAdminHealthUncached()
+    .then(report => {
+      cachedHealthReport = { report, expiresAt: Date.now() + HEALTH_CACHE_TTL_MS };
+      return report;
+    })
+    .finally(() => {
+      healthCollectionInFlight = null;
+    });
+  return healthCollectionInFlight;
+}
+
+export function resetAdminHealthCacheForTests(): void {
+  cachedHealthReport = null;
+  healthCollectionInFlight = null;
 }

--- a/tests/components/settings/SystemHealthCenter.test.tsx
+++ b/tests/components/settings/SystemHealthCenter.test.tsx
@@ -198,8 +198,9 @@ describe('SystemHealthCenter', () => {
 
     expect(screen.getByRole('heading', { name: 'System Health Center' })).toBeInTheDocument();
     expect(screen.getByText('Operational with Warnings')).toBeInTheDocument();
-    expect(screen.getByText('24-Hour System Health Trend')).toBeInTheDocument();
-    expect(screen.getByText('• 92.5% Operational')).toBeInTheDocument();
+    expect(screen.getByText('24-Hour Recorded Signal Trend')).toBeInTheDocument();
+    expect(screen.getByText('• 92.5% Signal Score')).toBeInTheDocument();
+    expect(screen.getByText(/not an uptime SLO/i)).toBeInTheDocument();
     expect(screen.getByText('24 hours ago')).toBeInTheDocument();
     expect(screen.getByText('12 hours ago')).toBeInTheDocument();
     expect(screen.getByText('Now')).toBeInTheDocument();
@@ -226,7 +227,7 @@ describe('SystemHealthCenter', () => {
       ],
     };
     render(<SystemHealthCenter initialReport={perfectReport} />);
-    expect(screen.getByText('• 100% Operational')).toBeInTheDocument();
+    expect(screen.getByText('• 100% Signal Score')).toBeInTheDocument();
   });
 
   it('renders visual telemetry gauges, latency pills, and queue distribution bars', () => {
@@ -276,9 +277,10 @@ describe('SystemHealthCenter', () => {
 
     expect(screen.getByText('PostgreSQL Database')).toBeInTheDocument();
     expect(screen.getByText('Database capacity')).toBeInTheDocument();
-    expect(screen.getByText('Database migrations')).toBeInTheDocument();
+    expect(screen.getAllByText('Database migrations').length).toBeGreaterThanOrEqual(1);
 
-    expect(screen.queryByText('Scheduler and workers')).not.toBeInTheDocument();
+    // It remains once in the global priority brief, but its diagnostic card is filtered out.
+    expect(screen.getAllByText('Scheduler and workers')).toHaveLength(1);
     expect(screen.queryByText('Encryption configuration')).not.toBeInTheDocument();
   });
 
@@ -288,9 +290,25 @@ describe('SystemHealthCenter', () => {
     const attentionToggle = screen.getByRole('button', { name: /needs attention only/i });
     fireEvent.click(attentionToggle);
 
-    expect(screen.getByText('Scheduler and workers')).toBeInTheDocument();
-    expect(screen.getByText('Background jobs')).toBeInTheDocument();
+    expect(screen.getAllByText('Scheduler and workers').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Background jobs').length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('PostgreSQL Database')).not.toBeInTheDocument();
+  });
+
+  it('includes unknown evidence in the attention filter', () => {
+    render(
+      <SystemHealthCenter
+        initialReport={{
+          ...mockReport,
+          checks: mockReport.checks.map(check =>
+            check.id === 'sla-performance' ? { ...check, status: 'unknown' as const } : check
+          ),
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /needs attention only/i }));
+    expect(screen.getAllByText('SLA query performance').length).toBeGreaterThanOrEqual(1);
   });
 
   it('re-runs diagnostics when clicking the Re-run Diagnostics button', async () => {
@@ -313,6 +331,19 @@ describe('SystemHealthCenter', () => {
     });
   });
 
+  it('keeps the last successful report visible and explains refresh failures', async () => {
+    const { refreshAdminHealthAction } = await import('@/app/(app)/settings/system/actions');
+    vi.mocked(refreshAdminHealthAction).mockRejectedValue(new Error('Diagnostics timed out'));
+
+    render(<SystemHealthCenter initialReport={mockReport} />);
+    fireEvent.click(screen.getByRole('button', { name: /re-run diagnostics/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Latest refresh failed; showing the last successful report.'
+    );
+    expect(screen.getByText('PostgreSQL Database')).toBeInTheDocument();
+  });
+
   it('renders countdown badge when Live (30s) auto-refresh is toggled on', () => {
     render(<SystemHealthCenter initialReport={mockReport} />);
 
@@ -332,6 +363,15 @@ describe('SystemHealthCenter', () => {
         ...mockReport.checks[0],
         summary: 'PostgreSQL responded in 8 ms.',
         telemetry: { latencyMs: 8 },
+      },
+      report: {
+        ...mockReport,
+        generatedAt: '2026-09-02T12:01:00.000Z',
+        checks: mockReport.checks.map(check =>
+          check.id === 'database'
+            ? { ...check, summary: 'PostgreSQL responded in 8 ms.', telemetry: { latencyMs: 8 } }
+            : check
+        ),
       },
     });
 

--- a/tests/lib/admin-health.test.ts
+++ b/tests/lib/admin-health.test.ts
@@ -188,6 +188,35 @@ describe('calculateOperationalScore and weighted health logic', () => {
     expect(result.criticalIssues[0].id).toBe('database');
   });
 
+  it('treats missing evidence as uncertainty instead of silently passing it', () => {
+    const checks = mockBaseChecks.map(check =>
+      check.id === 'sla-performance' ? { ...check, status: 'unknown' as const } : check
+    );
+    const result = calculateOperationalScore(checks);
+
+    expect(result.scorePercent).toBeLessThan(100);
+    expect(result.overall).toBe('degraded');
+    expect(result.warningIssues.some(check => check.id === 'sla-performance')).toBe(true);
+  });
+
+  it('does not degrade the cluster when an optional replica role is not running locally', () => {
+    const result = calculateOperationalScore([
+      ...mockBaseChecks,
+      {
+        id: 'worker-replica',
+        label: 'Local durable-job worker',
+        category: 'workers',
+        status: 'unknown',
+        required: false,
+        summary: 'This web replica does not run the durable-job worker.',
+        details: [],
+      },
+    ]);
+
+    expect(result.overall).toBe('healthy');
+    expect(result.warningIssues).toHaveLength(0);
+  });
+
   it('assigns higher weight to database, migrations, encryption, and scheduler than auxiliary checks', () => {
     expect(CHECK_WEIGHTS.database).toBe(10);
     expect(CHECK_WEIGHTS.migrations).toBe(10);
@@ -250,10 +279,10 @@ describe('generate24HourHistory', () => {
     expect(priorHours.every(s => s.scorePercent === 100)).toBe(true);
   });
 
-  it('does not allow incidents from before the 24-hour window to pollute current historical baseline', async () => {
+  it('does not classify customer incidents as OpsKnight platform-health failures', async () => {
     const prisma = (await import('@/lib/prisma')).default;
     const now = new Date('2026-09-05T12:00:00.000Z');
-    
+
     // Simulate prisma.incident returning only items within the 24-hour query where clause
     vi.mocked(prisma.incident.findMany).mockResolvedValueOnce([
       {
@@ -269,16 +298,8 @@ describe('generate24HourHistory', () => {
     const samples = await generate24HourHistory(mockBaseChecks, 'healthy', now);
     expect(samples).toHaveLength(24);
 
-    // Window ending at 11:00 (index 22, representing 10:00-11:00 UTC) was degraded during the incident
-    const windowEnd11 = new Date(now.getTime() - 1 * 3600000);
-    const expectedLabel = `${windowEnd11.getHours().toString().padStart(2, '0')}:00`;
-    const degradedSample = samples.find(s => s.hourLabel === expectedLabel);
-    expect(degradedSample?.status).toBe('degraded');
-    expect(degradedSample?.scorePercent).toBe(75);
-
-    // Other peaceful hours remain 100% healthy
-    const peacefulSamples = samples.filter(s => s !== degradedSample);
-    expect(peacefulSamples.every(s => s.status === 'healthy')).toBe(true);
-    expect(peacefulSamples.every(s => s.scorePercent === 100)).toBe(true);
+    expect(samples.every(s => s.status === 'healthy')).toBe(true);
+    expect(samples.every(s => s.scorePercent === 100)).toBe(true);
+    expect(prisma.incident.findMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- make system-health scoring truthful: unknown evidence lowers confidence instead of silently passing
- distinguish cluster, replica, configuration, and external evidence so local state is not presented as HA truth
- add durable analytics-rollup and integration-control-plane diagnostics plus local worker and realtime signals
- replace the misleading inferred uptime label with a clearly qualified recorded-signal trend
- add an operational-priorities brief with impact and remediation links
- redact raw database errors from client-visible diagnostics

## Performance and resilience

- share diagnostics through a 15-second per-replica cache
- coalesce concurrent collections with singleflight, including forced refreshes
- query historical evidence sources concurrently
- skip auto-refresh work while the tab is hidden or the browser is offline
- prevent overlapping manual/automatic/retest collections
- retain and clearly mark the last successful report when refresh fails

## Validation

- 2,232 unit tests passed; 4 skipped
- focused System Health tests: 23 passed
- TypeScript passed
- changed-file ESLint passed with zero warnings
- production Next.js build passed

The mixed full suite also ran 2,251 tests successfully; four PostgreSQL-only integration tests could not authenticate to the locally configured test database.