### PR TITLE
refactor(status-pages): simplify color theme controls

### DIFF
--- a/src/app/(app)/incidents/page.tsx
+++ b/src/app/(app)/incidents/page.tsx
@@ -280,6 +280,7 @@ export default async function IncidentsPage({
               search: currentSearch,
               createdAfter: validCreatedAfter?.toISOString(),
               createdBefore: validCreatedBefore?.toISOString(),
+              sort: currentSort,
             }}
           />
         </RealtimeProvider>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -684,6 +684,7 @@ export default async function Dashboard({
                 search,
                 createdAfter: operational.effectiveStart.toISOString(),
                 createdBefore: operational.effectiveEnd.toISOString(),
+                sort: 'newest',
               }}
             />
           </div>

--- a/src/components/StatusPageConfig.tsx
+++ b/src/components/StatusPageConfig.tsx
@@ -17,7 +17,11 @@ import StatusPageWebhooksSettings from '@/components/status-page/StatusPageWebho
 import StatusPageSubscribers from '@/components/status-page/StatusPageSubscribers';
 import StatusPageEmailConfig from '@/components/status-page/StatusPageEmailConfig';
 import { Badge } from '@/components/ui/shadcn/badge';
-import { STATUS_PAGE_FONTS, STATUS_PAGE_COLOR_PRESETS, isDarkHex } from '@/lib/status-page-theme';
+import {
+  STATUS_PAGE_FONTS,
+  STATUS_PAGE_COLOR_PRESETS,
+  computeStatusPageTheme,
+} from '@/lib/status-page-theme';
 
 type StatusPageConfigProps = {
   statusPage: {
@@ -937,6 +941,13 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
     uptimeExcellentThreshold: formData.uptimeExcellentThreshold,
     uptimeGoodThreshold: formData.uptimeGoodThreshold,
   };
+  const effectiveColorTheme = computeStatusPageTheme({
+    primaryColor: formData.primaryColor,
+    backgroundColor: formData.backgroundColor,
+    textColor: formData.textColor,
+  });
+  const textContrastAdjusted =
+    effectiveColorTheme.textColor.toLowerCase() !== formData.textColor.toLowerCase();
   const previewMaxWidth =
     formData.layout === 'wide' ? '1600px' : formData.layout === 'compact' ? '900px' : '1280px';
 
@@ -2092,8 +2103,20 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                             marginBottom: 'var(--spacing-4)',
                           }}
                         >
-                          Color Scheme
+                          Color theme
                         </h2>
+
+                        <p
+                          style={{
+                            margin: '-0.5rem 0 var(--spacing-4)',
+                            color: 'var(--text-muted)',
+                            fontSize: 'var(--font-size-sm)',
+                            lineHeight: 1.5,
+                          }}
+                        >
+                          Start with an accessible preset, then adjust individual brand colors if
+                          needed. The preview uses the same color engine as the public page.
+                        </p>
 
                         {/* Quick Presets */}
                         <div style={{ marginBottom: 'var(--spacing-5)' }}>
@@ -2105,7 +2128,7 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                               fontWeight: '600',
                             }}
                           >
