### PR TITLE
fix(incidents): remove redundant sidebar postmortem card and quick link

### DIFF
--- a/src/app/(app)/incidents/[id]/page.tsx
+++ b/src/app/(app)/incidents/[id]/page.tsx
@@ -11,7 +11,6 @@ import IncidentDetailTabs from '@/components/incident/IncidentDetailTabs';
 import IncidentNotes from '@/components/incident/detail/IncidentNotes';
 import IncidentTimeline from '@/components/incident/detail/IncidentTimeline';
 import IncidentResolutionSummary from '@/components/incident/detail/IncidentResolutionSummary';
-import IncidentPostmortemCard from '@/components/incident/detail/IncidentPostmortemCard';
 import IncidentPostmortemTabContent from '@/components/incident/detail/IncidentPostmortemTabContent';
 import IncidentDescriptionCard from '@/components/incident/detail/IncidentDescriptionCard';
 import IncidentSLABadges from '@/components/incident/detail/IncidentSLABadges';
@@ -453,17 +452,7 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
             }
             warRoomUrl={incident.warRoomUrl}
             slackChannelName={incident.slackChannelName}
-            status={incident.status}
-            postmortemExists={Boolean(postmortem)}
           />
-
-          {incident.status === 'RESOLVED' && (
-            <IncidentPostmortemCard
-              incidentId={id}
-              postmortemStatus={postmortem?.status ?? null}
-              canManage={canManageIncident}
-            />
-          )}
         </aside>
       </div>
     </div>

--- a/src/components/incident/detail/IncidentQuickLinksCard.tsx
+++ b/src/components/incident/detail/IncidentQuickLinksCard.tsx
@@ -9,7 +9,6 @@ import {
   BarChart2,
   Users,
   Video,
-  FileText,
   ArrowUpRight,
   ExternalLink,
 } from 'lucide-react';
@@ -33,8 +32,6 @@ export type IncidentQuickLinksCardProps = {
   } | null;
   warRoomUrl?: string | null;
   slackChannelName?: string | null;
-  status: string;
-  postmortemExists?: boolean;
   className?: string;
 };
 
