### PR TITLE
fix(auth): harden session and API key security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-change_this_to_a_random_secret_in_production}
+      API_KEY_SECRET: ${API_KEY_SECRET:-change_this_to_an_independent_api_key_secret_in_production}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08}
       NOTIFICATION_CONTROL_PLANE_PERSONAL: ${NOTIFICATION_CONTROL_PLANE_PERSONAL:-false}
       PROMETHEUS_SCRAPE_TOKEN: ${PROMETHEUS_SCRAPE_TOKEN:-}

--- a/docs/v1.5/api/README.md
+++ b/docs/v1.5/api/README.md
@@ -89,9 +89,30 @@ Common statuses are 400 invalid input, 401 invalid/missing key, 403 missing scop
 - Record request purpose and response status without logging tokens or sensitive payload data.
 - Test against a non-production service and verify resulting escalation/notifications before production rollout.
 
+## API-key hash secret
+
+`API_KEY_SECRET` is recommended for production and must differ from `NEXTAUTH_SECRET` when configured. It gives API-key lookup hashes independent key material from browser-session JWTs and decouples API-key hashes from ordinary session-secret rotation.
+
+For backward-compatible startup when `API_KEY_SECRET` is omitted, OpsKnight derives a domain-separated API-key root from `NEXTAUTH_SECRET` rather than using the session secret directly as the API-key HMAC key. This removes direct cryptographic key reuse, but API-key hashes still depend on the session secret's lifetime. Production operators should configure a separate `API_KEY_SECRET` when independent rotation is required.
+
+When upgrading from a release that hashed API keys directly from `NEXTAUTH_SECRET`, existing API keys do **not** need to be recreated. OpsKnight recognizes compatible legacy hashes and rewrites a matching stored hash under the current API-key hashing root after the key's next successful request.
+
+Generate independent secrets, for example:
+
+```bash
+openssl rand -base64 32  # NEXTAUTH_SECRET
+openssl rand -base64 32  # API_KEY_SECRET
+```
+
+Do not set both variables to the same value.
+
 ## Key rotation
 
-Create a replacement key, deploy it to consumers, confirm `lastUsedAt` moves on the replacement, then revoke the old key. If `API_KEY_SECRET` or its default `NEXTAUTH_SECRET` basis changes without a migration plan, stored key hashes can no longer be matched; rotate keys deliberately.
+To rotate a user-facing API key, create a replacement key, deploy it to consumers, confirm `lastUsedAt` moves on the replacement, then revoke the old key.
+
+For installations with an explicit `API_KEY_SECRET`, session-secret rotation does not change the primary API-key hash basis. Rotating `API_KEY_SECRET` itself still requires a planned API-key migration or key replacement; the compatibility lookup in this release is specifically for historical hashes written from the previous session-secret basis, not a general multi-secret keyring.
+
+If `API_KEY_SECRET` is omitted, changing `NEXTAUTH_SECRET` changes the derived API-key hash root. Configure an independent `API_KEY_SECRET` before planning session-secret rotation when preserving API-key continuity matters.
 
 ## Related topics
 

--- a/docs/v1.5/getting-started/configuration.md
+++ b/docs/v1.5/getting-started/configuration.md
@@ -16,13 +16,13 @@ cp env.example .env
 
 ## Required Variables
 
-These variables must be set for OpsKnight to start correctly in any environment.
+These variables must be set for OpsKnight to start correctly in production.
 
-| Variable          | Description                                    | Example / How to Generate             |
-| ----------------- | ---------------------------------------------- | ------------------------------------- |
-| `DATABASE_URL`    | PostgreSQL connection string                   | `postgresql://user:pass@host:5432/db` |
-| `NEXTAUTH_URL`    | Public-facing URL of the application           | `https://ops.yourcompany.com`         |
-| `NEXTAUTH_SECRET` | Secret used to sign and encrypt session tokens | `openssl rand -base64 32`             |
+| Variable          | Description                          | Example / How to Generate             |
+| ----------------- | ------------------------------------ | ------------------------------------- |
+| `DATABASE_URL`    | PostgreSQL connection string         | `postgresql://user:pass@host:5432/db` |
+| `NEXTAUTH_URL`    | Public-facing URL of the application | `https://ops.yourcompany.com`         |
+| `NEXTAUTH_SECRET` | Secret for session JWTs              | `openssl rand -base64 32`             |
 
 > **`NEXTAUTH_URL`** must match the exact base URL your users will access, including the scheme (`https://`). Mismatches cause OAuth callback failures.
 
@@ -34,6 +34,7 @@ These variables must be set for OpsKnight to start correctly in any environment.
 | --------------------------- | :--------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ENCRYPTION_KEYS`           |      Recommended       | Rotation keyring in `key-id:64-hex-key` entries. The first key encrypts new values; remaining keys decrypt older v3/legacy values.                                                                                             |
 | `ENCRYPTION_KEY`            |   Yes if no keyring    | Single 32-byte hex key used for compatibility and as an optional legacy key alongside `ENCRYPTION_KEYS`. API keys are keyed hashes and are not encrypted with this key.                                                        |
+| `API_KEY_SECRET`            |      Recommended       | Independent HMAC secret for API-key lookup hashes. Must differ from `NEXTAUTH_SECRET` when set. If omitted, OpsKnight derives a domain-separated API-key root from the session secret for backward-compatible startup.          |
 
 The notification control plane derives recipient identities from the existing `NEXTAUTH_SECRET`.
 It uses the active encryption key only for compatibility if no session secret is available. No
@@ -65,13 +66,21 @@ See [Encryption](../security/encryption) for key rotation, migration guidance, a
 
 ## Authentication
 
-| Variable          | Required | Description                                   | Generate With             |
-| ----------------- | :------: | --------------------------------------------- | ------------------------- |
-| `NEXTAUTH_SECRET` |   Yes    | Secret for signing session JWTs               | `openssl rand -base64 32` |
-| `NEXTAUTH_URL`    |   Yes    | Base URL for OAuth callbacks and redirects    | Your public domain        |
-| `ENCRYPTION_KEY`  |  Yes\*   | Master key for encrypting integration secrets | `openssl rand -hex 32`    |
+| Variable                  | Required | Description                                                                                           | Generate With             |
+| ------------------------- | :------: | ----------------------------------------------------------------------------------------------------- | ------------------------- |
+| `NEXTAUTH_SECRET`         |   Yes    | Secret for signing/encrypting session JWTs                                                            | `openssl rand -base64 32` |
+| `API_KEY_SECRET`          |    No    | Recommended independent API-key HMAC secret; must differ from `NEXTAUTH_SECRET` when configured       | `openssl rand -base64 32` |
+| `NEXTAUTH_URL`            |   Yes    | Base URL for OAuth callbacks and redirects                                                            | Your public domain        |
+| `ENCRYPTION_KEY`          |  Yes\*   | Master key for encrypting integration secrets                                                         | `openssl rand -hex 32`    |
+| `JWT_USER_REFRESH_TTL_MS` |    No    | Maximum cached user-authority age for JWT refresh checks                                              | Default `15000`           |
 
 \*Required in production; auto-fallback available in development.
+
+The default JWT authority refresh interval is **15 seconds**. Disabling a user, deleting an account, or incrementing `tokenVersion` is therefore observed on the next authoritative refresh after at most roughly that cache window for an active client. Setting `JWT_USER_REFRESH_TTL_MS=0` forces a database authority lookup on every applicable JWT callback; do this only if the extra database load is acceptable.
+
+If an authority refresh fails because the database is temporarily unavailable, OpsKnight does not advance the refresh timestamp. The next request retries the authoritative lookup instead of extending the stale cache window.
+
+When `API_KEY_SECRET` is omitted, OpsKnight derives a domain-separated API-key root from `NEXTAUTH_SECRET`. This avoids using the session secret directly as an API-key HMAC key, but the derived root still changes when the session secret changes. Configure an independent `API_KEY_SECRET` to decouple API-key hashes from session-secret rotation.
 
 ---
 
@@ -134,7 +143,7 @@ Set the public and private variables together. The database-backed Web Push prov
 
 | Variable                                  | Default                    | Description                                                                                                                                               |
 | ----------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LOG_LEVEL`                               | `info`                     | Minimum structured-log level: `debug`, `info`, `warn`, or `error`.                                                                                        |
