### PR TITLE
ci(github-actions): run integration certification on main merge only instead of PRs

### DIFF
--- a/.github/workflows/integration-certification.yml
+++ b/.github/workflows/integration-certification.yml
@@ -1,6 +1,8 @@
 name: Integration control-plane certification
 on:
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - 'src/lib/integrations/**'
       - 'src/lib/chatops/**'


### PR DESCRIPTION
### Summary
Updates `.github/workflows/integration-certification.yml` so that the heavy "Integration control-plane certification" resilience test suite runs exclusively on `push` to `main` (as well as manual `workflow_dispatch` and the weekly scheduled cron), rather than triggering on every pull request.

### Rationale
- The integration certification suite starts a multi-replica Docker cluster (3 web and 3 worker replicas) and takes ~7+ minutes to execute.
- Running it on PRs introduced unnecessary test execution overhead and occasional replica race conditions that caused spurious check statuses even after PRs had already merged.
- PRs continue to be guarded by fast, deterministic PR checks (unit tests, DOM tests, Next.js build, TypeScript typecheck, ESLint, CodeQL, and container/dependency security audits).
- When changes touching integrations or chatops merge into `main`, this workflow will run on `main` to certify the integration control-plane.

### Changes
- `.github/workflows/integration-certification.yml`: Replaced `on.pull_request` with `on.push.branches: [main]` while preserving path filtering for integration and chatops components.

### Verification
- YAML syntax verified and validated.
- All unit, DOM, and architecture tests passed pre-push (295 test files, 2,168 tests).
- Production build (`next build --webpack`) verified cleanly.