### PR TITLE
fix(status-pages): enforce multi-page admin isolation

### DIFF
--- a/prisma/migrations/20260906220000_status_page_default_invariant/migration.sql
+++ b/prisma/migrations/20260906220000_status_page_default_invariant/migration.sql
@@ -1,0 +1,19 @@
+-- Repair legacy zero/multiple-default states deterministically before fencing.
+WITH ranked AS (
+  SELECT "id", ROW_NUMBER() OVER (
+    ORDER BY "isDefault" DESC, "createdAt" ASC, "id" ASC
+  ) AS position
+  FROM "StatusPage"
+)
+UPDATE "StatusPage" AS page
+SET "isDefault" = (ranked.position = 1)
+FROM ranked
+WHERE page."id" = ranked."id"
+  AND page."isDefault" IS DISTINCT FROM (ranked.position = 1);
+
+-- At most one status page may own legacy/default routing at a time.
+-- Lifecycle operations serialize creation, promotion, and deletion with a
+-- transaction-scoped advisory lock so a non-empty collection retains one default.
+CREATE UNIQUE INDEX IF NOT EXISTS "StatusPage_single_default_idx"
+ON "StatusPage" ("isDefault")
+WHERE "isDefault" = true;

--- a/src/app/(app)/settings/status-page/page.tsx
+++ b/src/app/(app)/settings/status-page/page.tsx
@@ -1,120 +1,14 @@
-import { getServerSession } from 'next-auth';
-import { getAuthOptions } from '@/lib/auth';
-import { notFound, redirect } from 'next/navigation';
-import { assertAdmin } from '@/lib/rbac';
-import prisma from '@/lib/prisma';
-import StatusPageConfig from '@/components/StatusPageConfig';
-import { SettingsPageHeader } from '@/components/settings/layout/SettingsPageHeader';
-import Link from 'next/link';
-import { StatusPageManager } from '@/components/status-page/StatusPageManager';
+import { redirect } from 'next/navigation';
 
