### PR TITLE
fix: persist and apply profile timezone changes

### DIFF
--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -23,6 +23,7 @@ import {
   isWriteApiScope,
 } from '@/lib/authorization';
 import { getCurrentUser } from '@/lib/rbac';
+import { isValidTimeZone } from '@/lib/timezone';
 
 type ActionState = {
   error?: string | null;
@@ -184,7 +185,10 @@ export async function updatePreferences(
 ): Promise<ActionState> {
   try {
     const user = await getCurrentUser();
-    const timeZone = (formData.get('timeZone') as string | null)?.trim() ?? 'UTC';
+    const timeZone = (formData.get('timeZone') as string | null)?.trim() || 'UTC';
+    if (!isValidTimeZone(timeZone)) {
+      return { error: 'Please select a valid IANA timezone.' };
+    }
 
     await prisma.user.update({
       where: { id: user.id },
@@ -194,6 +198,7 @@ export async function updatePreferences(
     });
 
     revalidatePath('/settings/profile');
+    revalidatePath('/', 'layout');
     return { success: true };
   } catch (error) {
     return { error: error instanceof Error ? error.message : 'Unable to update preferences.' };

--- a/src/components/settings/PreferencesForm.tsx
+++ b/src/components/settings/PreferencesForm.tsx
@@ -8,6 +8,7 @@ import { Clock } from 'lucide-react';
 import { z } from 'zod';
 import { updatePreferences } from '@/app/(app)/settings/actions';
 import { useRouter } from 'next/navigation';
+import { useTimezone } from '@/contexts/TimezoneContext';
 import { Controller } from 'react-hook-form';
 import { notify as toast } from '@/lib/toast';
 
@@ -23,8 +24,13 @@ type PreferencesFormData = z.infer<typeof preferencesSchema>;
 
 export default function PreferencesForm({ timeZone }: Props) {
   const router = useRouter();
+  const { setUserTimeZone } = useTimezone();
   const [currentTimeStr, setCurrentTimeStr] = useState<string>('');
   const [selectedTimeZone, setSelectedTimeZone] = useState<string>(timeZone);
+
+  useEffect(() => {
+    setSelectedTimeZone(timeZone);
+  }, [timeZone]);
 
   // Live digital clock in selected timezone
   useEffect(() => {
@@ -53,7 +59,7 @@ export default function PreferencesForm({ timeZone }: Props) {
   }, [selectedTimeZone]);
 
   const defaultValues: PreferencesFormData = {
-    timeZone,
+    timeZone: selectedTimeZone,
   };
 
   const handleSave = async (data: PreferencesFormData) => {
@@ -63,6 +69,7 @@ export default function PreferencesForm({ timeZone }: Props) {
     const result = await updatePreferences({ error: null, success: false }, formData);
 
     if (result.success) {
+      setUserTimeZone(data.timeZone);
       toast.success('Timezone updated');
       setTimeout(() => {
         router.refresh();

--- a/tests/components/SLABreachWarningBadge.test.tsx
+++ b/tests/components/SLABreachWarningBadge.test.tsx
@@ -82,6 +82,9 @@ describe('SLABreachWarningBadge', () => {
     slaResolveTargetMs: null,
     slaTargetSource: null,
     slaTargetCapturedAt: null,
+    slaPolicyId: null,
+    slaPolicyVersion: null,
+    slaPolicyRule: null,
   };
 
   it('renders correctly with Date objects', () => {


### PR DESCRIPTION
## Summary
- Validate profile timezone updates as supported IANA timezone identifiers before persistence.
- Revalidate the authenticated app layout after saving so the updated timezone is applied consistently across server-rendered pages and the shared timezone provider.
- Synchronize the preferences form with refreshed server props and update the in-memory timezone context immediately after a successful save.
- Add the missing SLA fixture provenance required by the current branch typecheck.

## Verification
- `npx tsc --noEmit`
- Full local unit suite: 2,411 passed, 4 skipped
- Production build: successful
- Pre-push checks completed through build/security audit (existing dependency audit warning: moderate `ajv` advisory)

## Scope
This PR does not alter schedule timezones; it makes the authenticated user's profile timezone persistence and application consistent across desktop app layout, profile settings, and client context.
