### PR TITLE
fix(incidents): encode Slack and incident notes properly into timeline

### DIFF
--- a/src/app/(app)/incidents/[id]/page.tsx
+++ b/src/app/(app)/incidents/[id]/page.tsx
@@ -196,7 +196,14 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
       events={incident.events.map(e => ({
         id: e.id,
         message: e.message,
+        type: e.type,
         createdAt: e.createdAt,
+      }))}
+      notes={incident.notes.map(n => ({
+        id: n.id,
+        content: n.content,
+        user: n.user,
+        createdAt: n.createdAt,
       }))}
       incidentCreatedAt={incident.createdAt}
       incidentAcknowledgedAt={incident.acknowledgedAt}

--- a/src/app/api/slack/events/route.ts
+++ b/src/app/api/slack/events/route.ts
@@ -301,6 +301,14 @@ export async function POST(request: NextRequest) {
                   content: `📌 [Slack Pin by ${actorLabel}]: ${messageText}`,
                 },
               });
+
+              await tx.incidentEvent.create({
+                data: {
+                  incidentId: incident.id,
+                  type: 'COMMENT',
+                  message: `Note added via Slack pin by ${actorLabel}`,
+                },
+              });
               return true;
             });
           } catch (error) {

--- a/src/components/incident/detail/IncidentTimeline.tsx
+++ b/src/components/incident/detail/IncidentTimeline.tsx
@@ -6,7 +6,7 @@ import { useTimezone } from '@/contexts/TimezoneContext';
 import { formatDateTime } from '@/lib/timezone';
 import { Badge } from '@/components/ui/shadcn/badge';
 import { cn } from '@/lib/utils';
-import { Clock, AlertCircle, CheckCircle2, Target, Activity } from 'lucide-react';
+import { Clock, AlertCircle, CheckCircle2, Target, Activity, MessageSquare } from 'lucide-react';
 
 type TimelineFilter =
   | 'ALL'
@@ -30,26 +30,40 @@ const FILTERS: Array<{ id: TimelineFilter; label: string }> = [
 // Best-effort categorization from the free-text event message — there's no
 // structured "category" field on IncidentEvent, so this is a heuristic filter,
 // not an authoritative classification.
-function categorize(type: string, message: string): TimelineFilter {
+export function categorize(type: string, message: string): TimelineFilter {
+  if (type === 'NOTE' || type === 'COMMENT') return 'NOTES';
   if (type === 'CREATED' || type === 'ACKNOWLEDGED' || type === 'RESOLVED') return 'LIFECYCLE';
+  if (/\bnote\b|pinned message|comment/i.test(message)) return 'NOTES';
   if (/escalat/i.test(message)) return 'ESCALATION';
   if (/assign|unassigned/i.test(message)) return 'ASSIGNMENT';
   if (/notif|paged?\b|alert sent|sms|call attempt/i.test(message)) return 'NOTIFICATIONS';
   if (/jira|slack|webhook|integration|war.?room/i.test(message)) return 'INTEGRATIONS';
-  if (/\bnote\b/i.test(message)) return 'NOTES';
   if (/triggered|created|resolved|acknowledged|snooz|suppress|reopen/i.test(message))
     return 'LIFECYCLE';
   return 'ALL';
 }
 
-type Event = {
+export type Event = {
   id: string;
   message: string;
+  type?: string | null;
   createdAt: Date;
 };
 
-type IncidentTimelineProps = {
+export type Note = {
+  id: string;
+  content: string;
+  createdAt: Date;
+  user?: {
+    name?: string | null;
+    email?: string | null;
+    avatarUrl?: string | null;
+  } | null;
+};
+
+export type IncidentTimelineProps = {
   events: Event[];
+  notes?: Note[];
   incidentCreatedAt?: Date;
   incidentAcknowledgedAt?: Date | null;
   incidentResolvedAt?: Date | null;
@@ -57,6 +71,7 @@ type IncidentTimelineProps = {
 
 export default function IncidentTimeline({
   events,
+  notes = [],
   incidentCreatedAt,
   incidentAcknowledgedAt,
   incidentResolvedAt,
@@ -74,12 +89,12 @@ export default function IncidentTimeline({
     });
   };
 
-  // Create a comprehensive timeline with incident lifecycle events
+  // Create a comprehensive timeline with incident lifecycle events and notes
   const timelineEvents: Array<{
     id: string;
     message: string;
     createdAt: Date;
-    type: 'CREATED' | 'ACKNOWLEDGED' | 'RESOLVED' | 'EVENT';
+    type: string;
     sortPriority: number;
   }> = [];
 
@@ -120,14 +135,65 @@ export default function IncidentTimeline({
     });
   }
 
+  // Track matched notes to prevent duplicates when an incidentEvent already exists for a note
+  const matchedNoteIds = new Set<string>();
+
   // Add regular events
   events.forEach(event => {
+    const isNoteEvent =
+      event.type === 'NOTE' ||
+      event.type === 'COMMENT' ||
+      /\bnote\b|pinned message|comment/i.test(event.message);
+
+    let message = event.message;
+    let eventType = event.type || 'EVENT';
+
+    if (isNoteEvent) {
+      eventType = 'NOTE';
+      if (notes && notes.length > 0) {
+        const eventTime = new Date(event.createdAt).getTime();
+        const matchingNote = notes.find(n => {
+          if (matchedNoteIds.has(n.id)) return false;
+          const noteTime = new Date(n.createdAt).getTime();
+          return Math.abs(eventTime - noteTime) <= 15000;
+        });
+
+        if (matchingNote) {
+          matchedNoteIds.add(matchingNote.id);
+          if (!message.includes(matchingNote.content)) {
+            message = `${message}:\n${matchingNote.content}`;
+          }
+        }
+      }
+    }
+
     timelineEvents.push({
       ...event,
-      type: 'EVENT',
+      message,
+      type: eventType,
       sortPriority: 3,
     });
   });
+
+  // Synthesize timeline events for any notes that do not have a matching incidentEvent
+  if (notes && notes.length > 0) {
+    notes.forEach(note => {
+      if (!matchedNoteIds.has(note.id)) {
+        const author = note.user?.name || note.user?.email || 'Responder';
+        const formattedMsg = note.content.startsWith('📌')
+          ? note.content
+          : `Note added by ${author}:\n${note.content}`;
+
+        timelineEvents.push({
+          id: `note-${note.id}`,
+          message: formattedMsg,
+          createdAt: note.createdAt,
+          type: 'NOTE',
+          sortPriority: 3,
+        });
+      }
+    });
+  }
 
   // Sort by date (oldest first for timeline) with secondary ID tie-breaker for same-millisecond events
   timelineEvents.sort((a, b) => {
@@ -169,6 +235,15 @@ export default function IncidentTimeline({
           label: 'Resolved',
           avatarBg: 'bg-green-100',
           avatarText: 'text-green-600',
+        };
+      case 'NOTE':
+      case 'COMMENT':
+        return {
+          variant: 'info' as const,
+          icon: <MessageSquare className="h-4 w-4" />,
+          label: 'Note',
+          avatarBg: 'bg-blue-100 dark:bg-blue-950/40',
+          avatarText: 'text-blue-600 dark:text-blue-400',
         };
       default:
         return {
@@ -237,7 +312,9 @@ export default function IncidentTimeline({
         <div className="absolute left-[19px] top-2 bottom-4 w-px bg-slate-200 dark:bg-slate-700" />
         {filteredEvents.map((event, index) => {
           const config = getEventConfig(event.type);
-          const isMajorEvent = event.type !== 'EVENT';
+          const isLifecycleEvent =
+            event.type === 'CREATED' || event.type === 'ACKNOWLEDGED' || event.type === 'RESOLVED';
+          const isNote = event.type === 'NOTE' || event.type === 'COMMENT';
 
           return (
             <div
@@ -257,11 +334,11 @@ export default function IncidentTimeline({
                 <div className="flex items-center justify-between gap-2 mb-1">
                   <div className="flex items-center gap-2">
                     <span
-                      className={`text-sm font-semibold ${isMajorEvent ? 'text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
+                      className={`text-sm font-semibold ${isLifecycleEvent ? 'text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
                     >
                       {config.label}
                     </span>
-                    {isMajorEvent && (
+                    {isLifecycleEvent && (
                       <Badge variant={config.variant} size="xs" className="uppercase h-5">
                         {event.type}
                       </Badge>
@@ -273,7 +350,13 @@ export default function IncidentTimeline({
                 </div>
 
                 <p
-                  className={`text-sm leading-relaxed whitespace-pre-wrap ${isMajorEvent ? 'text-slate-900 dark:text-slate-100 font-medium' : 'text-slate-600 dark:text-slate-400'}`}
+                  className={`text-sm leading-relaxed whitespace-pre-wrap ${
+                    isLifecycleEvent
+                      ? 'text-slate-900 dark:text-slate-100 font-medium'
+                      : isNote
+                        ? 'text-slate-800 dark:text-slate-200'
+                        : 'text-slate-600 dark:text-slate-400'
+                  }`}
                 >
                   {formatEscalationMessage(event.message)}
                 </p>

--- a/src/lib/chatops/slash-commands.ts
+++ b/src/lib/chatops/slash-commands.ts
@@ -286,7 +286,7 @@ export async function handleSlashCommand(payload: SlashCommandPayload): Promise<
               data: {
                 incidentId: incident.id,
                 type: 'COMMENT',
-                message: `Note added via Slack ChatOps by @${payload.user_name}`,
+                message: `Note added via Slack ChatOps by @${payload.user_name}${args ? `:\n${args}` : ''}`,
               },
             });
             return { created: true };

--- a/tests/unit/incident-timeline-notes.test.tsx
+++ b/tests/unit/incident-timeline-notes.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import IncidentTimeline, { categorize } from '@/components/incident/detail/IncidentTimeline';
+
+vi.mock('@/contexts/TimezoneContext', () => ({
+  useTimezone: () => ({
+    userTimeZone: 'UTC',
+  }),
+}));
+
+describe('IncidentTimeline categorization logic', () => {
+  it('categorizes Slack ChatOps notes as NOTES, not INTEGRATIONS', () => {
+    const result = categorize(
+      'COMMENT',
+      'Note added via Slack ChatOps by @alice:\nDatabase connection restored'
+    );
+    expect(result).toBe('NOTES');
+
+    const untypedResult = categorize('EVENT', 'Note added via Slack ChatOps by @alice');
+    expect(untypedResult).toBe('NOTES');
+  });
+
+  it('categorizes Slack pinned messages as NOTES', () => {
+    const pinEventResult = categorize('COMMENT', 'Note added via Slack pin by @bob');
+    expect(pinEventResult).toBe('NOTES');
+
+    const pinContentResult = categorize(
+      'NOTE',
+      '📌 [Slack Pin by Bob]: Pod restarted successfully'
+    );
+    expect(pinContentResult).toBe('NOTES');
+  });
+
+  it('categorizes web-added notes and comments as NOTES', () => {
+    expect(categorize('COMMENT', 'Note added by Alice')).toBe('NOTES');
+    expect(categorize('NOTE', 'Customer reported 504 gateway timeout')).toBe('NOTES');
+    expect(categorize('EVENT', 'Comment added by responder')).toBe('NOTES');
+  });
+
+  it('still categorizes non-note Slack/Jira events as INTEGRATIONS', () => {
+    expect(categorize('EVENT', 'Jira issue OPS-123 linked to incident')).toBe('INTEGRATIONS');
+    expect(categorize('EVENT', 'Slack war room channel created: #inc-101')).toBe('INTEGRATIONS');
+    expect(categorize('EVENT', 'Webhook payload received from Datadog')).toBe('INTEGRATIONS');
+  });
+
+  it('categorizes lifecycle events accurately', () => {
+    expect(categorize('CREATED', 'Incident triggered and created')).toBe('LIFECYCLE');
+    expect(categorize('ACKNOWLEDGED', 'Incident acknowledged by responder')).toBe('LIFECYCLE');
+    expect(categorize('RESOLVED', 'Incident marked as resolved')).toBe('LIFECYCLE');
+  });
+
+  it('categorizes escalation, assignment, and notification events correctly', () => {
+    expect(categorize('EVENT', 'Escalated to Tier 2 on-call')).toBe('ESCALATION');
+    expect(categorize('EVENT', 'Assigned to Charlie')).toBe('ASSIGNMENT');
+    expect(categorize('EVENT', 'SMS alert sent to +1234567890')).toBe('NOTIFICATIONS');
+  });
+});
+
+describe('IncidentTimeline component with Notes filter', () => {
+  const now = new Date('2026-09-06T00:00:00Z');
+
+  it('displays Slack ChatOps note in Notes filter instead of empty state', () => {
+    const events = [
+      {
+        id: 'evt-1',
+        type: 'COMMENT',
+        message: 'Note added via Slack ChatOps by @alice:\nRestarting cache clusters',
+        createdAt: now,
+      },
+    ];
+
+    render(<IncidentTimeline events={events} incidentCreatedAt={now} />);
+
+    // Click on the Notes filter chip
+    const notesFilterButton = screen.getByRole('button', { name: 'Notes' });
+    fireEvent.click(notesFilterButton);
+
+    // Must NOT show "No matching events"
+    expect(screen.queryByText('No matching events')).toBeNull();
+
+    // Must show the Note content and label
+    expect(screen.getByText('Note')).toBeDefined();
+    expect(screen.getByText(/Restarting cache clusters/)).toBeDefined();
+  });
+
+  it('enriches event with corresponding note content and renders in Notes filter', () => {
+    const events = [
+      {
+        id: 'evt-2',
+        type: 'COMMENT',
+        message: 'Note added via Slack ChatOps by @bob',
+        createdAt: now,
+      },
+    ];
+
+    const notes = [
+      {
+        id: 'note-1',
+        content: 'Rolling back deployment v2.1.0',
+        createdAt: new Date(now.getTime() + 1000), // within 1 second
+        user: { name: 'Bob', email: 'bob@example.com' },
+      },
+    ];
+
+    render(<IncidentTimeline events={events} notes={notes} incidentCreatedAt={now} />);
+
+    // Switch to Notes filter
+    fireEvent.click(screen.getByRole('button', { name: 'Notes' }));
+
+    // Content should be enriched and visible
+    expect(screen.queryByText('No matching events')).toBeNull();
+    expect(screen.getByText(/Rolling back deployment v2.1.0/)).toBeDefined();
+  });
+
+  it('synthesizes timeline event when note has no corresponding DB event', () => {
+    const notes = [
+      {
+        id: 'note-orphan',
+        content: '📌 [Slack Pin by Charlie]: Investigating high CPU usage',
+        createdAt: now,
+        user: { name: 'Charlie', email: 'charlie@example.com' },
+      },
+    ];
+
+    render(<IncidentTimeline events={[]} notes={notes} incidentCreatedAt={now} />);
+
+    // Switch to Notes filter
+    fireEvent.click(screen.getByRole('button', { name: 'Notes' }));
+
+    expect(screen.queryByText('No matching events')).toBeNull();
+    expect(
+      screen.getByText(/📌 \[Slack Pin by Charlie\]: Investigating high CPU usage/)
+    ).toBeDefined();
+  });
+
+  it('shows empty state when filter has truly no matching events', () => {
+    const events = [
+      {
+        id: 'evt-lifecycle',
+        type: 'CREATED',
+        message: 'Incident triggered and created',
+        createdAt: now,
+      },
+    ];
+
+    render(<IncidentTimeline events={events} notes={[]} incidentCreatedAt={now} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Notes' }));
+    expect(screen.getByText('No matching events')).toBeDefined();
+    expect(
+      screen.getByText(/Try a different filter, or select "All" to see the full timeline\./)
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary of Changes
Fixes an issue where incident notes added via Slack (either via `/incident note` ChatOps slash command or via message pins) were not appearing under the "Notes" filter in the incident timeline tab, resulting in "No matching events. Try a different filter, or select 'All' to see the full timeline."

### Key Changes
1. **IncidentTimeline Categorization**:
   - Updated `categorize()` in `IncidentTimeline.tsx` to check for `type === 'NOTE' || type === 'COMMENT'` and note/pinned message keywords *before* the integrations regex. Previously, messages like `"Note added via Slack ChatOps by @..."` were caught by `/jira|slack.../i` and miscategorized under `INTEGRATIONS`.
   - Added `'NOTE'` and `'COMMENT'` event config to render a dedicated `MessageSquare` icon and label with appropriate styling.
2. **Note Enrichment & Synthesis**:
   - When note events are present, timeline events are enriched with the note content.
   - For notes without corresponding database events (e.g. historical Slack pins), synthesized timeline entries are created so notes are always visible.
3. **Detail Page Integration**:
   - Passed `incident.notes` and event `type` to `<IncidentTimeline>` in `src/app/(app)/incidents/[id]/page.tsx`.
4. **Slack Events & ChatOps Event Creation**:
   - In `src/app/api/slack/events/route.ts`, added `tx.incidentEvent.create` with `type: 'COMMENT'` when a message is pinned in Slack, ensuring parity with web and slash command note additions.
   - In `src/lib/chatops/slash-commands.ts`, included the note argument in the incident event message.
5. **Testing**:
   - Added unit test suite in `tests/unit/incident-timeline-notes.test.tsx` verifying categorization and timeline rendering for Slack ChatOps notes, Slack pins, and web notes under the "Notes" filter.