### PR TITLE
fix(v1.4): avoid Prisma void deserialization for advisory locks

### DIFF
--- a/src/lib/db-locks.ts
+++ b/src/lib/db-locks.ts
@@ -50,25 +50,32 @@ export const LOCK_KEYS = {
  * commits or rolls back. There is no `release` function on purpose —
  * if you forget to commit, the lock is still released by the engine
  * tearing down the session.
- *
- * Safe to call when the underlying database is not Postgres (e.g.
- * in unit tests against a mocked client): we catch the resulting
- * error, log it, and let the caller proceed without the lock. This
- * keeps the helper from breaking environments where it isn't
- * available; production correctness depends on the production
- * Postgres deploy actually applying the lock.
  */
 export async function acquireAdvisoryLock(
   tx: Prisma.TransactionClient,
   key: bigint
 ): Promise<void> {
   try {
-    await tx.$queryRaw`SELECT pg_advisory_xact_lock(${key}::bigint)`;
+    // PostgreSQL's pg_advisory_xact_lock() returns the `void` pseudo-type.
+    // Prisma cannot deserialize that value from $queryRaw, even though the
+    // lock itself was successfully acquired. Execute the lock in a subquery
+    // and expose only a normal boolean column to Prisma.
+    const rows = await tx.$queryRaw<Array<{ acquired: boolean }>>`
+      SELECT TRUE AS "acquired"
+      FROM (SELECT pg_advisory_xact_lock(${key}::bigint)) AS lock_result
+    `;
+
+    if (rows[0]?.acquired !== true) {
+      throw new Error(`PostgreSQL advisory lock ${key.toString()} was not acquired`);
+    }
   } catch (err) {
-    logger.warn(
-      '[DbLocks] pg_advisory_xact_lock failed (likely non-Postgres test env); proceeding without lock',
-      { key: key.toString(), error: err instanceof Error ? err.message : String(err) }
-    );
+    // Fail closed: if the lock statement genuinely fails, the surrounding
+    // transaction must roll back instead of continuing without serialization.
+    logger.error('[DbLocks] pg_advisory_xact_lock failed; rolling back transaction', {
+      key: key.toString(),
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
   }
 }
 
@@ -88,10 +95,12 @@ export async function tryAdvisoryLock(
     `;
     return rows[0]?.pg_try_advisory_xact_lock === true;
   } catch (err) {
-    logger.warn(
-      '[DbLocks] pg_try_advisory_xact_lock failed; treating as not-acquired',
-      { key: key.toString(), error: err instanceof Error ? err.message : String(err) }
-    );
-    return false;
+    // A real statement failure is not ordinary contention. Propagate it so
+    // the transaction can roll back and the actual database error is visible.
+    logger.error('[DbLocks] pg_try_advisory_xact_lock failed; rolling back transaction', {
+      key: key.toString(),
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
   }
 }

--- a/tests/integration/db-locks.test.ts
+++ b/tests/integration/db-locks.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { acquireAdvisoryLock } from '@/lib/db-locks';
+import { testPrisma } from '../helpers/test-db';
+
+describe('database advisory locks', () => {
+  it('acquires a transaction-scoped lock without deserializing PostgreSQL void', async () => {
+    const result = await testPrisma.$transaction(async tx => {
+      await acquireAdvisoryLock(tx, BigInt(9141002));
+
+      return tx.$queryRaw<Array<{ value: number }>>`SELECT 1 AS value`;
+    });
+
+    expect(result).toEqual([{ value: 1 }]);
+  });
+});

--- a/tests/lib/db-locks.test.ts
+++ b/tests/lib/db-locks.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { acquireAdvisoryLock, tryAdvisoryLock } from '@/lib/db-locks';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+describe('database advisory locks', () => {
+  it('accepts a supported boolean result after acquiring the lock', async () => {
+    const tx = { $queryRaw: vi.fn().mockResolvedValue([{ acquired: true }]) };
+    await expect(acquireAdvisoryLock(tx as never, BigInt(9141001))).resolves.toBeUndefined();
+  });
+
+  it('fails closed so the surrounding transaction can roll back', async () => {
+    const error = new Error('transaction aborted');
+    const tx = { $queryRaw: vi.fn().mockRejectedValue(error) };
+    await expect(acquireAdvisoryLock(tx as never, BigInt(9141001))).rejects.toBe(error);
+  });
+
+  it('distinguishes lock contention from a failed lock query', async () => {
+    const contended = {
+      $queryRaw: vi.fn().mockResolvedValue([{ pg_try_advisory_xact_lock: false }]),
+    };
+    await expect(tryAdvisoryLock(contended as never, BigInt(9141002))).resolves.toBe(false);
+
+    const error = new Error('connection lost');
+    const failed = { $queryRaw: vi.fn().mockRejectedValue(error) };
+    await expect(tryAdvisoryLock(failed as never, BigInt(9141002))).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

Backports the advisory-lock compatibility fix to the **v1.4 maintenance line only**.

A v1.4.0 Docker deployment can emit:

```text
[DbLocks] pg_advisory_xact_lock failed ...
Invalid prisma.$queryRaw() invocation
Failed to deserialize column of type 'void'
```

The lock statement itself is valid PostgreSQL, but `pg_advisory_xact_lock()` returns PostgreSQL's `void` pseudo-type. Prisma cannot deserialize that value through `$queryRaw`, so a successful lock acquisition is surfaced as an error.

## Fix

- Execute `pg_advisory_xact_lock()` in a subquery and return only a supported boolean value to Prisma.
- Fail closed on genuine advisory-lock query errors so the surrounding transaction rolls back instead of continuing after a database failure.
- Preserve ordinary `pg_try_advisory_xact_lock()` contention (`false`) as a normal non-error result.

## Tests

- Unit coverage for successful acquisition and fail-closed behavior.
- PostgreSQL integration regression test proving the lock can be acquired without Prisma attempting to deserialize `void` and that the transaction remains usable afterward.

## Scope / compatibility

- Base branch: `release/v1.4`, created directly from the immutable `v1.4.0` tag.
- No current-main runtime roles, scheduler changes, schema changes, migrations, or v1.5 features are included.
- One commit, three files only.

This is intentionally a narrow v1.4 backport for the production symptom reported from Docker deployments.