### PR TITLE
fix(health): distinguish missing data from deployment topology

### DIFF
--- a/src/components/settings/SystemHealthCenter.tsx
+++ b/src/components/settings/SystemHealthCenter.tsx
@@ -107,6 +107,14 @@ const STATUS_CONFIG: Record<
     iconBg: 'bg-muted',
     iconText: 'text-muted-foreground',
   },
+  informational: {
+    label: 'Informational',
+    badgeClass: 'bg-sky-500/10 text-sky-700 dark:text-sky-300 border-sky-500/30',
+    cardBorder: 'hover:border-sky-500/30 focus-within:border-sky-500/30',
+    icon: Info,
+    iconBg: 'bg-sky-500/10 dark:bg-sky-500/20',
+    iconText: 'text-sky-600 dark:text-sky-400',
+  },
 };
 
 const CATEGORY_META: Record<
@@ -255,7 +263,12 @@ export default function SystemHealthCenter({ initialReport }: Props) {
       if (activeTab !== 'all' && check.category !== activeTab) {
         return false;
       }
-      if (onlyAttention && check.status === 'healthy') {
+      if (
+        onlyAttention &&
+        check.status !== 'degraded' &&
+        check.status !== 'unhealthy' &&
+        check.status !== 'unknown'
+      ) {
         return false;
       }
       return true;
@@ -562,10 +575,14 @@ function OperationalBrief({ checks }: { checks: AdminHealthCheck[] }) {
       unhealthy: 0,
       degraded: 1,
       unknown: 2,
-      healthy: 3,
+      informational: 3,
+      healthy: 4,
     };
     return checks
-      .filter(check => check.status !== 'healthy' && check.required !== false)
+      .filter(
+        check =>
+          check.status !== 'healthy' && check.status !== 'informational' && check.required !== false
+      )
       .sort((left, right) => rank[left.status] - rank[right.status])
       .slice(0, 5);
   }, [checks]);