@@ -43,12 +40,8 @@ export default function IncidentQuickLinksCard({
   service,
   team,
   warRoomUrl,
-  status,
-  postmortemExists,
   className,
 }: IncidentQuickLinksCardProps) {
-  const isResolved = status === 'RESOLVED';
-
   return (
     <div
       className={cn(
@@ -184,29 +177,6 @@ export default function IncidentQuickLinksCard({
             </div>
             <ExternalLink className="h-3.5 w-3.5 text-rose-500 opacity-75 group-hover:opacity-100 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all shrink-0 ml-2" />
           </a>
-        )}
-
-        {/* Postmortem (if resolved or exists) */}
-        {isResolved && (
-          <Link
-            href={`/postmortems/${incidentId}`}
-            className="group flex items-center justify-between p-2.5 rounded-lg border border-slate-100 dark:border-slate-800/80 bg-slate-50/40 dark:bg-slate-800/20 hover:bg-slate-100/80 dark:hover:bg-slate-800/70 hover:border-slate-200 dark:hover:border-slate-700 transition-all text-left"
-          >
-            <div className="flex items-center gap-2.5 min-w-0">
-              <div className="w-7 h-7 rounded-md bg-indigo-50 dark:bg-indigo-950/50 text-indigo-600 dark:text-indigo-400 flex items-center justify-center shrink-0">
-                <FileText className="h-3.5 w-3.5" />
-              </div>
-              <div className="min-w-0">
-                <p className="text-xs font-semibold text-slate-800 dark:text-slate-200 truncate group-hover:text-primary transition-colors">
-                  {postmortemExists ? 'View Postmortem' : 'Create Postmortem'}
-                </p>
-                <p className="text-[10px] text-slate-400 dark:text-slate-500 truncate">
-                  Root Cause Analysis &amp; Action Items
-                </p>
-              </div>
-            </div>
-            <ArrowUpRight className="h-3.5 w-3.5 text-slate-400 opacity-60 group-hover:opacity-100 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all shrink-0 ml-2" />
-          </Link>
         )}
       </div>
     </div>

--- a/tests/components/incident/IncidentQuickLinksCard.test.tsx
+++ b/tests/components/incident/IncidentQuickLinksCard.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import IncidentQuickLinksCard from '@/components/incident/detail/IncidentQuickLinksCard';
+
+describe('IncidentQuickLinksCard', () => {
+  const defaultProps = {
+    incidentId: 'inc-123',
+    service: {
+      id: 'srv-1',
+      name: 'Authentication API',
+      status: 'OPERATIONAL',
+      slaTier: 'Tier 1',
+      policy: {
+        id: 'pol-1',
+        name: 'Critical Escalation',
+      },
+    },
+    team: {
+      id: 'team-1',
+      name: 'Core Infra',
+    },
+    warRoomUrl: 'https://meet.jit.si/opsknight-warroom-123',
+  };
+
+  it('renders standard service, policy, analytics, team, and war room quick links', () => {
+    render(<IncidentQuickLinksCard {...defaultProps} />);
+
+    expect(screen.getByText('Quick Links')).toBeInTheDocument();
+    expect(screen.getByText('Authentication API')).toBeInTheDocument();
+    expect(screen.getByText('Critical Escalation')).toBeInTheDocument();
+    expect(screen.getByText('Incident Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Core Infra')).toBeInTheDocument();
+    expect(screen.getByText('Join War Room')).toBeInTheDocument();
+  });
+
+  it('does not render any duplicate postmortem link in the sidebar quick links', () => {
+    render(<IncidentQuickLinksCard {...defaultProps} />);
+
+    expect(screen.queryByText(/postmortem/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/root cause analysis/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary of Changes

Removes duplicate post-mortem actions and cards from the incident detail page's response rail sidebar to eliminate clutter and duplication.

### Background & Analysis
Post-mortem workflows are already prominently accessible on the incident detail page through three centralized locations:
1. **Top Resolution Card (`IncidentResolutionSummary`)**: Located directly beneath the command bar and description card, this banner prominently displays the post-mortem status badge and the 1-click View/Create Postmortem button when resolved.
2. **Command Bar (`IncidentCommandBar`)**: The collaboration and lifecycle action bar includes a direct `Postmortem` button when an incident is resolved.
3. **Interactive Postmortem Tab (`IncidentDetailTabs`)**: The primary content area provides a full tab for editing, auto-drafting, timeline review, root causes, and action item tracking.

Previously, the sidebar ALSO rendered:
- A standalone `<IncidentPostmortemCard>` in the response rail.
- A duplicate "View/Create Postmortem" link item inside `<IncidentQuickLinksCard>`.

### Changes Made
1. **`src/app/(app)/incidents/[id]/page.tsx`**:
   - Removed `<IncidentPostmortemCard>` from the response rail sidebar `<aside>`.
   - Removed unused `IncidentPostmortemCard` import.
   - Cleaned up unused `status` and `postmortemExists` props passed to `IncidentQuickLinksCard`.
2. **`src/components/incident/detail/IncidentQuickLinksCard.tsx`**:
   - Removed duplicate postmortem entry (`{isResolved && <Link href={/postmortems/...}>...}`) from the quick links resource list.
   - Removed unused `FileText` icon import and cleaned up `IncidentQuickLinksCardProps`.
3. **`tests/components/incident/IncidentQuickLinksCard.test.tsx`**:
   - Added unit test suite ensuring `IncidentQuickLinksCard` renders core operational links and guarantees zero duplicate postmortem links appear in the sidebar.

### Verification
- `tests/components/incident/IncidentQuickLinksCard.test.tsx`: **PASSED** (2/2)
- `tests/components/incident/CreateIncidentModal.test.tsx`: **PASSED** (11/11)
- `tests/components/incident/TemplatesListAndCreate.test.tsx`: **PASSED** (8/8)
- Full pre-push verification: All 315 test files and Next.js production build: **PASSED**