+| `LOG_LEVEL`                               | `info`                     | Minimum structured-log level: `debug`, `info`, `warn`, or `error`. Authentication diagnostic traces are emitted at `debug`, not `warn`.                  |
 | `LOG_FORMAT`                              | Environment dependent      | Set to `json` for JSON output.                                                                                                                            |
 | `LOG_BUFFER_MAX`                          | `500`                      | Maximum in-memory log-buffer size.                                                                                                                        |
 | `SENTRY_DSN`                              | —                          | Requests optional Sentry initialization when a custom build includes `@sentry/nextjs`; the standard v1.4 dependency set does not.                         |
@@ -156,27 +165,28 @@ OpenTelemetry variables are not consumed by the v1.4 application code and are th
 | `INTEGRATION_VERIFY_SIGNATURES`  | `true`       | Set to `false` to disable signature checks on handlers that honor this flag. Use only for controlled diagnosis.                           |
 | `CORS_ALLOWED_ORIGINS`           | empty        | Comma-separated origins allowed by middleware for cross-origin API requests.                                                              |
 | `STATUS_PAGE_DOMAIN_CACHE_TTL`   | `60`         | Custom-status-domain middleware cache TTL in seconds.                                                                                     |
-| `EVENT_TRANSACTION_MAX_ATTEMPTS` | code default | Advanced transaction retry limit; tune only after reviewing database contention.                                                          |
+| `EVENT_TRANSACTION_MAX_ATTEMPTS` | code default | Advanced transaction retry limit; tune only after reviewing database contention.                                                         |
 | `ESCALATION_LOCK_TIMEOUT_MS`     | code default | Advanced escalation lock timeout in milliseconds.                                                                                         |
-| `SKIP_ENV_VALIDATION`            | unset        | Bypasses production environment validation. Use only for controlled build/diagnostic workflows.                                           |
+| `SKIP_ENV_VALIDATION`            | unset        | Bypasses production validation only for explicit enabled values (`true`, `1`, `yes`, or `on`). Use only for controlled diagnostics.      |
 | `DISABLE_PWA`                    | `false`      | Set to `true` at build time to disable production service-worker generation, PWA installation, push, and supported offline behavior.      |
 | `EMAIL_FROM`                     | derived      | Fallback sender address when code paths do not receive a provider-specific From address; prefer an explicitly verified provider identity. |
 | `MIGRATION_RECOVERY_MODE`        | `safe`       | Startup recovery policy. Do not use `aggressive` without database-owner review of the failed migration and actual schema state.           |
 
 ## Authentication and integration overrides
 
-| Variable                                                       | Purpose                                                                                                           |
-| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `AUTH_TRUST_HOST`                                              | Explicitly enables Auth.js host trust; setting `NEXTAUTH_URL` also enables it.                                    |
-| `TRUSTED_PROXY_HOPS`                                           | Number of trusted proxy entries read from the right side of `X-Forwarded-For`; defaults to `1`.                   |
-| `OIDC_REQUIRE_EMAIL_VERIFIED_STRICT`                           | Requires a verified-email claim from OIDC; defaults to `true`. Set `false` only after IdP-specific risk review.   |
-| `OIDC_CONFIG_CACHE_TTL_MS`, `OIDC_CONFIG_RECORD_CACHE_TTL_MS`  | Advanced OIDC cache TTLs.                                                                                         |
-| `AUTH_OPTIONS_CACHE_TTL_MS`, `JWT_USER_REFRESH_TTL_MS`         | Advanced authentication/session cache timing.                                                                     |
-| `API_KEY_SECRET`                                               | Overrides the secret used to hash API keys; otherwise `NEXTAUTH_SECRET` is used. Back up and rotate deliberately. |
-| `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_REDIRECT_URI` | Slack OAuth fallback values when equivalent stored settings are absent.                                           |
-| `SLACK_SIGNING_SECRET`                                         | Slack request-signature fallback/override.                                                                        |
-| `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL`                         | Legacy Slack sender fallbacks; prefer the encrypted Slack configuration UI.                                       |
-| `SLA_ALERT_EMAIL`                                              | Fallback recipient for configured SLA-breach email alerts.                                                        |
+| Variable                                                       | Purpose                                                                                                                                                          |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_TRUST_HOST`                                              | Explicitly enables Auth.js host trust; setting `NEXTAUTH_URL` also enables it.                                                                                   |
+| `TRUSTED_PROXY_HOPS`                                           | Number of trusted proxy entries read from the right side of `X-Forwarded-For`; defaults to `1`.                                                                  |
+| `OIDC_REQUIRE_EMAIL_VERIFIED_STRICT`                           | Requires a verified-email claim from OIDC; defaults to `true`. Set `false` only after IdP-specific risk review.                                                  |
+| `OIDC_CONFIG_CACHE_TTL_MS`, `OIDC_CONFIG_RECORD_CACHE_TTL_MS`  | Advanced OIDC cache TTLs.                                                                                                                                        |
+| `AUTH_OPTIONS_CACHE_TTL_MS`                                    | Advanced auth-options cache timing.                                                                                                                              |
+| `JWT_USER_REFRESH_TTL_MS`                                      | User/status/role/token-version refresh cache; defaults to `15000` ms. Lower values reduce revocation delay but increase DB reads.                               |
+| `API_KEY_SECRET`                                               | Recommended independent API-key HMAC secret. If omitted, a domain-separated key is derived from `NEXTAUTH_SECRET`; identical explicit values are rejected.       |
+| `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_REDIRECT_URI` | Slack OAuth fallback values when equivalent stored settings are absent.                                                                                          |
+| `SLACK_SIGNING_SECRET`                                         | Slack request-signature fallback/override.                                                                                                                       |
+| `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL`                         | Legacy Slack sender fallbacks; prefer the encrypted Slack configuration UI.                                                                                      |
+| `SLA_ALERT_EMAIL`                                              | Fallback recipient for configured SLA-breach email alerts.                                                                                                       |
 
 ---
 
@@ -192,12 +202,18 @@ DATABASE_URL=postgresql://opsknight:your_secure_password@db-host:5432/opsknight_
 NEXTAUTH_URL=https://ops.yourcompany.com
 NEXTAUTH_SECRET=<output of: openssl rand -base64 32>
 
+# --- Recommended API-key secret (independent from NEXTAUTH_SECRET) ---
+API_KEY_SECRET=<separate output of: openssl rand -base64 32>
+
 # --- Encryption (required in production) ---
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=<your-64-char-hex-key>
 
 # --- Application URL ---
 NEXT_PUBLIC_APP_URL=https://ops.yourcompany.com
+
+# Optional: default is 15 seconds.
+# JWT_USER_REFRESH_TTL_MS=15000
 
 # Configure notification-provider credentials in the application UI.
 ```
@@ -213,7 +229,8 @@ NEXT_PUBLIC_APP_URL=https://ops.yourcompany.com
 
 DATABASE_URL=postgresql://opsknight:opsknight@localhost:5432/opsknight_db
 NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=dev-secret-not-for-production
+NEXTAUTH_SECRET=dev-session-secret-not-for-production
+API_KEY_SECRET=dev-api-key-secret-not-for-production
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # ENCRYPTION_KEY is intentionally omitted in development.
@@ -225,9 +242,11 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 ## Configuration Tips
 
 - **Secrets management**: Use AWS Secrets Manager, HashiCorp Vault, or GCP Secret Manager in production. Never commit secrets to source control.