@@ -654,6 +671,7 @@ function HealthHistoryRibbon({
     degraded: 'Degraded',
     unhealthy: 'Action Required',
     unknown: 'Not Reported',
+    informational: 'Informational',
   };
 
   return (

--- a/src/lib/admin-health.ts
+++ b/src/lib/admin-health.ts
@@ -8,7 +8,7 @@ import { getMetricsByIntegration, getMetricsSummary } from '@/lib/integrations/m
 import { getJobWorkerStatus } from '@/lib/job-worker';
 import { getRealtimeControlPlaneStatus } from '@/lib/realtime-change-control-plane';
 
-export type HealthLevel = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+export type HealthLevel = 'healthy' | 'degraded' | 'unhealthy' | 'unknown' | 'informational';
 export type HealthCategory = 'database' | 'workers' | 'alerting' | 'security' | 'platform';
 
 /** Stable documentation channel; never pin health remediation to an aging release. */
@@ -268,7 +268,7 @@ export function calculateOperationalScore(checks: AdminHealthCheck[]): Operation
     } else if (check.status === 'degraded') {
       warningIssues.push(check);
       weightedScore += weight * 0.75;
-    } else if (check.status === 'healthy') {
+    } else if (check.status === 'healthy' || check.status === 'informational') {
       weightedScore += weight * 1.0;
     } else {
       // Unknown evidence must never inflate health. It is uncertainty, not success.
@@ -1324,7 +1324,7 @@ async function collectAdminHealthUncached(): Promise<AdminHealthReport> {
     required: false,
     observedAt: now.toISOString(),
     status: !worker.running
-      ? 'unknown'
+      ? 'informational'
       : worker.lastError || workerSuccessAgeMs === null || workerSuccessAgeMs > 5 * MINUTE
         ? 'degraded'
         : 'healthy',

--- a/src/lib/admin-health.ts
+++ b/src/lib/admin-health.ts
@@ -50,6 +50,7 @@ export type CheckTelemetry = {
     sampleCount24h?: number;
     maxMs?: number | null;
     slowCount?: number;
+    slowRate24h?: number;
     trend?: 'improving' | 'stable' | 'regressing' | 'insufficient-data';
   };
   rawPayload?: Record<string, unknown>;
@@ -174,6 +175,15 @@ function byteLabel(bytes: number): string {
   if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KiB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
+}
+
+export function healthDurationLabel(milliseconds: number | null | undefined): string {
+  if (milliseconds === null || milliseconds === undefined) return 'no samples';
+  if (milliseconds < 1000) return `${Math.round(milliseconds)} ms`;
+  if (milliseconds < MINUTE) return `${(milliseconds / 1000).toFixed(1)} s`;
+  const minutes = Math.floor(milliseconds / MINUTE);
+  const seconds = Math.round((milliseconds % MINUTE) / 1000);
+  return `${minutes}m ${seconds}s`;
 }
 
 /** Keep diagnostics actionable without reflecting credentials, URLs, or driver internals. */
@@ -797,6 +807,10 @@ async function collectAdminHealthUncached(): Promise<AdminHealthReport> {
       const displayedP50 = metrics?.p50Ms1h ?? metrics?.p50Ms24h ?? null;
       const displayedAverage = metrics?.avgMs1h ?? metrics?.avgMs24h ?? null;
       const displayWindow = sampleCount1h > 0 ? '1h' : '24h';
+      const slowRate24h =
+        sampleCount24h > 0
+          ? Math.round(((metrics?.slowCount24h ?? 0) / sampleCount24h) * 1000) / 10
+          : 0;
 
       checks.push({
         id: 'sla-performance',
@@ -812,17 +826,24 @@ async function collectAdminHealthUncached(): Promise<AdminHealthReport> {
           sampleCount24h === 0
             ? 'No recent SLA query timing data.'
             : sampleCount1h > 0
-              ? `${sampleCount1h} queries in the last hour; p95 ${Math.round(displayedP95 ?? 0)} ms (${trend} vs prior 23h).`
-              : `${sampleCount24h} queries in 24 hours; no executions last hour; 24h p95 ${Math.round(dailyP95 ?? 0)} ms.`,
+              ? `${sampleCount1h} queries in the last hour; p95 ${healthDurationLabel(displayedP95)} (${trend} vs prior 23h).`
+              : `No executions in the last hour; historical 24h p95 was ${healthDurationLabel(dailyP95)}.`,
         details:
           sampleCount24h === 0
             ? ['SLA performance metrics require recorded calculation events.']
             : [
-                `24 hours: ${sampleCount24h} queries, p95 ${Math.round(dailyP95 ?? 0)} ms, max ${metrics?.maxMs24h ?? 0} ms`,
-                `Last hour: p50 ${Math.round(metrics?.p50Ms1h ?? 0)} ms, average ${Math.round(metrics?.avgMs1h ?? 0)} ms, max ${metrics?.maxMs1h ?? 0} ms`,
-                `Queries exceeding 10s: ${metrics?.slowCount1h ?? 0} in 1h / ${metrics?.slowCount24h ?? 0} in 24h`,
-                `Execution rate: ${(sampleCount1h / 60).toFixed(1)} per minute in the last hour`,
-                `Average incidents scanned: ${Math.round(metrics?.avgIncidents1h ?? 0)} in 1h / ${Math.round(metrics?.avgIncidents24h ?? 0)} in 24h`,
+                `24 hours: ${sampleCount24h} queries, p50 ${healthDurationLabel(metrics?.p50Ms24h)}, p95 ${healthDurationLabel(dailyP95)}, max ${healthDurationLabel(metrics?.maxMs24h)}`,
+                `Slow queries over 10s: ${metrics?.slowCount24h ?? 0} (${slowRate24h}%) in 24h`,
+                ...(sampleCount1h > 0
+                  ? [
+                      `Last hour: p50 ${healthDurationLabel(metrics?.p50Ms1h)}, average ${healthDurationLabel(metrics?.avgMs1h)}, max ${healthDurationLabel(metrics?.maxMs1h)}`,
+                      `Last-hour slow queries: ${metrics?.slowCount1h ?? 0}; execution rate: ${(sampleCount1h / 60).toFixed(1)} per minute`,
+                      `Average incidents scanned: ${Math.round(metrics?.avgIncidents1h ?? 0)} in 1h / ${Math.round(metrics?.avgIncidents24h ?? 0)} in 24h`,
+                    ]
+                  : [
+                      'Last hour: no timing samples; current SLA-query performance is not established.',
+                      `Average incidents scanned per historical run: ${Math.round(metrics?.avgIncidents24h ?? 0)}`,
+                    ]),
               ],
         telemetry: {
           slaMetrics: {
@@ -837,6 +858,7 @@ async function collectAdminHealthUncached(): Promise<AdminHealthReport> {
             slowCount:
               displayWindow === '1h' ? (metrics?.slowCount1h ?? 0) : (metrics?.slowCount24h ?? 0),
             trend,
+            slowRate24h,
           },
           rawPayload: {
             window1h: {

--- a/tests/lib/admin-health.test.ts
+++ b/tests/lib/admin-health.test.ts
@@ -4,9 +4,23 @@ import {
   calculateOperationalScore,
   overallStatus,
   generate24HourHistory,
+  healthDurationLabel,
   CHECK_WEIGHTS,
   type AdminHealthCheck,
 } from '@/lib/admin-health';
+
+describe('health duration labels', () => {
+  it('distinguishes missing evidence from a real zero-duration sample', () => {
+    expect(healthDurationLabel(null)).toBe('no samples');
+    expect(healthDurationLabel(undefined)).toBe('no samples');
+    expect(healthDurationLabel(0)).toBe('0 ms');
+  });
+
+  it('makes severe latency readable without discarding precision', () => {
+    expect(healthDurationLabel(26_989)).toBe('27.0 s');
+    expect(healthDurationLabel(313_559)).toBe('5m 14s');
+  });
+});
 
 describe('admin health guide links', () => {
   it('uses stable latest-channel routes that exist in both published v1.4 and v1.5 docs', () => {

--- a/tests/lib/admin-health.test.ts
+++ b/tests/lib/admin-health.test.ts
@@ -246,6 +246,24 @@ describe('calculateOperationalScore and weighted health logic', () => {
     expect(result.warningIssues).toHaveLength(0);
   });
 
+  it('treats informational deployment topology as known non-degrading evidence', () => {
+    const result = calculateOperationalScore([
+      ...mockBaseChecks,
+      {
+        id: 'worker-replica',
+        label: 'Local durable-job worker',
+        category: 'workers',
+        status: 'informational',
+        summary: 'Dedicated workers own durable jobs.',
+        details: [],
+      },
+    ]);
+
+    expect(result.scorePercent).toBe(100);
+    expect(result.overall).toBe('healthy');
+    expect(result.warningIssues).toHaveLength(0);
+  });
+
   it('assigns higher weight to database, migrations, encryption, and scheduler than auxiliary checks', () => {
     expect(CHECK_WEIGHTS.database).toBe(10);
     expect(CHECK_WEIGHTS.migrations).toBe(10);


### PR DESCRIPTION
## Problems

- an empty one-hour SLA window displayed `0 ms`, which looked like excellent performance instead of missing evidence
- a web replica without the optional durable-job worker was labeled `Not Reported`, despite dedicated worker deployments being a valid topology

## Fix

- explicitly render no timing samples and separate current evidence from historical 24-hour degradation
- show human-readable SLA durations and slow-query percentage
- add an `Informational` health state for valid non-actionable deployment topology
- exclude informational signals from missing-evidence counts, attention filters, priority summaries, and health degradation
- retain cluster queue age as the authoritative worker-delivery signal

## Validation

- 27 focused tests passed
- TypeScript passed
- ESLint passed with zero warnings