### PR TITLE
fix(incidents): topbar visibility, selector consistency, postmortem draft wording, and integration refinements

### DIFF
--- a/src/app/(app)/incidents/[id]/page.tsx
+++ b/src/app/(app)/incidents/[id]/page.tsx
@@ -39,6 +39,13 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
           jiraServiceMapping: {
             select: { projectKey: true },
           },
+          slackIntegration: {
+            select: {
+              id: true,
+              enabled: true,
+              workspaceId: true,
+            },
+          },
         },
       },
       assignee: true,
@@ -79,8 +86,8 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
   // Check if postmortem exists for this incident
   const postmortem = incident.status === 'RESOLVED' ? await getPostmortem(id) : null;
 
-  // Fetch Jira data for the incident sidebar
-  const [jiraLinks, jiraConfig] = await Promise.all([
+  // Fetch Jira & ChatOps data for the incident sidebar
+  const [jiraLinks, jiraConfig, chatOpsConfig] = await Promise.all([
     prisma.externalIssueLink.findMany({
       where: { incidentId: id, provider: 'JIRA' },
       orderBy: { createdAt: 'desc' },
@@ -89,7 +96,18 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
       where: { id: 'default' },
       select: { enabled: true },
     }),
+    prisma.chatOpsConfig.findUnique({
+      where: { id: 'default' },
+      select: { enabled: true },
+    }),
   ]);
+
+  const isWarRoomEnabled = Boolean(
+    chatOpsConfig?.enabled &&
+    incident.service.slackIntegration?.enabled !== false &&
+    incident.service.slackIntegration?.workspaceId &&
+    incident.service.autoCreateWarRoom
+  );
 
   // The resolution note is stored as a regular Note prefixed with "Resolution:" —
   // there's no separate resolution-summary column on Incident.
@@ -294,6 +312,7 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
           slackChannelName: incident.slackChannelName,
           warRoomUrl: incident.warRoomUrl,
           warRoomArchivedAt: incident.warRoomArchivedAt,
+          enabled: isWarRoomEnabled,
         }}
         jira={{
           links: jiraLinks,

--- a/src/app/(app)/incidents/[id]/page.tsx
+++ b/src/app/(app)/incidents/[id]/page.tsx
@@ -6,7 +6,6 @@ import { addNote, addWatcher, removeWatcher, updateIncidentStatus } from '../act
 import { getPostmortem } from '@/app/(app)/postmortems/actions';
 import IncidentHeader from '@/components/incident/IncidentHeader';
 import IncidentWatchers from '@/components/incident/detail/IncidentWatchers';
-import IncidentJiraCard from '@/components/incident/detail/IncidentJiraCard';
 import IncidentCommandBar from '@/components/incident/detail/IncidentCommandBar';
 import IncidentDetailTabs from '@/components/incident/IncidentDetailTabs';
 import IncidentNotes from '@/components/incident/detail/IncidentNotes';
@@ -86,8 +85,8 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
   // Check if postmortem exists for this incident
   const postmortem = incident.status === 'RESOLVED' ? await getPostmortem(id) : null;
 
-  // Fetch Jira & ChatOps data for the incident sidebar
-  const [jiraLinks, jiraConfig, chatOpsConfig] = await Promise.all([
+  // Fetch Jira, ChatOps, and Slack data for the incident collaboration bar
+  const [jiraLinks, jiraConfig, chatOpsConfig, globalSlackIntegration] = await Promise.all([
     prisma.externalIssueLink.findMany({
       where: { incidentId: id, provider: 'JIRA' },
       orderBy: { createdAt: 'desc' },
@@ -100,14 +99,19 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
       where: { id: 'default' },
       select: { enabled: true },
     }),
+    prisma.slackIntegration.findFirst({
+      where: { enabled: true, services: { none: {} } },
+      select: { workspaceId: true },
+    }),
   ]);
 
-  const isWarRoomEnabled = Boolean(
-    chatOpsConfig?.enabled &&
-    incident.service.slackIntegration?.enabled !== false &&
-    incident.service.slackIntegration?.workspaceId &&
-    incident.service.autoCreateWarRoom
+  const hasSlackWorkspace = Boolean(
+    (incident.service.slackIntegration?.workspaceId &&
+      incident.service.slackIntegration?.enabled !== false) ||
+    globalSlackIntegration?.workspaceId
   );
+
+  const isWarRoomEnabled = Boolean(chatOpsConfig?.enabled && hasSlackWorkspace);
 
   // The resolution note is stored as a regular Note prefixed with "Resolution:" —
   // there's no separate resolution-summary column on Incident.
@@ -392,24 +396,6 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
               })) || []
             }
             allCustomFields={customFields}
-            canManage={canManageIncident}
-          />
-
-          {/* Jira Integration */}
-          <IncidentJiraCard
-            incidentId={incident.id}
-            serviceSettingsHref={`/services/${incident.serviceId}/settings`}
-            jiraLinks={jiraLinks.map(l => ({
-              id: l.id,
-              externalKey: l.externalKey,
-              externalUrl: l.externalUrl,
-              externalStatus: l.externalStatus,
-              externalAssignee: l.externalAssignee,
-              syncState: l.syncState,
-              lastSyncedAt: l.lastSyncedAt,
-            }))}
-            jiraEnabled={jiraConfig?.enabled ?? false}
-            serviceJiraMapped={Boolean(incident.service.jiraServiceMapping?.projectKey)}
             canManage={canManageIncident}
           />
 

--- a/src/components/TopbarBreadcrumbs.tsx
+++ b/src/components/TopbarBreadcrumbs.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/shadcn/dropdown-menu';
+import { cn } from '@/lib/utils';
 
 export default function TopbarBreadcrumbs() {
   const pathname = usePathname();
@@ -31,40 +32,62 @@ export default function TopbarBreadcrumbs() {
 
   const breadcrumbs = segments.map((segment, index) => {
     const href = '/' + segments.slice(0, index + 1).join('/');
-    const label = segment
-      .split('-')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+    const isId =
+      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+        segment
+      ) ||
+      (segment.length >= 20 && /^[a-zA-Z0-9_-]+$/.test(segment)) ||
+      /^c[a-z0-9]{16,}$/i.test(segment);
+
+    const label = isId
+      ? segment
+      : segment
+          .split('-')
+          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ');
 
     return {
       href,
       label,
+      isId,
       isLast: index === segments.length - 1,
     };
   });
 
   return (
     <Breadcrumb className="hidden md:flex">
-      <BreadcrumbList className="flex-nowrap whitespace-nowrap">
+      <BreadcrumbList className="flex-nowrap whitespace-nowrap text-xs text-zinc-400">
         <BreadcrumbItem>
-          <BreadcrumbLink asChild>
+          <BreadcrumbLink
+            asChild
+            className="text-zinc-400 hover:text-zinc-100 transition-colors text-xs font-medium"
+          >
             <Link href="/">Home</Link>
           </BreadcrumbLink>
         </BreadcrumbItem>
         {breadcrumbs.length > 2 ? (
           <>
             <Fragment>
-              <BreadcrumbSeparator />
+              <BreadcrumbSeparator className="text-zinc-600 [&>svg]:size-3" />
               <BreadcrumbItem>
                 <DropdownMenu>
-                  <DropdownMenuTrigger className="flex items-center gap-1">
-                    <BreadcrumbEllipsis className="h-4 w-4" />
+                  <DropdownMenuTrigger className="flex items-center gap-1 text-zinc-400 hover:text-zinc-100 transition-colors">
+                    <BreadcrumbEllipsis className="h-4 w-4 text-zinc-400 hover:text-zinc-100" />
                     <span className="sr-only">Toggle menu</span>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
+                  <DropdownMenuContent
+                    align="start"
+                    className="bg-[#18181b] border-zinc-800 text-zinc-200 shadow-xl"
+                  >
                     {breadcrumbs.slice(0, -2).map(breadcrumb => (
-                      <DropdownMenuItem key={breadcrumb.href} asChild>
-                        <Link href={breadcrumb.href}>{breadcrumb.label}</Link>
+                      <DropdownMenuItem
+                        key={breadcrumb.href}
+                        asChild
+                        className="focus:bg-zinc-800 focus:text-zinc-100 text-xs"
+                      >
+                        <Link href={breadcrumb.href} title={breadcrumb.label}>
+                          {breadcrumb.label}
+                        </Link>
                       </DropdownMenuItem>
                     ))}
                   </DropdownMenuContent>
@@ -73,13 +96,31 @@ export default function TopbarBreadcrumbs() {
             </Fragment>
             {breadcrumbs.slice(-2).map(breadcrumb => (
               <Fragment key={breadcrumb.href}>
-                <BreadcrumbSeparator />
+                <BreadcrumbSeparator className="text-zinc-600 [&>svg]:size-3" />
                 <BreadcrumbItem>
                   {breadcrumb.isLast ? (
-                    <BreadcrumbPage>{breadcrumb.label}</BreadcrumbPage>
+                    <BreadcrumbPage
+                      className={cn(
+                        'text-zinc-100 font-medium text-xs truncate max-w-[240px]',
+                        breadcrumb.isId &&
+                          'font-mono text-[11px] font-normal px-1.5 py-0.5 rounded bg-zinc-800/90 border border-zinc-700/70 text-zinc-200 tracking-tight'
+                      )}
+                      title={breadcrumb.label}
+                    >
+                      {breadcrumb.label}
+                    </BreadcrumbPage>
                   ) : (
-                    <BreadcrumbLink asChild>
-                      <Link href={breadcrumb.href}>{breadcrumb.label}</Link>
+                    <BreadcrumbLink
+                      asChild
+                      className={cn(
+                        'text-zinc-400 hover:text-zinc-100 transition-colors text-xs font-medium',
+                        breadcrumb.isId &&
+                          'font-mono text-[11px] px-1.5 py-0.5 rounded bg-zinc-800/80 border border-zinc-700/60 text-zinc-300 hover:text-zinc-100'
+                      )}
+                    >
+                      <Link href={breadcrumb.href} title={breadcrumb.label}>
+                        {breadcrumb.label}
+                      </Link>
                     </BreadcrumbLink>
                   )}
                 </BreadcrumbItem>
@@ -89,13 +130,31 @@ export default function TopbarBreadcrumbs() {
         ) : (
           breadcrumbs.map(breadcrumb => (
             <Fragment key={breadcrumb.href}>
-              <BreadcrumbSeparator />
+              <BreadcrumbSeparator className="text-zinc-600 [&>svg]:size-3" />
               <BreadcrumbItem>
                 {breadcrumb.isLast ? (
-                  <BreadcrumbPage>{breadcrumb.label}</BreadcrumbPage>
+                  <BreadcrumbPage
+                    className={cn(
+                      'text-zinc-100 font-medium text-xs truncate max-w-[240px]',
+                      breadcrumb.isId &&
+                        'font-mono text-[11px] font-normal px-1.5 py-0.5 rounded bg-zinc-800/90 border border-zinc-700/70 text-zinc-200 tracking-tight'
+                    )}
+                    title={breadcrumb.label}
+                  >
+                    {breadcrumb.label}
+                  </BreadcrumbPage>
                 ) : (
-                  <BreadcrumbLink asChild>
-                    <Link href={breadcrumb.href}>{breadcrumb.label}</Link>
+                  <BreadcrumbLink
+                    asChild
+                    className={cn(
+                      'text-zinc-400 hover:text-zinc-100 transition-colors text-xs font-medium',
+                      breadcrumb.isId &&
+                        'font-mono text-[11px] px-1.5 py-0.5 rounded bg-zinc-800/80 border border-zinc-700/60 text-zinc-300 hover:text-zinc-100'
+                    )}
+                  >
+                    <Link href={breadcrumb.href} title={breadcrumb.label}>
+                      {breadcrumb.label}
+                    </Link>
                   </BreadcrumbLink>
                 )}
               </BreadcrumbItem>

--- a/src/components/incident/AssigneeSection.tsx
+++ b/src/components/incident/AssigneeSection.tsx
@@ -15,8 +15,7 @@ import {
   CommandSeparator,
 } from '@/components/ui/shadcn/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/shadcn/popover';
-import { Button } from '@/components/ui/shadcn/button';
-import { Check, ChevronsUpDown, Users as UsersIcon, User, X } from 'lucide-react';
+import { Check, ChevronDown, Users as UsersIcon, User, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type AssigneeSectionProps = {
@@ -180,21 +179,77 @@ export default function AssigneeSection({
 
   // Header Variant - Button Trigger
   if (variant === 'header') {
+    const SELECTOR_BASE_CLASS =
+      'inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-semibold bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 text-slate-800 dark:text-zinc-200 shadow-2xs transition-all max-w-full select-none';
+
+    if (!canManage) {
+      return (
+        <div className={cn(SELECTOR_BASE_CLASS, 'cursor-default')}>
+          {team ? (
+            <>
+              <UsersIcon className="h-3.5 w-3.5 text-indigo-600 shrink-0" />
+              <span className="truncate max-w-[110px]">{team.name}</span>
+            </>
+          ) : assignee ? (
+            <>
+              <UserAvatar
+                userId={assignee.id}
+                name={assignee.name}
+                gender={assignee.gender}
+                avatarUrl={assignee.avatarUrl}
+                size="xs"
+                className="border-slate-200 shrink-0 h-4 w-4 text-[9px]"
+              />
+              <span className="truncate max-w-[110px]">{assignee.name}</span>
+            </>
+          ) : (
+            <>
+              <User className="h-3.5 w-3.5 text-slate-400 shrink-0" />
+              <span className="text-slate-500 dark:text-zinc-400 font-medium">Unassigned</span>
+            </>
+          )}
+        </div>
+      );
+    }
+
     return (
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            className="h-6 w-6 p-0 rounded-full bg-slate-100 hover:bg-slate-200 border border-slate-200 text-slate-500 hover:text-slate-900 shrink-0"
-            disabled={!canManage}
+          <button
+            type="button"
+            className={cn(
+              SELECTOR_BASE_CLASS,
+              'hover:bg-slate-50 dark:hover:bg-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 cursor-pointer group'
+            )}
             title="Change Assignee"
           >
-            <ChevronsUpDown className="h-3 w-3" />
-          </Button>
+            {team ? (
+              <>
+                <UsersIcon className="h-3.5 w-3.5 text-indigo-600 shrink-0" />
+                <span className="truncate max-w-[110px]">{team.name}</span>
+              </>
+            ) : assignee ? (
+              <>
+                <UserAvatar
+                  userId={assignee.id}
+                  name={assignee.name}
+                  gender={assignee.gender}
+                  avatarUrl={assignee.avatarUrl}
+                  size="xs"
+                  className="border-slate-200 shrink-0 h-4 w-4 text-[9px]"
+                />
+                <span className="truncate max-w-[110px]">{assignee.name}</span>
+              </>
+            ) : (
+              <>
+                <User className="h-3.5 w-3.5 text-slate-400 shrink-0" />
+                <span className="text-slate-500 dark:text-zinc-400 font-medium">Unassigned</span>
+              </>
+            )}
+            <ChevronDown className="h-3.5 w-3.5 text-slate-400 group-hover:text-slate-600 dark:text-zinc-500 transition-colors shrink-0 ml-auto" />
+          </button>
         </PopoverTrigger>
-        <PopoverContent className="p-0 w-64" align="end">
+        <PopoverContent className="p-0 w-64" align="start">
           {ReassignContent}
         </PopoverContent>
       </Popover>

--- a/src/components/incident/EscalationStatusBadge.tsx
+++ b/src/components/incident/EscalationStatusBadge.tsx
@@ -8,6 +8,7 @@ type EscalationStatusBadgeProps = {
   currentStep: number | null | undefined;
   nextEscalationAt: Date | null | undefined;
   size?: 'sm' | 'md';
+  className?: string;
 };
 
 function EscalationStatusBadge({
@@ -15,6 +16,7 @@ function EscalationStatusBadge({
   currentStep,
   nextEscalationAt,
   size = 'md',
+  className,
 }: EscalationStatusBadgeProps) {
   if (!status || status === 'COMPLETED') {
     return null;
@@ -57,10 +59,11 @@ function EscalationStatusBadge({
   return (
     <div
       className={cn(
-        'gap-1.5 font-semibold rounded-md border transition-colors inline-flex items-center text-sm px-2.5 py-0.5 shadow-2xs leading-normal',
+        'gap-1.5 font-semibold rounded-md border transition-colors inline-flex items-center text-xs px-2.5 py-0.5 shadow-2xs leading-normal',
         isEscalating
           ? 'bg-amber-50 text-amber-800 border-amber-200 hover:bg-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800'
-          : 'bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:border-slate-700'
+          : 'bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:border-slate-700',
+        className
       )}
       title={titleParts.join(' - ')}
     >

--- a/src/components/incident/IncidentHeader.tsx
+++ b/src/components/incident/IncidentHeader.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/navigation';
 import { Incident, Service } from '@prisma/client';
 import { useTimezone } from '@/contexts/TimezoneContext';
 import { formatDateTime } from '@/lib/timezone';
-import UserAvatar from '@/components/UserAvatar';
 import CopyButton from '@/components/common/CopyButton';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/shadcn/select';
 import { updateIncidentUrgency, updateIncidentVisibility } from '@/app/(app)/incidents/actions';
@@ -18,7 +17,6 @@ import {
   Server,
   Shield,
   Users,
-  User,
   AlertTriangle,
   Activity,
   ArrowUpRight,
@@ -117,12 +115,8 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
         ? 'bg-amber-500'
         : 'bg-emerald-500';
 
-  const urgencyTone =
-    incident.urgency === 'HIGH'
-      ? 'bg-rose-50 text-rose-700 border-rose-200 hover:bg-rose-100/80 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-800'
-      : incident.urgency === 'MEDIUM'
-        ? 'bg-amber-50 text-amber-800 border-amber-200 hover:bg-amber-100/80 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800'
-        : 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-100/80 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800';
+  const SELECTOR_BASE_CLASS =
+    'inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-semibold bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 text-slate-800 dark:text-zinc-200 shadow-2xs transition-all max-w-full select-none';
 
   const durationText = incident.resolvedAt
     ? `Resolved in ${formatDuration(incident.createdAt, incident.resolvedAt)}`
@@ -166,47 +160,42 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
               onValueChange={handleUrgencyChange}
               disabled={isPending}
             >
-              <SelectTrigger className="h-8 w-fit border-0 bg-transparent p-0 shadow-none focus:ring-0 [&>svg]:hidden group">
+              <SelectTrigger className="h-auto w-fit border-0 bg-transparent p-0 shadow-none focus:ring-0 [&>svg]:hidden group">
                 <div
                   className={cn(
-                    'inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md border text-sm font-semibold transition-all shadow-2xs group-hover:brightness-95 cursor-pointer',
-                    urgencyTone
+                    SELECTOR_BASE_CLASS,
+                    'hover:bg-slate-50 dark:hover:bg-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 cursor-pointer group'
                   )}
                 >
-                  <span className={cn('h-1.5 w-1.5 rounded-full', urgencyDot)} />
+                  <span className={cn('h-2 w-2 rounded-full shrink-0', urgencyDot)} />
                   <span>{incident.urgency}</span>
-                  <ChevronDown className="h-3.5 w-3.5 opacity-60 ml-0.5" />
+                  <ChevronDown className="h-3.5 w-3.5 text-slate-400 group-hover:text-slate-600 dark:text-zinc-500 transition-colors shrink-0 ml-auto" />
                 </div>
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="HIGH">
-                  <div className="flex items-center gap-2 font-semibold text-rose-700">
-                    <div className="w-2 h-2 rounded-full bg-rose-500 animate-pulse" />
-                    HIGH
+              <SelectContent align="start" className="min-w-[150px]">
+                <SelectItem value="HIGH" className="cursor-pointer">
+                  <div className="flex items-center gap-2 text-xs font-semibold text-rose-700 dark:text-rose-400">
+                    <span className="w-2 h-2 rounded-full bg-rose-500 animate-pulse shrink-0" />
+                    <span>HIGH</span>
                   </div>
                 </SelectItem>
-                <SelectItem value="MEDIUM">
-                  <div className="flex items-center gap-2 font-semibold text-amber-700">
-                    <div className="w-2 h-2 rounded-full bg-amber-500" />
-                    MEDIUM
+                <SelectItem value="MEDIUM" className="cursor-pointer">
+                  <div className="flex items-center gap-2 text-xs font-semibold text-amber-700 dark:text-amber-400">
+                    <span className="w-2 h-2 rounded-full bg-amber-500 shrink-0" />
+                    <span>MEDIUM</span>
                   </div>
                 </SelectItem>
-                <SelectItem value="LOW">
-                  <div className="flex items-center gap-2 font-semibold text-emerald-700">
-                    <div className="w-2 h-2 rounded-full bg-emerald-500" />
-                    LOW
+                <SelectItem value="LOW" className="cursor-pointer">
+                  <div className="flex items-center gap-2 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+                    <span className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />
+                    <span>LOW</span>
                   </div>
                 </SelectItem>
               </SelectContent>
             </Select>
           ) : (
-            <div
-              className={cn(
-                'inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md border text-sm font-semibold w-fit shadow-2xs',
-                urgencyTone
-              )}
-            >
-              <span className={cn('h-1.5 w-1.5 rounded-full', urgencyDot)} />
+            <div className={cn(SELECTOR_BASE_CLASS, 'cursor-default')}>
+              <span className={cn('h-2 w-2 rounded-full shrink-0', urgencyDot)} />
               <span>{incident.urgency}</span>
             </div>
           )}
@@ -230,44 +219,43 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
               onValueChange={val => handleVisibilityChange(val as 'PUBLIC' | 'PRIVATE')}
               disabled={isPending}
             >
-              <SelectTrigger className="h-8 w-fit border-0 bg-transparent p-0 shadow-none focus:ring-0 [&>svg]:hidden group">
-                <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md bg-slate-50 border border-slate-200 text-slate-800 text-sm font-semibold shadow-2xs group-hover:bg-slate-100 group-hover:border-slate-300 transition-all cursor-pointer">
+              <SelectTrigger className="h-auto w-fit border-0 bg-transparent p-0 shadow-none focus:ring-0 [&>svg]:hidden group">
+                <div
+                  className={cn(
+                    SELECTOR_BASE_CLASS,
+                    'hover:bg-slate-50 dark:hover:bg-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 cursor-pointer group'
+                  )}
+                >
                   {isPrivate ? (
-                    <EyeOff className="h-3.5 w-3.5 text-slate-500" />
+                    <EyeOff className="h-3.5 w-3.5 text-slate-500 shrink-0" />
                   ) : (
-                    <Eye className="h-3.5 w-3.5 text-slate-500" />
+                    <Eye className="h-3.5 w-3.5 text-slate-500 shrink-0" />
                   )}
                   <span>{isPrivate ? 'Private' : 'Public'}</span>
-                  <ChevronDown className="h-3.5 w-3.5 opacity-60 ml-0.5" />
+                  <ChevronDown className="h-3.5 w-3.5 text-slate-400 group-hover:text-slate-600 dark:text-zinc-500 transition-colors shrink-0 ml-auto" />
                 </div>
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="PUBLIC">
-                  <div className="flex items-center gap-2">
-                    <Eye className="h-3.5 w-3.5 text-slate-500" />
-                    <div className="flex flex-col text-left">
-                      <span className="font-semibold text-slate-900">Public</span>
-                      <span className="text-[10px] text-slate-500">Visible on Status Page</span>
-                    </div>
+              <SelectContent align="start" className="min-w-[150px]">
+                <SelectItem value="PUBLIC" className="cursor-pointer">
+                  <div className="flex items-center gap-2 text-xs font-semibold text-slate-800 dark:text-zinc-200">
+                    <Eye className="h-3.5 w-3.5 text-slate-500 shrink-0" />
+                    <span>Public</span>
                   </div>
                 </SelectItem>
-                <SelectItem value="PRIVATE">
-                  <div className="flex items-center gap-2">
-                    <EyeOff className="h-3.5 w-3.5 text-slate-500" />
-                    <div className="flex flex-col text-left">
-                      <span className="font-semibold text-slate-900">Private</span>
-                      <span className="text-[10px] text-slate-500">Internal Dashboard Only</span>
-                    </div>
+                <SelectItem value="PRIVATE" className="cursor-pointer">
+                  <div className="flex items-center gap-2 text-xs font-semibold text-slate-800 dark:text-zinc-200">
+                    <EyeOff className="h-3.5 w-3.5 text-slate-500 shrink-0" />
+                    <span>Private</span>
                   </div>
                 </SelectItem>
               </SelectContent>
             </Select>
           ) : (
-            <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md bg-slate-50 border border-slate-200 text-slate-800 text-sm font-semibold w-fit shadow-2xs">
+            <div className={cn(SELECTOR_BASE_CLASS, 'cursor-default')}>
               {isPrivate ? (
-                <EyeOff className="h-3.5 w-3.5 text-slate-500" />
+                <EyeOff className="h-3.5 w-3.5 text-slate-500 shrink-0" />
               ) : (
-                <Eye className="h-3.5 w-3.5 text-slate-500" />
+                <Eye className="h-3.5 w-3.5 text-slate-500 shrink-0" />
               )}
               <span>{isPrivate ? 'Private' : 'Public'}</span>
             </div>
@@ -295,55 +283,24 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
         </Link>
 
         {/* Assignee */}
-        <div className="flex flex-col justify-center p-3.5 min-h-[74px] relative">
+        <div className="flex flex-col justify-center p-3.5 min-h-[74px]">
           <div className="flex items-center gap-1.5 mb-1.5">
             <Users className="h-3 w-3 text-slate-400 shrink-0" />
             <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider">
               Assignee
             </span>
           </div>
-          <div className="flex items-center gap-2 min-w-0 pr-6">
-            {incident.team ? (
-              <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md bg-indigo-50 border border-indigo-200 text-indigo-900 text-sm font-semibold shadow-2xs truncate">
-                <Users className="h-3.5 w-3.5 text-indigo-600 shrink-0" />
-                <span className="truncate">{incident.team.name}</span>
-              </div>
-            ) : incident.assignee ? (
-              <div className="inline-flex items-center gap-1.5 min-w-0">
-                <UserAvatar
-                  userId={incident.assignee.id}
-                  name={incident.assignee.name}
-                  gender={incident.assignee.gender}
-                  avatarUrl={incident.assignee.avatarUrl}
-                  size="xs"
-                  className="border-slate-200 shrink-0"
-                />
-                <span className="text-sm font-semibold text-slate-900 truncate">
-                  {incident.assignee.name}
-                </span>
-              </div>
-            ) : (
-              <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md bg-slate-50 border border-dashed border-slate-300 text-slate-500 text-sm font-semibold">
-                <User className="h-3.5 w-3.5" />
-                <span>Unassigned</span>
-              </div>
-            )}
-          </div>
-          {canManage && (
-            <div className="absolute right-2 top-1/2 -translate-y-1/2">
-              <AssigneeSection
-                assignee={incident.assignee}
-                team={incident.team || null}
-                assigneeId={incident.assigneeId}
-                teamId={incident.teamId}
-                users={users}
-                teams={teams}
-                incidentId={incident.id}
-                canManage={canManage}
-                variant="header"
-              />
-            </div>
-          )}
+          <AssigneeSection
+            assignee={incident.assignee}
+            team={incident.team || null}
+            assigneeId={incident.assigneeId}
+            teamId={incident.teamId}
+            users={users}
+            teams={teams}
+            incidentId={incident.id}
+            canManage={canManage}
+            variant="header"
+          />
         </div>
 
         {/* Policy */}
@@ -391,7 +348,10 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
             if (incident.status === 'RESOLVED') {
               return (
                 <div
-                  className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-slate-50 border border-slate-200 text-slate-600 text-xs font-semibold w-fit shadow-2xs"
+                  className={cn(
+                    SELECTOR_BASE_CLASS,
+                    'cursor-default text-slate-700 dark:text-zinc-300'
+                  )}
                   title="Escalation ended upon resolution"
                 >
                   <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 shrink-0" />
@@ -404,7 +364,10 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
             if (incident.status === 'SNOOZED' || incident.status === 'SUPPRESSED') {
               return (
                 <div
-                  className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-indigo-50 border border-indigo-200 text-indigo-700 text-xs font-semibold w-fit shadow-2xs"
+                  className={cn(
+                    SELECTOR_BASE_CLASS,
+                    'cursor-default text-indigo-700 dark:text-indigo-400'
+                  )}
                   title="Escalation paused while incident is snoozed/suppressed"
                 >
                   <Pause className="h-3.5 w-3.5 text-indigo-600 shrink-0" />
@@ -422,7 +385,10 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
                   : 'Stopped (Acked)';
               return (
                 <div
-                  className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-emerald-50 border border-emerald-200 text-emerald-800 text-xs font-semibold w-fit shadow-2xs"
+                  className={cn(
+                    SELECTOR_BASE_CLASS,
+                    'cursor-default text-emerald-800 dark:text-emerald-400'
+                  )}
                   title="Escalation stopped because incident was acknowledged"
                 >
                   <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 shrink-0" />
@@ -439,6 +405,7 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
                   currentStep={incident.currentEscalationStep}
                   nextEscalationAt={incident.nextEscalationAt}
                   size="sm"
+                  className="h-8"
                 />
               );
             }
@@ -447,7 +414,10 @@ export default function IncidentHeader({ incident, users, teams, canManage }: In
             if (incident.escalationStatus === 'COMPLETED') {
               return (
                 <div
-                  className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-rose-50 border border-rose-200 text-rose-800 text-xs font-semibold w-fit shadow-2xs"
+                  className={cn(
+                    SELECTOR_BASE_CLASS,
+                    'cursor-default text-rose-800 dark:text-rose-400'
+                  )}
                   title="All escalation policy steps have been exhausted"
                 >
                   <AlertTriangle className="h-3.5 w-3.5 text-rose-600 shrink-0" />

--- a/src/components/incident/PriorityBadge.tsx
+++ b/src/components/incident/PriorityBadge.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { memo } from 'react';
+import { Badge } from '@/components/ui/shadcn/badge';
 import { cn } from '@/lib/utils';
-import { AlertCircle, ArrowUp, Zap, Info, ShieldAlert } from 'lucide-react';
+import { AlertCircle, ArrowUp, Zap, Info, ShieldAlert, type LucideIcon } from 'lucide-react';
 
 type PriorityBadgeProps = {
   priority: string | null | undefined;
@@ -11,80 +12,97 @@ type PriorityBadgeProps = {
   className?: string;
 };
 
-function getPriorityConfig(priority: string) {
+type PriorityConfig = {
+  label: string;
+  variant: 'danger' | 'warning' | 'info' | 'neutral';
+  icon: LucideIcon;
+  customClass?: string;
+};
+
+function getPriorityConfig(priority: string): PriorityConfig {
   switch (priority) {
     case 'P1':
       return {
         label: 'Crisis',
+        variant: 'danger',
         icon: ShieldAlert,
-        tone: 'bg-rose-50 text-rose-700 border-rose-200 hover:bg-rose-100/80 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-800',
       };
     case 'P2':
       return {
         label: 'High',
+        variant: 'warning',
         icon: ArrowUp,
-        tone: 'bg-amber-50 text-amber-800 border-amber-200 hover:bg-amber-100/80 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800',
       };
     case 'P3':
       return {
         label: 'Medium',
+        variant: 'warning',
         icon: AlertCircle,
-        tone: 'bg-orange-50 text-orange-800 border-orange-200 hover:bg-orange-100/80 dark:bg-orange-950/40 dark:text-orange-300 dark:border-orange-800',
+        customClass:
+          'bg-gradient-to-r from-orange-500 to-amber-600 border-transparent text-white shadow-sm',
       };
     case 'P4':
       return {
         label: 'Low',
+        variant: 'info',
         icon: Zap,
-        tone: 'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100/80 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-800',
       };
     case 'P5':
       return {
         label: 'Info',
+        variant: 'neutral',
         icon: Info,
-        tone: 'bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:border-slate-700',
       };
     default:
       return {
         label: priority,
+        variant: 'neutral',
         icon: Info,
-        tone: 'bg-slate-50 text-slate-700 border-slate-200',
       };
   }
 }
 
-function getSizeClasses(size: 'sm' | 'md' | 'lg'): string {
+function getBadgeSize(size: 'sm' | 'md' | 'lg'): 'xs' | 'sm' | 'md' {
   switch (size) {
     case 'sm':
-      return 'text-xs px-2 py-0.5';
+      return 'xs';
     case 'lg':
-      return 'text-base px-3 py-1';
+      return 'md';
     case 'md':
     default:
-      return 'text-sm px-2.5 py-0.5';
+      return 'sm';
   }
 }
 
 function PriorityBadge({ priority, size = 'md', showLabel = true, className }: PriorityBadgeProps) {
   if (!priority) return null;
 
-  const { label, icon: Icon, tone } = getPriorityConfig(priority);
-  const sizeClasses = getSizeClasses(size);
+  const { label, variant, icon: Icon, customClass } = getPriorityConfig(priority);
+  const badgeSize = getBadgeSize(size);
 
   const displayLabel =
     size === 'sm' && !showLabel ? priority : showLabel ? `${priority} · ${label}` : priority;
 
   return (
-    <div
+    <Badge
+      variant={variant}
+      size={badgeSize}
       className={cn(
-        'font-semibold rounded-md border shadow-2xs inline-flex items-center gap-1.5 shrink-0 transition-all leading-normal',
-        sizeClasses,
-        tone,
+        'font-bold tracking-wide shadow-2xs gap-1 shrink-0 transition-all uppercase',
+        customClass,
         className
       )}
     >
-      {Icon && <Icon className={cn('shrink-0', size === 'sm' ? 'h-3 w-3' : 'h-3.5 w-3.5')} />}
+      {Icon && (
+        <Icon
+          className={cn(
+            'shrink-0 text-white',
+            badgeSize === 'xs' ? 'h-3 w-3' : badgeSize === 'md' ? 'h-4 w-4' : 'h-3.5 w-3.5'
+          )}
+        />
+      )}
       <span>{displayLabel}</span>
-    </div>
+    </Badge>
   );
 }
 

--- a/src/components/incident/PrioritySelector.tsx
+++ b/src/components/incident/PrioritySelector.tsx
@@ -6,13 +6,20 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
-  SelectValue,
 } from '@/components/ui/shadcn/select';
-import { Badge } from '@/components/ui/shadcn/badge';
-import PriorityBadge from './PriorityBadge';
 import { updateIncidentPriority } from '@/app/(app)/incidents/actions';
-import { ChevronDown, AlertCircle } from 'lucide-react';
+import {
+  ShieldAlert,
+  ArrowUp,
+  AlertCircle,
+  Zap,
+  Info,
+  ChevronDown,
+  Activity,
+  X,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type PrioritySelectorProps = {
@@ -20,6 +27,52 @@ type PrioritySelectorProps = {
   priority: string | null;
   canManage: boolean;
 };
+
+const PRIORITY_OPTIONS = [
+  {
+    key: 'P1',
+    label: 'Crisis',
+    icon: ShieldAlert,
+    iconColor: 'text-rose-600 dark:text-rose-400',
+    textColor: 'text-rose-700 dark:text-rose-400',
+  },
+  {
+    key: 'P2',
+    label: 'High',
+    icon: ArrowUp,
+    iconColor: 'text-amber-600 dark:text-amber-400',
+    textColor: 'text-amber-700 dark:text-amber-400',
+  },
+  {
+    key: 'P3',
+    label: 'Medium',
+    icon: AlertCircle,
+    iconColor: 'text-orange-600 dark:text-orange-400',
+    textColor: 'text-orange-700 dark:text-orange-400',
+  },
+  {
+    key: 'P4',
+    label: 'Low',
+    icon: Zap,
+    iconColor: 'text-blue-600 dark:text-blue-400',
+    textColor: 'text-blue-700 dark:text-blue-400',
+  },
+  {
+    key: 'P5',
+    label: 'Info',
+    icon: Info,
+    iconColor: 'text-slate-500 dark:text-slate-400',
+    textColor: 'text-slate-700 dark:text-slate-400',
+  },
+] as const;
+
+function getPriorityItem(priority: string | null | undefined) {
+  if (!priority) return null;
+  return PRIORITY_OPTIONS.find(opt => opt.key === priority) || null;
+}
+
+const SELECTOR_BASE_CLASS =
+  'inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-semibold bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 text-slate-800 dark:text-zinc-200 shadow-2xs transition-all max-w-full select-none';
 
 export default function PrioritySelector({
   incidentId,
@@ -29,14 +82,26 @@ export default function PrioritySelector({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
+  const currentItem = getPriorityItem(priority);
+
   // Read-only view
   if (!canManage) {
-    return priority ? (
-      <PriorityBadge priority={priority} size="md" />
-    ) : (
-      <Badge variant="neutral" size="sm" className="border-dashed bg-transparent">
-        Unassigned
-      </Badge>
+    if (currentItem && priority) {
+      const Icon = currentItem.icon;
+      return (
+        <div className={cn(SELECTOR_BASE_CLASS, 'cursor-default')}>
+          <Icon className={cn('h-3.5 w-3.5 shrink-0', currentItem.iconColor)} />
+          <span className="truncate">
+            {priority} · {currentItem.label}
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div className={cn(SELECTOR_BASE_CLASS, 'cursor-default')}>
+        <Activity className="h-3.5 w-3.5 text-slate-400 shrink-0" />
+        <span className="text-slate-500 dark:text-zinc-400 font-medium">Unassigned</span>
+      </div>
     );
   }
 
@@ -51,50 +116,50 @@ export default function PrioritySelector({
       }}
       disabled={isPending}
     >
-      <SelectTrigger
-        className={cn(
-          'h-7 w-fit border-0 bg-transparent p-0 shadow-none focus:ring-0 [&>svg]:hidden group'
-        )}
-      >
-        <SelectValue placeholder="Priority">
-          {priority ? (
-            <div className="inline-flex items-center gap-1.5 cursor-pointer">
-              <PriorityBadge
-                priority={priority}
-                size="md"
-                className="transition-all group-hover:brightness-95"
-              />
-              <ChevronDown className="h-3.5 w-3.5 text-slate-400 group-hover:text-slate-600 transition-colors" />
-            </div>
-          ) : (
-            <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md bg-slate-50 text-slate-500 border border-dashed border-slate-300 hover:border-slate-400 hover:text-slate-700 transition-all cursor-pointer">
-              <AlertCircle className="h-3.5 w-3.5" />
-              <span className="text-sm font-semibold">Set Priority</span>
-              <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
-            </div>
+      <SelectTrigger className="h-auto w-fit border-0 bg-transparent p-0 shadow-none focus:ring-0 [&>svg]:hidden group">
+        <div
+          className={cn(
+            SELECTOR_BASE_CLASS,
+            'hover:bg-slate-50 dark:hover:bg-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 cursor-pointer group'
           )}
-        </SelectValue>
+        >
+          {currentItem && priority ? (
+            <>
+              <currentItem.icon className={cn('h-3.5 w-3.5 shrink-0', currentItem.iconColor)} />
+              <span className="truncate">
+                {priority} · {currentItem.label}
+              </span>
+            </>
+          ) : (
+            <>
+              <Activity className="h-3.5 w-3.5 text-slate-400 shrink-0" />
+              <span className="text-slate-500 dark:text-zinc-400 font-medium">Set Priority</span>
+            </>
+          )}
+          <ChevronDown className="h-3.5 w-3.5 text-slate-400 group-hover:text-slate-600 dark:text-zinc-500 transition-colors shrink-0 ml-auto" />
+        </div>
       </SelectTrigger>
       <SelectContent align="start" className="min-w-[160px]">
-        <SelectItem value="unassigned" className="text-muted-foreground text-xs py-2">
-          Unassigned
+        <SelectItem value="unassigned" className="cursor-pointer">
+          <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+            <X className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span>Unassigned</span>
+          </div>
         </SelectItem>
-        <div className="h-px bg-slate-100 my-1" />
-        <SelectItem value="P1">
-          <PriorityBadge priority="P1" size="sm" showLabel />
-        </SelectItem>
-        <SelectItem value="P2">
-          <PriorityBadge priority="P2" size="sm" showLabel />
-        </SelectItem>
-        <SelectItem value="P3">
-          <PriorityBadge priority="P3" size="sm" showLabel />
-        </SelectItem>
-        <SelectItem value="P4">
-          <PriorityBadge priority="P4" size="sm" showLabel />
-        </SelectItem>
-        <SelectItem value="P5">
-          <PriorityBadge priority="P5" size="sm" showLabel />
-        </SelectItem>
+        <SelectSeparator />
+        {PRIORITY_OPTIONS.map(opt => {
+          const Icon = opt.icon;
+          return (
+            <SelectItem key={opt.key} value={opt.key} className="cursor-pointer">
+              <div className={cn('flex items-center gap-2 text-xs font-semibold', opt.textColor)}>
+                <Icon className={cn('h-3.5 w-3.5 shrink-0', opt.iconColor)} />
+                <span>
+                  {opt.key} · {opt.label}
+                </span>
+              </div>
+            </SelectItem>
+          );
+        })}
       </SelectContent>
     </Select>
   );

--- a/src/components/incident/detail/IncidentCommandBar.tsx
+++ b/src/components/incident/detail/IncidentCommandBar.tsx
@@ -30,6 +30,8 @@ import { snoozeIncidentWithDuration } from '@/app/(app)/incidents/snooze-actions
 import {
   createJiraIssueFromIncident,
   linkJiraIssueToIncident,
+  unlinkJiraIssueFromIncident,
+  syncIncidentJiraIssue,
 } from '@/app/(app)/incidents/jira/actions';
 import { errorFromResponse } from '@/lib/client-error';
 import { toUserFacingError } from '@/lib/user-facing-error';
@@ -49,6 +51,8 @@ import {
   Loader2,
   AlertCircle,
   Archive,
+  Trash2,
+  RefreshCw,
 } from 'lucide-react';
 
 export type JiraLinkItem = {
@@ -201,11 +205,7 @@ export default function IncidentCommandBar({
   const primaryJira = jiraLinks[0];
   const jiraEnabled = jira?.enabled ?? false;
 
-  const hasAnyIntegrations =
-    hasActiveWarRoom ||
-    (warRoomEnabled && canManage) ||
-    Boolean(primaryJira) ||
-    (jiraEnabled && canManage);
+  const hasAnyIntegrations = hasActiveWarRoom || Boolean(primaryJira) || canManage;
 
   const handleCreateJira = () => {
     setJiraError(null);
@@ -231,6 +231,43 @@ export default function IncidentCommandBar({
         setJiraLinkKey('');
         setShowJiraDialog(false);
         router.refresh();
+      }
+    });
+  };
+
+  const [syncingLinkId, setSyncingLinkId] = useState<string | null>(null);
+  const [unlinkingLinkId, setUnlinkingLinkId] = useState<string | null>(null);
+
+  const handleUnlinkJira = (linkId: string) => {
+    setJiraError(null);
+    setUnlinkingLinkId(linkId);
+    startJiraTransition(async () => {
+      try {
+        const res = await unlinkJiraIssueFromIncident(linkId, incidentId);
+        if (!res.success && res.error) {
+          setJiraError(res.error);
+        } else {
+          router.refresh();
+        }
+      } finally {
+        setUnlinkingLinkId(null);
+      }
+    });
+  };
+
+  const handleSyncJira = (linkId: string) => {
+    setJiraError(null);
+    setSyncingLinkId(linkId);
+    startJiraTransition(async () => {
+      try {
+        const res = await syncIncidentJiraIssue(linkId, incidentId);
+        if (!res.success && res.error) {
+          setJiraError(res.error);
+        } else {
+          router.refresh();
+        }
+      } finally {
+        setSyncingLinkId(null);
       }
     });
   };
@@ -428,7 +465,20 @@ export default function IncidentCommandBar({
                     <span>{isWarRoomArchived ? 'Re-open War-Room' : 'Create War-Room'}</span>
                   </Button>
                 )
-              ) : null}
+              ) : (
+                canManage && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => router.push('/settings/integrations/slack')}
+                    className="h-9 gap-2 px-3 text-sm font-medium bg-white hover:bg-slate-50 border-slate-200 text-slate-800 shadow-xs hover:border-slate-300 transition-all"
+                  >
+                    <SlackLogo className="h-4 w-4 shrink-0" />
+                    <span>Connect Slack</span>
+                  </Button>
+                )
+              )}
 
               {/* Jira Integration */}
               {primaryJira ? (
@@ -450,9 +500,24 @@ export default function IncidentCommandBar({
                     <ExternalLink className="h-3.5 w-3.5 text-blue-600 ml-0.5" />
                   </a>
                   {jiraLinks.length > 1 && (
-                    <span className="text-xs font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">
+                    <button
+                      type="button"
+                      onClick={() => setShowJiraDialog(true)}
+                      className="text-xs font-bold text-blue-700 bg-blue-100 hover:bg-blue-200 px-1.5 py-0.5 rounded transition-colors cursor-pointer"
+                      title="View all linked Jira issues"
+                    >
                       +{jiraLinks.length - 1}
-                    </span>
+                    </button>
+                  )}
+                  {canManage && (
+                    <button
+                      type="button"
+                      onClick={() => setShowJiraDialog(true)}
+                      className="text-xs font-semibold text-blue-700 hover:text-blue-950 transition-colors ml-1 pl-2 border-l border-blue-200 cursor-pointer"
+                      title="Manage Jira issues"
+                    >
+                      Manage
+                    </button>
                   )}
                 </div>
               ) : jiraEnabled ? (
@@ -629,35 +694,65 @@ export default function IncidentCommandBar({
             <IncidentTags incidentId={incidentId} tags={tags} canManage={canManage} variant="bar" />
           </div>
           <div className="flex flex-col gap-2 py-2">
-            {canManage && !hasActiveWarRoom && warRoomEnabled && (
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full h-11 justify-start gap-2.5 text-sm font-medium"
-                onClick={() => {
-                  setShowMobileMore(false);
-                  handleCreateWarRoom();
-                }}
-                disabled={isWarRoomPending}
-              >
-                <SlackLogo className="h-4 w-4" />
-                <span>Create Slack War-Room</span>
-              </Button>
-            )}
-            {canManage && !primaryJira && jiraEnabled && (
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full h-11 justify-start gap-2.5 text-sm font-medium"
-                onClick={() => {
-                  setShowMobileMore(false);
-                  setShowJiraDialog(true);
-                }}
-              >
-                <JiraLogo className="h-4 w-4" />
-                <span>Link Jira Issue</span>
-              </Button>
-            )}
+            {canManage &&
+              !hasActiveWarRoom &&
+              (warRoomEnabled ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full h-11 justify-start gap-2.5 text-sm font-medium"
+                  onClick={() => {
+                    setShowMobileMore(false);
+                    handleCreateWarRoom();
+                  }}
+                  disabled={isWarRoomPending}
+                >
+                  <SlackLogo className="h-4 w-4" />
+                  <span>{isWarRoomArchived ? 'Re-open War-Room' : 'Create Slack War-Room'}</span>
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full h-11 justify-start gap-2.5 text-sm font-medium"
+                  onClick={() => {
+                    setShowMobileMore(false);
+                    router.push('/settings/integrations/slack');
+                  }}
+                >
+                  <SlackLogo className="h-4 w-4" />
+                  <span>Connect Slack</span>
+                </Button>
+              ))}
+            {canManage &&
+              !primaryJira &&
+              (jiraEnabled ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full h-11 justify-start gap-2.5 text-sm font-medium"
+                  onClick={() => {
+                    setShowMobileMore(false);
+                    setShowJiraDialog(true);
+                  }}
+                >
+                  <JiraLogo className="h-4 w-4" />
+                  <span>Link Jira Issue</span>
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full h-11 justify-start gap-2.5 text-sm font-medium"
+                  onClick={() => {
+                    setShowMobileMore(false);
+                    router.push('/settings/integrations/jira');
+                  }}
+                >
+                  <JiraLogo className="h-4 w-4" />
+                  <span>Connect Jira</span>
+                </Button>
+              ))}
             {showUnsnooze && (
               <form action={onUnsnooze}>
                 <Button
@@ -692,14 +787,16 @@ export default function IncidentCommandBar({
 
       {/* Jira Link / Create Modal */}
       <Dialog open={showJiraDialog} onOpenChange={setShowJiraDialog}>
-        <DialogContent className="sm:max-w-[425px]">
+        <DialogContent className="sm:max-w-[480px]">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <JiraLogo className="h-5 w-5" />
-              <span>Link Jira Issue</span>
+              <span>{jiraLinks.length > 0 ? 'Jira Integration' : 'Link Jira Issue'}</span>
             </DialogTitle>
             <DialogDescription>
-              Create a new issue from this incident or link an existing Jira issue key.
+              {jiraLinks.length > 0
+                ? 'Manage linked Jira issues or connect additional tickets to this incident.'
+                : 'Create a new issue from this incident or link an existing Jira issue key.'}
             </DialogDescription>
           </DialogHeader>
 
@@ -711,9 +808,79 @@ export default function IncidentCommandBar({
               </div>
             )}
 
+            {/* Existing Linked Issues */}
+            {jiraLinks.length > 0 && (
+              <div className="space-y-2">
+                <div className="text-xs font-semibold text-slate-800 dark:text-slate-200">
+                  Linked Issues ({jiraLinks.length})
+                </div>
+                <div className="space-y-1.5 max-h-48 overflow-y-auto pr-1">
+                  {jiraLinks.map(link => (
+                    <div
+                      key={link.id}
+                      className="flex items-center justify-between p-2.5 rounded-lg border border-slate-200/80 bg-slate-50/70 dark:bg-slate-800/40 dark:border-slate-800 text-xs"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <a
+                          href={link.externalUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-semibold text-blue-600 hover:underline inline-flex items-center gap-1"
+                        >
+                          <span>{link.externalKey}</span>
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                        {link.externalStatus && (
+                          <span className="px-1.5 py-0.5 rounded text-[10px] bg-slate-200 dark:bg-slate-700 font-medium">
+                            {link.externalStatus}
+                          </span>
+                        )}
+                        {link.externalAssignee && (
+                          <span className="text-slate-500 text-[11px] truncate max-w-[120px]">
+                            {link.externalAssignee}
+                          </span>
+                        )}
+                      </div>
+                      {canManage && (
+                        <div className="flex items-center gap-1 shrink-0">
+                          <button
+                            type="button"
+                            onClick={() => handleSyncJira(link.id)}
+                            disabled={isJiraPending || syncingLinkId === link.id}
+                            title="Sync Jira Issue"
+                            className="p-1 rounded text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors cursor-pointer"
+                          >
+                            <RefreshCw
+                              className={cn(
+                                'h-3.5 w-3.5',
+                                syncingLinkId === link.id && 'animate-spin text-blue-600'
+                              )}
+                            />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleUnlinkJira(link.id)}
+                            disabled={isJiraPending || unlinkingLinkId === link.id}
+                            title="Unlink Jira Issue"
+                            className="p-1 rounded text-slate-400 hover:text-rose-600 transition-colors cursor-pointer"
+                          >
+                            {unlinkingLinkId === link.id ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin text-rose-600" />
+                            ) : (
+                              <Trash2 className="h-3.5 w-3.5" />
+                            )}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
             {/* Option 1: Create New Issue */}
-            <div className="p-3 rounded-lg border bg-slate-50/50 space-y-2">
-              <div className="text-xs font-semibold text-slate-800">
+            <div className="p-3 rounded-lg border bg-slate-50/50 dark:bg-slate-800/20 space-y-2">
+              <div className="text-xs font-semibold text-slate-800 dark:text-slate-200">
                 Create new issue in project
               </div>
               <p className="text-xs text-slate-500">
@@ -735,11 +902,11 @@ export default function IncidentCommandBar({
                   <span>Create Jira Issue</span>
                 </Button>
               ) : (
-                <div className="text-xs text-amber-700 bg-amber-50 p-2 rounded border border-amber-200">
+                <div className="text-xs text-amber-700 bg-amber-50 p-2 rounded border border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900/50">
                   <span>Service needs a Jira project mapping. </span>
                   <Link
                     href={jira?.serviceSettingsHref || '#'}
-                    className="font-semibold underline hover:text-amber-900"
+                    className="font-semibold underline hover:text-amber-900 dark:hover:text-amber-100"
                   >
                     Configure Service Mapping
                   </Link>
@@ -748,8 +915,8 @@ export default function IncidentCommandBar({
             </div>
 
             {/* Option 2: Link Existing Key */}
-            <div className="p-3 rounded-lg border bg-slate-50/50 space-y-2">
-              <div className="text-xs font-semibold text-slate-800">
+            <div className="p-3 rounded-lg border bg-slate-50/50 dark:bg-slate-800/20 space-y-2">
+              <div className="text-xs font-semibold text-slate-800 dark:text-slate-200">
                 Or link an existing issue key
               </div>
               <div className="flex items-center gap-2">
@@ -782,7 +949,7 @@ export default function IncidentCommandBar({
               size="sm"
               onClick={() => setShowJiraDialog(false)}
             >
-              Cancel
+              Close
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/incident/detail/IncidentCommandBar.tsx
+++ b/src/components/incident/detail/IncidentCommandBar.tsx
@@ -81,6 +81,7 @@ type IncidentCommandBarProps = {
     slackChannelName: string | null;
     warRoomUrl: string | null;
     warRoomArchivedAt: Date | string | null;
+    enabled?: boolean;
   } | null;
   jira?: {
     links: JiraLinkItem[];
@@ -155,6 +156,7 @@ export default function IncidentCommandBar({
   // War-Room logic
   const isWarRoomArchived = Boolean(warRoom?.warRoomArchivedAt);
   const hasActiveWarRoom = Boolean(warRoom?.slackChannelId) && !isWarRoomArchived;
+  const warRoomEnabled = warRoom?.enabled ?? false;
 
   const handleCreateWarRoom = () => {
     setWarRoomError(null);
@@ -198,6 +200,12 @@ export default function IncidentCommandBar({
   const jiraLinks = jira?.links || [];
   const primaryJira = jiraLinks[0];
   const jiraEnabled = jira?.enabled ?? false;
+
+  const hasAnyIntegrations =
+    hasActiveWarRoom ||
+    (warRoomEnabled && canManage) ||
+    Boolean(primaryJira) ||
+    (jiraEnabled && canManage);
 
   const handleCreateJira = () => {
     setJiraError(null);
@@ -347,141 +355,145 @@ export default function IncidentCommandBar({
         )}
         data-command-bar
       >
-        {/* Left Side: Standard Collaboration Buttons with Integrations label */}
+        {/* Left Side: Collaboration & Tags */}
         <div className="flex items-center gap-3 flex-wrap min-w-0">
-          <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 dark:text-slate-500 select-none">
-            Integrations:
-          </span>
-          {/* Slack War-Room */}
-          {hasActiveWarRoom ? (
-            <div className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-emerald-50 text-emerald-900 border border-emerald-200 text-sm font-medium shadow-xs">
-              <SlackLogo className="h-4 w-4 shrink-0" />
-              <a
-                href={`slack://channel?team=&id=${warRoom?.slackChannelId}`}
-                className="hover:underline font-semibold"
-                title="Open in Slack App"
-              >
-                #{warRoom?.slackChannelName || 'war-room'}
-              </a>
-              <a
-                href={`https://slack.com/app_redirect?channel=${warRoom?.slackChannelId}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Open in Web Browser"
-                className="text-emerald-700 hover:text-emerald-900"
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-              </a>
-              {warRoom?.warRoomUrl && (
-                <a
-                  href={warRoom.warRoomUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  title="Join Video Huddle"
-                  className="ml-1 pl-2 border-l border-emerald-300 text-emerald-800 hover:text-emerald-950 inline-flex items-center gap-1.5 font-semibold"
-                >
-                  <Video className="h-3.5 w-3.5 text-emerald-600" />
-                  <span>Huddle</span>
-                </a>
-              )}
-              {canManage && isResolved && (
-                <button
-                  type="button"
-                  onClick={handleArchiveWarRoom}
-                  disabled={isWarRoomPending}
-                  title="Archive War-Room"
-                  className="ml-1 pl-2 border-l border-emerald-300 text-emerald-700 hover:text-rose-600 transition-colors"
-                >
-                  {isWarRoomPending ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Archive className="h-3.5 w-3.5" />
-                  )}
-                </button>
-              )}
-            </div>
-          ) : (
-            canManage && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={handleCreateWarRoom}
-                disabled={isWarRoomPending}
-                className="h-9 gap-2 px-3 text-sm font-medium bg-white hover:bg-slate-50 border-slate-200 text-slate-800 shadow-xs hover:border-slate-300 transition-all"
-              >
-                {isWarRoomPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin text-slate-500" />
-                ) : (
+          {hasAnyIntegrations && (
+            <>
+              <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 dark:text-slate-500 select-none">
+                Integrations:
+              </span>
+              {/* Slack War-Room */}
+              {hasActiveWarRoom ? (
+                <div className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-emerald-50 text-emerald-900 border border-emerald-200 text-sm font-medium shadow-xs">
                   <SlackLogo className="h-4 w-4 shrink-0" />
-                )}
-                <span>{isWarRoomArchived ? 'Re-open War-Room' : 'Create War-Room'}</span>
-              </Button>
-            )
-          )}
+                  <a
+                    href={`slack://channel?team=&id=${warRoom?.slackChannelId}`}
+                    className="hover:underline font-semibold"
+                    title="Open in Slack App"
+                  >
+                    #{warRoom?.slackChannelName || 'war-room'}
+                  </a>
+                  <a
+                    href={`https://slack.com/app_redirect?channel=${warRoom?.slackChannelId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Open in Web Browser"
+                    className="text-emerald-700 hover:text-emerald-900"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
+                  {warRoom?.warRoomUrl && (
+                    <a
+                      href={warRoom.warRoomUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="Join Video Huddle"
+                      className="ml-1 pl-2 border-l border-emerald-300 text-emerald-800 hover:text-emerald-950 inline-flex items-center gap-1.5 font-semibold"
+                    >
+                      <Video className="h-3.5 w-3.5 text-emerald-600" />
+                      <span>Huddle</span>
+                    </a>
+                  )}
+                  {canManage && isResolved && (
+                    <button
+                      type="button"
+                      onClick={handleArchiveWarRoom}
+                      disabled={isWarRoomPending}
+                      title="Archive War-Room"
+                      className="ml-1 pl-2 border-l border-emerald-300 text-emerald-700 hover:text-rose-600 transition-colors"
+                    >
+                      {isWarRoomPending ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Archive className="h-3.5 w-3.5" />
+                      )}
+                    </button>
+                  )}
+                </div>
+              ) : warRoomEnabled ? (
+                canManage && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCreateWarRoom}
+                    disabled={isWarRoomPending}
+                    className="h-9 gap-2 px-3 text-sm font-medium bg-white hover:bg-slate-50 border-slate-200 text-slate-800 shadow-xs hover:border-slate-300 transition-all"
+                  >
+                    {isWarRoomPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin text-slate-500" />
+                    ) : (
+                      <SlackLogo className="h-4 w-4 shrink-0" />
+                    )}
+                    <span>{isWarRoomArchived ? 'Re-open War-Room' : 'Create War-Room'}</span>
+                  </Button>
+                )
+              ) : null}
 
-          {/* Jira Integration */}
-          {primaryJira ? (
-            <div className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-blue-50 text-blue-900 border border-blue-200 text-sm font-medium shadow-xs">
-              <JiraLogo className="h-4 w-4 shrink-0" />
-              <a
-                href={primaryJira.externalUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:underline font-semibold inline-flex items-center gap-1"
-                title={`Jira: ${primaryJira.externalKey}`}
-              >
-                <span>{primaryJira.externalKey}</span>
-                {primaryJira.externalStatus && (
-                  <span className="ml-1 px-1.5 py-0.5 rounded text-xs bg-blue-100 text-blue-800 font-bold uppercase">
-                    {primaryJira.externalStatus}
-                  </span>
-                )}
-                <ExternalLink className="h-3.5 w-3.5 text-blue-600 ml-0.5" />
-              </a>
-              {jiraLinks.length > 1 && (
-                <span className="text-xs font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">
-                  +{jiraLinks.length - 1}
+              {/* Jira Integration */}
+              {primaryJira ? (
+                <div className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-blue-50 text-blue-900 border border-blue-200 text-sm font-medium shadow-xs">
+                  <JiraLogo className="h-4 w-4 shrink-0" />
+                  <a
+                    href={primaryJira.externalUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:underline font-semibold inline-flex items-center gap-1"
+                    title={`Jira: ${primaryJira.externalKey}`}
+                  >
+                    <span>{primaryJira.externalKey}</span>
+                    {primaryJira.externalStatus && (
+                      <span className="ml-1 px-1.5 py-0.5 rounded text-xs bg-blue-100 text-blue-800 font-bold uppercase">
+                        {primaryJira.externalStatus}
+                      </span>
+                    )}
+                    <ExternalLink className="h-3.5 w-3.5 text-blue-600 ml-0.5" />
+                  </a>
+                  {jiraLinks.length > 1 && (
+                    <span className="text-xs font-bold text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">
+                      +{jiraLinks.length - 1}
+                    </span>
+                  )}
+                </div>
+              ) : jiraEnabled ? (
+                canManage && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowJiraDialog(true)}
+                    className="h-9 gap-2 px-3 text-sm font-medium bg-white hover:bg-slate-50 border-slate-200 text-slate-800 shadow-xs hover:border-slate-300 transition-all"
+                  >
+                    <JiraLogo className="h-4 w-4 shrink-0" />
+                    <span>Link Jira Issue</span>
+                  </Button>
+                )
+              ) : (
+                canManage && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => router.push('/settings/integrations/jira')}
+                    className="h-9 gap-2 px-3 text-sm font-medium bg-white hover:bg-slate-50 border-slate-200 text-slate-800 shadow-xs hover:border-slate-300 transition-all"
+                  >
+                    <JiraLogo className="h-4 w-4 shrink-0" />
+                    <span>Connect Jira</span>
+                  </Button>
+                )
+              )}
+
+              {warRoomError && (
+                <span className="text-xs text-rose-600 inline-flex items-center gap-1 font-medium">
+                  <AlertCircle className="h-3.5 w-3.5" />
+                  {warRoomError}
                 </span>
               )}
-            </div>
-          ) : jiraEnabled ? (
-            canManage && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setShowJiraDialog(true)}
-                className="h-9 gap-2 px-3 text-sm font-medium bg-white hover:bg-slate-50 border-slate-200 text-slate-800 shadow-xs hover:border-slate-300 transition-all"
-              >
-                <JiraLogo className="h-4 w-4 shrink-0" />
-                <span>Link Jira Issue</span>
-              </Button>
-            )
-          ) : (
-            canManage && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => router.push('/settings/integrations/jira')}
-                className="h-9 gap-2 px-3 text-sm font-medium bg-white hover:bg-slate-50 border-slate-200 text-slate-800 shadow-xs hover:border-slate-300 transition-all"
-              >
-                <JiraLogo className="h-4 w-4 shrink-0" />
-                <span>Connect Jira</span>
-              </Button>
-            )
-          )}
 
-          {warRoomError && (
-            <span className="text-xs text-rose-600 inline-flex items-center gap-1 font-medium">
-              <AlertCircle className="h-3.5 w-3.5" />
-              {warRoomError}
-            </span>
+              {/* Vertical divider between Integrations and Tags */}
+              <div className="h-5 w-px bg-slate-200 dark:bg-slate-700 shrink-0 hidden md:block" />
+            </>
           )}
-
-          {/* Vertical divider between Integrations and Tags */}
-          <div className="h-5 w-px bg-slate-200 dark:bg-slate-700 shrink-0 hidden md:block" />
 
           {/* Tags Section */}
           <IncidentTags incidentId={incidentId} tags={tags} canManage={canManage} variant="bar" />
@@ -617,7 +629,7 @@ export default function IncidentCommandBar({
             <IncidentTags incidentId={incidentId} tags={tags} canManage={canManage} variant="bar" />
           </div>
           <div className="flex flex-col gap-2 py-2">
-            {canManage && !hasActiveWarRoom && (
+            {canManage && !hasActiveWarRoom && warRoomEnabled && (
               <Button
                 type="button"
                 variant="outline"

--- a/src/components/incident/detail/IncidentPostmortemTabContent.tsx
+++ b/src/components/incident/detail/IncidentPostmortemTabContent.tsx
@@ -14,7 +14,6 @@ import {
   CheckSquare,
   Globe,
   Lock,
-  Sparkles,
   ExternalLink,
 } from 'lucide-react';
 import { Button } from '@/components/ui/shadcn/button';
@@ -365,9 +364,9 @@ export default function IncidentPostmortemTabContent({
 
         {/* Readiness stats */}
         <div className="inline-flex items-center justify-center gap-3 p-2 rounded-lg bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 text-xs text-slate-600 dark:text-slate-300">
-          <span className="flex items-center gap-1.5">
-            <Sparkles className="h-3.5 w-3.5 text-amber-500" />
-            AI Draft Ready
+          <span className="flex items-center gap-1.5 font-medium text-indigo-600 dark:text-indigo-400">
+            <FileText className="h-3.5 w-3.5" />
+            Auto-Draft Ready
           </span>
           <span className="text-slate-300 dark:text-slate-700">|</span>
           <span>{eventCount} Timeline Events</span>

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -256,9 +256,20 @@ export async function createIncidentWarRoom(
     if (!botToken) {
       return { success: false, error: 'No Slack bot token configured' };
     }
-    const slackWorkspaceId = incident.service.slackIntegration?.workspaceId;
+    // Verify a Slack workspace installation exists (service-specific or global)
+    const slackWorkspaceId =
+      incident.service.slackIntegration?.workspaceId ||
+      (
+        await prisma.slackIntegration.findFirst({
+          where: { enabled: true, services: { none: {} } },
+          select: { workspaceId: true },
+        })
+      )?.workspaceId;
     if (!slackWorkspaceId) {
-      return { success: false, error: 'No Slack workspace installation configured for this service' };
+      return {
+        success: false,
+        error: 'No Slack workspace installation configured for this service or organization',
+      };
     }
 
     // Generate channel name
@@ -556,7 +567,10 @@ export async function createIncidentWarRoom(
     });
     if (attached.count !== 1) {
       logger.warn('[ChatOps] War-room completion lease was lost', { incidentId, channelId });
-      return { success: false, error: 'War-room provisioning lease was lost; reconciliation will adopt the channel' };
+      return {
+        success: false,
+        error: 'War-room provisioning lease was lost; reconciliation will adopt the channel',
+      };
     }
 
     // Log timeline event


### PR DESCRIPTION
## Summary

This PR bundles incident page improvements and refinements addressing topbar contrast, selector consistency, postmortem messaging, and collaboration tooling.

### Key Changes
1. **Topbar Breadcrumb ID Contrast**:
   - Updated `src/components/TopbarBreadcrumbs.tsx` to give incident/resource IDs dedicated high-contrast monospace pill styling (`font-mono bg-zinc-800/80 text-zinc-100 border border-zinc-700`) so IDs are easily readable against the `#09090b` dark header.
2. **Modernized Priority Badges**:
   - Refactored `src/components/incident/PriorityBadge.tsx` to use vibrant Shadcn `Badge` variants (`danger`, `warning`, gradient, `info`, `neutral`) to match the visual language of `StatusBadge`.
3. **Streamlined Metadata Ribbon Selectors**:
   - Unified all 7 metadata cells (`PRIORITY`, `URGENCY`, `VISIBILITY`, `ASSIGNEE`, `ESCALATION`, `SERVICE`, `TEAM`) to use the exact same pill button geometry (`h-8`, `px-2.5`, `rounded-md`, `shadow-2xs`, `text-xs font-semibold`, and consistent chevron placement).
   - Cleaned up `AssigneeSection` header variant so the entire pill button acts as the popover trigger.
4. **Slack War-Room & Workspace Gating**:
   - In `src/lib/chatops/war-room.ts` and `src/app/(app)/incidents/[id]/page.tsx`, check both service-specific and global Slack workspace installations before rejecting war-room creation.
   - Removed the block on `autoCreateWarRoom` for manual war-room actions, and provided a "Connect Slack" path when Slack is not configured.
5. **Jira Centralization & Sidebar Cleanup**:
   - Removed the duplicate `IncidentJiraCard` from the right-hand sidebar in `src/app/(app)/incidents/[id]/page.tsx`.
   - Centralized full Jira lifecycle management directly into `IncidentCommandBar` (viewing all linked issues with statuses and assignees, manual sync with spinner, unlinking, creating tickets against mapped projects, and linking existing keys).
6. **Postmortem Auto-Draft Indicator**:
   - Updated `IncidentPostmortemTabContent.tsx` readiness badge from "AI Draft Ready" to "Auto-Draft Ready" with a `FileText` icon to accurately reflect deterministic auto-drafting from incident events and responder notes.

### Verification
- Ran `npx eslint` across modified files (0 errors).
- Ran `npx tsc --noEmit` (0 errors).
- Ran full test suite with Vitest (306 test files passed, 2,236 tests passed).
- Ran complete Next.js production build in pre-push hook (102/102 static pages generated successfully).