-- **Per-environment isolation**: Use distinct values for `NEXTAUTH_SECRET` and `ENCRYPTION_KEY` across dev, staging, and production.
-- **Rotation**: Rotate `NEXTAUTH_SECRET` (invalidates all sessions) and `ENCRYPTION_KEY` (requires data re-encryption) on a regular cadence or after a suspected compromise.
-- **Validation**: OpsKnight validates `ENCRYPTION_KEY` format on startup. If it is set but malformed (not a 64-char hex string), encryption is disabled and an error is logged.
+- **Cryptographic separation**: Prefer independent `NEXTAUTH_SECRET`, `API_KEY_SECRET`, and `ENCRYPTION_KEY` values. If `API_KEY_SECRET` is omitted, OpsKnight still derives a domain-separated API-key key instead of directly reusing session key material.
+- **Per-environment isolation**: Use distinct values across dev, staging, and production.
+- **API-key upgrade migration**: Existing keys created from the historical direct session-secret basis migrate automatically on successful use. If you omit `API_KEY_SECRET`, plan session-secret rotation carefully because the derived API-key root changes with it.
+- **Rotation**: Rotating `NEXTAUTH_SECRET` invalidates all sessions. `ENCRYPTION_KEY` rotation requires the documented keyring/re-encryption process. With an explicit `API_KEY_SECRET`, session-secret rotation no longer changes the primary API-key hash basis.
+- **Validation**: Production startup rejects an explicitly configured `API_KEY_SECRET` that equals `NEXTAUTH_SECRET`. `SKIP_ENV_VALIDATION=false` does not bypass validation.
 
 ---
 
@@ -236,5 +255,6 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 - [Installation Guide](./installation) — Get OpsKnight running
 - [Encryption](../security/encryption) — Key management and rotation
 - [Authentication](../administration/authentication) — OIDC SSO configuration
+- [API Reference](../api/README) — API-key handling and migration
 - [Deployment: Docker](../deployment/docker) — Docker-specific configuration
 - [Deployment: Kubernetes](../deployment/kubernetes) — Kubernetes secrets and ConfigMaps

--- a/env.example
+++ b/env.example
@@ -27,8 +27,20 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Keep 1 for a single ingress/load balancer; raise only for known internal hops.
 TRUSTED_PROXY_HOPS=1
 
-# Generate with: openssl rand -base64 32
+# Session JWT signing/encryption secret. Generate with: openssl rand -base64 32
 NEXTAUTH_SECRET=changeme_to_a_secure_random_string
+
+# Recommended independent API-key HMAC secret. It MUST differ from
+# NEXTAUTH_SECRET when set. If omitted, OpsKnight derives a domain-separated
+# API-key root from NEXTAUTH_SECRET for backward-compatible startup, but API-key
+# hashes then remain coupled to session-secret rotation.
+# Generate with: openssl rand -base64 32
+API_KEY_SECRET=changeme_to_another_secure_random_string
+
+# Optional authoritative user/session refresh window. Lower values make user
+# disable/session revocation take effect sooner at the cost of more DB reads.
+# Default: 15000 (15 seconds)
+# JWT_USER_REFRESH_TTL_MS=15000
 
 # ----------------------------------------------
 # 3. ENCRYPTION (REQUIRED IN PRODUCTION)

--- a/helm/opsknight/templates/deployment.yaml
+++ b/helm/opsknight/templates/deployment.yaml
@@ -62,6 +62,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "opsknight.secretName" . }}
                   key: {{ .Values.secrets.keys.nextauthSecret }}
+            - name: API_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opsknight.secretName" . }}
+                  key: {{ .Values.secrets.keys.apiKeySecret }}
+                  optional: true
             - name: ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/opsknight/templates/secret.yaml
+++ b/helm/opsknight/templates/secret.yaml
@@ -9,6 +9,7 @@ type: Opaque
 data:
   {{ .Values.secrets.keys.databaseUrl }}: {{ include "opsknight.databaseUrl" . | b64enc | quote }}
   {{ .Values.secrets.keys.nextauthSecret }}: {{ .Values.secrets.nextauthSecret | b64enc | quote }}
+  {{ .Values.secrets.keys.apiKeySecret }}: {{ .Values.secrets.apiKeySecret | b64enc | quote }}
   {{ .Values.secrets.keys.encryptionKey }}: {{ .Values.secrets.encryptionKey | b64enc | quote }}
   {{ .Values.secrets.keys.postgresUser }}: {{ .Values.postgresql.username | b64enc | quote }}
   {{ .Values.secrets.keys.postgresPassword }}: {{ .Values.postgresql.password | b64enc | quote }}

--- a/helm/opsknight/values.yaml
+++ b/helm/opsknight/values.yaml
@@ -129,10 +129,12 @@ secrets:
   keys:
     databaseUrl: DATABASE_URL
     nextauthSecret: NEXTAUTH_SECRET
+    apiKeySecret: API_KEY_SECRET
     encryptionKey: ENCRYPTION_KEY
     postgresUser: POSTGRES_USER
     postgresPassword: POSTGRES_PASSWORD
   nextauthSecret: 'change_this_to_a_random_secret_in_production'
+  apiKeySecret: 'change_this_to_an_independent_api_key_secret_in_production'
   encryptionKey: '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'
 
 networkPolicy:

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -20,6 +20,11 @@ data:
   # checkov:skip=CKV_SECRET_6: This is a default placeholder secret
   NEXTAUTH_SECRET: Y2hhbmdlX3RoaXNfdG9fYV9yYW5kb21fc2VjcmV0X2luX3Byb2R1Y3Rpb24=
 
+  # API-key HMAC secret - must be independent from NEXTAUTH_SECRET in production.
+  # Default: change_this_to_an_independent_api_key_secret_in_production
+  # checkov:skip=CKV_SECRET_6: This is a default placeholder secret
+  API_KEY_SECRET: Y2hhbmdlX3RoaXNfdG9fYW5faW5kZXBlbmRlbnRfYXBpX2tleV9zZWNyZXRfaW5fcHJvZHVjdGlvbg==
+
   # Encryption Key - Mandatory in production. Must be exactly 64 hex characters (32 bytes).
   # Below is a base64-encoded placeholder of '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'
   # checkov:skip=CKV_SECRET_6: This is a default placeholder secret
@@ -30,6 +35,7 @@ data:
 # echo -n 'your-username' | base64
 # echo -n 'your-password' | base64
 # echo -n 'your-nextauth-secret' | base64
+# echo -n 'your-api-key-secret' | base64
 # echo -n 'your-64-char-hex-encryption-key' | base64
 #
 # Or use kubectl:
@@ -37,6 +43,7 @@ data:
 #   --from-literal=POSTGRES_USER=opsknight \
 #   --from-literal=POSTGRES_PASSWORD=your-secure-password \
 #   --from-literal=NEXTAUTH_SECRET=your-nextauth-secret \
+#   --from-literal=API_KEY_SECRET=your-independent-api-key-secret \
 #   --from-literal=ENCRYPTION_KEY=your-64-char-hex-encryption-key \
 #   -n opsknight
 #

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
-import { hashLegacyScryptToken, hashTokenV2 } from '@/lib/api-keys';
+import { hashLegacyScryptTokens, hashLegacyV2Tokens, hashTokenV2 } from '@/lib/api-keys';
 
 function extractApiKey(req: NextRequest) {
   const header = req.headers.get('authorization') || '';
@@ -28,27 +28,39 @@ export async function authenticateApiKey(req: NextRequest) {
     where: { tokenHash: v2Hash, ...activeFilter },
   });
 
