### PR TITLE
fix(services): fix ChatOps save button and sync Jira status metadata to incidents

### DIFF
--- a/src/app/(app)/services/actions.ts
+++ b/src/app/(app)/services/actions.ts
@@ -24,7 +24,9 @@ export async function createIntegration(formData: FormData) {
   const snsTopicArn = typeof rawSnsTopicArn === 'string' ? rawSnsTopicArn.trim() : '';
   if (!serviceId || !name) throw new Error('Missing required fields');
   if (type === 'CLOUDWATCH') {
-    if (!/^arn:(aws|aws-us-gov|aws-cn):sns:[a-z0-9-]+:\d{12}:[A-Za-z0-9_-]{1,256}$/.test(snsTopicArn)) {
+    if (
+      !/^arn:(aws|aws-us-gov|aws-cn):sns:[a-z0-9-]+:\d{12}:[A-Za-z0-9_-]{1,256}$/.test(snsTopicArn)
+    ) {
       throw new Error('A valid, exact AWS SNS Topic ARN is required for CloudWatch.');
     }
   }
@@ -200,32 +202,88 @@ export async function updateServiceNotificationSettings(serviceId: string, formD
   redirect(serviceSettingsRedirect(serviceId));
 }
 
-export async function updateServiceChatOpsSettings(serviceId: string, formData: FormData) {
-  const currentUser = await assertCanModifyService(serviceId);
-  const bridge = String(formData.get('warRoomVideoBridge') ?? 'INHERIT');
-  const warRoomVideoBridge = bridge === 'INHERIT' ? null : bridge;
-  const warRoomCustomBridgeUrl =
-    String(formData.get('warRoomCustomBridgeUrl') ?? '').trim() || null;
+const ALLOWED_VIDEO_BRIDGES = new Set(['INHERIT', 'JITSI', 'ZOOM', 'GOOGLE_MEET', 'NONE']);
 
-  await prisma.service.update({
-    where: { id: serviceId },
-    data: {
-      autoCreateWarRoom: formData.get('autoCreateWarRoom') === 'on',
-      warRoomVideoBridge,
-      warRoomCustomBridgeUrl,
-    },
-  });
+export async function updateServiceChatOpsSettings(
+  prevStateOrServiceId: { success?: boolean; error?: string | null } | string | undefined,
+  formData: FormData
+): Promise<{ success?: boolean; error?: string | null }> {
+  let currentUser: { id: string } | null = null;
+  try {
+    const serviceId = (
+      typeof prevStateOrServiceId === 'string'
+        ? prevStateOrServiceId
+        : ((formData.get('serviceId') as string | null) ?? '')
+    ).trim();
 
-  await logAudit({
-    action: 'service.chatops.updated',
-    entityType: 'SERVICE',
-    entityId: serviceId,
-    actorId: currentUser.id,
-    details: { warRoomVideoBridge, hasCustomBridgeUrl: Boolean(warRoomCustomBridgeUrl) },
-  });
+    if (!serviceId) {
+      return { error: 'Service ID is required.' };
+    }
 
-  revalidatePath(`/services/${serviceId}`);
-  redirect(serviceSettingsRedirect(serviceId));
+    currentUser = await assertCanModifyService(serviceId);
+
+    const bridge = String(formData.get('warRoomVideoBridge') ?? 'INHERIT').trim();
+    if (!ALLOWED_VIDEO_BRIDGES.has(bridge)) {
+      return { error: 'Invalid video bridge option.' };
+    }
+    const warRoomVideoBridge = bridge === 'INHERIT' ? null : bridge;
+
+    const rawCustomUrl = String(formData.get('warRoomCustomBridgeUrl') ?? '').trim();
+    let warRoomCustomBridgeUrl: string | null = null;
+    if (rawCustomUrl) {
+      let urlToTest = rawCustomUrl;
+      if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(urlToTest)) {
+        try {
+          const parsed = new URL(urlToTest.replace(/\{incidentId\}/g, 'test-incident-placeholder'));
+          if (!['http:', 'https:'].includes(parsed.protocol)) {
+            return { error: 'Custom bridge URL must use HTTP or HTTPS protocol.' };
+          }
+        } catch {
+          return { error: 'Please enter a valid URL for the custom bridge.' };
+        }
+      } else {
+        urlToTest = `https://${urlToTest}`;
+        try {
+          new URL(urlToTest.replace(/\{incidentId\}/g, 'test-incident-placeholder'));
+        } catch {
+          return { error: 'Please enter a valid URL for the custom bridge.' };
+        }
+      }
+      warRoomCustomBridgeUrl = urlToTest;
+    }
+
+    const autoCreateWarRoom = formData.get('autoCreateWarRoom') === 'on';
+
+    await prisma.service.update({
+      where: { id: serviceId },
+      data: {
+        autoCreateWarRoom,
+        warRoomVideoBridge,
+        warRoomCustomBridgeUrl,
+      },
+    });
+
+    await logAudit({
+      action: 'service.chatops.updated',
+      entityType: 'SERVICE',
+      entityId: serviceId,
+      actorId: currentUser.id,
+      details: {
+        autoCreateWarRoom,
+        warRoomVideoBridge,
+        hasCustomBridgeUrl: Boolean(warRoomCustomBridgeUrl),
+      },
+    });
+
+    revalidatePath(`/services/${serviceId}/settings`);
+    revalidatePath(`/services/${serviceId}`);
+
+    return { success: true, error: null };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : 'Failed to update ChatOps settings.',
+    };
+  }
 }
 
 export async function saveJiraServiceMapping(

--- a/src/app/api/jira/webhook/route.ts
+++ b/src/app/api/jira/webhook/route.ts
@@ -10,12 +10,30 @@ import { readIntegrationBody } from '@/lib/integrations/request-security';
 
 const JiraWebhookSchema = z
   .object({
-    webhookEvent: z.string(),
+    webhookEvent: z.string().optional(),
+    issue_event_type_name: z.string().optional(),
     issue: z
       .object({
         id: z.string().optional(),
         key: z.string().optional(),
         fields: z.record(z.unknown()).optional(),
+      })
+      .optional(),
+    changelog: z
+      .object({
+        id: z.string().optional(),
+        items: z
+          .array(
+            z.object({
+              field: z.string().optional(),
+              fieldId: z.string().optional(),
+              fromString: z.string().nullable().optional(),
+              toString: z.string().nullable().optional(),
+              from: z.string().nullable().optional(),
+              to: z.string().nullable().optional(),
+            })
+          )
+          .optional(),
       })
       .optional(),
     comment: z
@@ -24,7 +42,7 @@ const JiraWebhookSchema = z
         body: z.unknown().optional(),
       })
       .optional(),
-    timestamp: z.number().optional(),
+    timestamp: z.union([z.number(), z.string()]).optional(),
     user: z.record(z.unknown()).optional(),
   })
   .passthrough();
@@ -68,7 +86,24 @@ async function verifyWebhookSecret(request: NextRequest): Promise<boolean> {
   }
 }
 