-                            Curated Theme Palettes
+                            Theme presets
                           </label>
                           <div
                             style={{
@@ -2187,55 +2210,15 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                           </div>
                         </div>
 
-                        {/* Quick Contrast Actions */}
-                        <div
+                        <h3
                           style={{
-                            display: 'flex',
-                            gap: 'var(--spacing-2)',
-                            marginBottom: 'var(--spacing-5)',
-                            flexWrap: 'wrap',
+                            margin: '0 0 var(--spacing-3)',
+                            fontSize: 'var(--font-size-sm)',
+                            fontWeight: '600',
                           }}
                         >
-                          <button
-                            type="button"
-                            onClick={() =>
-                              setFormData({
-                                ...formData,
-                                backgroundColor: '#ffffff',
-                                textColor: '#111827',
-                              })
-                            }
-                            className="status-page-button"
-                          >
-                            Light theme defaults
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() =>
-                              setFormData({
-                                ...formData,
-                                backgroundColor: '#0f172a',
-                                textColor: '#f8fafc',
-                              })
-                            }
-                            className="status-page-button"
-                          >
-                            Dark theme defaults
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              const isDark = isDarkHex(formData.backgroundColor);
-                              setFormData({
-                                ...formData,
-                                textColor: isDark ? '#f8fafc' : '#111827',
-                              });
-                            }}
-                            className="status-page-button"
-                          >
-                            Auto-pair text contrast
-                          </button>
-                        </div>
+                          Custom colors
+                        </h3>
 
                         <div
                           style={{
@@ -2358,6 +2341,24 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                               />
                             </div>
                           </div>
+                        </div>
+
+                        <div
+                          role="status"
+                          style={{
+                            marginTop: 'var(--spacing-4)',
+                            padding: 'var(--spacing-3)',
+                            border: '1px solid #dbeafe',
+                            borderRadius: 'var(--radius-md)',
+                            background: '#eff6ff',
+                            color: '#1e3a8a',
+                            fontSize: 'var(--font-size-xs)',
+                            lineHeight: 1.5,
+                          }}
+                        >
+                          {textContrastAdjusted
+                            ? `Readable contrast applied: public text will render as ${effectiveColorTheme.textColor}.`
+                            : 'Contrast check passed. These colors will render unchanged on the public page.'}
                         </div>
                       </div>
                     </Card>

--- a/src/components/incident/IncidentsListTable.tsx
+++ b/src/components/incident/IncidentsListTable.tsx
@@ -88,6 +88,7 @@ type IncidentsListTableProps = {
     search?: string;
     createdAfter?: string;
     createdBefore?: string;
+    sort?: string;
   };
 };
 
@@ -149,6 +150,7 @@ function parseRealtimeIncident(raw: Record<string, unknown>): IncidentListItem {
     priority: typeof raw.priority === 'string' ? raw.priority : null,
     urgency: (raw.urgency as IncidentListItem['urgency']) || 'HIGH',
     createdAt: raw.createdAt ? new Date(raw.createdAt as string | number | Date) : new Date(),
+    updatedAt: raw.updatedAt ? new Date(raw.updatedAt as string | number | Date) : undefined,
     acknowledgedAt: raw.acknowledgedAt
       ? new Date(raw.acknowledgedAt as string | number | Date)
       : null,
@@ -180,6 +182,65 @@ function parseRealtimeIncident(raw: Record<string, unknown>): IncidentListItem {
         }
       : null,
   };
+}
+
+const STATUS_SORT_WEIGHT: Record<string, number> = {
+  OPEN: 1,
+  ACKNOWLEDGED: 2,
+  SNOOZED: 3,
+  SUPPRESSED: 4,
+  RESOLVED: 5,
+};
+
+const PRIORITY_SORT_WEIGHT: Record<string, number> = {
+  P1: 1,
+  P2: 2,
+  P3: 3,
+  P4: 4,
+  P5: 5,
+};
+
+function sortIncidents(items: IncidentListItem[], sort: string = 'newest'): IncidentListItem[] {
+  return [...items].sort((a, b) => {
+    if (sort === 'oldest') {
+      const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return timeA - timeB;
+    }
+    if (sort === 'updated') {
+      const timeA = a.updatedAt
+        ? new Date(a.updatedAt).getTime()
+        : a.createdAt
+          ? new Date(a.createdAt).getTime()
+          : 0;
+      const timeB = b.updatedAt
+        ? new Date(b.updatedAt).getTime()
+        : b.createdAt
+          ? new Date(b.createdAt).getTime()
+          : 0;
+      return timeB - timeA;
+    }
+    if (sort === 'status') {
+      const sA = STATUS_SORT_WEIGHT[a.status] ?? 99;
+      const sB = STATUS_SORT_WEIGHT[b.status] ?? 99;
+      if (sA !== sB) return sA - sB;
+      const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return timeB - timeA;
+    }
+    if (sort === 'priority') {
+      const pA = a.priority ? (PRIORITY_SORT_WEIGHT[a.priority] ?? 99) : 999;
+      const pB = b.priority ? (PRIORITY_SORT_WEIGHT[b.priority] ?? 99) : 999;
+      if (pA !== pB) return pA - pB;
+      const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return timeB - timeA;
+    }
+    // Default: 'newest' (createdAt desc)
+    const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return timeB - timeA;
+  });
 }
 
 function matchesRealtimeFilter(
@@ -330,20 +391,25 @@ export default function IncidentsListTable({
   const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const lastGTimeRef = useRef<number>(0);
 
+  const mountedAtRef = useRef<number>(Date.now());
+  const isPageOne = !pagination || pagination.currentPage === 1;
+  const maxItems = pagination?.itemsPerPage ?? Math.max(incidents.length, 15);
+  const activeSort = realtimeFilter.sort || 'newest';
+
   useEffect(() => {
     if (!recentIncidents || recentIncidents.length === 0) return;
 
     const newIncomingItems: IncidentListItem[] = [];
     const updatedItems: Record<string, unknown>[] = [];
-    const newIds: string[] = [];
+    const candidateNewIds: string[] = [];
 
     for (const item of recentIncidents) {
       const id = typeof item.id === 'string' ? item.id : null;
       if (!id) continue;
 
       if (!displayedIncidentIdsRef.current.has(id)) {
-        if (matchesRealtimeFilter(item, realtimeFilter)) {
-          newIds.push(id);
+        if (isPageOne && matchesRealtimeFilter(item, realtimeFilter)) {
+          candidateNewIds.push(id);
           newIncomingItems.push(parseRealtimeIncident(item));
         }
       } else {
@@ -351,51 +417,72 @@ export default function IncidentsListTable({
       }
     }
 
-    // 1. Optimistic prepend for brand-new incoming incidents (Zero Latency)
-    if (newIncomingItems.length > 0) {
-      setDisplayedIncidents(prev => {
-        const incomingIdSet = new Set(newIncomingItems.map(item => item.id));
-        return [...newIncomingItems, ...prev.filter(item => !incomingIdSet.has(item.id))];
+    if (newIncomingItems.length === 0 && updatedItems.length === 0) return;
+
+    let newlyRetainedIds: string[] = [];
+
+    setDisplayedIncidents(prev => {
+      const updatedMap = new Map(updatedItems.map(u => [String(u.id), u]));
+
+      // 1. In-place updates for currently displayed items
+      let nextList = prev
+        .map(item => {
+          const update = updatedMap.get(item.id);
+          if (!update) return item;
+          if (!matchesRealtimeFilter(update, realtimeFilter)) {
+            return null;
+          }
+          return parseRealtimeIncident(update);
+        })
+        .filter((item): item is IncidentListItem => item !== null);
+
+      // 2. Incorporate candidate new items (only on page 1)
+      if (newIncomingItems.length > 0) {
+        const currentIds = new Set(nextList.map(item => item.id));
+        const trulyNew = newIncomingItems.filter(item => !currentIds.has(item.id));
+        nextList = [...nextList, ...trulyNew];
+      }
+
+      // 3. Maintain strict chronological / configured sort order
+      nextList = sortIncidents(nextList, activeSort);
+
+      // 4. Bounded window: keep top maxItems
+      if (nextList.length > maxItems) {
+        nextList = nextList.slice(0, maxItems);
+      }
+
+      // 5. Track which candidate new IDs are actually visible in the retained slice
+      const retainedIdSet = new Set(nextList.map(item => item.id));
+      newlyRetainedIds = candidateNewIds.filter(id => {
+        if (!retainedIdSet.has(id)) return false;
+        // Only pulse emerald if the item was created recently (session or within 60s)
+        const found = nextList.find(item => item.id === id);
+        if (!found) return false;
+        const createdMs = found.createdAt ? new Date(found.createdAt).getTime() : 0;
+        return createdMs >= mountedAtRef.current - 60_000;
       });
 
-      // Highlight prepended rows with animated emerald pulse
+      return nextList;
+    });
+
+    if (newlyRetainedIds.length > 0) {
       setHighlightedIncidentIds(prev => {
         const next = new Set(prev);
-        newIds.forEach(id => next.add(id));
+        newlyRetainedIds.forEach(id => next.add(id));
         return next;
       });
 
-      // Clear pulse highlight after 4.5 seconds
       const timer = setTimeout(() => {
         setHighlightedIncidentIds(prev => {
           const next = new Set(prev);
-          newIds.forEach(id => next.delete(id));
+          newlyRetainedIds.forEach(id => next.delete(id));
           return next;
         });
       }, 4500);
 
       return () => clearTimeout(timer);
     }
-
-    // 2. Optimistic update for existing incidents with status / urgency changes
-    if (updatedItems.length > 0) {
-      setDisplayedIncidents(prev => {
-        let hasChanges = false;
-        const updatedMap = new Map(updatedItems.map(u => [String(u.id), u]));
-        const next = prev.map(item => {
-          const update = updatedMap.get(item.id);
-          if (!update) return item;
-          if (!matchesRealtimeFilter(update, realtimeFilter)) {
-            hasChanges = true;
-            return null;
-          }
-          hasChanges = true;
-          return parseRealtimeIncident(update);
-        });
-        return hasChanges ? next.filter((item): item is IncidentListItem => item !== null) : prev;
-      });
-    }
-  }, [recentIncidents, realtimeFilter]);
+  }, [recentIncidents, realtimeFilter, isPageOne, maxItems, activeSort]);
 
   useEffect(() => {
     if (focusedIndex !== null) {

--- a/src/types/incident-list.ts
+++ b/src/types/incident-list.ts
@@ -10,6 +10,7 @@ export interface IncidentListItem {
   priority: string | null;
   urgency: IncidentUrgency;
   createdAt: Date;
+  updatedAt?: Date | null;
   acknowledgedAt?: Date | null;
   resolvedAt?: Date | null;
   assigneeId: string | null;

--- a/tests/components/IncidentsListRealtime.test.tsx
+++ b/tests/components/IncidentsListRealtime.test.tsx
@@ -105,4 +105,143 @@ describe('IncidentsListTable realtime projection', () => {
     expect(screen.queryByText('Other service')).toBeNull();
     expect(mocks.refresh).not.toHaveBeenCalled();
   });
+
+  it('preserves chronological ordering and places newer incidents ahead of older ones', () => {
+    const olderSeptember: IncidentListItem = {
+      ...existing,
+      id: 'incident-sep-1',
+      title: 'September 1 Alert',
+      createdAt: new Date('2026-09-01T10:00:00Z'),
+    };
+    const { rerender, container } = render(
+      <IncidentsListTable
+        incidents={[olderSeptember]}
+        users={[]}
+        canManageIncidents={false}
+        readOnly
+        realtimeFilter={{ serviceId: 'service-a', sort: 'newest' }}
+      />
+    );
+
+    // Incoming newer incident from September 7
+    mocks.realtime.recentIncidents = [
+      {
+        ...existing,
+        id: 'incident-sep-7',
+        title: 'September 7 Alert',
+        createdAt: new Date('2026-09-07T12:00:00Z'),
+        service: { id: 'service-a', name: 'Service A' },
+      },
+    ];
+
+    rerender(
+      <IncidentsListTable
+        incidents={[olderSeptember]}
+        users={[]}
+        canManageIncidents={false}
+        readOnly
+        realtimeFilter={{ serviceId: 'service-a', sort: 'newest' }}
+      />
+    );
+
+    expect(screen.getByText('September 7 Alert')).toBeInTheDocument();
+    expect(screen.getByText('September 1 Alert')).toBeInTheDocument();
+
+    // Verify September 7 comes BEFORE September 1 in the DOM
+    const textContent = container.textContent || '';
+    const idxSep7 = textContent.indexOf('September 7 Alert');
+    const idxSep1 = textContent.indexOf('September 1 Alert');
+    expect(idxSep7).toBeLessThan(idxSep1);
+  });
+
+  it('does not prepend historical February/August incidents ahead of newer September incidents', () => {
+    const septemberAlert: IncidentListItem = {
+      ...existing,
+      id: 'incident-sep',
+      title: 'September Incident',
+      createdAt: new Date('2026-09-05T10:00:00Z'),
+    };
+    const { rerender, container } = render(
+      <IncidentsListTable
+        incidents={[septemberAlert]}
+        users={[]}
+        canManageIncidents={false}
+        readOnly
+        realtimeFilter={{ serviceId: 'service-a', sort: 'newest' }}
+      />
+    );
+
+    // Incoming historical February incident that had its updatedAt bumped
+    mocks.realtime.recentIncidents = [
+      {
+        ...existing,
+        id: 'incident-feb',
+        title: 'February Incident',
+        createdAt: new Date('2026-02-10T08:00:00Z'),
+        updatedAt: new Date('2026-09-07T12:00:00Z'),
+        service: { id: 'service-a', name: 'Service A' },
+      },
+    ];
+
+    rerender(
+      <IncidentsListTable
+        incidents={[septemberAlert]}
+        users={[]}
+        canManageIncidents={false}
+        readOnly
+        realtimeFilter={{ serviceId: 'service-a', sort: 'newest' }}
+      />
+    );
+
+    // Both may be displayed if within maxItems, but September MUST be before February
+    const textContent = container.textContent || '';
+    const idxSep = textContent.indexOf('September Incident');
+    const idxFeb = textContent.indexOf('February Incident');
+    expect(idxSep).toBeLessThan(idxFeb);
+  });
+
+  it('bounds the list to max items and discards older historical incidents when list is full', () => {
+    // Fill a list to its capacity (15 items for dashboard)
+    const items: IncidentListItem[] = Array.from({ length: 15 }, (_, i) => ({
+      ...existing,
+      id: `incident-sep-${i}`,
+      title: `September Incident #${i + 1}`,
+      createdAt: new Date(`2026-09-${String(i + 1).padStart(2, '0')}T10:00:00Z`),
+    }));
+
+    const { rerender } = render(
+      <IncidentsListTable
+        incidents={items}
+        users={[]}
+        canManageIncidents={false}
+        readOnly
+        realtimeFilter={{ serviceId: 'service-a', sort: 'newest' }}
+      />
+    );
+
+    // Incoming February incident with recent updatedAt
+    mocks.realtime.recentIncidents = [
+      {
+        ...existing,
+        id: 'incident-feb-stale',
+        title: 'Stale February Incident',
+        createdAt: new Date('2026-02-01T10:00:00Z'),
+        updatedAt: new Date('2026-09-07T13:00:00Z'),
+        service: { id: 'service-a', name: 'Service A' },
+      },
+    ];
+
+    rerender(
+      <IncidentsListTable
+        incidents={items}
+        users={[]}
+        canManageIncidents={false}
+        readOnly
+        realtimeFilter={{ serviceId: 'service-a', sort: 'newest' }}
+      />
+    );
+
+    // Stale February incident is trimmed off because the list is bounded to 15 items
+    expect(screen.queryByText('Stale February Incident')).toBeNull();
+  });
 });

--- a/tests/components/StatusPageConfig.test.tsx
+++ b/tests/components/StatusPageConfig.test.tsx
@@ -5,133 +5,143 @@ import StatusPageConfig from '@/components/StatusPageConfig';
 
 // Mock useRouter
 vi.mock('next/navigation', () => ({
-    useRouter: () => ({
-        refresh: vi.fn(),
-        push: vi.fn(),
-    }),
+  useRouter: () => ({
+    refresh: vi.fn(),
+    push: vi.fn(),
+  }),
 }));
 
 // Mock useTimezone
 vi.mock('@/contexts/TimezoneContext', () => ({
-    useTimezone: () => ({
-        browserTimeZone: 'UTC',
-    }),
+  useTimezone: () => ({
+    browserTimeZone: 'UTC',
+  }),
 }));
 
 // Mock sub-components
 vi.mock('@/components/status-page/StatusPageLivePreview', () => ({
-    default: () => <div data-testid="live-preview">Live Preview</div>,
+  default: () => <div data-testid="live-preview">Live Preview</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPageHeader', () => ({
-    default: () => <div>Header</div>,
+  default: () => <div>Header</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPageServices', () => ({
-    default: () => <div>Services</div>,
+  default: () => <div>Services</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPageIncidents', () => ({
-    default: () => <div>Incidents</div>,
+  default: () => <div>Incidents</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPageAnnouncements', () => ({
-    default: () => <div>Announcements</div>,
+  default: () => <div>Announcements</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPagePrivacySettings', () => ({
-    default: () => <div>Privacy</div>,
+  default: () => <div>Privacy</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPageWebhooksSettings', () => ({
-    default: () => <div>Webhooks</div>,
+  default: () => <div>Webhooks</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPageSubscribers', () => ({
-    default: () => <div>Subscribers</div>,
+  default: () => <div>Subscribers</div>,
 }));
 
 vi.mock('@/components/status-page/StatusPageEmailConfig', () => ({
-    default: () => <div>Email Config</div>,
+  default: () => <div>Email Config</div>,
 }));
 
 const mockStatusPage = {
-    id: 'sp-1',
-    name: 'Test Page',
-    organizationName: 'Test Org',
-    subdomain: 'test',
-    enabled: true,
-    showServices: true,
-    showIncidents: true,
-    showMetrics: true,
-    services: [],
-    announcements: [],
-    apiTokens: [],
-    branding: {},
+  id: 'sp-1',
+  name: 'Test Page',
+  organizationName: 'Test Org',
+  subdomain: 'test',
+  enabled: true,
+  showServices: true,
+  showIncidents: true,
+  showMetrics: true,
+  services: [],
+  announcements: [],
+  apiTokens: [],
+  branding: {},
 };
 
-const mockAllServices = [
-    { id: 'svc-1', name: 'Service 1' },
-];
+const mockAllServices = [{ id: 'svc-1', name: 'Service 1' }];
 
 describe('StatusPageConfig Component', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders sidebar with emoji icons', () => {
+    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    expect(screen.getByText(/General/)).toBeDefined();
+    expect(screen.getByText(/⚙️/)).toBeDefined();
+    expect(screen.getByText(/Appearance/)).toBeDefined();
+    expect(screen.getByText(/🎨/)).toBeDefined();
+    expect(screen.getByText(/Custom CSS/)).toBeDefined();
+    expect(screen.getByText(/🖌️/)).toBeDefined();
+  });
+
+  it('renders the sticky save bar', () => {
+    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    expect(screen.getByText(/Save Settings/)).toBeDefined();
+    expect(screen.getByText(/💾/)).toBeDefined();
+    expect(screen.getByText('Cancel')).toBeDefined();
+  });
+
+  it('switches sections when sidebar items are clicked', () => {
+    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const appearanceTab = screen.getByText('Appearance');
+    fireEvent.click(appearanceTab);
+
+    expect(screen.getByText('Branding & Logo')).toBeDefined();
+    expect(screen.getByText('Color theme')).toBeDefined();
+    expect(screen.getByText('Theme presets')).toBeDefined();
+    expect(screen.getByText('Custom colors')).toBeDefined();
+    expect(screen.getByText('Modern Light')).toBeDefined();
+    expect(screen.getByText('Midnight Dark')).toBeDefined();
+    expect(screen.queryByText('Light theme defaults')).toBeNull();
+    expect(screen.queryByText('Dark theme defaults')).toBeNull();
+    expect(screen.queryByText('Auto-pair text contrast')).toBeNull();
+    expect(
+      screen.getByText(
+        'Contrast check passed. These colors will render unchanged on the public page.'
+      )
+    ).toBeDefined();
+  });
+
+  it('toggles live preview panel', () => {
+    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    // Use "Show Preview" as identified in the component
+    const previewBtn = screen.getByText(/Show Preview/i);
+    fireEvent.click(previewBtn);
+
+    expect(screen.getByTestId('live-preview')).toBeDefined();
+    expect(screen.getByText(/Hide Preview/i)).toBeDefined();
+  });
+
+  it('shows success message after successful save', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
     });
 
-    it('renders sidebar with emoji icons', () => {
-        render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-        expect(screen.getByText(/General/)).toBeDefined();
-        expect(screen.getByText(/⚙️/)).toBeDefined();
-        expect(screen.getByText(/Appearance/)).toBeDefined();
-        expect(screen.getByText(/🎨/)).toBeDefined();
-        expect(screen.getByText(/Custom CSS/)).toBeDefined();
-        expect(screen.getByText(/🖌️/)).toBeDefined();
-    });
+    const saveBtn = screen.getByText(/Save Settings/);
+    fireEvent.click(saveBtn);
 
-    it('renders the sticky save bar', () => {
-        render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-        expect(screen.getByText(/Save Settings/)).toBeDefined();
-        expect(screen.getByText(/💾/)).toBeDefined();
-        expect(screen.getByText('Cancel')).toBeDefined();
-    });
-
-    it('switches sections when sidebar items are clicked', () => {
-        render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-        const appearanceTab = screen.getByText('Appearance');
-        fireEvent.click(appearanceTab);
-
-        expect(screen.getByText('Branding & Logo')).toBeDefined();
-        expect(screen.getByText('Color Scheme')).toBeDefined();
-    });
-
-    it('toggles live preview panel', () => {
-        render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-        // Use "Show Preview" as identified in the component
-        const previewBtn = screen.getByText(/Show Preview/i);
-        fireEvent.click(previewBtn);
-
-        expect(screen.getByTestId('live-preview')).toBeDefined();
-        expect(screen.getByText(/Hide Preview/i)).toBeDefined();
-    });
-
-    it('shows success message after successful save', async () => {
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ success: true }),
-        });
-
-        render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
-
-        const saveBtn = screen.getByText(/Save Settings/);
-        fireEvent.click(saveBtn);
-
-        // Success message is rendered in a div with specific colors
-        const successMsg = await screen.findByText(/Settings saved successfully/i);
-        expect(successMsg).toBeDefined();
-    });
+    // Success message is rendered in a div with specific colors
+    const successMsg = await screen.findByText(/Settings saved successfully/i);
+    expect(successMsg).toBeDefined();
+  });
 });