-export default async function StatusPageSettingsPage({
+/**
+ * Compatibility route for bookmarks from the single-page settings UI.
+ * Page identity now lives in the route instead of mutable query state.
+ */
+export default async function LegacyStatusPageSettings({
   searchParams,
 }: {
   searchParams: Promise<{ page?: string }>;
 }) {
-  const session = await getServerSession(await getAuthOptions());
-  if (!session) {
-    redirect('/login');
-  }
-
-  try {
-    await assertAdmin();
-  } catch {
-    redirect('/');
-  }
-
-  const { page: selectedPageId } = await searchParams;
-  const availablePages = await prisma.statusPage.findMany({
-    select: { id: true, name: true, slug: true, isDefault: true },
-    orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
-  });
-
-  // Get the explicitly selected page, falling back deterministically to the default page.
-  let statusPage = await prisma.statusPage.findFirst({
-    where: selectedPageId ? { id: selectedPageId } : undefined,
-    orderBy: selectedPageId
-      ? undefined
-      : [{ isDefault: 'desc' }, { createdAt: 'asc' }, { id: 'asc' }],
-    include: {
-      services: {
-        include: {
-          service: true,
-        },
-      },
-      announcements: {
-        orderBy: { startDate: 'desc' },
-        take: 20,
-      },
-    },
-  });
-
-  if (selectedPageId && !statusPage) notFound();
-
-  if (!statusPage) {
-    // Create default status page
-    statusPage = await prisma.statusPage.create({
-      data: {
-        name: 'Status Page',
-        enabled: false,
-        isDefault: true,
-      },
-      include: {
-        services: {
-          include: {
-            service: true,
-          },
-        },
-        announcements: {
-          orderBy: { startDate: 'desc' },
-          take: 20,
-        },
-      },
-    });
-  }
-
-  // Get all services
-  const allServices = await prisma.service.findMany({
-    orderBy: { name: 'asc' },
-  });
-
-  const formattedStatusPage: any = {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
-    ...statusPage,
-    announcements: statusPage.announcements.map(announcement => ({
-      ...announcement,
-      startDate: announcement.startDate.toISOString(),
-      endDate: announcement.endDate ? announcement.endDate.toISOString() : null,
-      affectedServiceIds: Array.isArray(announcement.affectedServiceIds)
-        ? (announcement.affectedServiceIds as string[])
-        : null,
-    })),
-  };
-
-  return (
-    <div className="space-y-6">
-      <SettingsPageHeader
-        title="Public Status Pages"
-        description="Customize your public status page appearance, incident broadcast settings, and service status monitors."
-        backHref="/settings"
-        backLabel="Back to Settings"
-      />
-      {availablePages.length > 1 && (
-        <nav aria-label="Status pages" className="flex flex-wrap gap-2">
-          {availablePages.map(page => (
-            <Link
-              key={page.id}
-              href={`/settings/status-page?page=${encodeURIComponent(page.id)}`}
-              className={`rounded-md border px-3 py-2 text-sm ${page.id === statusPage.id ? 'border-blue-500 bg-blue-50 font-semibold' : 'border-gray-200'}`}
-            >
-              {page.name}
-              {page.isDefault ? ' (default)' : ''}
-            </Link>
-          ))}
-        </nav>
-      )}
-      <StatusPageManager />
-      <StatusPageConfig statusPage={formattedStatusPage} allServices={allServices} />
-    </div>
-  );
+  const { page } = await searchParams;
+  redirect(page ? `/settings/status-pages/${encodeURIComponent(page)}` : '/settings/status-pages');
 }

--- a/src/app/(app)/settings/status-pages/[pageId]/page.tsx
+++ b/src/app/(app)/settings/status-pages/[pageId]/page.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { getAuthOptions } from '@/lib/auth';
+import { assertAdmin } from '@/lib/rbac';
+import prisma from '@/lib/prisma';
+import StatusPageConfig from '@/components/StatusPageConfig';
+import { SettingsPageHeader } from '@/components/settings/layout/SettingsPageHeader';
+
+export default async function StatusPageWorkspace({
+  params,
+}: {
+  params: Promise<{ pageId: string }>;
+}) {
+  const session = await getServerSession(await getAuthOptions());
+  if (!session) redirect('/login');
+  try {
+    await assertAdmin();
+  } catch {
+    redirect('/');
+  }
+
+  const { pageId } = await params;
+  const [statusPage, allServices] = await Promise.all([
+    prisma.statusPage.findUnique({
+      where: { id: pageId },
+      include: {
+        services: { include: { service: true } },
+        announcements: { orderBy: { startDate: 'desc' }, take: 20 },
+        apiTokens: { orderBy: { createdAt: 'desc' }, take: 50 },
+      },
+    }),
+    prisma.service.findMany({ orderBy: { name: 'asc' } }),
+  ]);
+  if (!statusPage) notFound();
+
+  const formattedStatusPage = {
+    ...statusPage,
+    allowedCustomFields: Array.isArray(statusPage.allowedCustomFields)
+      ? statusPage.allowedCustomFields.filter((value): value is string => typeof value === 'string')
+      : [],
+    announcements: statusPage.announcements.map(announcement => ({
+      ...announcement,
+      startDate: announcement.startDate.toISOString(),
+      endDate: announcement.endDate?.toISOString() || null,
+      affectedServiceIds: Array.isArray(announcement.affectedServiceIds)
+        ? (announcement.affectedServiceIds as string[])
+        : null,
+    })),
+    apiTokens: statusPage.apiTokens.map(token => ({
+      ...token,
+      createdAt: token.createdAt.toISOString(),
+      lastUsedAt: token.lastUsedAt?.toISOString() || null,
+      revokedAt: token.revokedAt?.toISOString() || null,
+    })),
+  };
+  const publicHref = `/status${statusPage.slug ? `/${statusPage.slug}` : ''}`;
+
+  return (
+    <div className="space-y-6">
+      <SettingsPageHeader
+        title={statusPage.name}
+        description={`${statusPage.isDefault ? 'Default status page · ' : ''}${statusPage.enabled ? 'Enabled' : 'Disabled'} · independently configured`}
+        backHref="/settings/status-pages"
+        backLabel="All status pages"
+        actions={
+          <Link
+            href={publicHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded bg-indigo-600 px-3 py-2 text-sm font-semibold text-white"
+          >
+            Open public page
+          </Link>
+        }
+      />
+      <StatusPageConfig
+        key={statusPage.id}
+        statusPage={formattedStatusPage}
+        allServices={allServices}
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/settings/status-pages/page.tsx
+++ b/src/app/(app)/settings/status-pages/page.tsx
@@ -1,0 +1,109 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { getAuthOptions } from '@/lib/auth';
+import { assertAdmin } from '@/lib/rbac';
+import prisma from '@/lib/prisma';
+import { SettingsPageHeader } from '@/components/settings/layout/SettingsPageHeader';
+import { StatusPageManager } from '@/components/status-page/StatusPageManager';
+
+export default async function StatusPagesControlCenter() {
+  const session = await getServerSession(await getAuthOptions());
+  if (!session) redirect('/login');
+  try {
+    await assertAdmin();
+  } catch {
+    redirect('/');
+  }
+
+  const pages = await prisma.statusPage.findMany({
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      enabled: true,
+      isDefault: true,
+      privacyMode: true,
+      customDomain: true,
+      subdomain: true,
+      updatedAt: true,
+      _count: { select: { services: true, subscriptions: true } },
+    },
+    orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+  });
+
+  return (
+    <div className="space-y-6">
+      <SettingsPageHeader
+        title="Status Pages"
+        description="Manage independent public communication surfaces. No page inherits configuration from the default page."
+        backHref="/settings"
+        backLabel="Back to Settings"
+        actions={<StatusPageManager />}
+      />
+      {pages.length === 0 ? (
+        <section className="rounded-lg border border-dashed bg-white p-10 text-center">
+          <h2 className="text-lg font-semibold">No public status pages yet</h2>
+          <p className="mt-2 text-sm text-gray-600">
+            Create your first disabled page, configure it, then publish it.
+          </p>
+          <div className="mt-5 flex justify-center">
+            <StatusPageManager />
+          </div>
+        </section>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {pages.map(page => {
+            const publicHref = page.customDomain
+              ? `https://${page.customDomain}`
+              : `/status${page.slug ? `/${page.slug}` : ''}`;
+            return (
+              <article key={page.id} className="rounded-lg border bg-white p-5 shadow-sm">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-lg font-semibold text-gray-950">{page.name}</h2>
+                      {page.isDefault && (
+                        <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">
+                          Default
+                        </span>
+                      )}
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-semibold ${page.enabled ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-100 text-gray-600'}`}
+                      >
+                        {page.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm text-gray-600">
+                      {page.customDomain || page.subdomain || publicHref}
+                    </p>
+                    <p className="mt-3 text-sm text-gray-600">
+                      {page._count.services} services · {page._count.subscriptions} subscribers ·{' '}
+                      {page.privacyMode || 'PUBLIC'}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-5 flex justify-end gap-2">
+                  <Link
+                    href={publicHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded border px-3 py-2 text-sm font-medium"
+                  >
+                    Open page
+                  </Link>
+                  <Link
+                    href={`/settings/status-pages/${encodeURIComponent(page.id)}`}
+                    className="rounded bg-indigo-600 px-3 py-2 text-sm font-semibold text-white"
+                  >
+                    Manage
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/settings/status-page/announcements/route.ts
+++ b/src/app/api/settings/status-page/announcements/route.ts
@@ -28,6 +28,18 @@ function normalizeAffectedServiceIds(value?: string[] | null) {
   return ids.length > 0 ? ids : null;
 }
 
+async function affectedServicesBelongToPage(
+  statusPageId: string,
+  serviceIds: string[] | null,
+  tx: Pick<typeof prisma, 'statusPageService'> = prisma
+) {
+  if (!serviceIds?.length) return true;
+  const count = await tx.statusPageService.count({
+    where: { statusPageId, serviceId: { in: serviceIds }, showOnPage: true },
+  });
+  return count === serviceIds.length;
+}
+
 export async function POST(req: NextRequest) {
   try {
     await assertAdmin();
@@ -58,6 +70,10 @@ export async function POST(req: NextRequest) {
       affectedServiceIds,
     } = parsed.data;
     const normalizedAffectedServiceIds = normalizeAffectedServiceIds(affectedServiceIds);
+
+    if (!(await affectedServicesBelongToPage(statusPageId, normalizedAffectedServiceIds))) {
+      return jsonError('Affected services must belong to this status page.', 400);
+    }
 
     const announcement = await prisma.$transaction(async tx => {
       const created = await tx.statusPageAnnouncement.create({
@@ -120,14 +136,29 @@ export async function PATCH(req: NextRequest) {
     if (!parsed.success) {
       return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
     }
-    const { id, title, message, type, startDate, endDate, isActive, affectedServiceIds } =
-      parsed.data;
+    const {
+      statusPageId,
+      id,
+      title,
+      message,
+      type,
+      startDate,
+      endDate,
+      isActive,
+      affectedServiceIds,
+    } = parsed.data;
     const normalizedAffectedServiceIds = normalizeAffectedServiceIds(affectedServiceIds);
-    const existing = await prisma.statusPageAnnouncement.findUnique({
-      where: { id },
+    const existing = await prisma.statusPageAnnouncement.findFirst({
+      where: { id, statusPageId },
       select: { startDate: true, endDate: true },
     });
     if (!existing) return jsonError('Announcement not found.', 404);
+    if (
+      affectedServiceIds !== undefined &&
+      !(await affectedServicesBelongToPage(statusPageId, normalizedAffectedServiceIds))
+    ) {
+      return jsonError('Affected services must belong to this status page.', 400);
+    }
     const effectiveStart = startDate ? parseDate(startDate, 'startDate') : existing.startDate;
     const effectiveEnd =
       endDate === undefined ? existing.endDate : endDate ? parseDate(endDate, 'endDate') : null;
@@ -183,9 +214,10 @@ export async function DELETE(req: NextRequest) {
     if (!parsed.success) {
       return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
     }
-    const { id } = parsed.data;
+    const { id, statusPageId } = parsed.data;
 
-    await prisma.statusPageAnnouncement.delete({ where: { id } });
+    const deleted = await prisma.statusPageAnnouncement.deleteMany({ where: { id, statusPageId } });
+    if (deleted.count === 0) return jsonError('Announcement not found.', 404);
 
     logger.info('api.status_page.announcement.deleted', { announcementId: id });
     return jsonOk({ success: true }, 200);

--- a/src/app/api/settings/status-page/api-tokens/route.ts
+++ b/src/app/api/settings/status-page/api-tokens/route.ts
@@ -41,7 +41,6 @@ export async function POST(req: NextRequest) {
     logger.info('api.status_page.api_token.created', { apiTokenId: apiToken.id });
     return jsonOk({ token, apiToken }, 200);
   } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
     logger.error('api.status_page.api_token.create_error', {
       error: error instanceof Error ? error.message : String(error),
     });
@@ -69,7 +68,9 @@ export async function DELETE(req: NextRequest) {
       return jsonError('Invalid request body.', 400, { issues: parsed.error.issues });
     }
 
-    const { id } = parsed.data;
+    const { id, statusPageId } = parsed.data;
+    const existing = await prisma.statusPageApiToken.findFirst({ where: { id, statusPageId } });
+    if (!existing) return jsonError('API token not found.', 404);
     const apiToken = await prisma.statusPageApiToken.update({
       where: { id },
       data: { revokedAt: new Date() },
@@ -78,7 +79,6 @@ export async function DELETE(req: NextRequest) {
     logger.info('api.status_page.api_token.revoked', { apiTokenId: apiToken.id });
     return jsonOk({ apiToken }, 200);
   } catch (error: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
     logger.error('api.status_page.api_token.revoke_error', {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/app/api/settings/status-page/route.ts
+++ b/src/app/api/settings/status-page/route.ts
@@ -165,26 +165,25 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const hasField = (field: keyof typeof parsed.data) =>
+      Object.prototype.hasOwnProperty.call(parsed.data, field);
+    const nullableText = (value: string | null | undefined) => value?.trim() || null;
+
     const updateData: Prisma.StatusPageUpdateInput = {
-      slug: slug !== undefined ? slug || null : undefined,
-      organizationName:
-        organizationName !== undefined
-          ? organizationName && organizationName.trim()
-            ? organizationName.trim()
-            : null
-          : undefined,
-      subdomain: subdomain && subdomain.trim() ? subdomain.trim() : null,
-      customDomain: customDomain && customDomain.trim() ? customDomain.trim() : null,
-      enabled: enabled !== false,
-      showServices: showServices !== false,
-      showIncidents: showIncidents !== false,
-      showMetrics: showMetrics !== false,
-      showSubscribe: showSubscribe !== false,
+      slug: hasField('slug') ? slug || null : undefined,
+      organizationName: hasField('organizationName') ? nullableText(organizationName) : undefined,
+      subdomain: hasField('subdomain') ? nullableText(subdomain) : undefined,
+      customDomain: hasField('customDomain') ? nullableText(customDomain) : undefined,
+      enabled: hasField('enabled') ? enabled : undefined,
+      showServices: hasField('showServices') ? showServices : undefined,
+      showIncidents: hasField('showIncidents') ? showIncidents : undefined,
+      showMetrics: hasField('showMetrics') ? showMetrics : undefined,
+      showSubscribe: hasField('showSubscribe') ? showSubscribe : undefined,
       uptimeExcellentThreshold: uptimeExcellentThreshold ?? undefined,
       uptimeGoodThreshold: uptimeGoodThreshold ?? undefined,
-      footerText: footerText && footerText.trim() ? footerText.trim() : null,
-      contactEmail: contactEmail && contactEmail.trim() ? contactEmail.trim() : null,
-      contactUrl: contactUrl && contactUrl.trim() ? contactUrl.trim() : null,
+      footerText: hasField('footerText') ? nullableText(footerText) : undefined,
+      contactEmail: hasField('contactEmail') ? nullableText(contactEmail) : undefined,
+      contactUrl: hasField('contactUrl') ? nullableText(contactUrl) : undefined,
     };
 
     if (name !== undefined && name !== null && name.trim().length > 0) {

--- a/src/app/api/settings/status-page/route.ts
+++ b/src/app/api/settings/status-page/route.ts
@@ -79,7 +79,6 @@ export async function POST(req: NextRequest) {
       id,
       name,
       slug,
-      isDefault,
       organizationName,
       subdomain,
       customDomain,
@@ -131,30 +130,20 @@ export async function POST(req: NextRequest) {
       statusApiRateLimitWindowSec,
     } = parsed.data;
 
-    let statusPage = id
-      ? await prisma.statusPage.findUnique({ where: { id } })
-      : await prisma.statusPage.findFirst({
-          orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }, { id: 'asc' }],
-        });
-
-    if (id && !statusPage) {
-      return jsonError('Status page not found.', 404);
+    if (!id) {
+      return jsonError(
+        new AppError({
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Status page ID is required for every administrative update.',
+          fields: [{ field: 'id', code: 'required', message: 'Status page ID is required.' }],
+        })
+      );
     }
 
+    const statusPage = await prisma.statusPage.findUnique({ where: { id } });
+
     if (!statusPage) {
-      statusPage = await prisma.statusPage.create({
-        data: {
-          name: name?.trim() || 'Status Page',
-          slug: slug || null,
-          isDefault: true,
-          organizationName: organizationName || null,
-          enabled: enabled !== false,
-          showServices: showServices !== false,
-          showIncidents: showIncidents !== false,
-          showMetrics: showMetrics !== false,
-          showSubscribe: showSubscribe !== false,
-        },
-      });
+      return jsonError('Status page not found.', 404);
     }
 
     const effectiveExcellent = uptimeExcellentThreshold ?? statusPage.uptimeExcellentThreshold;
@@ -178,7 +167,6 @@ export async function POST(req: NextRequest) {
 
     const updateData: Prisma.StatusPageUpdateInput = {
       slug: slug !== undefined ? slug || null : undefined,
-      isDefault: isDefault ?? undefined,
       organizationName:
         organizationName !== undefined
           ? organizationName && organizationName.trim()
@@ -289,12 +277,6 @@ export async function POST(req: NextRequest) {
       updateData.statusApiRateLimitWindowSec = statusApiRateLimitWindowSec;
 
     await prisma.$transaction(async tx => {
-      if (isDefault === true) {
-        await tx.statusPage.updateMany({
-          where: { isDefault: true, id: { not: statusPage.id } },
-          data: { isDefault: false },
-        });
-      }
       await tx.statusPage.update({ where: { id: statusPage.id }, data: updateData });
 
       // Omitted means leave mappings unchanged; an explicit empty array removes all mappings.

--- a/src/app/api/settings/status-pages/[pageId]/make-default/route.ts
+++ b/src/app/api/settings/status-pages/[pageId]/make-default/route.ts
@@ -1,0 +1,15 @@
+import { assertAdmin } from '@/lib/rbac';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { makeDefaultStatusPage, StatusPageAdminError } from '@/lib/status-pages/admin';
+
+export async function POST(_request: Request, context: { params: Promise<{ pageId: string }> }) {
+  try {
+    await assertAdmin();
+    const { pageId } = await context.params;
+    const page = await makeDefaultStatusPage(pageId);
+    return jsonOk({ page }, 200);
+  } catch (error) {
+    if (error instanceof StatusPageAdminError) return jsonError(error.message, 404);
+    return jsonError('Failed to change the default status page.', 500);
+  }
+}

--- a/src/app/api/settings/status-pages/route.ts
+++ b/src/app/api/settings/status-pages/route.ts
@@ -4,14 +4,13 @@ import prisma from '@/lib/prisma';
 import { assertAdmin } from '@/lib/rbac';
 import { jsonError, jsonOk } from '@/lib/api-response';
 import { isStatusPageSlug } from '@/lib/validation';
+import { createStatusPage, deleteStatusPage, StatusPageAdminError } from '@/lib/status-pages/admin';
 
 const CreatePageSchema = z.object({
   name: z.string().trim().min(1).max(200),
   slug: z.string().trim().refine(isStatusPageSlug, 'Invalid status page slug.'),
   isDefault: z.boolean().optional(),
 });
-
-class DefaultPageDeleteError extends Error {}
 
 export async function GET() {
   try {
@@ -32,19 +31,10 @@ export async function POST(req: NextRequest) {
     const parsed = CreatePageSchema.safeParse(await req.json());
     if (!parsed.success)
       return jsonError('Invalid status page.', 400, { issues: parsed.error.issues });
-    const page = await prisma.$transaction(async tx => {
-      const count = await tx.statusPage.count();
-      const makeDefault = parsed.data.isDefault === true || count === 0;
-      if (makeDefault)
-        await tx.statusPage.updateMany({ where: { isDefault: true }, data: { isDefault: false } });
-      return tx.statusPage.create({
-        data: {
-          name: parsed.data.name,
-          slug: parsed.data.slug,
-          isDefault: makeDefault,
-          enabled: false,
-        },
-      });
+    const page = await createStatusPage({
+      name: parsed.data.name,
+      slug: parsed.data.slug,
+      makeDefault: parsed.data.isDefault,
     });
     return jsonOk({ page }, 201);
   } catch {
@@ -57,21 +47,13 @@ export async function DELETE(req: NextRequest) {
     await assertAdmin();
     const id = new URL(req.url).searchParams.get('id');
     if (!id) return jsonError('Status page id is required.', 400);
-    await prisma.$transaction(async tx => {
-      const page = await tx.statusPage.findUnique({ where: { id }, select: { isDefault: true } });
-      if (!page) return;
-      if (page.isDefault && (await tx.statusPage.count()) > 1) {
-        throw new DefaultPageDeleteError();
-      }
-      await tx.statusPage.delete({ where: { id } });
-    });
+    const replacementDefaultId = new URL(req.url).searchParams.get('replacementDefaultId');
+    await deleteStatusPage(id, replacementDefaultId || undefined);
     return jsonOk({ success: true }, 200);
   } catch (error) {
     return jsonError(
-      error instanceof DefaultPageDeleteError
-        ? 'Choose another default status page before deleting this page.'
-        : 'Failed to delete status page.',
-      409
+      error instanceof StatusPageAdminError ? error.message : 'Failed to delete status page.',
+      error instanceof StatusPageAdminError && error.code === 'STATUS_PAGE_NOT_FOUND' ? 404 : 409
     );
   }
 }

--- a/src/app/api/status-page/subscribers/route.ts
+++ b/src/app/api/status-page/subscribers/route.ts
@@ -53,7 +53,8 @@ export async function GET(req: NextRequest) {
     const skip = (page - 1) * limit;
     const where: Prisma.StatusPageSubscriptionWhereInput = {};
 
-    if (statusPageId) where.statusPageId = statusPageId;
+    if (!statusPageId) return jsonError('Status page ID is required', 400);
+    where.statusPageId = statusPageId;
     if (verifiedFilter === 'true') where.verified = true;
     else if (verifiedFilter === 'false') where.verified = false;
     if (searchEmail) {
@@ -99,20 +100,19 @@ export async function DELETE(req: NextRequest) {
     await assertAdmin();
 
     const subscriptionId = req.nextUrl.searchParams.get('id');
-    if (!subscriptionId) {
+    const statusPageId = req.nextUrl.searchParams.get('statusPageId');
+    if (!subscriptionId || !statusPageId) {
       return jsonError(
         new AppError({
           code: 'VALIDATION_FAILED',
           userMessage: 'Subscription ID is required',
-          fields: [
-            { field: 'id', code: 'required', message: 'Subscription ID is required' },
-          ],
+          fields: [{ field: 'id', code: 'required', message: 'Subscription ID is required' }],
         })
       );
     }
 
-    const subscription = await prisma.statusPageSubscription.findUnique({
-      where: { id: subscriptionId },
+    const subscription = await prisma.statusPageSubscription.findFirst({
+      where: { id: subscriptionId, statusPageId },
     });
     if (!subscription) {
       return jsonError(new AppError(SUBSCRIPTION_NOT_FOUND));

--- a/src/app/api/status-page/webhooks/route.ts
+++ b/src/app/api/status-page/webhooks/route.ts
@@ -130,13 +130,20 @@ export async function PATCH(req: NextRequest) {
     }
     const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
     const id = typeof payload.id === 'string' ? payload.id : null;
+    const statusPageId = typeof payload.statusPageId === 'string' ? payload.statusPageId : null;
 
-    if (!id) {
+    if (!id || !statusPageId) {
       return jsonError(
         new AppError({
           code: 'VALIDATION_FAILED',
           userMessage: LEGACY_REQUIRED_MESSAGE,
-          fields: [{ field: 'id', code: 'required', message: 'id is required' }],
+          fields: [
+            {
+              field: !id ? 'id' : 'statusPageId',
+              code: 'required',
+              message: 'Page and webhook IDs are required',
+            },
+          ],
         })
       );
     }
@@ -184,7 +191,9 @@ export async function PATCH(req: NextRequest) {
           new AppError({
             code: 'VALIDATION_FAILED',
             userMessage: 'enabled must be a boolean',
-            fields: [{ field: 'enabled', code: 'invalid_type', message: 'enabled must be a boolean' }],
+            fields: [
+              { field: 'enabled', code: 'invalid_type', message: 'enabled must be a boolean' },
+            ],
           })
         );
       }
@@ -197,6 +206,8 @@ export async function PATCH(req: NextRequest) {
       );
     }
 
+    const existing = await prisma.statusPageWebhook.findFirst({ where: { id, statusPageId } });
+    if (!existing) return jsonError(new AppError(WEBHOOK_NOT_FOUND), 404);
     const webhook = await prisma.statusPageWebhook.update({ where: { id }, data: updateData });
 
     logger.info('api.status_page.webhook.updated', { webhookId: id });
@@ -217,18 +228,26 @@ export async function DELETE(req: NextRequest) {
 
   try {
     const id = new URL(req.url).searchParams.get('id');
+    const statusPageId = new URL(req.url).searchParams.get('statusPageId');
 
-    if (!id) {
+    if (!id || !statusPageId) {
       return jsonError(
         new AppError({
           code: 'VALIDATION_FAILED',
           userMessage: LEGACY_REQUIRED_MESSAGE,
-          fields: [{ field: 'id', code: 'required', message: 'id is required' }],
+          fields: [
+            {
+              field: !id ? 'id' : 'statusPageId',
+              code: 'required',
+              message: 'Page and webhook IDs are required',
+            },
+          ],
         })
       );
     }
 
-    await prisma.statusPageWebhook.delete({ where: { id } });
+    const deleted = await prisma.statusPageWebhook.deleteMany({ where: { id, statusPageId } });
+    if (deleted.count === 0) return jsonError(new AppError(WEBHOOK_NOT_FOUND), 404);
 
     logger.info('api.status_page.webhook.deleted', { webhookId: id });
     return jsonOk({ success: true }, 200);

--- a/src/components/SettingsNav.tsx
+++ b/src/components/SettingsNav.tsx
@@ -26,7 +26,7 @@ export default function SettingsNav({ isAdmin = false }: Props) {
       disabled: !isAdmin,
     },
     {
-      href: '/settings/status-page',
+      href: '/settings/status-pages',
       label: 'Status Page',
       description: 'Public status page configuration (Admin only)',
       adminOnly: true,

--- a/src/components/StatusPageConfig.tsx
+++ b/src/components/StatusPageConfig.tsx
@@ -50,7 +50,7 @@ type StatusPageConfigProps = {
     emailProvider?: string | null;
     branding?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     requireAuth?: boolean;
-    privacyMode?: string;
+    privacyMode?: string | null;
     showIncidentDetails?: boolean;
     showIncidentTitles?: boolean;
     showIncidentDescriptions?: boolean;
@@ -974,7 +974,6 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
             id: statusPage.id,
             name: formData.name,
             slug: formData.slug || null,
-            isDefault: formData.isDefault,
             organizationName: formData.organizationName || null,
             subdomain: formData.subdomain || null,
             customDomain: formData.customDomain || null,
@@ -1058,7 +1057,22 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
       setError(payload?.error || 'Unable to delete status page.');
       return;
     }
-    router.push('/settings/status-page');
+    router.push('/settings/status-pages');
+    router.refresh();
+  };
+
+  const handleMakeDefault = async () => {
+    setError(null);
+    const response = await fetch(
+      `/api/settings/status-pages/${encodeURIComponent(statusPage.id)}/make-default`,
+      { method: 'POST' }
+    );
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      setError(payload?.error || 'Unable to change the default status page.');
+      return;
+    }
+    setFormData(prev => ({ ...prev, isDefault: true }));
     router.refresh();
   };
 
@@ -1174,7 +1188,7 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
         const response = await fetch('/api/settings/status-page/announcements', {
           method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id }),
+          body: JSON.stringify({ id, statusPageId: statusPage.id }),
         });
 
         if (!response.ok) {
@@ -1260,7 +1274,7 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
         const response = await fetch('/api/settings/status-page/api-tokens', {
           method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id }),
+          body: JSON.stringify({ id, statusPageId: statusPage.id }),
         });
 
         if (!response.ok) {
@@ -1603,19 +1617,19 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                             helperText="Optional for the default page; required for a dedicated /status/your-slug URL."
                           />
 
-                          <Switch
-                            checked={formData.isDefault}
-                            disabled={statusPage.isDefault}
-                            onChange={checked =>
-                              setFormData(prev => ({ ...prev, isDefault: checked }))
-                            }
-                            label="Default Status Page"
-                            helperText={
-                              statusPage.isDefault
-                                ? 'Make another page the default before changing or deleting this page.'
-                                : 'Serve this page from the backward-compatible /status and /api/status routes.'
-                            }
-                          />
+                          <div className="rounded-md border bg-gray-50 p-4">
+                            <div className="font-medium text-gray-900">Default routing</div>
+                            <p className="mt-1 text-sm text-gray-600">
+                              {statusPage.isDefault
+                                ? 'This page serves /status and the legacy /api/status endpoint. It does not provide settings to other pages.'
+                                : 'This page is independent. Make it the default only to route legacy /status requests here.'}
+                            </p>
+                            {!statusPage.isDefault && (
+                              <Button type="button" variant="secondary" onClick={handleMakeDefault}>
+                                Make default
+                              </Button>
+                            )}
+                          </div>
 
                           <FormField
                             type="input"

--- a/src/components/settings/navConfig.ts
+++ b/src/components/settings/navConfig.ts
@@ -84,7 +84,7 @@ export const SETTINGS_NAV_SECTIONS: SettingsNavSection[] = [
         id: 'status-page',
         label: 'Public Status Page',
         description: 'Customize public status page appearance, custom domains, and announcements',
-        href: '/settings/status-page',
+        href: '/settings/status-pages',
         icon: 'globe',
         requiresAdmin: true,
         badge: 'Admin',

--- a/src/components/status-page/StatusPageEmailConfig.tsx
+++ b/src/components/status-page/StatusPageEmailConfig.tsx
@@ -5,279 +5,290 @@ import { logger } from '@/lib/logger';
 import { Mail, CheckCircle2, AlertCircle } from 'lucide-react';
 
 interface EmailProviderConfigProps {
-    statusPageId: string;
-    currentProvider?: string | null;
+  statusPageId: string;
+  currentProvider?: string | null;
 }
 
-export default function StatusPageEmailConfig({ statusPageId: _statusPageId, currentProvider }: EmailProviderConfigProps) {
-    const [provider, setProvider] = useState<string>(currentProvider || 'auto');
-    const [saving, setSaving] = useState(false);
-    const [availableProviders, setAvailableProviders] = useState<string[]>([]);
-    const [loading, setLoading] = useState(true);
+export default function StatusPageEmailConfig({
+  statusPageId,
+  currentProvider,
+}: EmailProviderConfigProps) {
+  const [provider, setProvider] = useState<string>(currentProvider || 'auto');
+  const [saving, setSaving] = useState(false);
+  const [availableProviders, setAvailableProviders] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        // Fetch available email providers
-        fetch('/api/settings/email-providers')
-            .then(res => res.json())
-            .then(data => {
-                const emailProviders = data.providers
-                    ?.filter((p: any) => ['resend', 'sendgrid', 'smtp', 'ses'].includes(p.provider) && p.enabled) // eslint-disable-line @typescript-eslint/no-explicit-any
-                    .map((p: any) => p.provider) || []; // eslint-disable-line @typescript-eslint/no-explicit-any
-                setAvailableProviders(emailProviders);
-            })
-            .catch(err => {
-                if (err instanceof Error) {
-                    logger.error('Failed to fetch providers', { error: err.message });
-                } else {
-                    logger.error('Failed to fetch providers', { error: String(err) });
-                }
-            })
-            .finally(() => setLoading(false));
-    }, []);
-
-    const handleSave = async () => {
-        setSaving(true);
-        try {
-            const response = await fetch('/api/settings/status-page', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    emailProvider: provider === 'auto' ? null : provider,
-                }),
-            });
-
-            if (response.ok) {
-                // eslint-disable-next-line no-alert
-                alert('Settings saved successfully');
-            } else {
-                const result = await response.json();
-                // eslint-disable-next-line no-alert
-                alert('Failed to save settings: ' + result.error);
-            }
-        } catch (error) {
-            if (error instanceof Error) {
-                logger.error('Error saving email provider', { error: error.message });
-            } else {
-                logger.error('Error saving email provider', { error: String(error) });
-            }
-            // eslint-disable-next-line no-alert
-            alert('An error occurred while saving settings');
-        } finally {
-            setSaving(false);
+  useEffect(() => {
+    // Fetch available email providers
+    fetch('/api/settings/email-providers')
+      .then(res => res.json())
+      .then(data => {
+        const emailProviders =
+          data.providers
+            ?.filter(
+              (p: any) => ['resend', 'sendgrid', 'smtp', 'ses'].includes(p.provider) && p.enabled
+            ) // eslint-disable-line @typescript-eslint/no-explicit-any
+            .map((p: any) => p.provider) || []; // eslint-disable-line @typescript-eslint/no-explicit-any
+        setAvailableProviders(emailProviders);
+      })
+      .catch(err => {
+        if (err instanceof Error) {
+          logger.error('Failed to fetch providers', { error: err.message });
+        } else {
+          logger.error('Failed to fetch providers', { error: String(err) });
         }
-    };
+      })
+      .finally(() => setLoading(false));
+  }, []);
 
-    const providerOptions = [
-        { value: 'auto', label: 'Auto (Use System Default)', description: 'Automatically uses the first available email provider' },
-        { value: 'resend', label: 'Resend', description: 'Use Resend for subscription emails' },
-        { value: 'sendgrid', label: 'SendGrid', description: 'Use SendGrid for subscription emails' },
-        { value: 'smtp', label: 'SMTP', description: 'Use SMTP for subscription emails' },
-        { value: 'ses', label: 'Amazon SES', description: 'Use Amazon SES for subscription emails' },
-    ];
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const response = await fetch('/api/settings/status-page', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: statusPageId,
+          emailProvider: provider === 'auto' ? null : provider,
+        }),
+      });
 
-    return (
-        <div className="email-provider-config">
-            <style jsx>{`
-                .email-provider-config {
-                    background: white;
-                    border-radius: 8px;
-                    padding: 24px;
-                    border: 1px solid #e5e7eb;
-                }
+      if (response.ok) {
+        // eslint-disable-next-line no-alert
+        alert('Settings saved successfully');
+      } else {
+        const result = await response.json();
+        // eslint-disable-next-line no-alert
+        alert('Failed to save settings: ' + result.error);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.error('Error saving email provider', { error: error.message });
+      } else {
+        logger.error('Error saving email provider', { error: String(error) });
+      }
+      // eslint-disable-next-line no-alert
+      alert('An error occurred while saving settings');
+    } finally {
+      setSaving(false);
+    }
+  };
 
-                .config-header {
-                    display: flex;
-                    align-items: center;
-                    gap: 12px;
-                    margin-bottom: 16px;
-                }
+  const providerOptions = [
+    {
+      value: 'auto',
+      label: 'Auto (Use System Default)',
+      description: 'Automatically uses the first available email provider',
+    },
+    { value: 'resend', label: 'Resend', description: 'Use Resend for subscription emails' },
+    { value: 'sendgrid', label: 'SendGrid', description: 'Use SendGrid for subscription emails' },
+    { value: 'smtp', label: 'SMTP', description: 'Use SMTP for subscription emails' },
+    { value: 'ses', label: 'Amazon SES', description: 'Use Amazon SES for subscription emails' },
+  ];
 
-                .config-title {
-                    font-size: 16px;
-                    font-weight: 600;
-                    color: #1f2937;
-                }
+  return (
+    <div className="email-provider-config">
+      <style jsx>{`
+        .email-provider-config {
+          background: white;
+          border-radius: 8px;
+          padding: 24px;
+          border: 1px solid #e5e7eb;
+        }
 
-                .config-description {
-                    font-size: 14px;
-                    color: #6b7280;
-                    margin-bottom: 20px;
-                }
+        .config-header {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          margin-bottom: 16px;
+        }
 
-                .provider-options {
-                    display: flex;
-                    flex-direction: column;
-                    gap: 12px;
-                    margin-bottom: 20px;
-                }
+        .config-title {
+          font-size: 16px;
+          font-weight: 600;
+          color: #1f2937;
+        }
 
-                .provider-option {
-                    display: flex;
-                    align-items: flex-start;
-                    gap: 12px;
-                    padding: 16px;
-                    border: 2px solid #e5e7eb;
-                    border-radius: 8px;
-                    cursor: pointer;
-                    transition: all 0.2s;
-                }
+        .config-description {
+          font-size: 14px;
+          color: #6b7280;
+          margin-bottom: 20px;
+        }
 
-                .provider-option:hover {
-                    border-color: #667eea;
-                    background: #f9fafb;
-                }
+        .provider-options {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          margin-bottom: 20px;
+        }
 
-                .provider-option.selected {
-                    border-color: #667eea;
-                    background: #eef2ff;
-                }
+        .provider-option {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+          padding: 16px;
+          border: 2px solid #e5e7eb;
+          border-radius: 8px;
+          cursor: pointer;
+          transition: all 0.2s;
+        }
 
-                .provider-option.disabled {
-                    opacity: 0.5;
-                    cursor: not-allowed;
-                }
+        .provider-option:hover {
+          border-color: #667eea;
+          background: #f9fafb;
+        }
 
-                .provider-option.disabled:hover {
-                    border-color: #e5e7eb;
-                    background: white;
-                }
+        .provider-option.selected {
+          border-color: #667eea;
+          background: #eef2ff;
+        }
 
-                .radio-input {
-                    margin-top: 4px;
-                    width: 18px;
-                   height: 18px;
-                    cursor: pointer;
-                }
+        .provider-option.disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
 
-                .provider-info {
-                    flex: 1;
-                }
+        .provider-option.disabled:hover {
+          border-color: #e5e7eb;
+          background: white;
+        }
 
-                .provider-label {
-                    font-size: 14px;
-                    font-weight: 600;
-                    color: #1f2937;
-                    margin-bottom: 4px;
-                }
+        .radio-input {
+          margin-top: 4px;
+          width: 18px;
+          height: 18px;
+          cursor: pointer;
+        }
 
-                .provider-description {
-                    font-size: 13px;
-                    color: #6b7280;
-                }
+        .provider-info {
+          flex: 1;
+        }
 
-                .provider-status {
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 6px;
-                    margin-top: 6px;
-                    font-size: 12px;
-                    padding: 4px 8px;
-                    border-radius: 4px;
-                }
+        .provider-label {
+          font-size: 14px;
+          font-weight: 600;
+          color: #1f2937;
+          margin-bottom: 4px;
+        }
 
-                .provider-status.available {
-                    background: #d1fae5;
-                    color: #065f46;
-                }
+        .provider-description {
+          font-size: 13px;
+          color: #6b7280;
+        }
 
-                .provider-status.unavailable {
-                    background: #fee2e2;
-                    color: #991b1b;
-                }
+        .provider-status {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          margin-top: 6px;
+          font-size: 12px;
+          padding: 4px 8px;
+          border-radius: 4px;
+        }
 
-                .save-button {
-                    padding: 10px 20px;
-                    background: #667eea;
-                    color: white;
-                    border: none;
-                    border-radius: 6px;
-                    cursor: pointer;
-                    font-size: 14px;
-                    font-weight: 600;
-                    transition: background 0.2s;
-                }
+        .provider-status.available {
+          background: #d1fae5;
+          color: #065f46;
+        }
 
-                .save-button:hover {
-                    background: #5568d3;
-                }
+        .provider-status.unavailable {
+          background: #fee2e2;
+          color: #991b1b;
+        }
 
-                .save-button:disabled {
-                    opacity: 0.5;
-                    cursor: not-allowed;
-                }
+        .save-button {
+          padding: 10px 20px;
+          background: #667eea;
+          color: white;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 14px;
+          font-weight: 600;
+          transition: background 0.2s;
+        }
 
-                .loading {
-                    padding: 20px;
-                    text-align: center;
-                    color: #6b7280;
-                }
-            `}</style>
+        .save-button:hover {
+          background: #5568d3;
+        }
 
-            <div className="config-header">
-                <Mail size={20} style={{ color: '#667eea' }} />
-                <h3 className="config-title">Email Provider for Subscriptions</h3>
-            </div>
+        .save-button:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
 
-            <p className="config-description">
-                Choose which email provider to use for sending verification and notification emails to status page subscribers.
-            </p>
+        .loading {
+          padding: 20px;
+          text-align: center;
+          color: #6b7280;
+        }
+      `}</style>
 
-            {loading ? (
-                <div className="loading">Loading providers...</div>
-            ) : (
-                <>
-                    <div className="provider-options">
-                        {providerOptions.map((option) => {
-                            const isConfigured = option.value === 'auto' || availableProviders.includes(option.value);
-                            const isDisabled = !isConfigured && option.value !== 'auto';
+      <div className="config-header">
+        <Mail size={20} style={{ color: '#667eea' }} />
+        <h3 className="config-title">Email Provider for Subscriptions</h3>
+      </div>
 
-                            return (
-                                <label
-                                    key={option.value}
-                                    className={`provider-option ${provider === option.value ? 'selected' : ''} ${isDisabled ? 'disabled' : ''}`}
-                                >
-                                    <input
-                                        type="radio"
-                                        className="radio-input"
-                                        name="emailProvider"
-                                        value={option.value}
-                                        checked={provider === option.value}
-                                        onChange={(e) => setProvider(e.target.value)}
-                                        disabled={isDisabled}
-                                    />
-                                    <div className="provider-info">
-                                        <div className="provider-label">{option.label}</div>
-                                        <div className="provider-description">{option.description}</div>
-                                        {option.value !== 'auto' && (
-                                            <div className={`provider-status ${isConfigured ? 'available' : 'unavailable'}`}>
-                                                {isConfigured ? (
-                                                    <>
-                                                        <CheckCircle2 size={12} />
-                                                        Configured in System Settings
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        <AlertCircle size={12} />
-                                                        Not configured
-                                                    </>
-                                                )}
-                                            </div>
-                                        )}
-                                    </div>
-                                </label>
-                            );
-                        })}
-                    </div>
+      <p className="config-description">
+        Choose which email provider to use for sending verification and notification emails to
+        status page subscribers.
+      </p>
 
-                    <button
-                        className="save-button"
-                        onClick={handleSave}
-                        disabled={saving}
-                    >
-                        {saving ? 'Saving...' : 'Save Email Provider'}
-                    </button>
-                </>
-            )}
-        </div>
-    );
+      {loading ? (
+        <div className="loading">Loading providers...</div>
+      ) : (
+        <>
+          <div className="provider-options">
+            {providerOptions.map(option => {
+              const isConfigured =
+                option.value === 'auto' || availableProviders.includes(option.value);
+              const isDisabled = !isConfigured && option.value !== 'auto';
+
+              return (
+                <label
+                  key={option.value}
+                  className={`provider-option ${provider === option.value ? 'selected' : ''} ${isDisabled ? 'disabled' : ''}`}
+                >
+                  <input
+                    type="radio"
+                    className="radio-input"
+                    name="emailProvider"
+                    value={option.value}
+                    checked={provider === option.value}
+                    onChange={e => setProvider(e.target.value)}
+                    disabled={isDisabled}
+                  />
+                  <div className="provider-info">
+                    <div className="provider-label">{option.label}</div>
+                    <div className="provider-description">{option.description}</div>
+                    {option.value !== 'auto' && (
+                      <div
+                        className={`provider-status ${isConfigured ? 'available' : 'unavailable'}`}
+                      >
+                        {isConfigured ? (
+                          <>
+                            <CheckCircle2 size={12} />
+                            Configured in System Settings
+                          </>
+                        ) : (
+                          <>
+                            <AlertCircle size={12} />
+                            Not configured
+                          </>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+
+          <button className="save-button" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving...' : 'Save Email Provider'}
+          </button>
+        </>
+      )}
+    </div>
+  );
 }

--- a/src/components/status-page/StatusPageEmailConfig.tsx
+++ b/src/components/status-page/StatusPageEmailConfig.tsx
@@ -9,6 +9,11 @@ interface EmailProviderConfigProps {
   currentProvider?: string | null;
 }
 
+interface EmailProviderSummary {
+  provider: string;
+  enabled: boolean;
+}
+
 export default function StatusPageEmailConfig({
   statusPageId,
   currentProvider,
@@ -17,18 +22,17 @@ export default function StatusPageEmailConfig({
   const [saving, setSaving] = useState(false);
   const [availableProviders, setAvailableProviders] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState<{ kind: 'success' | 'error'; message: string } | null>(null);
 
   useEffect(() => {
     // Fetch available email providers
     fetch('/api/settings/email-providers')
       .then(res => res.json())
-      .then(data => {
+      .then((data: { providers?: EmailProviderSummary[] }) => {
         const emailProviders =
           data.providers
-            ?.filter(
-              (p: any) => ['resend', 'sendgrid', 'smtp', 'ses'].includes(p.provider) && p.enabled
-            ) // eslint-disable-line @typescript-eslint/no-explicit-any
-            .map((p: any) => p.provider) || []; // eslint-disable-line @typescript-eslint/no-explicit-any
+            ?.filter(p => ['resend', 'sendgrid', 'smtp', 'ses'].includes(p.provider) && p.enabled)
+            .map(p => p.provider) || [];
         setAvailableProviders(emailProviders);
       })
       .catch(err => {
@@ -43,6 +47,7 @@ export default function StatusPageEmailConfig({
 
   const handleSave = async () => {
     setSaving(true);
+    setNotice(null);
     try {
       const response = await fetch('/api/settings/status-page', {
         method: 'POST',
@@ -54,12 +59,10 @@ export default function StatusPageEmailConfig({
       });
 
       if (response.ok) {
-        // eslint-disable-next-line no-alert
-        alert('Settings saved successfully');
+        setNotice({ kind: 'success', message: 'Email provider saved.' });
       } else {
-        const result = await response.json();
-        // eslint-disable-next-line no-alert
-        alert('Failed to save settings: ' + result.error);
+        const result = (await response.json()) as { error?: string };
+        setNotice({ kind: 'error', message: result.error || 'Failed to save email provider.' });
       }
     } catch (error) {
       if (error instanceof Error) {
@@ -67,8 +70,7 @@ export default function StatusPageEmailConfig({
       } else {
         logger.error('Error saving email provider', { error: String(error) });
       }
-      // eslint-disable-next-line no-alert
-      alert('An error occurred while saving settings');
+      setNotice({ kind: 'error', message: 'An error occurred while saving email settings.' });
     } finally {
       setSaving(false);
     }
@@ -287,6 +289,15 @@ export default function StatusPageEmailConfig({
           <button className="save-button" onClick={handleSave} disabled={saving}>
             {saving ? 'Saving...' : 'Save Email Provider'}
           </button>
+          {notice && (
+            <p
+              role="status"
+              aria-live="polite"
+              style={{ marginTop: 12, color: notice.kind === 'success' ? '#047857' : '#b91c1c' }}
+            >
+              {notice.message}
+            </p>
+          )}
         </>
       )}
     </div>

--- a/src/components/status-page/StatusPageLivePreview.tsx
+++ b/src/components/status-page/StatusPageLivePreview.tsx
@@ -9,6 +9,7 @@ import StatusPageAnnouncements from '@/components/status-page/StatusPageAnnounce
 import { logger } from '@/lib/logger';
 import { toSafeStyleTagContent } from '@/lib/status-page-content';
 import { computeStatusPageTheme } from '@/lib/status-page-theme';
+import { STATUS_PAGE_PREVIEW_BASE_CSS } from '@/lib/status-page-preview-css';
 
 export interface StatusPagePreviewService {
   id: string;
@@ -923,6 +924,7 @@ export default function StatusPageLivePreview({
             {previewRoot &&
               createPortal(
                 <>
+                  <style data-status-page-preview-baseline>{STATUS_PAGE_PREVIEW_BASE_CSS}</style>
                   {previewData.branding?.customCss && (
                     <style
                       dangerouslySetInnerHTML={{

--- a/src/components/status-page/StatusPageLivePreview.tsx
+++ b/src/components/status-page/StatusPageLivePreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import StatusPageHeader from '@/components/status-page/StatusPageHeader';
 import StatusPageServices from '@/components/status-page/StatusPageServices';
 import StatusPageIncidents from '@/components/status-page/StatusPageIncidents';
@@ -143,6 +144,8 @@ export default function StatusPageLivePreview({
   const [scale, setScale] = useState(1);
   const [zoomMode, setZoomMode] = useState<'fit' | 'manual'>('fit');
   const containerRef = useRef<HTMLDivElement>(null);
+  const shadowHostRef = useRef<HTMLDivElement>(null);
+  const [previewRoot, setPreviewRoot] = useState<ShadowRoot | null>(null);
   const [frameHeight, setFrameHeight] = useState('100%');
 
   // Calculate overall status based on services
@@ -294,6 +297,12 @@ export default function StatusPageLivePreview({
   const scaledFrameHeightStyle = Number.isFinite(frameHeightNumber)
     ? `${Math.round(frameHeightNumber * scale)}px`
     : 'auto';
+
+  useEffect(() => {
+    const host = shadowHostRef.current;
+    if (!host) return;
+    setPreviewRoot(host.shadowRoot || host.attachShadow({ mode: 'open' }));
+  }, []);
 
   const renderStatusPageContent = (contentMaxWidthValue: string) => (
     <>
@@ -589,14 +598,6 @@ export default function StatusPageLivePreview({
 
   return (
     <>
-      {/* Custom CSS */}
-      {previewData.branding?.customCss && (
-        <style
-          dangerouslySetInnerHTML={{
-            __html: toSafeStyleTagContent(previewData.branding.customCss),
-          }}
-        />
-      )}
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
         {/* Device & Zoom Controls */}
         <div
@@ -905,6 +906,7 @@ export default function StatusPageLivePreview({
               </>
             )}
             <div
+              ref={shadowHostRef}
               className="status-page-container"
               style={{
                 width: `${targetWidth}px`,
@@ -920,11 +922,23 @@ export default function StatusPageLivePreview({
                 fontFamily: computedTheme.fontFamily,
                 ...(computedTheme.cssVariables as React.CSSProperties),
               }}
-            >
-              <div style={{ minHeight: '100%', display: 'flex', flexDirection: 'column' }}>
-                {renderStatusPageContent(contentMaxWidth)}
-              </div>
-            </div>
+            />
+            {previewRoot &&
+              createPortal(
+                <>
+                  {previewData.branding?.customCss && (
+                    <style
+                      dangerouslySetInnerHTML={{
+                        __html: toSafeStyleTagContent(previewData.branding.customCss),
+                      }}
+                    />
+                  )}
+                  <div style={{ minHeight: '100%', display: 'flex', flexDirection: 'column' }}>
+                    {renderStatusPageContent(contentMaxWidth)}
+                  </div>
+                </>,
+                previewRoot
+              )}
           </div>
         </div>
       </div>

--- a/src/components/status-page/StatusPageLivePreview.tsx
+++ b/src/components/status-page/StatusPageLivePreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import StatusPageHeader from '@/components/status-page/StatusPageHeader';
 import StatusPageServices from '@/components/status-page/StatusPageServices';
@@ -144,7 +144,6 @@ export default function StatusPageLivePreview({
   const [scale, setScale] = useState(1);
   const [zoomMode, setZoomMode] = useState<'fit' | 'manual'>('fit');
   const containerRef = useRef<HTMLDivElement>(null);
-  const shadowHostRef = useRef<HTMLDivElement>(null);
   const [previewRoot, setPreviewRoot] = useState<ShadowRoot | null>(null);
   const [frameHeight, setFrameHeight] = useState('100%');
 
@@ -298,10 +297,8 @@ export default function StatusPageLivePreview({
     ? `${Math.round(frameHeightNumber * scale)}px`
     : 'auto';
 
-  useEffect(() => {
-    const host = shadowHostRef.current;
-    if (!host) return;
-    setPreviewRoot(host.shadowRoot || host.attachShadow({ mode: 'open' }));
+  const bindPreviewRoot = useCallback((host: HTMLDivElement | null) => {
+    if (host) setPreviewRoot(host.shadowRoot || host.attachShadow({ mode: 'open' }));
   }, []);
 
   const renderStatusPageContent = (contentMaxWidthValue: string) => (
@@ -906,7 +903,7 @@ export default function StatusPageLivePreview({
               </>
             )}
             <div
-              ref={shadowHostRef}
+              ref={bindPreviewRoot}
               className="status-page-container"
               style={{
                 width: `${targetWidth}px`,

--- a/src/components/status-page/StatusPageManager.tsx
+++ b/src/components/status-page/StatusPageManager.tsx
@@ -26,7 +26,7 @@ export function StatusPageManager() {
       };
       const page = payload.data?.page;
       if (!response.ok || !page) throw new Error(payload.error || 'Unable to create page.');
-      router.push(`/settings/status-page?page=${encodeURIComponent(page.id)}`);
+      router.push(`/settings/status-pages/${encodeURIComponent(page.id)}`);
       router.refresh();
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : 'Unable to create page.');

--- a/src/components/status-page/StatusPageSubscribers.tsx
+++ b/src/components/status-page/StatusPageSubscribers.tsx
@@ -40,6 +40,8 @@ export default function StatusPageSubscribers({ statusPageId }: { statusPageId: 
   const [filter, setFilter] = useState<'all' | 'verified' | 'unverified'>('all');
   const [searchEmail, setSearchEmail] = useState('');
   const [searchInput, setSearchInput] = useState('');
+  const [unsubscribeCandidate, setUnsubscribeCandidate] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const limit = 10;
 
   const fetchSubscribers = useCallback(
@@ -80,16 +82,17 @@ export default function StatusPageSubscribers({ statusPageId }: { statusPageId: 
 
   useEffect(() => {
     const controller = new AbortController();
-    setData(null);
     void fetchSubscribers(controller.signal);
     return () => controller.abort();
   }, [fetchSubscribers]);
 
   const handleUnsubscribe = async (subscriptionId: string) => {
-    // eslint-disable-next-line no-alert
-    if (!confirm('Are you sure you want to remove this subscriber?')) {
+    if (unsubscribeCandidate !== subscriptionId) {
+      setUnsubscribeCandidate(subscriptionId);
       return;
     }
+
+    setActionError(null);
 
     try {
       const response = await fetch(
@@ -100,11 +103,11 @@ export default function StatusPageSubscribers({ statusPageId }: { statusPageId: 
       );
 
       if (response.ok) {
-        fetchSubscribers();
+        setUnsubscribeCandidate(null);
+        void fetchSubscribers();
       } else {
-        const result = await response.json();
-        // eslint-disable-next-line no-alert
-        alert(`Failed to unsubscribe: ${result.error}`);
+        const result = (await response.json()) as { error?: string };
+        setActionError(result.error || 'Failed to unsubscribe.');
       }
     } catch (error) {
       if (error instanceof Error) {
@@ -112,8 +115,7 @@ export default function StatusPageSubscribers({ statusPageId }: { statusPageId: 
       } else {
         logger.error('Error unsubscribing', { error: String(error) });
       }
-      // eslint-disable-next-line no-alert
-      alert('Failed to remove subscriber');
+      setActionError('Failed to remove subscriber.');
     }
   };
 
@@ -349,6 +351,11 @@ export default function StatusPageSubscribers({ statusPageId }: { statusPageId: 
           </div>
         )}
       </div>
+      {actionError && (
+        <p role="alert" className="mb-4 text-sm text-red-700">
+          {actionError}
+        </p>
+      )}
 
       <div className="subscribers-filters">
         <div className="search-box">
@@ -456,7 +463,9 @@ export default function StatusPageSubscribers({ statusPageId }: { statusPageId: 
                         onClick={() => handleUnsubscribe(subscriber.id)}
                       >
                         <Trash2 size={14} />
-                        Unsubscribe
+                        {unsubscribeCandidate === subscriber.id
+                          ? 'Confirm unsubscribe'
+                          : 'Unsubscribe'}
                       </button>
                     )}
                   </td>

--- a/src/components/status-page/StatusPageSubscribers.tsx
+++ b/src/components/status-page/StatusPageSubscribers.tsx
@@ -1,467 +1,497 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { ChevronLeft, ChevronRight, Mail, CheckCircle2, XCircle, Trash2, Search } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Mail,
+  CheckCircle2,
+  XCircle,
+  Trash2,
+  Search,
+} from 'lucide-react';
 import { logger } from '@/lib/logger';
 import { Badge } from '@/components/ui/shadcn/badge';
 
 interface Subscriber {
+  id: string;
+  email: string;
+  verified: boolean;
+  subscribedAt: string;
+  unsubscribedAt: string | null;
+  statusPage: {
     id: string;
-    email: string;
-    verified: boolean;
-    subscribedAt: string;
-    unsubscribedAt: string | null;
-    statusPage: {
-        id: string;
-        name: string;
-    };
+    name: string;
+  };
 }
 
 interface SubscribersData {
-    subscribers: Subscriber[];
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
+  subscribers: Subscriber[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
 }
 
 export default function StatusPageSubscribers({ statusPageId }: { statusPageId: string }) {
-    const [data, setData] = useState<SubscribersData | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [page, setPage] = useState(1);
-    const [filter, setFilter] = useState<'all' | 'verified' | 'unverified'>('all');
-    const [searchEmail, setSearchEmail] = useState('');
-    const [searchInput, setSearchInput] = useState('');
-    const limit = 10;
+  const [data, setData] = useState<SubscribersData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [filter, setFilter] = useState<'all' | 'verified' | 'unverified'>('all');
+  const [searchEmail, setSearchEmail] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const limit = 10;
 
-    const fetchSubscribers = useCallback(async () => {
-        setLoading(true);
-        try {
-            const params = new URLSearchParams({
-                page: page.toString(),
-                limit: limit.toString(),
-                statusPageId,
-            });
+  const fetchSubscribers = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({
+          page: page.toString(),
+          limit: limit.toString(),
+          statusPageId,
+        });
 
-            if (filter === 'verified') params.set('verified', 'true');
-            if (filter === 'unverified') params.set('verified', 'false');
-            if (searchEmail) params.set('email', searchEmail);
+        if (filter === 'verified') params.set('verified', 'true');
+        if (filter === 'unverified') params.set('verified', 'false');
+        if (searchEmail) params.set('email', searchEmail);
 
-            const response = await fetch(`/api/status-page/subscribers?${params}`);
-            const result = await response.json();
+        const response = await fetch(`/api/status-page/subscribers?${params}`, { signal });
+        const result = await response.json();
 
-            if (response.ok) {
-                setData(result);
-            } else {
-                logger.error('Failed to fetch subscribers', { error: result.error });
-            }
-        } catch (error) {
-            if (error instanceof Error) {
-                logger.error('Error fetching subscribers', { error: error.message });
-            } else {
-                logger.error('Error fetching subscribers', { error: String(error) });
-            }
-        } finally {
-            setLoading(false);
+        if (response.ok) {
+          setData(result);
+        } else {
+          logger.error('Failed to fetch subscribers', { error: result.error });
         }
-    }, [page, limit, statusPageId, filter, searchEmail]);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        if (error instanceof Error) {
+          logger.error('Error fetching subscribers', { error: error.message });
+        } else {
+          logger.error('Error fetching subscribers', { error: String(error) });
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [page, limit, statusPageId, filter, searchEmail]
+  );
 
-    useEffect(() => {
+  useEffect(() => {
+    const controller = new AbortController();
+    setData(null);
+    void fetchSubscribers(controller.signal);
+    return () => controller.abort();
+  }, [fetchSubscribers]);
+
+  const handleUnsubscribe = async (subscriptionId: string) => {
+    // eslint-disable-next-line no-alert
+    if (!confirm('Are you sure you want to remove this subscriber?')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/api/status-page/subscribers?id=${subscriptionId}&statusPageId=${encodeURIComponent(statusPageId)}`,
+        {
+          method: 'DELETE',
+        }
+      );
+
+      if (response.ok) {
         fetchSubscribers();
-    }, [fetchSubscribers]);
-
-    const handleUnsubscribe = async (subscriptionId: string) => {
+      } else {
+        const result = await response.json();
         // eslint-disable-next-line no-alert
-        if (!confirm('Are you sure you want to remove this subscriber?')) { return; }
+        alert(`Failed to unsubscribe: ${result.error}`);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.error('Error unsubscribing', { error: error.message });
+      } else {
+        logger.error('Error unsubscribing', { error: String(error) });
+      }
+      // eslint-disable-next-line no-alert
+      alert('Failed to remove subscriber');
+    }
+  };
 
-        try {
-            const response = await fetch(`/api/status-page/subscribers?id=${subscriptionId}`, {
-                method: 'DELETE',
-            });
+  const handleSearch = () => {
+    setSearchEmail(searchInput);
+    setPage(1);
+  };
 
-            if (response.ok) {
-                fetchSubscribers();
-            } else {
-                const result = await response.json();
-                // eslint-disable-next-line no-alert
-                alert(`Failed to unsubscribe: ${result.error}`);
-            }
-        } catch (error) {
-            if (error instanceof Error) {
-                logger.error('Error unsubscribing', { error: error.message });
-            } else {
-                logger.error('Error unsubscribing', { error: String(error) });
-            }
-            // eslint-disable-next-line no-alert
-            alert('Subscriber removed successfully');
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  return (
+    <div className="status-page-subscribers">
+      <style jsx>{`
+        .status-page-subscribers {
+          background: white;
+          border-radius: 8px;
+          padding: 24px;
+          border: 1px solid #e5e7eb;
         }
-    };
 
-    const handleSearch = () => {
-        setSearchEmail(searchInput);
-        setPage(1);
-    };
-
-    const handleKeyPress = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter') {
-            handleSearch();
+        .subscribers-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 24px;
         }
-    };
 
-    return (
-        <div className="status-page-subscribers">
-            <style jsx>{`
-                .status-page-subscribers {
-                    background: white;
-                    border-radius: 8px;
-                    padding: 24px;
-                    border: 1px solid #e5e7eb;
-                }
+        .subscribers-title {
+          font-size: 18px;
+          font-weight: 600;
+          color: #1f2937;
+        }
 
-                .subscribers-header {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    margin-bottom: 24px;
-                }
+        .subscribers-filters {
+          display: flex;
+          gap: 12px;
+          margin-bottom: 20px;
+          flex-wrap: wrap;
+        }
 
-                .subscribers-title {
-                    font-size: 18px;
-                    font-weight: 600;
-                    color: #1f2937;
-                }
+        .search-box {
+          display: flex;
+          gap: 8px;
+          flex: 1;
+          min-width: 250px;
+        }
 
-                .subscribers-filters {
-                    display: flex;
-                    gap: 12px;
-                    margin-bottom: 20px;
-                    flex-wrap: wrap;
-                }
+        .search-input {
+          flex: 1;
+          padding: 8px 12px;
+          border: 1px solid #d1d5db;
+          border-radius: 6px;
+          font-size: 14px;
+        }
 
-                .search-box {
-                    display: flex;
-                    gap: 8px;
-                    flex: 1;
-                    min-width: 250px;
-                }
+        .search-btn {
+          padding: 8px 16px;
+          background: #667eea;
+          color: white;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 14px;
+          font-weight: 500;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
 
-                .search-input {
-                    flex: 1;
-                    padding: 8px 12px;
-                    border: 1px solid #d1d5db;
-                    border-radius: 6px;
-                    font-size: 14px;
-                }
+        .search-btn:hover {
+          background: #5568d3;
+        }
 
-                .search-btn {
-                    padding: 8px 16px;
-                    background: #667eea;
-                    color: white;
-                    border: none;
-                    border-radius: 6px;
-                    cursor: pointer;
-                    font-size: 14px;
-                    font-weight: 500;
-                    display: flex;
-                    align-items: center;
-                    gap: 6px;
-                }
+        .filter-group {
+          display: flex;
+          gap: 8px;
+          border: 1px solid #d1d5db;
+          border-radius: 6px;
+          padding: 4px;
+          background: #f9fafb;
+        }
 
-                .search-btn:hover {
-                    background: #5568d3;
-                }
+        .filter-btn {
+          padding: 6px 12px;
+          border: none;
+          background: transparent;
+          color: #6b7280;
+          font-size: 14px;
+          font-weight: 500;
+          border-radius: 4px;
+          cursor: pointer;
+          transition: all 0.2s;
+        }
 
-                .filter-group {
-                    display: flex;
-                    gap: 8px;
-                    border: 1px solid #d1d5db;
-                    border-radius: 6px;
-                    padding: 4px;
-                    background: #f9fafb;
-                }
+        .filter-btn.active {
+          background: white;
+          color: #667eea;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+        }
 
-                .filter-btn {
-                    padding: 6px 12px;
-                    border: none;
-                    background: transparent;
-                    color: #6b7280;
-                    font-size: 14px;
-                    font-weight: 500;
-                    border-radius: 4px;
-                    cursor: pointer;
-                    transition: all 0.2s;
-                }
+        .subscribers-table {
+          width: 100%;
+          border-collapse: collapse;
+        }
 
-                .filter-btn.active {
-                    background: white;
-                    color: #667eea;
-                    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-                }
+        .subscribers-table th {
+          text-align: left;
+          padding: 12px;
+          background: #f9fafb;
+          border-bottom: 1px solid #e5e7eb;
+          font-size: 13px;
+          font-weight: 600;
+          color: #6b7280;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+        }
 
-                .subscribers-table {
-                    width: 100%;
-                    border-collapse: collapse;
-                }
+        .subscribers-table td {
+          padding: 16px 12px;
+          border-bottom: 1px solid #e5e7eb;
+          font-size: 14px;
+          color: #374151;
+        }
 
-                .subscribers-table th {
-                    text-align: left;
-                    padding: 12px;
-                    background: #f9fafb;
-                    border-bottom: 1px solid #e5e7eb;
-                    font-size: 13px;
-                    font-weight: 600;
-                    color: #6b7280;
-                    text-transform: uppercase;
-                    letter-spacing: 0.05em;
-                }
+        .email-cell {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+        }
 
-                .subscribers-table td {
-                    padding: 16px 12px;
-                    border-bottom: 1px solid #e5e7eb;
-                    font-size: 14px;
-                    color: #374151;
-                }
+        .status-badge {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 4px 10px;
+          border-radius: 12px;
+          font-size: 12px;
+          font-weight: 600;
+        }
 
-                .email-cell {
-                    display: flex;
-                    align-items: center;
-                    gap: 10px;
-                }
+        .status-verified {
+          background: #d1fae5;
+          color: #065f46;
+        }
 
-                .status-badge {
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 6px;
-                    padding: 4px 10px;
-                    border-radius: 12px;
-                    font-size: 12px;
-                    font-weight: 600;
-                }
+        .status-unverified {
+          background: #fee2e2;
+          color: #991b1b;
+        }
 
-                .status-verified {
-                    background: #d1fae5;
-                    color: #065f46;
-                }
+        .status-unsubscribed {
+          background: #f3f4f6;
+          color: #6b7280;
+        }
 
-                .status-unverified {
-                    background: #fee2e2;
-                    color: #991b1b;
-                }
+        .action-btn {
+          padding: 6px 12px;
+          border: 1px solid #d1d5db;
+          background: white;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 13px;
+          color: #dc2626;
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          transition: all 0.2s;
+        }
 
-                .status-unsubscribed {
-                    background: #f3f4f6;
-                    color: #6b7280;
-                }
+        .action-btn:hover {
+          background: #fee2e2;
+          border-color: #dc2626;
+        }
 
-                .action-btn {
-                    padding: 6px 12px;
-                    border: 1px solid #d1d5db;
-                    background: white;
-                    border-radius: 6px;
-                    cursor: pointer;
-                    font-size: 13px;
-                    color: #dc2626;
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 6px;
-                    transition: all 0.2s;
-                }
+        .pagination {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-top: 20px;
+          padding-top: 20px;
+          border-top: 1px solid #e5e7eb;
+        }
 
-                .action-btn:hover {
-                    background: #fee2e2;
-                    border-color: #dc2626;
-                }
+        .pagination-info {
+          font-size: 14px;
+          color: #6b7280;
+        }
 
-                .pagination {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    margin-top: 20px;
-                    padding-top: 20px;
-                    border-top: 1px solid #e5e7eb;
-                }
+        .pagination-controls {
+          display: flex;
+          gap: 8px;
+        }
 
-                .pagination-info {
-                    font-size: 14px;
-                    color: #6b7280;
-                }
+        .pagination-btn {
+          padding: 8px 12px;
+          border: 1px solid #d1d5db;
+          background: white;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 14px;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          color: #374151;
+        }
 
-                .pagination-controls {
-                    display: flex;
-                    gap: 8px;
-                }
+        .pagination-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
 
-                .pagination-btn {
-                    padding: 8px 12px;
-                    border: 1px solid #d1d5db;
-                    background: white;
-                    border-radius: 6px;
-                    cursor: pointer;
-                    font-size: 14px;
-                    display: flex;
-                    align-items: center;
-                    gap: 6px;
-                    color: #374151;
-                }
+        .pagination-btn:hover:not(:disabled) {
+          background: #f9fafb;
+        }
 
-                .pagination-btn:disabled {
-                    opacity: 0.5;
-                    cursor: not-allowed;
-                }
+        .loading,
+        .no-data {
+          text-align: center;
+          padding: 40px;
+          color: #6b7280;
+        }
+      `}</style>
 
-                .pagination-btn:hover:not(:disabled) {
-                    background: #f9fafb;
-                }
+      <div className="subscribers-header">
+        <h2 className="subscribers-title">Email Subscribers</h2>
+        {data && (
+          <div style={{ fontSize: '14px', color: '#6b7280' }}>
+            {data.total} total subscriber{data.total !== 1 && 's'}
+          </div>
+        )}
+      </div>
 
-                .loading, .no-data {
-                    text-align: center;
-                    padding: 40px;
-                    color: #6b7280;
-                }
-            `}</style>
-
-            <div className="subscribers-header">
-                <h2 className="subscribers-title">Email Subscribers</h2>
-                {data && (
-                    <div style={{ fontSize: '14px', color: '#6b7280' }}>
-                        {data.total} total subscriber{data.total !== 1 && 's'}
-                    </div>
-                )}
-            </div>
-
-            <div className="subscribers-filters">
-                <div className="search-box">
-                    <input
-                        type="text"
-                        className="search-input"
-                        placeholder="Search by email..."
-                        value={searchInput}
-                        onChange={(e) => setSearchInput(e.target.value)}
-                        onKeyPress={handleKeyPress}
-                    />
-                    <button className="search-btn" onClick={handleSearch}>
-                        <Search size={16} />
-                        Search
-                    </button>
-                </div>
-
-                <div className="filter-group">
-                    <button
-                        className={`filter-btn ${filter === 'all' ? 'active' : ''}`}
-                        onClick={() => { setFilter('all'); setPage(1); }}
-                    >
-                        All
-                    </button>
-                    <button
-                        className={`filter-btn ${filter === 'verified' ? 'active' : ''}`}
-                        onClick={() => { setFilter('verified'); setPage(1); }}
-                    >
-                        Verified
-                    </button>
-                    <button
-                        className={`filter-btn ${filter === 'unverified' ? 'active' : ''}`}
-                        onClick={() => { setFilter('unverified'); setPage(1); }}
-                    >
-                        Unverified
-                    </button>
-                </div>
-            </div>
-
-            {loading ? (
-                <div className="loading">Loading subscribers...</div>
-            ) : !data || data.subscribers.length === 0 ? (
-                <div className="no-data">
-                    <Mail size={48} style={{ margin: '0 auto 16px', opacity: 0.3 }} />
-                    <p>No subscribers found.</p>
-                </div>
-            ) : (
-                <>
-                    <table className="subscribers-table">
-                        <thead>
-                            <tr>
-                                <th>Email</th>
-                                <th>Status</th>
-                                <th>Subscribed</th>
-                                <th>Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {data.subscribers.map((subscriber) => (
-                                <tr key={subscriber.id}>
-                                    <td>
-                                        <div className="email-cell">
-                                            <Mail size={16} style={{ color: '#9ca3af' }} />
-                                            {subscriber.email}
-                                        </div>
-                                    </td>
-                                    <td>
-                                        {subscriber.unsubscribedAt ? (
-                                            <Badge variant="neutral" size="xs" className="gap-1">
-                                                <XCircle className="h-3 w-3" />
-                                                Unsubscribed
-                                            </Badge>
-                                        ) : subscriber.verified ? (
-                                            <Badge variant="success" size="xs" className="gap-1">
-                                                <CheckCircle2 className="h-3 w-3" />
-                                                Verified
-                                            </Badge>
-                                        ) : (
-                                            <Badge variant="danger" size="xs" className="gap-1">
-                                                <XCircle className="h-3 w-3" />
-                                                Unverified
-                                            </Badge>
-                                        )}
-                                    </td>
-                                    <td>
-                                        {new Date(subscriber.subscribedAt).toLocaleDateString('en-US', {
-                                            year: 'numeric',
-                                            month: 'short',
-                                            day: 'numeric',
-                                        })}
-                                    </td>
-                                    <td>
-                                        {!subscriber.unsubscribedAt && (
-                                            <button
-                                                className="action-btn"
-                                                onClick={() => handleUnsubscribe(subscriber.id)}
-                                            >
-                                                <Trash2 size={14} />
-                                                Unsubscribe
-                                            </button>
-                                        )}
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-
-                    {data.totalPages > 1 && (
-                        <div className="pagination">
-                            <div className="pagination-info">
-                                Page {data.page} of {data.totalPages}
-                            </div>
-                            <div className="pagination-controls">
-                                <button
-                                    className="pagination-btn"
-                                    onClick={() => setPage(page - 1)}
-                                    disabled={page === 1}
-                                >
-                                    <ChevronLeft size={16} />
-                                    Previous
-                                </button>
-                                <button
-                                    className="pagination-btn"
-                                    onClick={() => setPage(page + 1)}
-                                    disabled={page === data.totalPages}
-                                >
-                                    Next
-                                    <ChevronRight size={16} />
-                                </button>
-                            </div>
-                        </div>
-                    )}
-                </>
-            )}
+      <div className="subscribers-filters">
+        <div className="search-box">
+          <input
+            type="text"
+            className="search-input"
+            placeholder="Search by email..."
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            onKeyPress={handleKeyPress}
+          />
+          <button className="search-btn" onClick={handleSearch}>
+            <Search size={16} />
+            Search
+          </button>
         </div>
-    );
+
+        <div className="filter-group">
+          <button
+            className={`filter-btn ${filter === 'all' ? 'active' : ''}`}
+            onClick={() => {
+              setFilter('all');
+              setPage(1);
+            }}
+          >
+            All
+          </button>
+          <button
+            className={`filter-btn ${filter === 'verified' ? 'active' : ''}`}
+            onClick={() => {
+              setFilter('verified');
+              setPage(1);
+            }}
+          >
+            Verified
+          </button>
+          <button
+            className={`filter-btn ${filter === 'unverified' ? 'active' : ''}`}
+            onClick={() => {
+              setFilter('unverified');
+              setPage(1);
+            }}
+          >
+            Unverified
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="loading">Loading subscribers...</div>
+      ) : !data || data.subscribers.length === 0 ? (
+        <div className="no-data">
+          <Mail size={48} style={{ margin: '0 auto 16px', opacity: 0.3 }} />
+          <p>No subscribers found.</p>
+        </div>
+      ) : (
+        <>
+          <table className="subscribers-table">
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Status</th>
+                <th>Subscribed</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.subscribers.map(subscriber => (
+                <tr key={subscriber.id}>
+                  <td>
+                    <div className="email-cell">
+                      <Mail size={16} style={{ color: '#9ca3af' }} />
+                      {subscriber.email}
+                    </div>
+                  </td>
+                  <td>
+                    {subscriber.unsubscribedAt ? (
+                      <Badge variant="neutral" size="xs" className="gap-1">
+                        <XCircle className="h-3 w-3" />
+                        Unsubscribed
+                      </Badge>
+                    ) : subscriber.verified ? (
+                      <Badge variant="success" size="xs" className="gap-1">
+                        <CheckCircle2 className="h-3 w-3" />
+                        Verified
+                      </Badge>
+                    ) : (
+                      <Badge variant="danger" size="xs" className="gap-1">
+                        <XCircle className="h-3 w-3" />
+                        Unverified
+                      </Badge>
+                    )}
+                  </td>
+                  <td>
+                    {new Date(subscriber.subscribedAt).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </td>
+                  <td>
+                    {!subscriber.unsubscribedAt && (
+                      <button
+                        className="action-btn"
+                        onClick={() => handleUnsubscribe(subscriber.id)}
+                      >
+                        <Trash2 size={14} />
+                        Unsubscribe
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {data.totalPages > 1 && (
+            <div className="pagination">
+              <div className="pagination-info">
+                Page {data.page} of {data.totalPages}
+              </div>
+              <div className="pagination-controls">
+                <button
+                  className="pagination-btn"
+                  onClick={() => setPage(page - 1)}
+                  disabled={page === 1}
+                >
+                  <ChevronLeft size={16} />
+                  Previous
+                </button>
+                <button
+                  className="pagination-btn"
+                  onClick={() => setPage(page + 1)}
+                  disabled={page === data.totalPages}
+                >
+                  Next
+                  <ChevronRight size={16} />
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
 }

--- a/src/components/status-page/StatusPageWebhooksSettings.tsx
+++ b/src/components/status-page/StatusPageWebhooksSettings.tsx
@@ -39,6 +39,7 @@ export default function StatusPageWebhooksSettings({
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
+  const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     url: '',
     events: [] as string[],
@@ -67,8 +68,6 @@ export default function StatusPageWebhooksSettings({
 
   useEffect(() => {
     const controller = new AbortController();
-    setWebhooks([]);
-    setIsLoading(true);
     void loadWebhooks(controller.signal);
     return () => controller.abort();
   }, [loadWebhooks]);
@@ -105,8 +104,10 @@ export default function StatusPageWebhooksSettings({
   };
 
   const handleDelete = (id: string) => {
-    // eslint-disable-next-line no-alert
-    if (!confirm('Are you sure you want to delete this webhook?')) return;
+    if (deleteCandidate !== id) {
+      setDeleteCandidate(id);
+      return;
+    }
 
     startTransition(async () => {
       try {
@@ -121,6 +122,7 @@ export default function StatusPageWebhooksSettings({
           throw await errorFromResponse(response, 'Failed to delete webhook');
         }
 
+        setDeleteCandidate(null);
         await loadWebhooks();
       } catch (err) {
         setError(displayError(err, 'Failed to delete webhook'));
@@ -363,7 +365,7 @@ export default function StatusPageWebhooksSettings({
                           onClick={() => handleDelete(webhook.id)}
                           isLoading={isPending}
                         >
-                          Delete
+                          {deleteCandidate === webhook.id ? 'Confirm delete' : 'Delete'}
                         </Button>
                       </div>
                     </div>

--- a/src/components/status-page/StatusPageWebhooksSettings.tsx
+++ b/src/components/status-page/StatusPageWebhooksSettings.tsx
@@ -6,280 +6,374 @@ import { errorFromResponse } from '@/lib/client-error';
 import { toUserFacingError } from '@/lib/user-facing-error';
 
 interface Webhook {
-    id: string;
-    url: string;
-    events: string[];
-    enabled: boolean;
-    lastTriggeredAt?: string | null;
-    createdAt: string;
+  id: string;
+  url: string;
+  events: string[];
+  enabled: boolean;
+  lastTriggeredAt?: string | null;
+  createdAt: string;
 }
 
 interface StatusPageWebhooksSettingsProps {
-    statusPageId: string;
+  statusPageId: string;
 }
 
 const WEBHOOK_EVENTS = [
-    { value: 'incident.created', label: 'Incident Created' },
-    { value: 'incident.updated', label: 'Incident Updated' },
-    { value: 'incident.resolved', label: 'Incident Resolved' },
-    { value: 'status.changed', label: 'Status Changed' },
-    { value: 'maintenance.scheduled', label: 'Maintenance Scheduled' },
+  { value: 'incident.created', label: 'Incident Created' },
+  { value: 'incident.updated', label: 'Incident Updated' },
+  { value: 'incident.resolved', label: 'Incident Resolved' },
+  { value: 'status.changed', label: 'Status Changed' },
+  { value: 'maintenance.scheduled', label: 'Maintenance Scheduled' },
 ];
 
 function displayError(error: unknown, fallback: string): string {
-    const friendly = toUserFacingError(error, fallback);
-    return friendly.description || friendly.title;
+  const friendly = toUserFacingError(error, fallback);
+  return friendly.description || friendly.title;
 }
 
-export default function StatusPageWebhooksSettings({ statusPageId }: StatusPageWebhooksSettingsProps) {
-    const [webhooks, setWebhooks] = useState<Webhook[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [isPending, startTransition] = useTransition();
-    const [error, setError] = useState<string | null>(null);
-    const [showForm, setShowForm] = useState(false);
-    const [formData, setFormData] = useState({
-        url: '',
-        events: [] as string[],
-    });
+export default function StatusPageWebhooksSettings({
+  statusPageId,
+}: StatusPageWebhooksSettingsProps) {
+  const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formData, setFormData] = useState({
+    url: '',
+    events: [] as string[],
+  });
 
-    const loadWebhooks = useCallback(async () => {
-        try {
-            const response = await fetch(`/api/status-page/webhooks?statusPageId=${statusPageId}`);
-            if (!response.ok) {
-                throw await errorFromResponse(response, 'Failed to load webhooks');
-            }
-            const data = await response.json();
-            setWebhooks(data.webhooks || []);
-        } catch (err) {
-            setError(displayError(err, 'Failed to load webhooks'));
-        } finally {
-            setIsLoading(false);
-        }
-    }, [statusPageId]);
-
-    useEffect(() => {
-        loadWebhooks();
-    }, [loadWebhooks]);
-
-    const handleCreate = () => {
-        if (!formData.url || formData.events.length === 0) {
-            setError('URL and at least one event are required');
-            return;
-        }
-
-        startTransition(async () => {
-            try {
-                const response = await fetch('/api/status-page/webhooks', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        statusPageId,
-                        url: formData.url,
-                        events: formData.events,
-                    }),
-                });
-
-                if (!response.ok) {
-                    throw await errorFromResponse(response, 'Failed to create webhook');
-                }
-
-                setFormData({ url: '', events: [] });
-                setShowForm(false);
-                await loadWebhooks();
-            } catch (err) {
-                setError(displayError(err, 'Failed to create webhook'));
-            }
+  const loadWebhooks = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        const response = await fetch(`/api/status-page/webhooks?statusPageId=${statusPageId}`, {
+          signal,
         });
-    };
+        if (!response.ok) {
+          throw await errorFromResponse(response, 'Failed to load webhooks');
+        }
+        const data = await response.json();
+        setWebhooks(data.webhooks || []);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setError(displayError(err, 'Failed to load webhooks'));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [statusPageId]
+  );
 
-    const handleDelete = (id: string) => {
-        // eslint-disable-next-line no-alert
-        if (!confirm('Are you sure you want to delete this webhook?')) return;
+  useEffect(() => {
+    const controller = new AbortController();
+    setWebhooks([]);
+    setIsLoading(true);
+    void loadWebhooks(controller.signal);
+    return () => controller.abort();
+  }, [loadWebhooks]);
 
-        startTransition(async () => {
-            try {
-                const response = await fetch(`/api/status-page/webhooks?id=${id}`, {
-                    method: 'DELETE',
-                });
-
-                if (!response.ok) {
-                    throw await errorFromResponse(response, 'Failed to delete webhook');
-                }
-
-                await loadWebhooks();
-            } catch (err) {
-                setError(displayError(err, 'Failed to delete webhook'));
-            }
-        });
-    };
-
-    const toggleEvent = (event: string) => {
-        setFormData(prev => ({
-            ...prev,
-            events: prev.events.includes(event)
-                ? prev.events.filter(e => e !== event)
-                : [...prev.events, event],
-        }));
-    };
-
-    if (isLoading) {
-        return <div>Loading webhooks...</div>;
+  const handleCreate = () => {
+    if (!formData.url || formData.events.length === 0) {
+      setError('URL and at least one event are required');
+      return;
     }
 
-    return (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-6)' }}>
+    startTransition(async () => {
+      try {
+        const response = await fetch('/api/status-page/webhooks', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            statusPageId,
+            url: formData.url,
+            events: formData.events,
+          }),
+        });
+
+        if (!response.ok) {
+          throw await errorFromResponse(response, 'Failed to create webhook');
+        }
+
+        setFormData({ url: '', events: [] });
+        setShowForm(false);
+        await loadWebhooks();
+      } catch (err) {
+        setError(displayError(err, 'Failed to create webhook'));
+      }
+    });
+  };
+
+  const handleDelete = (id: string) => {
+    // eslint-disable-next-line no-alert
+    if (!confirm('Are you sure you want to delete this webhook?')) return;
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(
+          `/api/status-page/webhooks?id=${id}&statusPageId=${encodeURIComponent(statusPageId)}`,
+          {
+            method: 'DELETE',
+          }
+        );
+
+        if (!response.ok) {
+          throw await errorFromResponse(response, 'Failed to delete webhook');
+        }
+
+        await loadWebhooks();
+      } catch (err) {
+        setError(displayError(err, 'Failed to delete webhook'));
+      }
+    });
+  };
+
+  const toggleEvent = (event: string) => {
+    setFormData(prev => ({
+      ...prev,
+      events: prev.events.includes(event)
+        ? prev.events.filter(e => e !== event)
+        : [...prev.events, event],
+    }));
+  };
+
+  if (isLoading) {
+    return <div>Loading webhooks...</div>;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-6)' }}>
+      <Card>
+        <div style={{ padding: 'var(--spacing-6)' }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 'var(--spacing-4)',
+            }}
+          >
+            <div>
+              <h2
+                style={{
+                  fontSize: 'var(--font-size-xl)',
+                  fontWeight: '700',
+                  marginBottom: 'var(--spacing-2)',
+                }}
+              >
+                Webhooks
+              </h2>
+              <p style={{ fontSize: 'var(--font-size-sm)', color: 'var(--text-muted)' }}>
+                Receive real-time notifications when incidents occur or status changes
+              </p>
+            </div>
+            <Button variant="primary" onClick={() => setShowForm(!showForm)}>
+              {showForm ? 'Cancel' : 'Add Webhook'}
+            </Button>
+          </div>
+
+          {error && (
+            <div
+              style={{
+                padding: 'var(--spacing-3)',
+                background: 'var(--color-error-light)',
+                borderRadius: 'var(--radius-md)',
+                color: 'var(--color-error-dark)',
+                marginBottom: 'var(--spacing-4)',
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          {showForm && (
             <Card>
-                <div style={{ padding: 'var(--spacing-6)' }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-4)' }}>
-                        <div>
-                            <h2 style={{ fontSize: 'var(--font-size-xl)', fontWeight: '700', marginBottom: 'var(--spacing-2)' }}>
-                                Webhooks
-                            </h2>
-                            <p style={{ fontSize: 'var(--font-size-sm)', color: 'var(--text-muted)' }}>
-                                Receive real-time notifications when incidents occur or status changes
-                            </p>
+              <div style={{ padding: 'var(--spacing-4)' }}>
+                <h3
+                  style={{
+                    fontSize: 'var(--font-size-lg)',
+                    fontWeight: '600',
+                    marginBottom: 'var(--spacing-4)',
+                  }}
+                >
+                  Create Webhook
+                </h3>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-4)' }}>
+                  <FormField
+                    type="input"
+                    inputType="url"
+                    label="Webhook URL"
+                    value={formData.url}
+                    onChange={e => setFormData({ ...formData, url: e.target.value })}
+                    placeholder="https://your-api.com/webhooks/status"
+                    required
+                  />
+                  <p className="text-sm text-gray-500">
+                    Webhooks allow you to receive HTTP POST requests when incidents are created,
+                    updated, or resolved. The payload will include the event type and incident
+                    details. For security, you can verify the{' '}
+                    <code className="text-xs bg-gray-100 px-1 py-0.5 rounded">
+                      X-Webhook-Signature
+                    </code>{' '}
+                    header using your webhook secret.
+                  </p>
+                  <div>
+                    <label
+                      style={{
+                        display: 'block',
+                        marginBottom: 'var(--spacing-2)',
+                        fontSize: 'var(--font-size-sm)',
+                        fontWeight: '500',
+                      }}
+                    >
+                      Events to Subscribe To
+                    </label>
+                    <div
+                      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}
+                    >
+                      {WEBHOOK_EVENTS.map(event => (
+                        <label
+                          key={event.value}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            padding: 'var(--spacing-2)',
+                            cursor: 'pointer',
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={formData.events.includes(event.value)}
+                            onChange={() => toggleEvent(event.value)}
+                            style={{ marginRight: 'var(--spacing-2)' }}
+                          />
+                          <span>{event.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <Button variant="primary" onClick={handleCreate} isLoading={isPending}>
+                    Create Webhook
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          )}
+
+          {webhooks.length === 0 && !showForm && (
+            <div
+              style={{
+                padding: 'var(--spacing-6)',
+                textAlign: 'center',
+                color: 'var(--text-muted)',
+              }}
+            >
+              <p>No webhooks configured. Click &quot;Add Webhook&quot; to create one.</p>
+            </div>
+          )}
+
+          {webhooks.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 'var(--spacing-3)',
+                marginTop: 'var(--spacing-4)',
+              }}
+            >
+              {webhooks.map(webhook => (
+                <Card key={webhook.id}>
+                  <div style={{ padding: 'var(--spacing-4)' }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'start',
+                        marginBottom: 'var(--spacing-3)',
+                      }}
+                    >
+                      <div style={{ flex: 1 }}>
+                        <div
+                          style={{
+                            fontSize: 'var(--font-size-sm)',
+                            fontWeight: '600',
+                            marginBottom: 'var(--spacing-1)',
+                          }}
+                        >
+                          {webhook.url}
+                        </div>
+                        <div
+                          style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)' }}
+                        >
+                          Events:{' '}
+                          {Array.isArray(webhook.events) ? webhook.events.join(', ') : 'None'}
+                        </div>
+                        {webhook.lastTriggeredAt && (
+                          <div
+                            style={{
+                              fontSize: 'var(--font-size-xs)',
+                              color: 'var(--text-muted)',
+                              marginTop: 'var(--spacing-1)',
+                            }}
+                          >
+                            Last triggered: {new Date(webhook.lastTriggeredAt).toLocaleString()}
+                          </div>
+                        )}
+                      </div>
+                      <div
+                        style={{ display: 'flex', gap: 'var(--spacing-2)', alignItems: 'center' }}
+                      >
+                        <div
+                          style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-2)' }}
+                        >
+                          <label
+                            style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)' }}
+                          >
+                            Enabled
+                          </label>
+                          <Switch
+                            checked={webhook.enabled}
+                            onChange={async enabled => {
+                              try {
+                                const response = await fetch('/api/status-page/webhooks', {
+                                  method: 'PATCH',
+                                  headers: { 'Content-Type': 'application/json' },
+                                  body: JSON.stringify({
+                                    id: webhook.id,
+                                    statusPageId,
+                                    enabled,
+                                  }),
+                                });
+                                if (!response.ok) {
+                                  throw await errorFromResponse(
+                                    response,
+                                    'Failed to update webhook'
+                                  );
+                                }
+                                await loadWebhooks();
+                              } catch (err) {
+                                setError(displayError(err, 'Failed to update webhook'));
+                              }
+                            }}
+                          />
                         </div>
                         <Button
-                            variant="primary"
-                            onClick={() => setShowForm(!showForm)}
+                          variant="danger"
+                          size="sm"
+                          onClick={() => handleDelete(webhook.id)}
+                          isLoading={isPending}
                         >
-                            {showForm ? 'Cancel' : 'Add Webhook'}
+                          Delete
                         </Button>
+                      </div>
                     </div>
-
-                    {error && (
-                        <div style={{ padding: 'var(--spacing-3)', background: 'var(--color-error-light)', borderRadius: 'var(--radius-md)', color: 'var(--color-error-dark)', marginBottom: 'var(--spacing-4)' }}>
-                            {error}
-                        </div>
-                    )}
-
-                    {showForm && (
-                        <Card>
-                            <div style={{ padding: 'var(--spacing-4)' }}>
-                                <h3 style={{ fontSize: 'var(--font-size-lg)', fontWeight: '600', marginBottom: 'var(--spacing-4)' }}>
-                                    Create Webhook
-                                </h3>
-                                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-4)' }}>
-                                    <FormField
-                                        type="input"
-                                        inputType="url"
-                                        label="Webhook URL"
-                                        value={formData.url}
-                                        onChange={(e) => setFormData({ ...formData, url: e.target.value })}
-                                        placeholder="https://your-api.com/webhooks/status"
-                                        required
-                                    />
-                                    <p className="text-sm text-gray-500">
-                                        Webhooks allow you to receive HTTP POST requests when incidents are created, updated, or resolved. The payload will include the event type and incident details.
-                                        For security, you can verify the <code className="text-xs bg-gray-100 px-1 py-0.5 rounded">X-Webhook-Signature</code> header using your webhook secret.
-                                    </p>
-                                    <div>
-                                        <label style={{ display: 'block', marginBottom: 'var(--spacing-2)', fontSize: 'var(--font-size-sm)', fontWeight: '500' }}>
-                                            Events to Subscribe To
-                                        </label>
-                                        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}>
-                                            {WEBHOOK_EVENTS.map((event) => (
-                                                <label
-                                                    key={event.value}
-                                                    style={{
-                                                        display: 'flex',
-                                                        alignItems: 'center',
-                                                        padding: 'var(--spacing-2)',
-                                                        cursor: 'pointer',
-                                                    }}
-                                                >
-                                                    <input
-                                                        type="checkbox"
-                                                        checked={formData.events.includes(event.value)}
-                                                        onChange={() => toggleEvent(event.value)}
-                                                        style={{ marginRight: 'var(--spacing-2)' }}
-                                                    />
-                                                    <span>{event.label}</span>
-                                                </label>
-                                            ))}
-                                        </div>
-                                    </div>
-                                    <Button
-                                        variant="primary"
-                                        onClick={handleCreate}
-                                        isLoading={isPending}
-                                    >
-                                        Create Webhook
-                                    </Button>
-                                </div>
-                            </div>
-                        </Card>
-                    )}
-
-                    {webhooks.length === 0 && !showForm && (
-                        <div style={{ padding: 'var(--spacing-6)', textAlign: 'center', color: 'var(--text-muted)' }}>
-                            <p>No webhooks configured. Click &quot;Add Webhook&quot; to create one.</p>
-                        </div>
-                    )}
-
-                    {webhooks.length > 0 && (
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-3)', marginTop: 'var(--spacing-4)' }}>
-                            {webhooks.map((webhook) => (
-                                <Card key={webhook.id}>
-                                    <div style={{ padding: 'var(--spacing-4)' }}>
-                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start', marginBottom: 'var(--spacing-3)' }}>
-                                            <div style={{ flex: 1 }}>
-                                                <div style={{ fontSize: 'var(--font-size-sm)', fontWeight: '600', marginBottom: 'var(--spacing-1)' }}>
-                                                    {webhook.url}
-                                                </div>
-                                                <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)' }}>
-                                                    Events: {Array.isArray(webhook.events) ? webhook.events.join(', ') : 'None'}
-                                                </div>
-                                                {webhook.lastTriggeredAt && (
-                                                    <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)', marginTop: 'var(--spacing-1)' }}>
-                                                        Last triggered: {new Date(webhook.lastTriggeredAt).toLocaleString()}
-                                                    </div>
-                                                )}
-                                            </div>
-                                            <div style={{ display: 'flex', gap: 'var(--spacing-2)', alignItems: 'center' }}>
-                                                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-2)' }}>
-                                                    <label style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)' }}>
-                                                        Enabled
-                                                    </label>
-                                                    <Switch
-                                                        checked={webhook.enabled}
-                                                        onChange={async (enabled) => {
-                                                            try {
-                                                                const response = await fetch('/api/status-page/webhooks', {
-                                                                    method: 'PATCH',
-                                                                    headers: { 'Content-Type': 'application/json' },
-                                                                    body: JSON.stringify({
-                                                                        id: webhook.id,
-                                                                        enabled,
-                                                                    }),
-                                                                });
-                                                                if (!response.ok) {
-                                                                    throw await errorFromResponse(response, 'Failed to update webhook');
-                                                                }
-                                                                await loadWebhooks();
-                                                            } catch (err) {
-                                                                setError(displayError(err, 'Failed to update webhook'));
-                                                            }
-                                                        }}
-                                                    />
-                                                </div>
-                                                <Button
-                                                    variant="danger"
-                                                    size="sm"
-                                                    onClick={() => handleDelete(webhook.id)}
-                                                    isLoading={isPending}
-                                                >
-                                                    Delete
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </Card>
-                            ))}
-                        </div>
-                    )}
-                </div>
-            </Card>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
         </div>
-    );
+      </Card>
+    </div>
+  );
 }

--- a/src/lib/status-page-preview-css.ts
+++ b/src/lib/status-page-preview-css.ts
@@ -1,0 +1,93 @@
+/**
+ * Baseline styles used by public status-page components that render inside the
+ * admin preview's ShadowRoot. Keep these selectors aligned with globals.css;
+ * customer CSS is injected after this baseline so its normal cascade wins.
+ */
+export const STATUS_PAGE_PREVIEW_BASE_CSS = `
+:host {
+  display: block;
+  color: inherit;
+  font: inherit;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+button, input, select, textarea {
+  color: inherit;
+  font: inherit;
+}
+
+.status-page-input,
+.status-page-select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  background: #ffffff;
+  color: inherit;
+}
+
+.status-page-input:focus,
+.status-page-input:focus-visible,
+.status-page-select:focus,
+.status-page-select:focus-visible {
+  border-color: var(--status-primary, #2563eb);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--status-primary, #2563eb) 18%, transparent);
+  outline: none;
+}
+
+.status-page-button {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #64748b;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.status-page-button:disabled,
+.status-page-button[aria-disabled="true"] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-page-button[data-active="true"] {
+  background: var(--status-primary, #2563eb);
+  border-color: var(--status-primary, #2563eb);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.status-page-button[data-variant="primary"] {
+  background: var(--status-primary, #0f172a);
+  border-color: var(--status-primary, #0f172a);
+  color: #ffffff;
+  font-weight: 600;
+  border-radius: 0.625rem;
+  padding: 0.625rem 1.25rem;
+}
+
+.status-page-button:focus,
+.status-page-button:focus-visible {
+  border-color: var(--status-primary, #2563eb);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--status-primary, #2563eb) 18%, transparent);
+  outline: none;
+}
+
+.status-page-button:hover {
+  background: #f9fafb;
+  border-color: #d1d5db;
+}
+
+.status-page-button[data-active="true"]:hover,
+.status-page-button[data-variant="primary"]:hover {
+  background: var(--status-primary-hover, #1d4ed8);
+  border-color: var(--status-primary-hover, #1d4ed8);
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--status-primary, #2563eb) 22%, transparent);
+}
+`;

--- a/src/lib/status-pages/admin.ts
+++ b/src/lib/status-pages/admin.ts
@@ -1,0 +1,93 @@
+import 'server-only';
+
+import type { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
+
+const STATUS_PAGE_LIFECYCLE_LOCK = 'opsknight:status-pages:lifecycle:v1';
+
+export class StatusPageAdminError extends Error {
+  constructor(
+    readonly code:
+      | 'STATUS_PAGE_NOT_FOUND'
+      | 'STATUS_PAGE_DEFAULT_REPLACEMENT_REQUIRED'
+      | 'STATUS_PAGE_DEFAULT_REPLACEMENT_INVALID',
+    message: string
+  ) {
+    super(message);
+    this.name = 'StatusPageAdminError';
+  }
+}
+
+async function lockLifecycle(tx: Prisma.TransactionClient) {
+  await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${STATUS_PAGE_LIFECYCLE_LOCK}, 0))`;
+}
+
+export async function requireStatusPageForAdmin(
+  statusPageId: string,
+  tx: Prisma.TransactionClient | typeof prisma = prisma
+) {
+  const page = await tx.statusPage.findUnique({ where: { id: statusPageId } });
+  if (!page) throw new StatusPageAdminError('STATUS_PAGE_NOT_FOUND', 'Status page not found.');
+  return page;
+}
+
+export async function createStatusPage(input: {
+  name: string;
+  slug: string;
+  makeDefault?: boolean;
+}) {
+  return prisma.$transaction(async tx => {
+    await lockLifecycle(tx);
+    const count = await tx.statusPage.count();
+    const isDefault = count === 0 || input.makeDefault === true;
+    if (isDefault) {
+      await tx.statusPage.updateMany({ where: { isDefault: true }, data: { isDefault: false } });
+    }
+    return tx.statusPage.create({
+      data: { name: input.name, slug: input.slug, enabled: false, isDefault },
+    });
+  });
+}
+
+export async function makeDefaultStatusPage(statusPageId: string) {
+  return prisma.$transaction(async tx => {
+    await lockLifecycle(tx);
+    await requireStatusPageForAdmin(statusPageId, tx);
+    await tx.statusPage.updateMany({
+      where: { isDefault: true, id: { not: statusPageId } },
+      data: { isDefault: false },
+    });
+    return tx.statusPage.update({ where: { id: statusPageId }, data: { isDefault: true } });
+  });
+}
+
+export async function deleteStatusPage(statusPageId: string, replacementDefaultId?: string) {
+  return prisma.$transaction(async tx => {
+    await lockLifecycle(tx);
+    const page = await requireStatusPageForAdmin(statusPageId, tx);
+    const count = await tx.statusPage.count();
+
+    if (page.isDefault && count > 1) {
+      if (!replacementDefaultId) {
+        throw new StatusPageAdminError(
+          'STATUS_PAGE_DEFAULT_REPLACEMENT_REQUIRED',
+          'Choose a replacement default status page before deleting this page.'
+        );
+      }
+      if (replacementDefaultId === statusPageId) {
+        throw new StatusPageAdminError(
+          'STATUS_PAGE_DEFAULT_REPLACEMENT_INVALID',
+          'The replacement default must be a different status page.'
+        );
+      }
+      await requireStatusPageForAdmin(replacementDefaultId, tx);
+      await tx.statusPage.update({ where: { id: statusPageId }, data: { isDefault: false } });
+      await tx.statusPage.update({
+        where: { id: replacementDefaultId },
+        data: { isDefault: true },
+      });
+    }
+
+    await tx.statusPage.delete({ where: { id: statusPageId } });
+  });
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -110,12 +110,36 @@ export const StatusPageBrandingSchema = z
     logoUrl: statusPageAssetUrl.optional(),
     logo: statusPageAssetUrl.optional(),
     faviconUrl: statusPageAssetUrl.optional(),
-    primaryColor: z.string().trim().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-    primary: z.string().trim().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-    backgroundColor: z.string().trim().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-    background: z.string().trim().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-    textColor: z.string().trim().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-    text: z.string().trim().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+    primaryColor: z
+      .string()
+      .trim()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
+    primary: z
+      .string()
+      .trim()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
+    backgroundColor: z
+      .string()
+      .trim()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
+    background: z
+      .string()
+      .trim()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
+    textColor: z
+      .string()
+      .trim()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
+    text: z
+      .string()
+      .trim()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
     fontFamily: z.string().trim().max(100).optional(),
     customCss: z.string().max(200_000).optional(),
     layout: z.enum(['default', 'compact', 'wide']).optional(),
@@ -142,7 +166,6 @@ export const StatusPageSettingsSchema = z
       .refine(isStatusPageSlug, 'Use lowercase letters, numbers, and single hyphens only.')
       .optional()
       .nullable(),
-    isDefault: z.boolean().optional(),
     organizationName: z.string().trim().max(200).optional().nullable(),
     subdomain: statusPageHostname.optional().nullable(),
     customDomain: statusPageHostname.optional().nullable(),
@@ -238,6 +261,7 @@ export const StatusApiTokenCreateSchema = z.object({
 });
 
 export const StatusApiTokenRevokeSchema = z.object({
+  statusPageId: z.string().min(1),
   id: z.string().min(1),
 });
 
@@ -264,6 +288,7 @@ export const StatusAnnouncementCreateSchema = z
   });
 
 export const StatusAnnouncementPatchSchema = z.object({
+  statusPageId: z.string().min(1),
   id: z.string().min(1),
   title: z.string().trim().min(1).max(200).optional(),
   message: z.string().trim().min(1).max(5000).optional(),
@@ -275,6 +300,7 @@ export const StatusAnnouncementPatchSchema = z.object({
 });
 
 export const StatusAnnouncementDeleteSchema = z.object({
+  statusPageId: z.string().min(1),
   id: z.string().min(1),
 });
 

--- a/tests/architecture/status-page-admin-isolation-contract.test.ts
+++ b/tests/architecture/status-page-admin-isolation-contract.test.ts
@@ -1,32 +1,34 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-
-const root = process.cwd();
-const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
 
 describe('status-page administration isolation contract', () => {
   it('never provisions a page while rendering settings and remounts editors by page identity', () => {
-    const legacy = read('src/app/(app)/settings/status-page/page.tsx');
-    const workspace = read('src/app/(app)/settings/status-pages/[pageId]/page.tsx');
+    const legacy = fs.readFileSync('src/app/(app)/settings/status-page/page.tsx', 'utf8');
+    const workspace = fs.readFileSync(
+      'src/app/(app)/settings/status-pages/[pageId]/page.tsx',
+      'utf8'
+    );
     expect(legacy).not.toContain('prisma.statusPage.create(');
     expect(legacy).toContain("'/settings/status-pages'");
     expect(workspace).toContain('key={statusPage.id}');
   });
 
   it('requires explicit page identity for every legacy settings update', () => {
-    const route = read('src/app/api/settings/status-page/route.ts');
-    const email = read('src/components/status-page/StatusPageEmailConfig.tsx');
+    const route = fs.readFileSync('src/app/api/settings/status-page/route.ts', 'utf8');
+    const email = fs.readFileSync('src/components/status-page/StatusPageEmailConfig.tsx', 'utf8');
     expect(route).toContain('if (!id)');
     expect(route).not.toContain(': await prisma.statusPage.findFirst');
     expect(email).toContain('id: statusPageId');
   });
 
   it('binds child mutations to both page and resource identity', () => {
-    const webhooks = read('src/app/api/status-page/webhooks/route.ts');
-    const subscribers = read('src/app/api/status-page/subscribers/route.ts');
-    const announcements = read('src/app/api/settings/status-page/announcements/route.ts');
-    const tokens = read('src/app/api/settings/status-page/api-tokens/route.ts');
+    const webhooks = fs.readFileSync('src/app/api/status-page/webhooks/route.ts', 'utf8');
+    const subscribers = fs.readFileSync('src/app/api/status-page/subscribers/route.ts', 'utf8');
+    const announcements = fs.readFileSync(
+      'src/app/api/settings/status-page/announcements/route.ts',
+      'utf8'
+    );
+    const tokens = fs.readFileSync('src/app/api/settings/status-page/api-tokens/route.ts', 'utf8');
     expect(webhooks).toContain('where: { id, statusPageId }');
     expect(subscribers).toContain('where: { id: subscriptionId, statusPageId }');
     expect(announcements).toContain('where: { id, statusPageId }');
@@ -34,9 +36,10 @@ describe('status-page administration isolation contract', () => {
   });
 
   it('serializes and fences the default-page lifecycle', () => {
-    const service = read('src/lib/status-pages/admin.ts');
-    const migration = read(
-      'prisma/migrations/20260906220000_status_page_default_invariant/migration.sql'
+    const service = fs.readFileSync('src/lib/status-pages/admin.ts', 'utf8');
+    const migration = fs.readFileSync(
+      'prisma/migrations/20260906220000_status_page_default_invariant/migration.sql',
+      'utf8'
     );
     expect(service).toContain('pg_advisory_xact_lock');
     expect(service).toContain('STATUS_PAGE_DEFAULT_REPLACEMENT_REQUIRED');
@@ -45,18 +48,22 @@ describe('status-page administration isolation contract', () => {
   });
 
   it('cancels stale page-owned resource requests after navigation', () => {
-    for (const file of [
+    const subscribers = fs.readFileSync(
       'src/components/status-page/StatusPageSubscribers.tsx',
+      'utf8'
+    );
+    const webhooks = fs.readFileSync(
       'src/components/status-page/StatusPageWebhooksSettings.tsx',
-    ]) {
-      const source = read(file);
+      'utf8'
+    );
+    for (const source of [subscribers, webhooks]) {
       expect(source).toContain('new AbortController()');
       expect(source).toContain('controller.abort()');
     }
   });
 
   it('executes custom CSS only inside an isolated preview root', () => {
-    const preview = read('src/components/status-page/StatusPageLivePreview.tsx');
+    const preview = fs.readFileSync('src/components/status-page/StatusPageLivePreview.tsx', 'utf8');
     expect(preview).toContain("attachShadow({ mode: 'open' })");
     expect(preview).toContain('createPortal(');
     expect(preview.indexOf('dangerouslySetInnerHTML')).toBeGreaterThan(

--- a/tests/architecture/status-page-admin-isolation-contract.test.ts
+++ b/tests/architecture/status-page-admin-isolation-contract.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
+
+describe('status-page administration isolation contract', () => {
+  it('never provisions a page while rendering settings and remounts editors by page identity', () => {
+    const legacy = read('src/app/(app)/settings/status-page/page.tsx');
+    const workspace = read('src/app/(app)/settings/status-pages/[pageId]/page.tsx');
+    expect(legacy).not.toContain('prisma.statusPage.create(');
+    expect(legacy).toContain("'/settings/status-pages'");
+    expect(workspace).toContain('key={statusPage.id}');
+  });
+
+  it('requires explicit page identity for every legacy settings update', () => {
+    const route = read('src/app/api/settings/status-page/route.ts');
+    const email = read('src/components/status-page/StatusPageEmailConfig.tsx');
+    expect(route).toContain('if (!id)');
+    expect(route).not.toContain(': await prisma.statusPage.findFirst');
+    expect(email).toContain('id: statusPageId');
+  });
+
+  it('binds child mutations to both page and resource identity', () => {
+    const webhooks = read('src/app/api/status-page/webhooks/route.ts');
+    const subscribers = read('src/app/api/status-page/subscribers/route.ts');
+    const announcements = read('src/app/api/settings/status-page/announcements/route.ts');
+    const tokens = read('src/app/api/settings/status-page/api-tokens/route.ts');
+    expect(webhooks).toContain('where: { id, statusPageId }');
+    expect(subscribers).toContain('where: { id: subscriptionId, statusPageId }');
+    expect(announcements).toContain('where: { id, statusPageId }');
+    expect(tokens).toContain('where: { id, statusPageId }');
+  });
+
+  it('serializes and fences the default-page lifecycle', () => {
+    const service = read('src/lib/status-pages/admin.ts');
+    const migration = read(
+      'prisma/migrations/20260906220000_status_page_default_invariant/migration.sql'
+    );
+    expect(service).toContain('pg_advisory_xact_lock');
+    expect(service).toContain('STATUS_PAGE_DEFAULT_REPLACEMENT_REQUIRED');
+    expect(migration).toContain('StatusPage_single_default_idx');
+    expect(migration).toContain('WHERE "isDefault" = true');
+  });
+
+  it('cancels stale page-owned resource requests after navigation', () => {
+    for (const file of [
+      'src/components/status-page/StatusPageSubscribers.tsx',
+      'src/components/status-page/StatusPageWebhooksSettings.tsx',
+    ]) {
+      const source = read(file);
+      expect(source).toContain('new AbortController()');
+      expect(source).toContain('controller.abort()');
+    }
+  });
+
+  it('executes custom CSS only inside an isolated preview root', () => {
+    const preview = read('src/components/status-page/StatusPageLivePreview.tsx');
+    expect(preview).toContain("attachShadow({ mode: 'open' })");
+    expect(preview).toContain('createPortal(');
+    expect(preview.indexOf('dangerouslySetInnerHTML')).toBeGreaterThan(
+      preview.indexOf('createPortal(')
+    );
+  });
+});

--- a/tests/architecture/status-page-admin-isolation-contract.test.ts
+++ b/tests/architecture/status-page-admin-isolation-contract.test.ts
@@ -65,6 +65,7 @@ describe('status-page administration isolation contract', () => {
   it('executes custom CSS only inside an isolated preview root', () => {
     const preview = fs.readFileSync('src/components/status-page/StatusPageLivePreview.tsx', 'utf8');
     expect(preview).toContain("attachShadow({ mode: 'open' })");
+    expect(preview).toContain('STATUS_PAGE_PREVIEW_BASE_CSS');
     expect(preview).toContain('createPortal(');
     expect(preview.indexOf('dangerouslySetInnerHTML')).toBeGreaterThan(
       preview.indexOf('createPortal(')

--- a/tests/components/status-page/StatusPageLivePreview.test.tsx
+++ b/tests/components/status-page/StatusPageLivePreview.test.tsx
@@ -142,6 +142,22 @@ describe('StatusPageLivePreview Component', () => {
     expect(statusContainer.style.getPropertyValue('--status-text')).toBe('#f8fafc');
   });
 
+  it('injects the public component baseline before customer CSS in the shadow root', () => {
+    const customData: StatusPagePreviewData = {
+      ...mockPreviewData,
+      branding: { ...mockPreviewData.branding, customCss: '.status-page-button { color: red; }' },
+    };
+
+    const { container } = render(<StatusPageLivePreview previewData={customData} />);
+    const host = container.querySelector('.status-page-container');
+    const styles = Array.from(host?.shadowRoot?.querySelectorAll('style') ?? []);
+
+    expect(styles).toHaveLength(2);
+    expect(styles[0].hasAttribute('data-status-page-preview-baseline')).toBe(true);
+    expect(styles[0].textContent).toContain('.status-page-button[data-variant="primary"]');
+    expect(styles[1].textContent).toContain('.status-page-button { color: red; }');
+  });
+
   it('safely adapts contrast when user sets dark background with default text', () => {
     const darkData: StatusPagePreviewData = {
       ...mockPreviewData,

--- a/tests/features/status-page/status-page.test.ts
+++ b/tests/features/status-page/status-page.test.ts
@@ -234,18 +234,18 @@ describe('Status Page Settings Save Flow', () => {
                 ? organizationName.trim()
                 : null
               : undefined,
-          subdomain: subdomain && subdomain.trim() ? subdomain.trim() : null,
-          customDomain: customDomain && customDomain.trim() ? customDomain.trim() : null,
-          enabled: enabled !== false,
-          showServices: showServices !== false,
-          showIncidents: showIncidents !== false,
-          showMetrics: showMetrics !== false,
-          showSubscribe: showSubscribe !== false,
+          subdomain: subdomain !== undefined ? subdomain?.trim() || null : undefined,
+          customDomain: customDomain !== undefined ? customDomain?.trim() || null : undefined,
+          enabled,
+          showServices,
+          showIncidents,
+          showMetrics,
+          showSubscribe,
           uptimeExcellentThreshold: uptimeExcellentThreshold ?? undefined,
           uptimeGoodThreshold: uptimeGoodThreshold ?? undefined,
-          footerText: footerText && footerText.trim() ? footerText.trim() : null,
-          contactEmail: contactEmail && contactEmail.trim() ? contactEmail.trim() : null,
-          contactUrl: contactUrl && contactUrl.trim() ? contactUrl.trim() : null,
+          footerText: footerText !== undefined ? footerText?.trim() || null : undefined,
+          contactEmail: contactEmail !== undefined ? contactEmail?.trim() || null : undefined,
+          contactUrl: contactUrl !== undefined ? contactUrl?.trim() || null : undefined,
         };
       };
 
@@ -270,23 +270,23 @@ describe('Status Page Settings Save Flow', () => {
     });
 
     it('should handle explicit false for boolean fields', () => {
-      const buildBooleanField = (value: boolean | undefined) => value !== false;
+      const buildBooleanField = (value: boolean | undefined) => value;
 
       expect(buildBooleanField(false)).toBe(false);
       expect(buildBooleanField(true)).toBe(true);
-      expect(buildBooleanField(undefined)).toBe(true);
+      expect(buildBooleanField(undefined)).toBeUndefined();
     });
 
     it('should handle empty strings correctly', () => {
       const normalizeStringField = (value: string | null | undefined) =>
-        value && value.trim() ? value.trim() : null;
+        value !== undefined ? value?.trim() || null : undefined;
 
       expect(normalizeStringField('')).toBe(null);
       expect(normalizeStringField('  ')).toBe(null);
       expect(normalizeStringField('test')).toBe('test');
       expect(normalizeStringField('  test  ')).toBe('test');
       expect(normalizeStringField(null)).toBe(null);
-      expect(normalizeStringField(undefined)).toBe(null);
+      expect(normalizeStringField(undefined)).toBeUndefined();
     });
 
     it('should handle uptime threshold coercion', () => {

--- a/tests/integration/status-page-settings-isolation.test.ts
+++ b/tests/integration/status-page-settings-isolation.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '@/app/api/settings/status-page/route';
+import {
+  createTestService,
+  createTestStatusPage,
+  createTestUser,
+  resetDatabase,
+  testPrisma,
+} from '../helpers/test-db';
+
+const describeIfRealDB =
+  process.env.VITEST_USE_REAL_DB === '1' || process.env.CI ? describe : describe.skip;
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/lib/auth', () => ({ getAuthOptions: vi.fn() }));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+import { getServerSession } from 'next-auth';
+
+const settingsSelect = {
+  enabled: true,
+  showSubscribe: true,
+  customDomain: true,
+  subdomain: true,
+  footerText: true,
+  contactEmail: true,
+  emailProvider: true,
+  branding: true,
+  privacyMode: true,
+  showIncidentTitles: true,
+  statusApiRequireToken: true,
+  statusApiRateLimitEnabled: true,
+} as const;
+
+describeIfRealDB('status-page settings isolation', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await resetDatabase();
+    const admin = await createTestUser({ email: 'status-admin@example.com', role: 'ADMIN' });
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: admin.id, email: admin.email, role: 'ADMIN', tokenVersion: 0 },
+    } as never);
+  });
+
+  it('preserves omitted settings and isolates every settings section to the selected page', async () => {
+    const pageA = await createTestStatusPage({
+      name: 'Status Page A',
+      enabled: true,
+      showSubscribe: true,
+      customDomain: 'status-a.example.com',
+      subdomain: 'status-a',
+      footerText: 'Page A footer',
+      contactEmail: 'a@example.com',
+      emailProvider: 'smtp',
+      branding: { primaryColor: '#ff0000' },
+      privacyMode: 'PUBLIC',
+      showIncidentTitles: true,
+      statusApiRequireToken: false,
+      statusApiRateLimitEnabled: false,
+    });
+    const pageB = await createTestStatusPage({
+      name: 'Status Page B',
+      enabled: false,
+      showSubscribe: false,
+      customDomain: 'status-b.example.com',
+      subdomain: 'status-b',
+      footerText: 'Page B footer',
+      contactEmail: 'b@example.com',
+      emailProvider: 'smtp',
+      branding: { primaryColor: '#0000ff' },
+      privacyMode: 'PUBLIC',
+      showIncidentTitles: true,
+      statusApiRequireToken: false,
+      statusApiRateLimitEnabled: false,
+    });
+    const serviceA = await createTestService('Payments');
+    const serviceB = await createTestService('Platform');
+    await testPrisma.statusPageService.create({
+      data: { statusPageId: pageA.id, serviceId: serviceA.id },
+    });
+
+    const originalA = await testPrisma.statusPage.findUniqueOrThrow({
+      where: { id: pageA.id },
+      select: settingsSelect,
+    });
+    let expectedB = await testPrisma.statusPage.findUniqueOrThrow({
+      where: { id: pageB.id },
+      select: settingsSelect,
+    });
+
+    const patchAndAssert = async (patch: Record<string, unknown>) => {
+      const response = await POST(
+        new Request('http://localhost/api/settings/status-page', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: pageB.id, ...patch }),
+        }) as never
+      );
+      expect(response.status).toBe(200);
+      expectedB = { ...expectedB, ...patch } as typeof expectedB;
+      expect(
+        await testPrisma.statusPage.findUniqueOrThrow({
+          where: { id: pageB.id },
+          select: settingsSelect,
+        })
+      ).toEqual(expectedB);
+      expect(
+        await testPrisma.statusPage.findUniqueOrThrow({
+          where: { id: pageA.id },
+          select: settingsSelect,
+        })
+      ).toEqual(originalA);
+    };
+
+    await patchAndAssert({ emailProvider: 'ses' });
+    await patchAndAssert({ branding: { primaryColor: '#00ff00' } });
+    await patchAndAssert({ privacyMode: 'PRIVATE', showIncidentTitles: false });
+    await patchAndAssert({ statusApiRequireToken: true, statusApiRateLimitEnabled: true });
+    await patchAndAssert({ customDomain: 'new-status-b.example.com', subdomain: 'new-status-b' });
+    await patchAndAssert({ showSubscribe: true });
+
+    const serviceResponse = await POST(
+      new Request('http://localhost/api/settings/status-page', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id: pageB.id, serviceIds: [serviceB.id] }),
+      }) as never
+    );
+    expect(serviceResponse.status).toBe(200);
+    expect(
+      await testPrisma.statusPage.findUniqueOrThrow({
+        where: { id: pageB.id },
+        select: settingsSelect,
+      })
+    ).toEqual(expectedB);
+    expect(
+      await testPrisma.statusPage.findUniqueOrThrow({
+        where: { id: pageA.id },
+        select: settingsSelect,
+      })
+    ).toEqual(originalA);
+    expect(
+      await testPrisma.statusPageService.findMany({
+        where: { statusPageId: pageA.id },
+        select: { serviceId: true },
+      })
+    ).toEqual([{ serviceId: serviceA.id }]);
+    expect(
+      await testPrisma.statusPageService.findMany({
+        where: { statusPageId: pageB.id },
+        select: { serviceId: true },
+      })
+    ).toEqual([{ serviceId: serviceB.id }]);
+  });
+
+  it('clears nullable text only when the field is explicitly submitted', async () => {
+    const page = await createTestStatusPage({
+      footerText: 'Keep me',
+      contactEmail: 'status@example.com',
+      customDomain: 'status.example.com',
+    });
+
+    const response = await POST(
+      new Request('http://localhost/api/settings/status-page', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id: page.id, footerText: '', contactEmail: '' }),
+      }) as never
+    );
+    expect(response.status).toBe(200);
+
+    expect(
+      await testPrisma.statusPage.findUniqueOrThrow({
+        where: { id: page.id },
+        select: { footerText: true, contactEmail: true, customDomain: true },
+      })
+    ).toEqual({ footerText: null, contactEmail: null, customDomain: 'status.example.com' });
+  });
+});

--- a/tests/integration/status-page-subscription.test.ts
+++ b/tests/integration/status-page-subscription.test.ts
@@ -184,7 +184,7 @@ describeIfRealDB('Status Page Subscription Integration', () => {
 
       const req = {
         nextUrl: {
-          searchParams: new URLSearchParams({ id: sub.id }),
+          searchParams: new URLSearchParams({ id: sub.id, statusPageId: sp.id }),
         },
       };
 

--- a/tests/integration/status-page-webhooks.test.ts
+++ b/tests/integration/status-page-webhooks.test.ts
@@ -119,6 +119,7 @@ describeIfRealDB('Status Page Webhooks Integration', () => {
         method: 'PATCH',
         body: JSON.stringify({
           id: webhook.id,
+          statusPageId: sp.id,
           url: 'https://new.com',
           enabled: false,
         }),
@@ -136,12 +137,13 @@ describeIfRealDB('Status Page Webhooks Integration', () => {
       const sp = await createTestStatusPage();
       const webhook = await createTestStatusPageWebhook(sp.id, 'https://delete-me.com');
 
-      const req = new Request(`http://localhost/api/status-page/webhooks?id=${webhook.id}`, {
-        method: 'DELETE',
-      });
+      const req = new Request(
+        `http://localhost/api/status-page/webhooks?id=${webhook.id}&statusPageId=${sp.id}`,
+        { method: 'DELETE' }
+      );
       // Also mock nextUrl as some routes might use it
       (req as any).nextUrl = {
-        searchParams: new URLSearchParams({ id: webhook.id }),
+        searchParams: new URLSearchParams({ id: webhook.id, statusPageId: sp.id }),
       };
 
       const res = await DELETE(req as any);

--- a/tests/lib/status-page-validation.test.ts
+++ b/tests/lib/status-page-validation.test.ts
@@ -504,6 +504,7 @@ describe('Status Page Validation Schemas', () => {
   describe('StatusAnnouncementPatchSchema', () => {
     it('should validate valid patch', () => {
       const validData = {
+        statusPageId: 'page-123',
         id: 'announcement-123',
         title: 'Updated Title',
         message: 'Updated message',
@@ -514,8 +515,9 @@ describe('Status Page Validation Schemas', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should validate minimal patch with just id', () => {
+    it('should validate a minimal page-scoped patch', () => {
       const minimalData = {
+        statusPageId: 'page-123',
         id: 'announcement-123',
       };
 
@@ -525,6 +527,7 @@ describe('Status Page Validation Schemas', () => {
 
     it('should reject empty id', () => {
       const invalidData = {
+        statusPageId: 'page-123',
         id: '',
         title: 'Title',
       };


### PR DESCRIPTION
## Summary

- establish status pages as independent administration aggregates with explicit page identity
- replace mutable query-parameter management with `/settings/status-pages/:pageId` workspaces and a control-center overview
- remove render-time status-page creation so opening Settings never mutates production state
- prevent cross-page writes for email settings, announcements, API tokens, subscribers, and webhooks
- isolate arbitrary preview CSS from the OpsKnight administration DOM
- serialize and database-fence the default-page lifecycle

## Isolation and correctness

- legacy status-page settings updates now require an explicit page ID and never fall back to the default page
- child mutations verify both the page ID and resource ID before update, revoke, unsubscribe, or deletion
- maintenance announcement service IDs must belong to the selected status page
- page-owned subscriber and webhook requests use `AbortController`, preventing late responses from a previously selected page from replacing current state
- editor identity is route-owned and keyed by `statusPage.id`
- default selection is a dedicated operation; it is no longer submitted as an ordinary settings checkbox
- deletion of a default page requires an explicit replacement when other pages exist

## Database safety

- lifecycle operations use a PostgreSQL transaction-scoped advisory lock
- migration repairs legacy zero/multiple-default states deterministically
- a partial unique index prevents more than one default page
- the relational model remains shared; page-local mappings and resources stay isolated by `statusPageId`

## UI

- adds a Status Pages control center with independent page cards, state/privacy summaries, and explicit Manage/Open actions
- adds stable page-specific management routes
- keeps the legacy settings URL as a redirect for existing bookmarks
- custom preview CSS is rendered inside a Shadow DOM boundary and cannot style the surrounding admin interface

## Validation

- TypeScript: passed
- unit tests: 331 files, 2,389 passed, 4 skipped
- production Next.js build: passed
- Prisma migration validation: 0 errors, 15 pre-existing warnings
- fresh PostgreSQL migration of all 81 migrations: passed
- new architecture contract covers explicit identity, child ownership, stale-request cancellation, CSS isolation, and default lifecycle fencing

## Rollout notes

The migration is additive except for deterministic repair of invalid legacy default-page states. If pages exist, the earliest existing default (or earliest page when none is marked) becomes the single default. New pages remain disabled until explicitly published.

This PR intentionally preserves the existing public HTML/API/RSS/export projection behavior while hardening the administration/control-plane side.