-  // Lazy migration: Check legacy hash if V2 not found
+  // Lazy migration: releases before API_KEY_SECRET became a production
+  // boundary could write V2 HMACs directly from NEXTAUTH_SECRET. Accept those
+  // hashes once and immediately migrate them to the current API-key secret.
   if (!apiKey) {
-    const v1Hash = await hashLegacyScryptToken(token);
-    apiKey = await prisma.apiKey.findFirst({
-      where: { tokenHash: v1Hash, ...activeFilter },
-    });
-
-    if (apiKey) {
-      // Found with legacy hash - migrate to secure HMAC hash immediately
-      await prisma.apiKey.update({
-        where: { id: apiKey.id },
-        data: {
-          tokenHash: v2Hash,
-          lastUsedAt: new Date(),
-        },
+    const legacyV2Hashes = hashLegacyV2Tokens(token);
+    if (legacyV2Hashes.length > 0) {
+      apiKey = await prisma.apiKey.findFirst({
+        where: { tokenHash: { in: legacyV2Hashes }, ...activeFilter },
       });
-      return apiKey;
     }
   }
 
+  // Older releases used scrypt for lookup hashes. Check every compatible
+  // historical secret basis, then migrate successful matches to V2 HMAC.
+  if (!apiKey) {
+    const legacyScryptHashes = await hashLegacyScryptTokens(token);
+    apiKey = await prisma.apiKey.findFirst({
+      where: { tokenHash: { in: legacyScryptHashes }, ...activeFilter },
+    });
+  }
+
   if (!apiKey) return null;
+
+  if (apiKey.tokenHash !== v2Hash) {
+    await prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: {
+        tokenHash: v2Hash,
+        lastUsedAt: new Date(),
+      },
+    });
+    return apiKey;
+  }
 
   await prisma.apiKey.updateMany({
     where: {

--- a/src/lib/api-keys.ts
+++ b/src/lib/api-keys.ts
@@ -2,8 +2,43 @@ import { createHmac, randomBytes, scrypt } from 'crypto';
 import { promisify } from 'util';
 import { getNextAuthSecretSync } from './secret-manager';
 
-function getDefaultSecret(): string {
-  return process.env.API_KEY_SECRET || getNextAuthSecretSync();
+const API_KEY_SECRET_DERIVATION_CONTEXT = 'opsknight:api-key:root:v1';
+
+function getConfiguredApiKeySecret(): string | null {
+  const value = process.env.API_KEY_SECRET;
+  return value && value.length > 0 ? value : null;
+}
+
+function getSessionSecret(): string {
+  return getNextAuthSecretSync();
+}
+
+/**
+ * Keep API-key hashing in a cryptographic domain separate from session JWTs.
+ * Operators can provide an independent API_KEY_SECRET; otherwise derive a
+ * dedicated key from NEXTAUTH_SECRET instead of using the session secret
+ * directly as the HMAC key.
+ */
+function getPrimaryApiKeySecret(): string {
+  const configured = getConfiguredApiKeySecret();
+  if (configured) return configured;
+
+  return createHmac('sha256', getSessionSecret())
+    .update(API_KEY_SECRET_DERIVATION_CONTEXT)
+    .digest('hex');
+}
+
+/**
+ * Hashing secrets used by older releases. These are lookup-only and allow
+ * successful requests to migrate stored hashes to the current V2 key without
+ * forcing an immediate API-key rotation during upgrade.
+ */
+function getLegacyLookupSecrets(): string[] {
+  return [...new Set([getConfiguredApiKeySecret(), getSessionSecret()].filter(Boolean) as string[])];
+}
+
+function hashV2WithSecret(token: string, secret: string): string {
+  return createHmac('sha256', secret).update(`opsknight:api-key:v2:${token}`).digest('hex');
 }
 
 export function generateApiKey() {
@@ -22,8 +57,9 @@ export function generateApiKey() {
  * legacy identifier without performing expensive password hashing.
  */
 export function hashTokenV1(token: string) {
-  const secret = getDefaultSecret();
-  return createHmac('sha256', secret).update(`opsknight:api-key:v1:${token}`).digest('hex');
+  return createHmac('sha256', getPrimaryApiKeySecret())
+    .update(`opsknight:api-key:v1:${token}`)
+    .digest('hex');
 }
 
 /**
@@ -31,20 +67,49 @@ export function hashTokenV1(token: string) {
  * password KDF adds event-loop pressure without improving brute-force safety.
  */
 export function hashTokenV2(token: string) {
-  const secret = getDefaultSecret();
   // API keys contain 256 random bits and are not user passwords. A keyed,
   // domain-separated lookup hash prevents offline guessing without imposing a
   // password-KDF cost on every authenticated API request.
   // lgtm[js/insufficient-password-hash]
-  return createHmac('sha256', secret).update(`opsknight:api-key:v2:${token}`).digest('hex');
+  return hashV2WithSecret(token, getPrimaryApiKeySecret());
+}
+
+/**
+ * V2 hashes written before API-key/session-secret domain separation. The
+ * current primary hash is excluded so callers only perform compatibility work
+ * when there is a genuinely different legacy representation to check.
+ */
+export function hashLegacyV2Tokens(token: string): string[] {
+  const current = hashTokenV2(token);
+  return [
+    ...new Set(
+      getLegacyLookupSecrets()
+        .map(secret => hashV2WithSecret(token, secret))
+        .filter(hash => hash !== current)
+    ),
+  ];
 }
 
 const scryptAsync = promisify(scrypt);
 
-/** Compute hashes written by releases that used synchronous scrypt. */
-export async function hashLegacyScryptToken(token: string): Promise<string> {
-  const derived = (await scryptAsync(token, getDefaultSecret(), 32)) as Buffer;
+async function hashScryptWithSecret(token: string, secret: string): Promise<string> {
+  const derived = (await scryptAsync(token, secret, 32)) as Buffer;
   return derived.toString('hex');
+}
+
+/** Compute all hashes written by releases that used synchronous scrypt. */
+export async function hashLegacyScryptTokens(token: string): Promise<string[]> {
+  return Promise.all(getLegacyLookupSecrets().map(secret => hashScryptWithSecret(token, secret)));
+}
+
+/**
+ * Backward-compatible single-hash helper retained for older callers/tests.
+ * New authentication code should check hashLegacyScryptTokens().
+ */
+export async function hashLegacyScryptToken(token: string): Promise<string> {
+  const [hash] = await hashLegacyScryptTokens(token);
+  if (!hash) throw new Error('No API-key lookup secret is available');
+  return hash;
 }
 
 export const hashToken = hashTokenV2;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,9 +18,9 @@ import {
 } from '@/lib/auth-cookies';
 
 function getJwtUserRefreshTtlMs() {
-  const raw = process.env.JWT_USER_REFRESH_TTL_MS ?? '60000';
+  const raw = process.env.JWT_USER_REFRESH_TTL_MS ?? '15000';
   const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 60000;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 15000;
 }
 
 import type { JWT } from 'next-auth/jwt';
@@ -125,7 +125,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
     //   - Web with "Remember Me" gets the long ceiling.
     //   - The only way to log a user out is server-side revocation:
     //     `tokenVersion` is bumped (user disabled, password reset,
-    //     deletion) and the next JWT callback rejects the stale token.
+    //     deletion) and the next authoritative JWT refresh rejects the stale token.
     const sessionMaxAgeSeconds = 60 * 60 * 24 * 7; // 7 days (web, no Remember Me)
     const rememberMeMaxAgeSeconds = 60 * 60 * 24 * 365; // 1 year (web + RM, all mobile)
     const sessionUpdateAgeSeconds = 60 * 60; // sliding refresh at most hourly
@@ -144,7 +144,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
 
     return {
       // No adapter - using pure JWT sessions (industry standard for OIDC)
-      // Session cap is `rememberMeMaxAgeSeconds` (30 days) so a
+      // Session cap is `rememberMeMaxAgeSeconds` (1 year) so a
       // remember-me JWT can outlive 7 days. Non-remember-me sessions
       // are still pinned to 7 days via the JWT's own `exp` set in the
       // jwt callback below — NextAuth respects whichever is shorter.
@@ -263,7 +263,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             const ip = getClientIp(req?.headers);
             const userAgent = userAgentHeader || 'Unknown';
 
-            logger.warn('[Auth-Debug] Authorize started', {
+            logger.debug('[Auth-Debug] Authorize started', {
               component: 'auth:credentials',
               email,
               ip,
@@ -317,7 +317,8 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 'ACCOUNT_LOCKED',
                 attemptCheck.lockoutDurationMs || undefined
               );
-              console.warn('[Auth] Login blocked - account locked', {
+              logger.warn('[Auth] Login blocked - account locked', {
+                component: 'auth:credentials',
                 email,
                 ip,
                 lockedUntil: attemptCheck.lockedUntil?.toISOString(),
@@ -329,7 +330,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             if (!user || !user.passwordHash) {
               recordFailedAttempt(email, ip);
               await logLoginFailed(email, ip, userAgent, 'USER_NOT_FOUND');
-              logger.warn('[Auth-Debug] User not found or no password hash', {
+              logger.debug('[Auth-Debug] User not found or no password hash', {
                 component: 'auth:credentials',
                 email,
               });
@@ -354,13 +355,14 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               );
 
               if (result.locked) {
-                console.warn('[Auth] Account locked after failed attempts', {
+                logger.warn('[Auth] Account locked after failed attempts', {
+                  component: 'auth:credentials',
                   email,
                   attemptCount: result.attemptCount,
                   lockoutDurationMs: result.lockoutDurationMs,
                 });
               }
-              logger.warn('[Auth-Debug] Invalid Password', {
+              logger.debug('[Auth-Debug] Invalid Password', {
                 component: 'auth:credentials',
                 email,
               });
@@ -371,7 +373,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             resetLoginAttempts(email, ip);
             await logLoginSuccess(email, user.id, ip, userAgent, 'credentials');
 
-            // Log remember me usage (Note: extending session maxAge dynamically requires JWT callback changes)
             if (rememberMe) {
               logger.debug('[Auth] User requested "Remember Me"', { email });
             }
@@ -388,7 +389,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               });
             }
 
-            logger.warn('[Auth-Debug] Authorize Success', {
+            logger.debug('[Auth-Debug] Authorize Success', {
               component: 'auth:credentials',
               id: user.id,
               tokenVersion: user.tokenVersion,
@@ -396,7 +397,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
 
             // Stash the rememberMe flag onto the user object so the
             // jwt callback can pick it up and cap the JWT exp at the
-            // appropriate value (7d default, 30d when set).
+            // appropriate value (7d default, 1y when set).
             return {
               id: user.id,
               name: user.name,
@@ -414,8 +415,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
       },
       callbacks: {
         async jwt({ token, user, account, trigger, session: _session }) {
-          // Debug: Log incoming token state
-          logger.warn('[Auth-Debug] JWT callback started', {
+          logger.debug('[Auth-Debug] JWT callback started', {
             component: 'auth:jwt',
             hasSub: !!token.sub,
             sub: token.sub,
@@ -425,12 +425,11 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           // Initial sign in
           if (user && account) {
             delete (token as AugmentedJWT).error;
-            logger.warn('[Auth-Debug] Initial Sign In', {
+            logger.debug('[Auth-Debug] Initial Sign In', {
               component: 'auth:jwt',
               userId: user.id,
               provider: account.provider,
             });
-            // ... (keep existing initial sign-in logic)
             // For OIDC, we must look up the user in the DB to get the internal CUID and current role
             // The 'user' object from OIDC is just the profile, so 'user.id' is the OIDC 'sub' (not our DB ID)
             if (account.provider === 'oidc' && user.email) {
@@ -458,20 +457,20 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                   token.role = dbUser.role;
                   token.name = dbUser.name;
                   token.email = dbUser.email;
-                  // Include tokenVersion so we can revoke sessions later
                   (token as AugmentedJWT).tokenVersion = dbUser.tokenVersion ?? 0;
                 } else {
-                  // This should technically not happen if signIn passed, but just in case
-                  logger.error('[Auth] JWT callback - OIDC user not found in DB', {
+                  logger.warn('[Auth] JWT callback - OIDC user not found in DB', {
                     component: 'auth:jwt',
                     email: user.email,
                   });
+                  return clearSessionToken(token as AugmentedJWT, 'USER_NOT_FOUND');
                 }
               } catch (error) {
                 logger.error('[Auth] JWT callback - DB lookup failed', {
                   component: 'auth:jwt',
                   error,
                 });
+                return clearSessionToken(token as AugmentedJWT, 'AUTHORITY_LOOKUP_FAILED');
               }
             } else {
               // For Credentials, 'user' comes from authorize() and is already the DB user object
@@ -484,22 +483,12 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               (token as AugmentedJWT).rememberMe = (user as AugmentedUser).rememberMe === true;
             }
 
-            // Pick the JWT exp cap based on rememberMe. The session
-            // cookie itself uses the 30-day NextAuth maxAge so the
-            // browser will hold either token; the JWT's own `exp`
-            // claim is what makes verification fail at 7 days for
-            // non-remember-me sessions.
             const remember = (token as AugmentedJWT).rememberMe === true;
             const ttlSeconds = remember ? rememberMeMaxAgeSeconds : sessionMaxAgeSeconds;
             token.exp = Math.floor(Date.now() / 1000) + ttlSeconds;
-          }
-          // The user provided in the jwt callback is the one returned by the `authorize` function
-          // or the OIDC provider. We need to ensure `token.sub` is set to our internal user ID
-          // and `token.role` is set correctly.
-          // This block handles the initial population of the token from the `user` object.
-          else if (user) {
+          } else if (user) {
             delete (token as AugmentedJWT).error;
-            logger.warn('[Auth-Debug] Initial Sign In (Fallback)', {
+            logger.debug('[Auth-Debug] Initial Sign In (Fallback)', {
               component: 'auth:jwt',
               userId: user.id || (user as AugmentedUser).id,
             });
@@ -510,26 +499,15 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             (token as AugmentedJWT).tokenVersion = (user as AugmentedUser).tokenVersion ?? 0;
           }
 
-          // Handle client-side update() calls
-          // If trigger is "update", we can accept partial updates from the client if needed,
-          // OR simply force a refresh (which is safer/better).
-          // We'll treat trigger="update" as a signal to bypass cache.
-          if (trigger === 'update') {
-            // ...
-          }
+          // trigger="update" is treated as a signal to bypass the authority cache.
 
-          // Fetch latest user data from database on each request to ensure name is up-to-date
-          // This ensures name changes reflect immediately without requiring re-login
           if (token.sub && typeof token.sub === 'string') {
-            // Session revocation: if the user increments tokenVersion, older JWTs are invalid.
-            // Session revocation: if the user increments tokenVersion, older JWTs are invalid.
             const currentTokenVersion = (token as AugmentedJWT).tokenVersion;
             const lastFetchedAt = (token as AugmentedJWT).userFetchedAt;
             const ttlMs = getJwtUserRefreshTtlMs();
 
-            // Skip DB fetch if cached AND NOT forced by update trigger
             if (trigger !== 'update' && lastFetchedAt && Date.now() - lastFetchedAt < ttlMs) {
-              // Cached
+              // Cached authority state is still inside the configured refresh window.
             } else {
               try {
                 const dbUser = await prisma.user.findUnique({
@@ -545,58 +523,64 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                   },
                 });
 
-                if (dbUser) {
-                  const dbTokenVersion =
-                    typeof dbUser.tokenVersion === 'number' ? dbUser.tokenVersion : 0;
-                  logger.warn('[Auth-Debug] User Check', {
+                if (!dbUser) {
+                  logger.warn('[Auth] Revoking session because user no longer exists', {
                     component: 'auth:jwt',
-                    dbId: token.sub,
-                    dbVer: dbTokenVersion,
-                    tokenVer: currentTokenVersion,
+                    userId: token.sub,
                   });
-
-                  // If disabled, force logout.
-                  if (dbUser.status === 'DISABLED') {
-                    return clearSessionToken(token as AugmentedJWT, 'USER_DISABLED');
-                  }
-
-                  if (
-                    typeof currentTokenVersion === 'number' &&
-                    dbTokenVersion !== currentTokenVersion
-                  ) {
-                    logger.warn('[Auth-Debug] REVOKING SESSION: Version Mismatch', {
-                      component: 'auth:jwt',
-                      db: dbTokenVersion,
-                      token: currentTokenVersion,
-                    });
-                    return clearSessionToken(token as AugmentedJWT, 'SESSION_REVOKED');
-                  }
-
-                  token.name = dbUser.name;
-                  token.email = dbUser.email;
-                  token.role = dbUser.role;
-                  token.avatarUrl = dbUser.avatarUrl;
-                  token.gender = dbUser.gender;
-                  (token as AugmentedJWT).tokenVersion = dbTokenVersion;
-                } else {
-                  logger.warn('[Auth-Debug] User NOT FOUND in DB', {
-                    component: 'auth:jwt',
-                    id: token.sub,
-                  });
+                  return clearSessionToken(token as AugmentedJWT, 'USER_NOT_FOUND');
                 }
+
+                const dbTokenVersion =
+                  typeof dbUser.tokenVersion === 'number' ? dbUser.tokenVersion : 0;
+                logger.debug('[Auth-Debug] User Check', {
+                  component: 'auth:jwt',
+                  dbId: token.sub,
+                  dbVer: dbTokenVersion,
+                  tokenVer: currentTokenVersion,
+                });
+
+                if (dbUser.status === 'DISABLED') {
+                  return clearSessionToken(token as AugmentedJWT, 'USER_DISABLED');
+                }
+
+                if (
+                  typeof currentTokenVersion === 'number' &&
+                  dbTokenVersion !== currentTokenVersion
+                ) {
+                  logger.info('[Auth] Revoking session after token-version change', {
+                    component: 'auth:jwt',
+                    userId: token.sub,
+                  });
+                  return clearSessionToken(token as AugmentedJWT, 'SESSION_REVOKED');
+                }
+
+                token.name = dbUser.name;
+                token.email = dbUser.email;
+                token.role = dbUser.role;
+                token.avatarUrl = dbUser.avatarUrl;
+                token.gender = dbUser.gender;
+                (token as AugmentedJWT).tokenVersion = dbTokenVersion;
+                // Advance freshness only after a successful authoritative lookup.
+                (token as AugmentedJWT).userFetchedAt = Date.now();
               } catch (error) {
-                console.error('[Auth-Debug] DB Fetch Error', error);
+                // Do not advance userFetchedAt on a failed authority lookup. The next
+                // request retries instead of extending a stale authorization window.
+                logger.error('[Auth] JWT authority refresh failed', {
+                  component: 'auth:jwt',
+                  userId: token.sub,
+                  error,
+                });
               }
-              (token as AugmentedJWT).userFetchedAt = Date.now();
             }
           } else {
-            logger.warn('[Auth-Debug] No token.sub found!', { component: 'auth:jwt', token });
+            logger.debug('[Auth-Debug] No token.sub found', { component: 'auth:jwt' });
           }
 
           return token;
         },
         async session({ session, token }) {
-          logger.warn('[Auth-Debug] Session callback', {
+          logger.debug('[Auth-Debug] Session callback', {
             component: 'auth:session',
             hasToken: !!token,
             sub: token?.sub,
@@ -606,7 +590,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           if ((token as AugmentedJWT)?.error || !token.sub) {
             // Force unauthenticated session shape.
             (session as unknown as { user: unknown }).user = undefined;
-            logger.warn('[Auth-Debug] Session CLEARED due to error/missing sub', {
+            logger.debug('[Auth-Debug] Session cleared due to error/missing sub', {
               component: 'auth:session',
             });
             return session;
@@ -617,12 +601,10 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             (session.user as AugmentedUser).id = token.sub;
             (session.user as AugmentedUser).tokenVersion =
               (token as AugmentedJWT).tokenVersion ?? 0;
-            // Always use the latest name from token (which is fetched from DB)
             session.user.name = (token.name as string) || session.user.name;
             session.user.email = (token.email as string) || session.user.email;
             session.user.avatarUrl = token.avatarUrl;
             session.user.gender = token.gender;
-            // Map to standard image field as well for compatibility
             session.user.image = token.avatarUrl || getDefaultAvatar(token.gender, token.sub);
           }
 
@@ -669,8 +651,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               return false;
             }
 
-            // Enforce email verification when available (recommended).
-            // If strict mode is enabled, require an explicit true value.
             const emailVerifiedClaim = coerceBooleanClaim((profile as any)?.email_verified); // eslint-disable-line @typescript-eslint/no-explicit-any
             if (emailVerifiedClaim === false) {
               logger.warn('[Auth] OIDC sign-in rejected: email not verified by IdP', {
@@ -721,7 +701,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               });
             }
 
-            // Create new user if auto-provision is enabled
             if (!existing) {
               if (!activeConfig.autoProvision) {
                 logger.warn('[Auth] OIDC sign-in rejected: auto-provision disabled', {
@@ -731,13 +710,12 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 return false;
               }
 
-              // Create new user from OIDC profile
               try {
                 const newUser = await prisma.user.create({
                   data: {
                     email,
                     name: user.name || email.split('@')[0],
-                    role: 'USER', // Default role, can be overridden by role mapping below
+                    role: 'USER',
                     status: 'ACTIVE',
                   },
                 });
@@ -748,7 +726,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                   email,
                 });
 
-                // Update user object with new ID for JWT callback
                 user.id = newUser.id;
               } catch (error) {
                 logger.error('[Auth] Failed to create OIDC user', {
@@ -759,7 +736,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               }
             }
 
-            // Get user for updates (either existing or newly created)
             const targetUser = existing || (await prisma.user.findUnique({ where: { email } }));
 
             if (!targetUser) {
@@ -770,9 +746,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               return false;
             }
 
-            // Administrative disable is authoritative. OIDC must never create a
-            // new identity link or reactivate a disabled account, even when a
-            // historical invite record exists for that email address.
             if (targetUser.status === 'DISABLED') {
               logger.warn('[Auth] OIDC sign-in rejected: user is disabled', {
                 component: 'auth:signIn',
@@ -782,7 +755,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               return false;
             }
 
-            // Create/validate stable issuer+subject identity link to avoid unsafe email-only linking.
             const issuer = normalizeIssuer(activeConfig.issuer);
             const subject =
               account?.providerAccountId ||
@@ -824,8 +796,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                     return linked;
                   }
 
-                  // An existing account must prove control of a verified address. ACTIVE
-                  // accounts additionally require a fresh, one-time administrator approval.
                   if (existing && emailVerifiedClaim !== true) {
                     throw new Error('OIDC_LINK_NOT_APPROVED');
                   }
@@ -887,11 +857,8 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
 
             const updateData: any = {};
 
-            // Ensure user object has correct ID for JWT
             user.id = targetUser.id;
 
-            // First successful SSO completes an outstanding invitation. A
-            // DISABLED account was rejected above and is never reactivated.
             if (targetUser.status === 'INVITED') {
               updateData.status = 'ACTIVE';
               updateData.invitedAt = null;
@@ -903,7 +870,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               });
             }
 
-            // Role Evaluation
             if (
               activeConfig.roleMapping &&
               Array.isArray(activeConfig.roleMapping) &&
@@ -956,7 +922,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                       matchedValue: rule.value,
                     });
                   }
-                  break; // Stop at first match
+                  break;
                 }
               }
 
@@ -968,7 +934,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               }
             }
 
-            // JIT Profile Sync - sync attributes from OIDC profile
             if (
               activeConfig.profileMapping &&
               typeof activeConfig.profileMapping === 'object' &&
@@ -982,7 +947,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               const mapping = activeConfig.profileMapping as Record<string, string>;
               const oidcProfile = profile as Record<string, unknown>;
 
-              // Sync department
               if (mapping.department && oidcProfile[mapping.department]) {
                 const dept = String(oidcProfile[mapping.department]);
                 if (dept && dept !== targetUser.department) {
@@ -996,7 +960,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 }
               }
 
-              // Sync job title
               if (mapping.jobTitle && oidcProfile[mapping.jobTitle]) {
                 const title = String(oidcProfile[mapping.jobTitle]);
                 if (title && title !== targetUser.jobTitle) {
@@ -1010,7 +973,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 }
               }
 
-              // Sync avatar URL
               if (mapping.avatarUrl && oidcProfile[mapping.avatarUrl]) {
                 const avatar = String(oidcProfile[mapping.avatarUrl]);
                 let safeAvatar: string | null = null;
@@ -1022,8 +984,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 } catch {
                   safeAvatar = null;
                 }
-                // Only sync if value changed AND the current value is NOT a locally uploaded file
-                // This prevents OIDC from overwriting a user's custom uploaded photo.
                 const isLocalUpload =
                   targetUser.avatarUrl?.startsWith('/api/users/') ||
                   targetUser.avatarUrl?.startsWith('/uploads/');
@@ -1038,7 +998,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 }
               }
 
-              // Update lastOidcSync timestamp if any profile data was synced
               if (updateData.department || updateData.jobTitle || updateData.avatarUrl) {
                 updateData.lastOidcSync = new Date();
                 logger.info('[Auth] OIDC profile sync completed', {

--- a/src/lib/env-validation.ts
+++ b/src/lib/env-validation.ts
@@ -7,6 +7,11 @@
 
 import { logger } from './logger';
 
+function isEnabledFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
 /**
  * Get the base application URL with proper validation
  * Throws an error in production if not configured
@@ -42,8 +47,9 @@ export function getBaseUrl(): string {
  * Call this early in application startup
  */
 export function validateProductionEnv(): void {
-  if (process.env.NODE_ENV !== 'production' || process.env.SKIP_ENV_VALIDATION) {
-    if (process.env.SKIP_ENV_VALIDATION) {
+  const skipValidation = isEnabledFlag(process.env.SKIP_ENV_VALIDATION);
+  if (process.env.NODE_ENV !== 'production' || skipValidation) {
+    if (skipValidation) {
       logger.warn('⚠️  Skipping environment validation due to SKIP_ENV_VALIDATION flag');
     }
     return; // Skip validation
@@ -67,6 +73,10 @@ export function validateProductionEnv(): void {
   // Optional environment variables for reference and documentation
   const _optional: Array<{ name: string; description: string }> = [
     {
+      name: 'API_KEY_SECRET',
+      description: 'Independent HMAC secret for API-key lookup hashes',
+    },
+    {
       name: 'PROMETHEUS_SCRAPE_TOKEN',
       description: 'Bearer token for scraping Prometheus metrics endpoint (/api/metrics)',
     },
@@ -74,7 +84,7 @@ export function validateProductionEnv(): void {
 
   // Safe because 'name' comes from the hardcoded 'required' array above
   // eslint-disable-next-line security/detect-object-injection
-  const missing = required.filter(({ name }) => !process.env[name]);
+  const missing = required.filter(({ name }) => !process.env[name]?.trim());
 
   if (!process.env.ENCRYPTION_KEY && !process.env.ENCRYPTION_KEYS) {
     missing.push({
@@ -97,6 +107,18 @@ export function validateProductionEnv(): void {
     ].join('\n');
 
     throw new Error(errorMessage);
+  }
+
+  const apiKeySecret = process.env.API_KEY_SECRET;
+  if (apiKeySecret && apiKeySecret === process.env.NEXTAUTH_SECRET) {
+    throw new Error(
+      '❌ PRODUCTION CONFIGURATION ERROR\n\nAPI_KEY_SECRET must be different from NEXTAUTH_SECRET so API-key hashes and session JWTs do not share cryptographic key material.'
+    );
+  }
+  if (!apiKeySecret) {
+    logger.warn(
+      'API_KEY_SECRET is not configured. API-key hashes will use a domain-separated key derived from NEXTAUTH_SECRET. Configure an independent API_KEY_SECRET to decouple API-key hashes from session-secret rotation.'
+    );
   }
 
   // Validate NEXT_PUBLIC_APP_URL format if present

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -186,6 +186,9 @@ async function fetchStatusDomainConfig(): Promise<StatusDomainConfig | null> {
  */
 function getSecurityHeaders(): Record<string, string> {
   const isProduction = process.env.NODE_ENV === 'production';
+  const scriptSrc = isProduction
+    ? "script-src 'self' 'unsafe-inline'"
+    : "script-src 'self' 'unsafe-eval' 'unsafe-inline'";
 
   return {
     // Prevent MIME type sniffing
@@ -199,12 +202,11 @@ function getSecurityHeaders(): Record<string, string> {
     // Permissions policy (formerly Feature-Policy)
     'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
     // Content Security Policy
-    // Note: 'unsafe-eval' is required by Next.js for development hot reloading
-    // Note: 'unsafe-inline' is required for styled-jsx and inline styles
-    // For stricter CSP, consider using nonce-based approach with next-safe package
+    // 'unsafe-eval' is limited to development for Next.js hot reloading.
+    // 'unsafe-inline' remains until the application adopts nonce-based script/style handling.
     'Content-Security-Policy': [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+      scriptSrc,
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: https:",
       "font-src 'self' data: https://fonts.gstatic.com",

--- a/tests/lib/api-auth-secret-migration.test.ts
+++ b/tests/lib/api-auth-secret-migration.test.ts
@@ -1,0 +1,76 @@
+import { createHmac } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    apiKey: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+import prisma from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import { hashTokenV2 } from '@/lib/api-keys';
+
+const token = 'ok_test_legacy_v2_key_material';
+
+function legacySessionV2Hash(secret: string) {
+  return createHmac('sha256', secret)
+    .update(`opsknight:api-key:v2:${token}`)
+    .digest('hex');
+}
+
+describe('API-key secret migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('NEXTAUTH_SECRET', 'historical-session-secret');
+    vi.stubEnv('API_KEY_SECRET', 'new-independent-api-key-secret');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('accepts a legacy NEXTAUTH_SECRET V2 hash once and rewrites it with API_KEY_SECRET', async () => {
+    const legacyHash = legacySessionV2Hash('historical-session-secret');
+    const apiKey = {
+      id: 'key-1',
+      tokenHash: legacyHash,
+      userId: 'user-1',
+      scopes: ['incidents:read'],
+    };
+
+    vi.mocked(prisma.apiKey.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(apiKey as never);
+    vi.mocked(prisma.apiKey.update).mockResolvedValue(apiKey as never);
+
+    const request = new NextRequest('https://ops.example.com/api/incidents', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    const result = await authenticateApiKey(request);
+
+    expect(result).toEqual(apiKey);
+    expect(prisma.apiKey.findFirst).toHaveBeenCalledTimes(2);
+    expect(prisma.apiKey.findFirst).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tokenHash: { in: expect.arrayContaining([legacyHash]) },
+        }),
+      })
+    );
+    expect(prisma.apiKey.update).toHaveBeenCalledWith({
+      where: { id: 'key-1' },
+      data: {
+        tokenHash: hashTokenV2(token),
+        lastUsedAt: expect.any(Date),
+      },
+    });
+  });
+});

--- a/tests/lib/api-key-secret-hardening.test.ts
+++ b/tests/lib/api-key-secret-hardening.test.ts
@@ -1,0 +1,42 @@
+import { createHmac } from 'crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hashLegacyV2Tokens, hashTokenV2 } from '@/lib/api-keys';
+
+const token = 'ok_test_example_token_for_secret_hardening';
+const v2Payload = `opsknight:api-key:v2:${token}`;
+
+function directHash(secret: string) {
+  return createHmac('sha256', secret).update(v2Payload).digest('hex');
+}
+
+describe('API-key secret hardening', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses API_KEY_SECRET instead of session JWT key material when configured', () => {
+    vi.stubEnv('NEXTAUTH_SECRET', 'session-secret-for-tests');
+    vi.stubEnv('API_KEY_SECRET', 'independent-api-key-secret-for-tests');
+
+    expect(hashTokenV2(token)).toBe(directHash('independent-api-key-secret-for-tests'));
+    expect(hashTokenV2(token)).not.toBe(directHash('session-secret-for-tests'));
+  });
+
+  it('retains the pre-hardening NEXTAUTH_SECRET V2 hash as a migration lookup', () => {
+    vi.stubEnv('NEXTAUTH_SECRET', 'old-session-secret-for-tests');
+    vi.stubEnv('API_KEY_SECRET', 'new-api-key-secret-for-tests');
+
+    const legacySessionHash = directHash('old-session-secret-for-tests');
+    expect(hashLegacyV2Tokens(token)).toContain(legacySessionHash);
+    expect(hashTokenV2(token)).not.toBe(legacySessionHash);
+  });
+
+  it('domain-separates the development fallback from the raw session secret', () => {
+    vi.stubEnv('NEXTAUTH_SECRET', 'development-session-secret');
+    vi.stubEnv('API_KEY_SECRET', '');
+
+    const oldDirectHash = directHash('development-session-secret');
+    expect(hashTokenV2(token)).not.toBe(oldDirectHash);
+    expect(hashLegacyV2Tokens(token)).toContain(oldDirectHash);
+  });
+});

--- a/tests/lib/auth-session-hardening.test.ts
+++ b/tests/lib/auth-session-hardening.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/oidc-config', () => ({
+  getOidcConfig: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    oidcIdentity: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import prisma from '@/lib/prisma';
+import { getAuthOptions, resetAuthOptionsCache } from '@/lib/auth';
+
+describe('JWT authority refresh hardening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAuthOptionsCache();
+    delete process.env.JWT_USER_REFRESH_TTL_MS;
+    process.env.AUTH_OPTIONS_CACHE_TTL_MS = '0';
+  });
+
+  it('revokes a JWT when the backing user no longer exists', async () => {
+    const authOptions = await getAuthOptions();
+    const jwt = authOptions.callbacks?.jwt as unknown as (args: any) => Promise<any>;
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+    const token = await jwt({
+      token: { sub: 'deleted-user', tokenVersion: 0, userFetchedAt: Date.now() - 20_000 },
+    });
+
+    expect(token.error).toBe('USER_NOT_FOUND');
+    expect(token.sub).toBeUndefined();
+  });
+
+  it('does not extend the authority-cache timestamp after a failed DB refresh', async () => {
+    const authOptions = await getAuthOptions();
+    const jwt = authOptions.callbacks?.jwt as unknown as (args: any) => Promise<any>;
+    const staleFetchedAt = Date.now() - 20_000;
+    vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error('database unavailable'));
+
+    const token = await jwt({
+      token: { sub: 'user-1', tokenVersion: 0, userFetchedAt: staleFetchedAt },
+    });
+
+    expect(token.sub).toBe('user-1');
+    expect(token.userFetchedAt).toBe(staleFetchedAt);
+  });
+
+  it('refreshes authority after the new 15-second default window', async () => {
+    const authOptions = await getAuthOptions();
+    const jwt = authOptions.callbacks?.jwt as unknown as (args: any) => Promise<any>;
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      name: 'User',
+      email: 'user@example.com',
+      role: 'RESPONDER',
+      tokenVersion: 0,
+      status: 'ACTIVE',
+      avatarUrl: null,
+      gender: null,
+    } as never);
+
+    const token = await jwt({
+      token: { sub: 'user-1', role: 'USER', tokenVersion: 0, userFetchedAt: Date.now() - 16_000 },
+    });
+
+    expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
+    expect(token.role).toBe('RESPONDER');
+    expect(token.userFetchedAt).toEqual(expect.any(Number));
+  });
+});

--- a/tests/lib/env-validation-auth-secrets.test.ts
+++ b/tests/lib/env-validation-auth-secrets.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { validateProductionEnv } from '@/lib/env-validation';
+
+function configureValidProductionEnv() {
+  vi.stubEnv('NODE_ENV', 'production');
+  vi.stubEnv('DATABASE_URL', 'postgresql://user:pass@example.invalid:5432/opsknight');
+  vi.stubEnv('NEXTAUTH_URL', 'https://ops.example.com');
+  vi.stubEnv('NEXTAUTH_SECRET', 'session-secret-for-production-tests');
+  vi.stubEnv('API_KEY_SECRET', 'independent-api-key-secret-for-production-tests');
+  vi.stubEnv('ENCRYPTION_KEY', 'a'.repeat(64));
+  vi.stubEnv('SKIP_ENV_VALIDATION', '');
+}
+
+describe('production authentication secret validation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('allows API_KEY_SECRET to be omitted for domain-separated fallback compatibility', () => {
+    configureValidProductionEnv();
+    vi.stubEnv('API_KEY_SECRET', '');
+
+    expect(() => validateProductionEnv()).not.toThrow();
+  });
+
+  it('rejects reuse of NEXTAUTH_SECRET for API-key hashing', () => {
+    configureValidProductionEnv();
+    vi.stubEnv('API_KEY_SECRET', 'session-secret-for-production-tests');
+
+    expect(() => validateProductionEnv()).toThrow(/must be different from NEXTAUTH_SECRET/);
+  });
+
+  it('does not treat SKIP_ENV_VALIDATION=false as an enabled bypass', () => {
+    configureValidProductionEnv();
+    vi.stubEnv('SKIP_ENV_VALIDATION', 'false');
+    vi.stubEnv('DATABASE_URL', '');
+
+    expect(() => validateProductionEnv()).toThrow(/DATABASE_URL/);
+  });
+
+  it('honors an explicitly enabled production validation bypass', () => {
+    configureValidProductionEnv();
+    vi.stubEnv('SKIP_ENV_VALIDATION', 'true');
+    vi.stubEnv('DATABASE_URL', '');
+
+    expect(() => validateProductionEnv()).not.toThrow();
+  });
+
+  it('accepts independent session, API-key, and encryption secrets', () => {
+    configureValidProductionEnv();
+
+    expect(() => validateProductionEnv()).not.toThrow();
+  });
+});

--- a/tests/security/middleware-csp.test.ts
+++ b/tests/security/middleware-csp.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import middleware from '../../src/middleware';
+
+function request() {
+  return new NextRequest('https://ops.example.com/api/health', {
+    headers: { 'user-agent': 'Mozilla/5.0' },
+  });
+}
+
+describe('middleware Content-Security-Policy', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('does not allow unsafe-eval in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const response = await middleware(request());
+    const csp = response.headers.get('Content-Security-Policy') || '';
+
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).not.toContain("'unsafe-eval'");
+  });
+
+  it('retains unsafe-eval only for development HMR compatibility', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const response = await middleware(request());
+    const csp = response.headers.get('Content-Security-Policy') || '';
+
+    expect(csp).toContain("script-src 'self' 'unsafe-eval' 'unsafe-inline'");
+  });
+});


### PR DESCRIPTION
## Summary

Hardens OpsKnight authentication/session and API-key security without redesigning the existing NextAuth/OIDC architecture.

### API-key cryptographic separation and upgrade compatibility

- stop using `NEXTAUTH_SECRET` directly as the API-key HMAC key
- support an independent `API_KEY_SECRET` for production deployments
- when `API_KEY_SECRET` is absent, derive a domain-separated API-key root from `NEXTAUTH_SECRET` for backward-compatible startup
- reject an explicitly configured `API_KEY_SECRET` that is identical to `NEXTAUTH_SECRET`
- recognize historical V2 hashes written directly from the session secret and lazily rewrite them after successful authentication
- retain legacy scrypt lookup compatibility and migrate successful matches to the current V2 HMAC
- wire the independent API-key secret through Compose, Helm, and the static Kubernetes secret template; Helm external Secrets may omit it and use the derived fallback

### Session revocation and authority freshness

- reduce the default authoritative JWT user refresh cache from 60s to 15s
- revoke a JWT when its backing user has been deleted instead of leaving the stale token usable
- fail closed when the initial OIDC JWT authority lookup fails or cannot resolve a DB user
- only advance `userFetchedAt` after a successful authoritative DB lookup
- on a transient refresh failure, preserve the current token but do not extend the stale authority-cache window, so the next request retries immediately
- keep `trigger="update"` as an authority-cache bypass

### Logging and browser hardening

- move verbose `[Auth-Debug]` traces from WARN to DEBUG
- replace credential lockout `console.warn` calls with structured logger events
- avoid dumping the full JWT when `sub` is missing
- remove `unsafe-eval` from production CSP while retaining it in development for Next.js HMR
- intentionally retain `unsafe-inline`; removing it safely requires a nonce-based rendering migration and is outside this narrow hardening PR

### Production environment validation

- fix `SKIP_ENV_VALIDATION=false` incorrectly bypassing validation due to string truthiness
- only explicit enabled values (`true`, `1`, `yes`, `on`) bypass production validation
- document independent API-key secret behavior, fallback semantics, migration, and rotation guidance

## Upgrade behavior

No database migration is required.

Existing API keys do not need to be recreated. Keys whose stored lookup hash was written from the historical `NEXTAUTH_SECRET` basis are recognized and lazily migrated after their next successful request.

For strongest rotation isolation, configure a random `API_KEY_SECRET` that differs from `NEXTAUTH_SECRET`. Packaged Compose/Helm/Kubernetes examples now provide the setting. Custom deployments that omit it continue to start using the domain-separated derived root, but API-key hash continuity then remains coupled to `NEXTAUTH_SECRET` rotation.

## Tests added

- API-key secret/domain-separation behavior
- historical V2 API-key hash migration
- deleted-user JWT revocation
- authority-refresh retry behavior after DB failure
- 15-second default authority refresh
- production validation and `SKIP_ENV_VALIDATION=false`
- production/development CSP behavior

## Out of scope / follow-ups

This PR does **not** claim to add native MFA/WebAuthn/passkeys or durable per-device JWT revocation. Those require product, schema, UI, recovery, and lifecycle design and should land as separate feature work rather than being mixed into this security-hardening change.

Local executable validation was not available from this session because the repository clone endpoint was unreachable from the execution container. The branch was statically reviewed against the latest `main`; GitHub Actions should perform the repository's normal lint/test/build/deployment-render checks on this PR.