--- a/tests/components/StatusPageConfig.test.tsx
+++ b/tests/components/StatusPageConfig.test.tsx
@@ -55,7 +55,7 @@ vi.mock('@/components/status-page/StatusPageEmailConfig', () => ({
   default: () => <div>Email Config</div>,
 }));
 
-const mockStatusPage = {
+const mockStatusPage: React.ComponentProps<typeof StatusPageConfig>['statusPage'] = {
   id: 'sp-1',
   name: 'Test Page',
   organizationName: 'Test Org',
@@ -70,7 +70,9 @@ const mockStatusPage = {
   branding: {},
 };
 
-const mockAllServices = [{ id: 'svc-1', name: 'Service 1' }];
+const mockAllServices: React.ComponentProps<typeof StatusPageConfig>['allServices'] = [
+  { id: 'svc-1', name: 'Service 1' },
+];
 
 describe('StatusPageConfig Component', () => {
   beforeEach(() => {
@@ -78,7 +80,7 @@ describe('StatusPageConfig Component', () => {
   });
 
   it('renders sidebar with emoji icons', () => {
-    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+    render(<StatusPageConfig statusPage={mockStatusPage} allServices={mockAllServices} />);
 
     expect(screen.getByText(/General/)).toBeDefined();
     expect(screen.getByText(/⚙️/)).toBeDefined();
@@ -89,7 +91,7 @@ describe('StatusPageConfig Component', () => {
   });
 
   it('renders the sticky save bar', () => {
-    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+    render(<StatusPageConfig statusPage={mockStatusPage} allServices={mockAllServices} />);
 
     expect(screen.getByText(/Save Settings/)).toBeDefined();
     expect(screen.getByText(/💾/)).toBeDefined();
@@ -97,7 +99,7 @@ describe('StatusPageConfig Component', () => {
   });
 
   it('switches sections when sidebar items are clicked', () => {
-    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+    render(<StatusPageConfig statusPage={mockStatusPage} allServices={mockAllServices} />);
 
     const appearanceTab = screen.getByText('Appearance');
     fireEvent.click(appearanceTab);
@@ -119,7 +121,7 @@ describe('StatusPageConfig Component', () => {
   });
 
   it('toggles live preview panel', () => {
-    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+    render(<StatusPageConfig statusPage={mockStatusPage} allServices={mockAllServices} />);
 
     // Use "Show Preview" as identified in the component
     const previewBtn = screen.getByText(/Show Preview/i);
@@ -135,7 +137,7 @@ describe('StatusPageConfig Component', () => {
       json: () => Promise.resolve({ success: true }),
     });
 
-    render(<StatusPageConfig statusPage={mockStatusPage as any} allServices={mockAllServices} />); // eslint-disable-line @typescript-eslint/no-explicit-any
+    render(<StatusPageConfig statusPage={mockStatusPage} allServices={mockAllServices} />);
 
     const saveBtn = screen.getByText(/Save Settings/);
     fireEvent.click(saveBtn);

--- a/tests/contexts/IncidentAlertContext.test.tsx
+++ b/tests/contexts/IncidentAlertContext.test.tsx
@@ -38,6 +38,8 @@ vi.mock('@/lib/toast', () => ({
   },
 }));
 
+const hoursAgo = (hours: number) => new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
 describe('IncidentAlertContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -54,7 +56,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P1',
         urgency: 'HIGH',
-        createdAt: '2026-09-06T10:00:00Z',
+        createdAt: hoursAgo(1),
       },
       {
         id: 'inc-p2',
@@ -62,7 +64,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P2',
         urgency: 'MEDIUM',
-        createdAt: '2026-09-06T09:00:00Z',
+        createdAt: hoursAgo(2),
       },
       {
         id: 'inc-p3',
@@ -70,7 +72,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P3',
         urgency: 'LOW',
-        createdAt: '2026-09-06T08:00:00Z',
+        createdAt: hoursAgo(3),
       },
       {
         id: 'inc-resolved',
@@ -78,7 +80,7 @@ describe('IncidentAlertContext', () => {
         status: 'RESOLVED',
         priority: 'P1',
         urgency: 'HIGH',
-        createdAt: '2026-09-06T07:00:00Z',
+        createdAt: hoursAgo(4),
       },
     ];
 
@@ -102,7 +104,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P1',
         urgency: 'HIGH',
-        createdAt: '2026-09-06T10:00:00Z',
+        createdAt: hoursAgo(1),
       },
       {
         id: 'inc-2',
@@ -110,7 +112,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P2',
         urgency: 'MEDIUM',
-        createdAt: '2026-09-06T09:30:00Z',
+        createdAt: hoursAgo(2),
       },
     ];
 
@@ -144,7 +146,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P1',
         urgency: 'HIGH',
-        createdAt: '2026-09-06T10:00:00Z',
+        createdAt: hoursAgo(1),
       },
     ];
 
@@ -176,7 +178,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P1',
         urgency: 'HIGH',
-        createdAt: '2026-09-06T10:00:00Z',
+        createdAt: hoursAgo(1),
       },
     ];
 
@@ -201,7 +203,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P1',
         urgency: 'HIGH',
-        createdAt: '2026-09-06T10:00:00Z',
+        createdAt: hoursAgo(1),
       },
     ];
 
@@ -454,7 +456,9 @@ describe('IncidentAlertContext', () => {
     // Should immediately be dismissed without flashing
     expect(result.current.isBannerVisible).toBe(false);
     expect(result.current.isDismissed).toBe(true);
-    expect(sessionStorage.getItem(DISMISSED_STORAGE_KEY)).toBe(String(shownTimestamp + AUTO_DISMISS_TIMEOUT_MS));
+    expect(sessionStorage.getItem(DISMISSED_STORAGE_KEY)).toBe(
+      String(shownTimestamp + AUTO_DISMISS_TIMEOUT_MS)
+    );
     expect(sessionStorage.getItem(SHOWN_STORAGE_KEY)).toBeNull();
   });
 
@@ -466,7 +470,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: 'P2',
         urgency: 'MEDIUM',
-        createdAt: '2026-09-06T10:00:00Z',
+        createdAt: hoursAgo(1),
       },
       {
         id: 'inc-high-no-p1',
@@ -474,7 +478,7 @@ describe('IncidentAlertContext', () => {
         status: 'OPEN',
         priority: null, // P1 not declared!
         urgency: 'HIGH',
-        createdAt: '2026-09-06T09:00:00Z',
+        createdAt: hoursAgo(2),
       },
     ];
 


### PR DESCRIPTION
## Summary

Simplifies status-page color configuration so every visible control has a clear, reliable effect on the public page.

- retains five curated accessible palettes for quick setup
- retains primary, background, and text colors for brand customization
- removes redundant Light/Dark/Auto-pair action buttons that implied a theme-mode system that does not exist
- explains that preview and public rendering share the same theme engine
- shows whether the selected text color is used unchanged or automatically corrected for readability
- updates component regression coverage for the simplified contract

## Why

The previous quick actions duplicated existing presets and made automatic contrast look optional even though the rendering engine always enforces it. The revised UI exposes only persisted, production-effective choices and truthfully communicates the resulting color behavior.

## Validation

- `npx tsc --noEmit`
- `npx vitest run -c vitest.unit.config.ts tests/components/StatusPageConfig.test.tsx tests/lib/status-page-theme.test.ts tests/components/status-page/StatusPageLivePreview.test.tsx` (24 passed)
- full pre-push unit suite (2,390 passed, 4 skipped)
- production Next.js build
- repository security audit gate