### PR TITLE
fix(v1.4): harden Docker deployment and advisory locks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,16 +24,16 @@ services:
       - opsknight-network
 
   opsknight-app:
-    # Pin OPSKNIGHT_IMAGE to an immutable release tag/digest for production.
-    image: ${OPSKNIGHT_IMAGE:-ghcr.io/opsknight-labs/opsknight:latest}
-    pull_policy: always
+    # This maintenance Compose file is tied to the v1.4 runtime contract.
+    # Override OPSKNIGHT_IMAGE only with a tested v1.4-compatible tag/digest.
+    image: ${OPSKNIGHT_IMAGE:-ghcr.io/opsknight-labs/opsknight:1.4.0}
     restart: unless-stopped
     ports:
       - '${APP_PORT:-3000}:3000'
     environment:
       NODE_ENV: production
       # Set OPSKNIGHT_DATABASE_URL for managed PostgreSQL, TLS/PgBouncer options,
-      # or URI-encoded credentials. The fallback targets the bundled database.
+      # URI-encoded credentials, or a bundled-database password containing URI-reserved characters.
       DATABASE_URL: ${OPSKNIGHT_DATABASE_URL:-postgresql://${POSTGRES_USER:-opsknight}:${POSTGRES_PASSWORD:-opsknight_secure_password_change_me}@opsknight-db:5432/${POSTGRES_DB:-opsknight_db}?sslmode=prefer&connection_limit=40&pool_timeout=30}
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
@@ -54,7 +54,9 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      # v1.4 runs fail-closed migrations before starting the HTTP server.
+      # Allow slow upgrades/recovery attempts to complete before health failures count.
+      start_period: 5m
     networks:
       - opsknight-network
 

--- a/src/lib/db-locks.ts
+++ b/src/lib/db-locks.ts
@@ -51,6 +51,10 @@ export const LOCK_KEYS = {
  * if you forget to commit, the lock is still released by the engine
  * tearing down the session.
  *
+ * Prisma cannot deserialize Postgres' `void` return type from a direct
+ * `SELECT pg_advisory_xact_lock(...)`. Keep the lock call in a subquery
+ * and return a supported scalar instead.
+ *
  * Safe to call when the underlying database is not Postgres (e.g.
  * in unit tests against a mocked client): we catch the resulting
  * error, log it, and let the caller proceed without the lock. This
@@ -63,12 +67,15 @@ export async function acquireAdvisoryLock(
   key: bigint
 ): Promise<void> {
   try {
-    await tx.$queryRaw`SELECT pg_advisory_xact_lock(${key}::bigint)`;
+    await tx.$queryRaw`
+      SELECT TRUE AS "acquired"
+      FROM (SELECT pg_advisory_xact_lock(${key}::bigint)) AS lock_result
+    `;
   } catch (err) {
-    logger.warn(
-      '[DbLocks] pg_advisory_xact_lock failed (likely non-Postgres test env); proceeding without lock',
-      { key: key.toString(), error: err instanceof Error ? err.message : String(err) }
-    );
+    logger.warn('[DbLocks] pg_advisory_xact_lock failed; proceeding without lock', {
+      key: key.toString(),
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Hotfixes the v1.4 maintenance line without depending on current `main` behavior.

## Changes
- fixes `pg_advisory_xact_lock()` usage so Prisma does not try to deserialize PostgreSQL `void`
- keeps advisory-lock behavior transaction-scoped while returning a Prisma-supported scalar
- removes the misleading assumption that advisory-lock failures imply a non-Postgres environment
- hardens the v1.4 Docker Compose defaults already prepared on this branch

## Why
A real v1.4 deployment reported:

`Failed to deserialize column of type 'void'`

The v1.4 helper directly selected `pg_advisory_xact_lock(...)`, whose return type is PostgreSQL `void`. Prisma attempts to deserialize that result and throws. The exception is caught, so the app continues without the intended advisory lock.

## Scope
- based on the original `v1.4.0` release line
- targets `release/v1.4`, not `main`
- no current-main readiness semantics or unrelated feature backports
- no schema migration required

## Deployment
After merge, this branch can be used to build a `1.4.0-hotfix` container image without creating a new GitHub Release.