### PR TITLE
fix: handle notification SSE disconnects as recoverable

### DIFF
--- a/src/components/TopbarNotifications.tsx
+++ b/src/components/TopbarNotifications.tsx
@@ -272,8 +272,17 @@ export default function TopbarNotifications() {
       }
     };
 
-    eventSource.onerror = error => {
-      logger.error('SSE connection error', { component: 'TopbarNotifications', error });
+    eventSource.onerror = () => {
+      // EventSource emits `error` for ordinary network/proxy disconnects and
+      // reconnect attempts; browsers intentionally do not expose a useful
+      // Error object here. Treat this as a recoverable transport state rather
+      // than an application error, and keep the polling fallback alive.
+      logger.warn('SSE notification transport interrupted; using polling fallback', {
+        component: 'TopbarNotifications',
+        readyState: eventSource.readyState,
+        online: typeof navigator === 'undefined' ? undefined : navigator.onLine,
+        visibilityState: typeof document === 'undefined' ? undefined : document.visibilityState,
+      });
       setIsLive(false);
       if (!pollIntervalRef.current) {
         pollIntervalRef.current = setInterval(fetchNotifications, 30000);


### PR DESCRIPTION
## Summary
- Treat browser `EventSource.onerror` events as recoverable transport interruptions rather than application exceptions.
- Avoid logging a misleading `error` object for browser SSE disconnects; browsers do not expose a useful error payload there.
- Preserve polling fallback and reconnect behavior, while including ready state, browser online state, and document visibility in a warning for diagnosis.

## Investigation
The reported log was emitted by `TopbarNotifications` on the client. The server notification stream has an explicit abort/cleanup path and the browser `EventSource` error callback receives a generic event during normal proxy/network disconnects. This was client transport noise, not evidence of an application exception.

## Verification
- `npx eslint src/components/TopbarNotifications.tsx --max-warnings 0` passed.
- `git diff --check` passed.
- Full isolated worktree TypeScript verification is blocked by the clean worktree's dependency/Prisma setup and pre-existing repository-wide type errors unrelated to this one-file fix.