-const HANDLED_EVENTS = new Set(['jira:issue_updated', 'jira:issue_deleted']);
+const HANDLED_EVENTS = new Set([
+  'jira:issue_updated',
+  'jira:issue_generic',
+  'jira:issue_created',
+  'jira:issue_deleted',
+  'issue_updated',
+  'issue_generic',
+  'issue_created',
+  'issue_deleted',
+]);
+
+function isHandledJiraEvent(event?: string, eventType?: string): boolean {
+  const candidate = (event || eventType || '').toLowerCase().trim();
+  if (!candidate) return false;
+  if (HANDLED_EVENTS.has(candidate)) return true;
+  if (candidate.startsWith('jira:issue_') || candidate.startsWith('issue_')) return true;
+  return false;
+}
 
 async function postJiraWebhook(request: NextRequest) {
   try {
@@ -105,8 +140,7 @@ async function postJiraWebhook(request: NextRequest) {
 
     const payload = parsed.data;
 
-    const event = payload.webhookEvent;
-    if (!event || !HANDLED_EVENTS.has(event)) {
+    if (!isHandledJiraEvent(payload.webhookEvent, payload.issue_event_type_name)) {
       // Acknowledge but don't process unrecognized events
       return new NextResponse(null, { status: 204 });
     }

--- a/src/components/incident/detail/IncidentCommandBar.tsx
+++ b/src/components/incident/detail/IncidentCommandBar.tsx
@@ -33,7 +33,24 @@ import {
   unlinkJiraIssueFromIncident,
   syncIncidentJiraIssue,
 } from '@/app/(app)/incidents/jira/actions';
+import { isJiraStatusDone } from '@/lib/jira-validation';
 import { errorFromResponse } from '@/lib/client-error';
+
+function jiraStatusBadgeStyle(status: string | null): string {
+  if (!status)
+    return 'bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:border-slate-700';
+  if (isJiraStatusDone(status)) {
+    return 'bg-emerald-100 text-emerald-800 border-emerald-300 dark:bg-emerald-950/60 dark:text-emerald-300 dark:border-emerald-800';
+  }
+  const lower = status.toLowerCase();
+  if (lower === 'in progress' || lower === 'in review' || lower === 'investigating') {
+    return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-950/60 dark:text-blue-300 dark:border-blue-800';
+  }
+  if (lower === 'to do' || lower === 'open' || lower === 'backlog') {
+    return 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-950/60 dark:text-amber-300 dark:border-amber-800';
+  }
+  return 'bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:border-slate-700';
+}
 import { toUserFacingError } from '@/lib/user-facing-error';
 import {
   Check,
@@ -493,7 +510,12 @@ export default function IncidentCommandBar({
                   >
                     <span>{primaryJira.externalKey}</span>
                     {primaryJira.externalStatus && (
-                      <span className="ml-1 px-1.5 py-0.5 rounded text-xs bg-blue-100 text-blue-800 font-bold uppercase">
+                      <span
+                        className={cn(
+                          'ml-1 px-1.5 py-0.5 rounded text-xs font-bold uppercase border',
+                          jiraStatusBadgeStyle(primaryJira.externalStatus)
+                        )}
+                      >
                         {primaryJira.externalStatus}
                       </span>
                     )}
@@ -831,7 +853,12 @@ export default function IncidentCommandBar({
                           <ExternalLink className="h-3 w-3" />
                         </a>
                         {link.externalStatus && (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] bg-slate-200 dark:bg-slate-700 font-medium">
+                          <span
+                            className={cn(
+                              'px-1.5 py-0.5 rounded text-[10px] font-bold uppercase border',
+                              jiraStatusBadgeStyle(link.externalStatus)
+                            )}
+                          >
                             {link.externalStatus}
                           </span>
                         )}

--- a/src/components/service/ChatOpsWarRoomSettings.tsx
+++ b/src/components/service/ChatOpsWarRoomSettings.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useActionState, useEffect } from 'react';
+import { useFormStatus } from 'react-dom';
 import {
   Card,
   CardContent,
@@ -10,9 +12,11 @@ import {
 import { Input } from '@/components/ui/shadcn/input';
 import { Label } from '@/components/ui/shadcn/label';
 import { Badge } from '@/components/ui/shadcn/badge';
-import { MessageCircle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/shadcn/alert';
+import { CheckCircle2, Loader2, MessageCircle, XCircle } from 'lucide-react';
 import { Button } from '@/components/ui/shadcn/button';
 import { updateServiceChatOpsSettings } from '@/app/(app)/services/actions';
+import { notify } from '@/lib/toast';
 
 const VIDEO_BRIDGE_OPTIONS = [
   { value: 'INHERIT', label: 'Inherit Global' },
@@ -21,6 +25,16 @@ const VIDEO_BRIDGE_OPTIONS = [
   { value: 'GOOGLE_MEET', label: 'Google Meet' },
   { value: 'NONE', label: 'None' },
 ];
+
+function SubmitButton({ disabled }: { disabled: boolean }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={disabled || pending}>
+      {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+      {pending ? 'Saving ChatOps settings...' : 'Save ChatOps settings'}
+    </Button>
+  );
+}
 
 export default function ChatOpsWarRoomSettings({
   serviceId,
@@ -37,7 +51,18 @@ export default function ChatOpsWarRoomSettings({
   chatOpsEnabled: boolean;
   canManage: boolean;
 }) {
-  const saveChatOpsSettings = updateServiceChatOpsSettings.bind(null, serviceId);
+  const [state, formAction] = useActionState(updateServiceChatOpsSettings, {
+    error: null,
+    success: false,
+  });
+
+  useEffect(() => {
+    if (state?.success) {
+      notify.success('ChatOps settings saved');
+    } else if (state?.error) {
+      notify.error(state.error);
+    }
+  }, [state]);
 
   return (
     <Card>
@@ -59,17 +84,39 @@ export default function ChatOpsWarRoomSettings({
         </div>
       </CardHeader>
       <CardContent>
-        <form action={saveChatOpsSettings} className="space-y-4">
+        <form action={formAction} className="space-y-4">
+          <input type="hidden" name="serviceId" value={serviceId} />
+
+          {state?.error && (
+            <Alert variant="destructive">
+              <XCircle className="h-4 w-4" />
+              <AlertDescription>{state.error}</AlertDescription>
+            </Alert>
+          )}
+
+          {state?.success && (
+            <Alert className="border-emerald-200 bg-emerald-50 text-emerald-800">
+              <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+              <AlertDescription>ChatOps & war room settings saved.</AlertDescription>
+            </Alert>
+          )}
+
           <div className="space-y-4">
-            <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+            <label className="flex items-center gap-3 rounded-md border p-3 text-sm cursor-pointer">
               <input
                 type="checkbox"
                 name="autoCreateWarRoom"
                 defaultChecked={autoCreateWarRoom}
                 disabled={!canManage}
-                className="h-4 w-4"
+                className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
               />
-              Auto-create War Room
+              <div>
+                <div className="font-medium">Auto-create War Room</div>
+                <div className="text-xs text-muted-foreground">
+                  Automatically spin up dedicated Slack channel and video bridge when an incident
+                  occurs.
+                </div>
+              </div>
             </label>
 
             <div className="grid gap-4 md:grid-cols-2">
@@ -98,14 +145,16 @@ export default function ChatOpsWarRoomSettings({
                   placeholder="https://meet.company.com/{incidentId}"
                   disabled={!canManage}
                 />
+                <p className="text-[11px] text-muted-foreground">
+                  Optional. Use <code className="text-xs">{'{incidentId}'}</code> as a placeholder
+                  for dynamic room links.
+                </p>
               </div>
             </div>
           </div>
           {canManage && (
             <div className="flex justify-end">
-              <Button type="submit" size="sm">
-                Save ChatOps settings
-              </Button>
+              <SubmitButton disabled={!canManage} />
             </div>
           )}
         </form>

--- a/src/lib/jira-sync.ts
+++ b/src/lib/jira-sync.ts
@@ -6,9 +6,32 @@ import {
   enqueueJiraCreateOperation,
   processExternalOperation,
 } from '@/lib/external-operations';
-import { isValidJiraKey, extractJiraKey } from '@/lib/jira-validation';
+import { isValidJiraKey, extractJiraKey, isJiraStatusDone } from '@/lib/jira-validation';
 import { logAudit, getDefaultActorId } from '@/lib/audit';
 import { logger } from '@/lib/logger';
+import { revalidatePath } from 'next/cache';
+
+function safeRevalidateIncident(incidentId: string): void {
+  try {
+    revalidatePath(`/incidents/${incidentId}`);
+    revalidatePath('/incidents');
+    revalidatePath('/');
+  } catch {
+    // Non-request context (e.g. background worker or test)
+  }
+}
+
+function safeRevalidateActionItems(postmortemId?: string | null): void {
+  try {
+    revalidatePath('/action-items');
+    revalidatePath('/postmortems');
+    if (postmortemId) {
+      revalidatePath(`/postmortems/${postmortemId}`);
+    }
+  } catch {
+    // Non-request context
+  }
+}
 
 export type CreateAndLinkParams = {
   provider?: 'JIRA';
@@ -136,146 +159,124 @@ export async function linkExistingJiraIssue(params: LinkExistingParams) {
 /**
  * Re-fetch status and assignee from Jira for a single ExternalIssueLink.
  */
-export async function syncExternalIssueLink(linkId: string) {
-  const link = await prisma.externalIssueLink.findUnique({
-    where: { id: linkId },
-  });
+/**
+ * Extract status and status category from Jira webhook payload (checking both fields and changelog).
+ */
+export function extractJiraWebhookStatus(payload: JiraWebhookPayload): {
+  statusName?: string;
+  statusCategoryKey?: string;
+  statusCategoryName?: string;
+  isStatusPresent: boolean;
+} {
+  const fields = payload.issue?.fields;
+  let statusName: string | undefined;
+  let statusCategoryKey: string | undefined;
+  let statusCategoryName: string | undefined;
+  let isStatusPresent = false;
 
-  if (!link) throw new Error('External issue link not found.');
-
-  try {
-    const issue = await getJiraIssue(link.externalKey);
-
-    return await prisma.externalIssueLink.update({
-      where: { id: linkId },
-      data: {
-        externalStatus: issue.status ?? null,
-        externalAssignee: issue.assignee ?? null,
-        syncState: 'SYNCED',
-        lastSyncedAt: new Date(),
-      },
-    });
-  } catch (_error) {
-    await prisma.externalIssueLink.update({
-      where: { id: linkId },
-      data: { syncState: 'FAILED' },
-    });
-    // Intentionally NOT re-throwing: callers that loop over multiple links
-    // should not have a single failure abort the entire batch.
-    return null;
+  if (fields && 'status' in fields) {
+    isStatusPresent = true;
+    const rawStatus = fields.status;
+    if (typeof rawStatus === 'string') {
+      statusName = rawStatus.trim() || undefined;
+    } else if (rawStatus && typeof rawStatus === 'object') {
+      statusName = (rawStatus as { name?: string }).name?.trim() || undefined;
+      const category = (rawStatus as { statusCategory?: { key?: string; name?: string } })
+        .statusCategory;
+      if (category) {
+        statusCategoryKey = category.key?.trim() || undefined;
+        statusCategoryName = category.name?.trim() || undefined;
+      }
+    }
   }
+
+  // If not found in fields, check changelog
+  if (!statusName && payload.changelog?.items && Array.isArray(payload.changelog.items)) {
+    const statusItem = payload.changelog.items.find(
+      i => i.field?.toLowerCase() === 'status' || i.fieldId?.toLowerCase() === 'status'
+    );
+    if (statusItem) {
+      isStatusPresent = true;
+      if (statusItem.toString) {
+        statusName = statusItem.toString.trim() || undefined;
+      }
+    }
+  }
+
+  return {
+    statusName,
+    statusCategoryKey,
+    statusCategoryName,
+    isStatusPresent,
+  };
 }
 
-// ---------------------------------------------------------------------------
-// Webhook processing
-// ---------------------------------------------------------------------------
+/**
+ * Extract assignee from Jira webhook payload (checking both fields and changelog).
+ */
+export function extractJiraWebhookAssignee(payload: JiraWebhookPayload): {
+  assignee: string | null;
+  isAssigneePresent: boolean;
+} {
+  const fields = payload.issue?.fields;
+  let assignee: string | null = null;
+  let isAssigneePresent = false;
 
-export type JiraWebhookPayload = {
-  timestamp?: number | string;
-  webhookEvent?: string;
-  issue?: {
-    id?: string;
-    key?: string;
-    fields?: {
-      status?: { name?: string; statusCategory?: { key?: string } };
-      assignee?: { displayName?: string; emailAddress?: string };
-      updated?: string;
-    };
+  if (fields && 'assignee' in fields) {
+    isAssigneePresent = true;
+    const raw = fields.assignee;
+    if (raw === null) {
+      assignee = null;
+    } else if (typeof raw === 'string') {
+      assignee = raw.trim() || null;
+    } else if (raw && typeof raw === 'object') {
+      const obj = raw as { displayName?: string; emailAddress?: string; name?: string };
+      assignee = obj.displayName?.trim() || obj.emailAddress?.trim() || obj.name?.trim() || null;
+    }
+  }
+
+  // If not found in fields, check changelog
+  if (!isAssigneePresent && payload.changelog?.items && Array.isArray(payload.changelog.items)) {
+    const assigneeItem = payload.changelog.items.find(
+      i => i.field?.toLowerCase() === 'assignee' || i.fieldId?.toLowerCase() === 'assignee'
+    );
+    if (assigneeItem) {
+      isAssigneePresent = true;
+      assignee = assigneeItem.toString?.trim() || null;
+    }
+  }
+
+  return {
+    assignee,
+    isAssigneePresent,
   };
+}
+
+export type LinkedEntitySyncParams = {
+  externalKey: string;
+  externalStatus: string;
+  isDone: boolean;
+  actionItemIds: string[];
+  incidentLinks: Array<{
+    id: string;
+    incidentId: string;
+    externalKey: string;
+    externalStatus: string | null;
+  }>;
 };
 
 /**
- * Process an inbound Jira webhook event. Finds matching ExternalIssueLink
- * rows by external issue id or key and updates their status/assignee.
- *
- * Idempotent: replay-safe, duplicate events produce the same result.
+ * Synchronize action items and incident metadata/timeline when Jira issue status changes.
  */
-export async function processJiraWebhookEvent(
-  payload: JiraWebhookPayload
-): Promise<{ updated: number }> {
-  const issueId = payload.issue?.id;
-  const issueKey = payload.issue?.key;
-
-  if (!issueId && !issueKey) {
-    return { updated: 0 };
-  }
-
-  // Find all links that reference this Jira issue
-  const links = await prisma.externalIssueLink.findMany({
-    where: {
-      provider: 'JIRA',
-      OR: [
-        ...(issueId ? [{ externalId: issueId }] : []),
-        ...(issueKey ? [{ externalKey: issueKey }] : []),
-      ],
-    },
-  });
-
-  if (links.length === 0) {
-    return { updated: 0 };
-  }
-
-  // Discard out-of-order stale webhooks if event timestamp is older than lastSyncedAt
-  const eventTime = payload.timestamp
-    ? new Date(
-        typeof payload.timestamp === 'number' ? payload.timestamp : String(payload.timestamp)
-      )
-    : payload.issue?.fields?.updated
-      ? new Date(payload.issue.fields.updated)
-      : null;
-
-  const validLinks =
-    eventTime && !isNaN(eventTime.getTime())
-      ? links.filter(
-          l => !l.lastSyncedAt || l.lastSyncedAt.getTime() <= eventTime.getTime() + 5_000
-        )
-      : links;
-
-  if (validLinks.length === 0) {
-    return { updated: 0 };
-  }
-
-  // Only update fields that are actually present in the webhook payload.
-  // Jira webhooks often omit unchanged fields — blindly setting them to null
-  // would erase valid data stored from a previous sync.
-  const data: Record<string, unknown> = {
-    syncState: 'SYNCED',
-    lastSyncedAt: eventTime && !isNaN(eventTime.getTime()) ? eventTime : new Date(),
-  };
-
-  if (payload.issue?.fields && 'status' in payload.issue.fields) {
-    data.externalStatus = payload.issue.fields.status?.name ?? null;
-  }
-
-  if (payload.issue?.fields && 'assignee' in payload.issue.fields) {
-    data.externalAssignee =
-      payload.issue.fields.assignee?.displayName ??
-      payload.issue.fields.assignee?.emailAddress ??
-      null;
-  }
-
-  await prisma.externalIssueLink.updateMany({
-    where: {
-      id: { in: validLinks.map(l => l.id) },
-    },
-    data,
-  });
-
-  const actionItemIds = validLinks.map(l => l.actionItemId).filter(Boolean) as string[];
-  if (actionItemIds.length > 0 && data.externalStatus) {
-    const isDone =
-      payload.issue?.fields?.status?.statusCategory?.key?.toLowerCase() === 'done' ||
-      [
-        'done',
-        'closed',
-        'resolved',
-        'complete',
-        'completed',
-        'fixed',
-        'deployed',
-        'verified',
-        'shipped',
-      ].includes(String(data.externalStatus).toLowerCase());
+export async function syncLinkedEntitiesForJiraIssue({
+  externalKey: _externalKey,
+  externalStatus,
+  isDone,
+  actionItemIds,
+  incidentLinks,
+}: LinkedEntitySyncParams): Promise<void> {
+  // 1. Process action items
+  if (actionItemIds.length > 0) {
     await prisma.$transaction(async tx => {
       await tx.actionItem.updateMany({
         where: {
@@ -286,11 +287,13 @@ export async function processJiraWebhookEvent(
           ? { status: 'COMPLETED', completedAt: new Date() }
           : { status: 'OPEN', completedAt: null },
       });
+
       const records = await tx.actionItem.findMany({
         where: { id: { in: actionItemIds } },
         select: { id: true, postmortemId: true, status: true, completedAt: true },
       });
-      for (const postmortemId of new Set(records.map(record => record.postmortemId))) {
+
+      for (const postmortemId of new Set(records.map(r => r.postmortemId))) {
         const postmortem = await tx.postmortem.findUnique({
           where: { id: postmortemId },
           select: { actionItems: true },
@@ -312,7 +315,285 @@ export async function processJiraWebhookEvent(
           where: { id: postmortemId },
           data: { actionItems: synced as Prisma.InputJsonValue },
         });
+        safeRevalidateActionItems(postmortemId);
       }
+    });
+    safeRevalidateActionItems();
+  }
+
+  // 2. Process incident links
+  if (incidentLinks.length > 0) {
+    const actorId = await getDefaultActorId();
+    for (const link of incidentLinks) {
+      if (!link.incidentId) continue;
+
+      const previousStatus = link.externalStatus;
+      const statusChanged =
+        previousStatus?.trim().toLowerCase() !== externalStatus.trim().toLowerCase();
+
+      if (statusChanged) {
+        const message = isDone
+          ? `Jira issue ${link.externalKey} marked as Done (${externalStatus})`
+          : `Jira issue ${link.externalKey} status updated to "${externalStatus}"`;
+
+        // Create IncidentEvent in timeline
+        await prisma.incidentEvent.create({
+          data: {
+            incidentId: link.incidentId,
+            type: 'STATUS_CHANGE',
+            message,
+          },
+        });
+
+        // Touch incident updatedAt to trigger PostgreSQL RealtimeChange trigger
+        await prisma.incident.update({
+          where: { id: link.incidentId },
+          data: { updatedAt: new Date() },
+        });
+
+        // Audit log
+        await logAudit({
+          action: 'jira.issue.synced',
+          entityType: 'INCIDENT',
+          entityId: link.incidentId,
+          actorId,
+          details: {
+            externalKey: link.externalKey,
+            previousStatus,
+            newStatus: externalStatus,
+            isDone,
+          },
+        });
+
+        // Revalidate Next.js cache
+        safeRevalidateIncident(link.incidentId);
+      }
+    }
+  }
+}
+
+/**
+ * Re-fetch status and assignee from Jira for a single ExternalIssueLink and sync linked entities.
+ */
+export async function syncExternalIssueLink(linkId: string) {
+  const link = await prisma.externalIssueLink.findUnique({
+    where: { id: linkId },
+  });
+
+  if (!link) throw new Error('External issue link not found.');
+
+  try {
+    const issue = await getJiraIssue(link.externalKey);
+    const newStatus = issue.status ?? null;
+    const newAssignee = issue.assignee ?? null;
+
+    const updated = await prisma.externalIssueLink.update({
+      where: { id: linkId },
+      data: {
+        externalStatus: newStatus,
+        externalAssignee: newAssignee,
+        syncState: 'SYNCED',
+        lastSyncedAt: new Date(),
+      },
+    });
+
+    if (newStatus) {
+      const isDone = isJiraStatusDone(newStatus, issue.statusCategoryKey, issue.statusCategoryName);
+      await syncLinkedEntitiesForJiraIssue({
+        externalKey: link.externalKey,
+        externalStatus: newStatus,
+        isDone,
+        actionItemIds: link.actionItemId ? [link.actionItemId] : [],
+        incidentLinks: link.incidentId
+          ? [
+              {
+                id: link.id,
+                incidentId: link.incidentId,
+                externalKey: link.externalKey,
+                externalStatus: link.externalStatus,
+              },
+            ]
+          : [],
+      });
+    }
+
+    return updated;
+  } catch (_error) {
+    await prisma.externalIssueLink.update({
+      where: { id: linkId },
+      data: { syncState: 'FAILED' },
+    });
+    // Intentionally NOT re-throwing: callers that loop over multiple links
+    // should not have a single failure abort the entire batch.
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Webhook processing
+// ---------------------------------------------------------------------------
+
+export type JiraWebhookPayload = {
+  timestamp?: number | string;
+  webhookEvent?: string;
+  issue_event_type_name?: string;
+  issue?: {
+    id?: string;
+    key?: string;
+    fields?: {
+      status?:
+        | string
+        | {
+            name?: string;
+            statusCategory?: {
+              id?: number;
+              key?: string;
+              name?: string;
+              colorName?: string;
+            };
+          };
+      assignee?:
+        | string
+        | {
+            displayName?: string;
+            emailAddress?: string;
+            name?: string;
+          }
+        | null;
+      updated?: string;
+      [key: string]: unknown;
+    };
+  };
+  changelog?: {
+    id?: string;
+    items?: Array<{
+      field?: string;
+      fieldId?: string;
+      fromString?: string | null;
+      toString?: string | null;
+      from?: string | null;
+      to?: string | null;
+    }>;
+  };
+  [key: string]: unknown;
+};
+
+/**
+ * Process an inbound Jira webhook event. Finds matching ExternalIssueLink
+ * rows by external issue id or key and updates their status/assignee,
+ * syncing incidents and action items.
+ *
+ * Idempotent: replay-safe, duplicate events produce the same result.
+ */
+export async function processJiraWebhookEvent(
+  payload: JiraWebhookPayload
+): Promise<{ updated: number }> {
+  const issueId = payload.issue?.id;
+  const issueKey = payload.issue?.key;
+
+  if (!issueId && !issueKey) {
+    return { updated: 0 };
+  }
+
+  // Find all links that reference this Jira issue (supporting normalized/uppercase keys)
+  const normalizedKey = issueKey ? extractJiraKey(issueKey) : undefined;
+  const keyCandidates = Array.from(
+    new Set(
+      [issueKey, normalizedKey, issueKey?.toUpperCase(), issueKey?.toLowerCase()].filter(
+        Boolean
+      ) as string[]
+    )
+  );
+
+  const links = await prisma.externalIssueLink.findMany({
+    where: {
+      provider: 'JIRA',
+      OR: [
+        ...(issueId ? [{ externalId: issueId }] : []),
+        ...keyCandidates.map(k => ({ externalKey: k })),
+      ],
+    },
+  });
+
+  if (links.length === 0) {
+    return { updated: 0 };
+  }
+
+  // Extract status and assignee from payload fields or changelog
+  const { statusName, statusCategoryKey, statusCategoryName, isStatusPresent } =
+    extractJiraWebhookStatus(payload);
+  const { assignee, isAssigneePresent } = extractJiraWebhookAssignee(payload);
+
+  // Discard out-of-order stale webhooks if event timestamp is older than lastSyncedAt.
+  // Note: 5 minutes (300,000ms) skew tolerance prevents dropping legitimate webhooks.
+  // If the status is different from link's current status, we always process it.
+  const eventTime = payload.timestamp
+    ? new Date(
+        typeof payload.timestamp === 'number' ? payload.timestamp : String(payload.timestamp)
+      )
+    : payload.issue?.fields?.updated
+      ? new Date(payload.issue.fields.updated)
+      : null;
+
+  const validLinks =
+    eventTime && !isNaN(eventTime.getTime())
+      ? links.filter(l => {
+          if (!l.lastSyncedAt) return true;
+          if (
+            statusName &&
+            statusName.trim().toLowerCase() !== (l.externalStatus || '').trim().toLowerCase()
+          ) {
+            return true;
+          }
+          return l.lastSyncedAt.getTime() <= eventTime.getTime() + 300_000;
+        })
+      : links;
+
+  if (validLinks.length === 0) {
+    return { updated: 0 };
+  }
+
+  // Only update fields that are actually present in the webhook payload.
+  // Jira webhooks often omit unchanged fields — blindly setting them to null
+  // would erase valid data stored from a previous sync.
+  const data: Record<string, unknown> = {
+    syncState: 'SYNCED',
+    lastSyncedAt: eventTime && !isNaN(eventTime.getTime()) ? eventTime : new Date(),
+  };
+
+  if (isStatusPresent) {
+    data.externalStatus = statusName ?? null;
+  }
+
+  if (isAssigneePresent) {
+    data.externalAssignee = assignee;
+  }
+
+  await prisma.externalIssueLink.updateMany({
+    where: {
+      id: { in: validLinks.map(l => l.id) },
+    },
+    data,
+  });
+
+  if (isStatusPresent && statusName) {
+    const isDone = isJiraStatusDone(statusName, statusCategoryKey, statusCategoryName);
+    const actionItemIds = validLinks.map(l => l.actionItemId).filter(Boolean) as string[];
+    const incidentLinks = validLinks
+      .filter(l => Boolean(l.incidentId))
+      .map(l => ({
+        id: l.id,
+        incidentId: l.incidentId!,
+        externalKey: l.externalKey,
+        externalStatus: l.externalStatus,
+      }));
+
+    await syncLinkedEntitiesForJiraIssue({
+      externalKey: issueKey || validLinks[0].externalKey,
+      externalStatus: statusName,
+      isDone,
+      actionItemIds,
+      incidentLinks,
     });
   }
 

--- a/src/lib/jira-validation.ts
+++ b/src/lib/jira-validation.ts
@@ -60,3 +60,40 @@ export function assertJiraIssueType(value: string, fieldName: string): string {
   }
   return normalized;
 }
+
+const DONE_STATUS_NAMES = new Set([
+  'done',
+  'closed',
+  'resolved',
+  'complete',
+  'completed',
+  'fixed',
+  'deployed',
+  'verified',
+  'shipped',
+  'cancelled',
+  'canceled',
+  'fin',
+  'finished',
+]);
+
+/**
+ * Determine whether a Jira status or status category represents completion.
+ * Checks statusCategoryKey (e.g. 'done'), statusCategoryName, and standard Done status names.
+ */
+export function isJiraStatusDone(
+  statusName?: string | null,
+  statusCategoryKey?: string | null,
+  statusCategoryName?: string | null
+): boolean {
+  if (statusCategoryKey && statusCategoryKey.trim().toLowerCase() === 'done') {
+    return true;
+  }
+  if (statusCategoryName && statusCategoryName.trim().toLowerCase() === 'done') {
+    return true;
+  }
+  if (!statusName) return false;
+  const normalized = statusName.trim().toLowerCase();
+  if (DONE_STATUS_NAMES.has(normalized)) return true;
+  return /^(done|closed|resolved|completed?|finished|fixed)$/i.test(normalized);
+}

--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -10,6 +10,8 @@ export type JiraIssueSummary = {
   url: string;
   status?: string;
   assignee?: string;
+  statusCategoryKey?: string;
+  statusCategoryName?: string;
 };
 
 type JiraConfigForRequest = {
@@ -23,7 +25,15 @@ type JiraIssueResponse = {
   key: string;
   self?: string;
   fields?: {
-    status?: { name?: string };
+    status?: {
+      name?: string;
+      statusCategory?: {
+        id?: number;
+        key?: string;
+        name?: string;
+        colorName?: string;
+      };
+    };
     assignee?: { displayName?: string; emailAddress?: string };
   };
 };
@@ -193,6 +203,8 @@ export async function getJiraIssue(issueKeyOrId: string): Promise<JiraIssueSumma
     url: jiraIssueUrl(config.baseUrl, issue.key),
     status: issue.fields?.status?.name,
     assignee: issue.fields?.assignee?.displayName ?? issue.fields?.assignee?.emailAddress,
+    statusCategoryKey: issue.fields?.status?.statusCategory?.key,
+    statusCategoryName: issue.fields?.status?.statusCategory?.name,
   };
 }
 
@@ -218,13 +230,12 @@ export async function findJiraIssueByCorrelationLabel(
     url: jiraIssueUrl(config.baseUrl, issue.key),
     status: issue.fields?.status?.name,
     assignee: issue.fields?.assignee?.displayName ?? issue.fields?.assignee?.emailAddress,
+    statusCategoryKey: issue.fields?.status?.statusCategory?.key,
+    statusCategoryName: issue.fields?.status?.statusCategory?.name,
   };
 }
 
-export async function addJiraComment(
-  issueKeyOrId: string,
-  commentText: string
-): Promise<void> {
+export async function addJiraComment(issueKeyOrId: string, commentText: string): Promise<void> {
   const config = await getDecryptedJiraConfig();
   if (!config) return;
 
@@ -239,12 +250,15 @@ export async function addJiraComment(
 }
 
 export async function hasJiraCommentMarker(issueKeyOrId: string, marker: string): Promise<boolean> {
-  if (!/^opsknight-comment-[A-Za-z0-9_-]{1,200}$/.test(marker)) throw new Error('Invalid Jira comment marker');
+  if (!/^opsknight-comment-[A-Za-z0-9_-]{1,200}$/.test(marker))
+    throw new Error('Invalid Jira comment marker');
   const config = await getDecryptedJiraConfig();
   if (!config) throw jiraNotConfigured();
   const result = await jiraRequest<{ comments?: Array<{ body?: unknown }> }>(
     config,
     `/rest/api/3/issue/${encodeURIComponent(issueKeyOrId)}/comment?maxResults=100&orderBy=-created`
   );
-  return (result.comments ?? []).some(comment => JSON.stringify(comment.body ?? '').includes(marker));
+  return (result.comments ?? []).some(comment =>
+    JSON.stringify(comment.body ?? '').includes(marker)
+  );
 }

--- a/tests/actions/service-chatops-actions.test.ts
+++ b/tests/actions/service-chatops-actions.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertCanModifyService: vi.fn(),
+  serviceUpdate: vi.fn(),
+  logAudit: vi.fn(),
+  revalidatePath: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  assertCanModifyService: mocks.assertCanModifyService,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    service: {
+      update: mocks.serviceUpdate,
+    },
+  },
+}));
+
+vi.mock('@/lib/audit', () => ({
+  logAudit: mocks.logAudit,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: mocks.redirect,
+}));
+
+import { updateServiceChatOpsSettings } from '@/app/(app)/services/actions';
+
+describe('updateServiceChatOpsSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.assertCanModifyService.mockResolvedValue({ id: 'user-1' });
+    mocks.serviceUpdate.mockResolvedValue({});
+  });
+
+  it('updates chatops settings successfully when called with (serviceId, formData)', async () => {
+    const formData = new FormData();
+    formData.set('autoCreateWarRoom', 'on');
+    formData.set('warRoomVideoBridge', 'ZOOM');
+    formData.set('warRoomCustomBridgeUrl', 'https://zoom.us/j/123456');
+
+    const result = await updateServiceChatOpsSettings('svc-1', formData);
+
+    expect(result).toEqual({ success: true, error: null });
+    expect(mocks.serviceUpdate).toHaveBeenCalledWith({
+      where: { id: 'svc-1' },
+      data: {
+        autoCreateWarRoom: true,
+        warRoomVideoBridge: 'ZOOM',
+        warRoomCustomBridgeUrl: 'https://zoom.us/j/123456',
+      },
+    });
+    expect(mocks.logAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'service.chatops.updated',
+        entityId: 'svc-1',
+        actorId: 'user-1',
+      })
+    );
+    expect(mocks.revalidatePath).toHaveBeenCalledWith('/services/svc-1');
+    expect(mocks.revalidatePath).toHaveBeenCalledWith('/services/svc-1/settings');
+    expect(mocks.redirect).not.toHaveBeenCalled();
+  });
+
+  it('updates chatops settings successfully when called via useActionState (prevState, formData)', async () => {
+    const formData = new FormData();
+    formData.set('serviceId', 'svc-2');
+    formData.set('warRoomVideoBridge', 'INHERIT');
+    // autoCreateWarRoom not checked (omitted in formData)
+    formData.set('warRoomCustomBridgeUrl', '');
+
+    const result = await updateServiceChatOpsSettings({ success: false }, formData);
+
+    expect(result).toEqual({ success: true, error: null });
+    expect(mocks.serviceUpdate).toHaveBeenCalledWith({
+      where: { id: 'svc-2' },
+      data: {
+        autoCreateWarRoom: false,
+        warRoomVideoBridge: null,
+        warRoomCustomBridgeUrl: null,
+      },
+    });
+    expect(mocks.redirect).not.toHaveBeenCalled();
+  });
+
+  it('accepts valid custom bridge URL containing {incidentId}', async () => {
+    const formData = new FormData();
+    formData.set('autoCreateWarRoom', 'on');
+    formData.set('warRoomVideoBridge', 'NONE');
+    formData.set('warRoomCustomBridgeUrl', 'https://meet.custom.io/{incidentId}');
+
+    const result = await updateServiceChatOpsSettings('svc-1', formData);
+
+    expect(result).toEqual({ success: true, error: null });
+    expect(mocks.serviceUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          warRoomCustomBridgeUrl: 'https://meet.custom.io/{incidentId}',
+        }),
+      })
+    );
+  });
+
+  it('rejects invalid custom bridge URL protocol', async () => {
+    const formData = new FormData();
+    formData.set('warRoomCustomBridgeUrl', 'javascript:alert(1)');
+
+    const result = await updateServiceChatOpsSettings('svc-1', formData);
+
+    expect(result).toEqual({
+      error: 'Custom bridge URL must use HTTP or HTTPS protocol.',
+    });
+    expect(mocks.serviceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed custom bridge URL', async () => {
+    const formData = new FormData();
+    formData.set('warRoomCustomBridgeUrl', 'http://::invalid::');
+
+    const result = await updateServiceChatOpsSettings('svc-1', formData);
+
+    expect(result).toEqual({
+      error: 'Please enter a valid URL for the custom bridge.',
+    });
+    expect(mocks.serviceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported video bridge option', async () => {
+    const formData = new FormData();
+    formData.set('warRoomVideoBridge', 'INVALID_BRIDGE');
+
+    const result = await updateServiceChatOpsSettings('svc-1', formData);
+
+    expect(result).toEqual({
+      error: 'Invalid video bridge option.',
+    });
+    expect(mocks.serviceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns error when serviceId is missing', async () => {
+    const formData = new FormData();
+    const result = await updateServiceChatOpsSettings(undefined, formData);
+
+    expect(result).toEqual({
+      error: 'Service ID is required.',
+    });
+    expect(mocks.serviceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns error when assertCanModifyService throws', async () => {
+    mocks.assertCanModifyService.mockRejectedValue(new Error('Permission denied'));
+
+    const formData = new FormData();
+    const result = await updateServiceChatOpsSettings('svc-1', formData);
+
+    expect(result).toEqual({
+      error: 'Permission denied',
+    });
+    expect(mocks.serviceUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/service/ChatOpsWarRoomSettings.test.tsx
+++ b/tests/components/service/ChatOpsWarRoomSettings.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ChatOpsWarRoomSettings from '@/components/service/ChatOpsWarRoomSettings';
+
+vi.mock('@/lib/toast', () => ({
+  notify: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/app/(app)/services/actions', () => ({
+  updateServiceChatOpsSettings: vi.fn(),
+}));
+
+describe('ChatOpsWarRoomSettings', () => {
+  it('renders correctly with chatOpsEnabled and populated values', () => {
+    render(
+      <ChatOpsWarRoomSettings
+        serviceId="svc-123"
+        autoCreateWarRoom={true}
+        warRoomVideoBridge="ZOOM"
+        warRoomCustomBridgeUrl="https://zoom.us/j/999"
+        chatOpsEnabled={true}
+        canManage={true}
+      />
+    );
+
+    expect(screen.getByText('ChatOps & War Room Settings')).toBeInTheDocument();
+    expect(screen.getByText('ChatOps Enabled')).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /auto-create war room/i,
+    }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.disabled).toBe(false);
+
+    const bridgeSelect = screen.getByLabelText(/override video bridge/i) as HTMLSelectElement;
+    expect(bridgeSelect.value).toBe('ZOOM');
+    expect(bridgeSelect.disabled).toBe(false);
+
+    const urlInput = screen.getByLabelText(/custom bridge url/i) as HTMLInputElement;
+    expect(urlInput.value).toBe('https://zoom.us/j/999');
+    expect(urlInput.disabled).toBe(false);
+
+    const submitBtn = screen.getByRole('button', { name: /save chatops settings/i });
+    expect(submitBtn).toBeInTheDocument();
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it('renders unconfigured badge and disabled inputs when canManage is false', () => {
+    render(
+      <ChatOpsWarRoomSettings
+        serviceId="svc-456"
+        autoCreateWarRoom={false}
+        warRoomVideoBridge={null}
+        warRoomCustomBridgeUrl={null}
+        chatOpsEnabled={false}
+        canManage={false}
+      />
+    );
+
+    expect(screen.getByText('ChatOps not configured')).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /auto-create war room/i,
+    }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.disabled).toBe(true);
+
+    const bridgeSelect = screen.getByLabelText(/override video bridge/i) as HTMLSelectElement;
+    expect(bridgeSelect.value).toBe('INHERIT');
+    expect(bridgeSelect.disabled).toBe(true);
+
+    const urlInput = screen.getByLabelText(/custom bridge url/i) as HTMLInputElement;
+    expect(urlInput.value).toBe('');
+    expect(urlInput.disabled).toBe(true);
+
+    expect(
+      screen.queryByRole('button', { name: /save chatops settings/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('includes serviceId in hidden input', () => {
+    const { container } = render(
+      <ChatOpsWarRoomSettings
+        serviceId="svc-789"
+        autoCreateWarRoom={true}
+        warRoomVideoBridge="JITSI"
+        warRoomCustomBridgeUrl=""
+        chatOpsEnabled={true}
+        canManage={true}
+      />
+    );
+
+    const hiddenServiceId = container.querySelector('input[name="serviceId"]') as HTMLInputElement;
+    expect(hiddenServiceId).not.toBeNull();
+    expect(hiddenServiceId.value).toBe('svc-789');
+  });
+});

--- a/tests/lib/jira-sync.test.ts
+++ b/tests/lib/jira-sync.test.ts
@@ -5,7 +5,9 @@ import {
   assertJiraProjectKey,
   assertJiraIssueType,
   parseLabels,
+  isJiraStatusDone,
 } from '@/lib/jira-validation';
+import { extractJiraWebhookStatus, extractJiraWebhookAssignee } from '@/lib/jira-sync';
 
 describe('jira validation helpers', () => {
   // -------------------------------------------------------------------------
@@ -49,15 +51,11 @@ describe('jira validation helpers', () => {
     });
 
     it('auto-prepends https:// when no protocol is provided', () => {
-      expect(normalizeJiraBaseUrl('myteam.atlassian.net')).toBe(
-        'https://myteam.atlassian.net'
-      );
+      expect(normalizeJiraBaseUrl('myteam.atlassian.net')).toBe('https://myteam.atlassian.net');
     });
 
     it('auto-prepends https:// and strips trailing slashes', () => {
-      expect(normalizeJiraBaseUrl('myteam.atlassian.net/')).toBe(
-        'https://myteam.atlassian.net'
-      );
+      expect(normalizeJiraBaseUrl('myteam.atlassian.net/')).toBe('https://myteam.atlassian.net');
     });
 
     it('rejects HTTP URLs', () => {
@@ -67,9 +65,7 @@ describe('jira validation helpers', () => {
     });
 
     it('throws a user-friendly message for completely invalid input', () => {
-      expect(() => normalizeJiraBaseUrl('not a url at all!!!')).toThrow(
-        'Invalid Jira URL'
-      );
+      expect(() => normalizeJiraBaseUrl('not a url at all!!!')).toThrow('Invalid Jira URL');
     });
 
     it('handles whitespace around the URL', () => {
@@ -119,11 +115,7 @@ describe('jira validation helpers', () => {
   // -------------------------------------------------------------------------
   describe('parseLabels', () => {
     it('splits comma-separated labels', () => {
-      expect(parseLabels('opsknight, frontend, bug')).toEqual([
-        'opsknight',
-        'frontend',
-        'bug',
-      ]);
+      expect(parseLabels('opsknight, frontend, bug')).toEqual(['opsknight', 'frontend', 'bug']);
     });
 
     it('deduplicates labels', () => {
@@ -133,6 +125,46 @@ describe('jira validation helpers', () => {
     it('handles empty input', () => {
       expect(parseLabels('')).toEqual([]);
       expect(parseLabels('   ')).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isJiraStatusDone
+  // -------------------------------------------------------------------------
+  describe('isJiraStatusDone', () => {
+    it('returns true when statusCategoryKey is done (case insensitive)', () => {
+      expect(isJiraStatusDone('Custom Complete', 'done')).toBe(true);
+      expect(isJiraStatusDone('Custom Complete', 'DONE')).toBe(true);
+      expect(isJiraStatusDone(undefined, 'done')).toBe(true);
+    });
+
+    it('returns true when statusCategoryName is done (case insensitive)', () => {
+      expect(isJiraStatusDone('Done Custom', undefined, 'Done')).toBe(true);
+      expect(isJiraStatusDone('Done Custom', undefined, 'done')).toBe(true);
+    });
+
+    it('returns true for recognized done status names', () => {
+      expect(isJiraStatusDone('Done')).toBe(true);
+      expect(isJiraStatusDone('done')).toBe(true);
+      expect(isJiraStatusDone('Closed')).toBe(true);
+      expect(isJiraStatusDone('Resolved')).toBe(true);
+      expect(isJiraStatusDone('Complete')).toBe(true);
+      expect(isJiraStatusDone('Completed')).toBe(true);
+      expect(isJiraStatusDone('Fixed')).toBe(true);
+      expect(isJiraStatusDone('Deployed')).toBe(true);
+      expect(isJiraStatusDone('Verified')).toBe(true);
+      expect(isJiraStatusDone('Shipped')).toBe(true);
+      expect(isJiraStatusDone('Cancelled')).toBe(true);
+      expect(isJiraStatusDone('Canceled')).toBe(true);
+    });
+
+    it('returns false for non-done statuses', () => {
+      expect(isJiraStatusDone('In Progress')).toBe(false);
+      expect(isJiraStatusDone('To Do')).toBe(false);
+      expect(isJiraStatusDone('Under Review')).toBe(false);
+      expect(isJiraStatusDone('Open')).toBe(false);
+      expect(isJiraStatusDone(null)).toBe(false);
+      expect(isJiraStatusDone(undefined)).toBe(false);
     });
   });
 });
@@ -240,6 +272,155 @@ describe('webhook payload handling', () => {
 
     expect(payload.issue?.id).toBeUndefined();
     expect(payload.issue?.key).toBeUndefined();
+  });
+
+  describe('extractJiraWebhookStatus', () => {
+    it('extracts status name and statusCategory from nested status object in fields', () => {
+      const result = extractJiraWebhookStatus({
+        issue: {
+          fields: {
+            status: {
+              name: 'Done',
+              statusCategory: { key: 'done', name: 'Done' },
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        statusName: 'Done',
+        statusCategoryKey: 'done',
+        statusCategoryName: 'Done',
+        isStatusPresent: true,
+      });
+    });
+
+    it('extracts string status in fields', () => {
+      const result = extractJiraWebhookStatus({
+        issue: {
+          fields: {
+            status: 'In Progress',
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        statusName: 'In Progress',
+        statusCategoryKey: undefined,
+        statusCategoryName: undefined,
+        isStatusPresent: true,
+      });
+    });
+
+    it('extracts status from changelog.items when fields.status is omitted', () => {
+      const result = extractJiraWebhookStatus({
+        issue: {
+          fields: {},
+        },
+        changelog: {
+          items: [
+            { field: 'description', fromString: 'old', toString: 'new' },
+            { field: 'status', fromString: 'In Progress', toString: 'Resolved' },
+          ],
+        },
+      });
+
+      expect(result).toEqual({
+        statusName: 'Resolved',
+        statusCategoryKey: undefined,
+        statusCategoryName: undefined,
+        isStatusPresent: true,
+      });
+    });
+
+    it('returns isStatusPresent false when status is absent in both fields and changelog', () => {
+      const result = extractJiraWebhookStatus({
+        issue: {
+          fields: {
+            summary: 'My bug',
+          },
+        },
+      });
+
+      expect(result.isStatusPresent).toBe(false);
+      expect(result.statusName).toBeUndefined();
+    });
+  });
+
+  describe('extractJiraWebhookAssignee', () => {
+    it('extracts displayName from fields.assignee', () => {
+      const result = extractJiraWebhookAssignee({
+        issue: {
+          fields: {
+            assignee: { displayName: 'Alice Admin', emailAddress: 'alice@example.com' },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        assignee: 'Alice Admin',
+        isAssigneePresent: true,
+      });
+    });
+
+    it('extracts emailAddress when displayName is missing', () => {
+      const result = extractJiraWebhookAssignee({
+        issue: {
+          fields: {
+            assignee: { emailAddress: 'alice@example.com' },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        assignee: 'alice@example.com',
+        isAssigneePresent: true,
+      });
+    });
+
+    it('handles explicit unassigned (null assignee) in fields', () => {
+      const result = extractJiraWebhookAssignee({
+        issue: {
+          fields: {
+            assignee: null,
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        assignee: null,
+        isAssigneePresent: true,
+      });
+    });
+
+    it('extracts assignee from changelog when omitted in fields', () => {
+      const result = extractJiraWebhookAssignee({
+        issue: {
+          fields: {},
+        },
+        changelog: {
+          items: [{ fieldId: 'assignee', fromString: 'Old', toString: 'New Assignee' }],
+        },
+      });
+
+      expect(result).toEqual({
+        assignee: 'New Assignee',
+        isAssigneePresent: true,
+      });
+    });
+
+    it('returns isAssigneePresent false when assignee is omitted from fields and changelog', () => {
+      const result = extractJiraWebhookAssignee({
+        issue: {
+          fields: {
+            summary: 'Test issue',
+          },
+        },
+      });
+
+      expect(result.isAssigneePresent).toBe(false);
+      expect(result.assignee).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary of Changes

### 1. Fix "Save ChatOps settings" Button & Action
- **No Pending / Loading Feedback**: Replaced plain button submit with `useActionState` and a `SubmitButton` using `useFormStatus()`. It displays `<Loader2 className="mr-2 h-4 w-4 animate-spin" />` and disables during submission to prevent duplicate clicks.
- **Removed Jarring Page Redirect / Scroll Reset**: Removed `redirect(serviceSettingsRedirect(serviceId))` from `updateServiceChatOpsSettings`. Next.js redirects in client forms triggered full page re-renders that reset the scroll position to the top of the page. Replaced with `revalidatePath` and a return object `{ success: true, error: null }`.
- **Inline Alerts & Toast Feedback**: Added inline `<Alert>` components for both success (`border-emerald-200`) and failure (`variant="destructive"`), and integrated `notify.success` / `notify.error` toast messages.
- **Robust Validation**: Validated `serviceId`, user permission (`assertCanModifyService`), `warRoomVideoBridge` (against allowed enum values), and `warRoomCustomBridgeUrl` (protocol validation handling `{incidentId}` token).
- **Hidden Input**: Added `<input type="hidden" name="serviceId" value={serviceId} />` to properly supply the service ID to the form action.

### 2. Synchronize Jira Status Metadata to Incidents
- **Status Category & Completion Detection**: Added `isJiraStatusDone(statusName, statusCategoryKey, statusCategoryName)` in `src/lib/jira-validation.ts` to detect completion status via categories (`done`) or standard status names (`Done`, `Resolved`, `Closed`, `Completed`, etc.).
- **Jira Issue Metadata Retrieval**: Updated `getJiraIssue` in `src/lib/jira.ts` to retrieve `statusCategoryKey` and `statusCategoryName` from Atlassian REST responses.
- **Webhook Route Event Expansion**: Extended `/api/jira/webhook/route.ts` to accept `jira:issue_generic`, `issue_generic`, and transition events that were previously dropped. Added `changelog` parsing and flexible string/numeric timestamp support.
- **Incident Synchronization & Timeline Events**:
  - Implemented `extractJiraWebhookStatus` and `extractJiraWebhookAssignee` to pull status from both issue fields and changelog items.
  - In `src/lib/jira-sync.ts`, created `syncLinkedEntitiesForJiraIssue`: logs an `IncidentEvent` of type `STATUS_CHANGE` on the incident timeline, touches `updatedAt` for PostgreSQL `RealtimeChange` triggers, updates linked action items to `COMPLETED`, and revalidates incident and action-item routes.
  - Added a 5-minute clock skew tolerance to prevent dropping out-of-order webhooks from Atlassian Cloud.
- **Status-Aware UI Badges**: Enhanced `IncidentCommandBar.tsx` with `jiraStatusBadgeStyle` color coding (emerald for Done, blue for In Progress, amber for To Do, slate for unknown).

### 3. Automated Tests
- `tests/actions/service-chatops-actions.test.ts`: 8 unit tests covering `updateServiceChatOpsSettings` (direct call, `useActionState` signature, URL validation, protocol rejection, bridge options, permissions, and audit logging).
- `tests/components/service/ChatOpsWarRoomSettings.test.tsx`: 3 component tests verifying rendering, form population, permission gating, and hidden input.
- `tests/lib/jira-sync.test.ts`: 43 unit tests covering Jira key validation, URL normalization, `isJiraStatusDone`, `extractJiraWebhookStatus`, and `extractJiraWebhookAssignee`.

## Verification
- Unit tests: `npx vitest run` passed (54/54 tests passing).
- TypeScript check: `npx tsc --noEmit` passed with 0 errors.
- ESLint: passed with 0 errors.
- Production build: `npm run build` completed successfully.