### PR TITLE
fix(settings): make help tooltips accessible and unclipped

### DIFF
--- a/src/components/settings/forms/FormField.tsx
+++ b/src/components/settings/forms/FormField.tsx
@@ -9,7 +9,12 @@ import {
 import { Label } from '@/components/ui/shadcn/label';
 import { cn } from '@/lib/utils';
 import { HelpCircle } from 'lucide-react';
-import Tooltip from '@/components/ui/Tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/shadcn/tooltip';
 
 interface FormFieldProps {
   name: string;
@@ -52,9 +57,22 @@ export function FormField({
               {required && <span className="text-destructive ml-1">*</span>}
             </Label>
             {tooltip && (
-              <Tooltip content={tooltip}>
-                <HelpCircle className="h-4 w-4 text-muted-foreground cursor-help" />
-              </Tooltip>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={`More information about ${label}`}
+                      className="inline-flex rounded-sm text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                      <HelpCircle aria-hidden="true" className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="start" className="max-w-xs leading-relaxed">
+                    {tooltip}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
           </div>
           {description && <p className="text-xs text-muted-foreground">{description}</p>}

--- a/src/components/settings/layout/SettingsRow.tsx
+++ b/src/components/settings/layout/SettingsRow.tsx
@@ -2,7 +2,12 @@
 
 import { cn } from '@/lib/utils';
 import { HelpCircle } from 'lucide-react';
-import Tooltip from '@/components/ui/Tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/shadcn/tooltip';
 
 interface SettingsRowProps {
   label: string;
@@ -43,9 +48,22 @@ export function SettingsRow({
             {required && <span className="text-destructive ml-1">*</span>}
           </label>
           {tooltip && (
-            <Tooltip content={tooltip} position="top">
-              <HelpCircle className="h-4 w-4 text-muted-foreground cursor-help" />
-            </Tooltip>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`More information about ${label}`}
+                    className="inline-flex rounded-sm text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    <HelpCircle aria-hidden="true" className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" align="start" className="max-w-xs leading-relaxed">
+                  {tooltip}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
         {description && (

--- a/tests/components/settings/SettingsRow.test.tsx
+++ b/tests/components/settings/SettingsRow.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SettingsRow } from '@/components/settings/layout/SettingsRow';
+import { SettingsSection } from '@/components/settings/layout/SettingsSection';
+
+describe('SettingsRow help tooltip', () => {
+  it('uses an accessible, portalled help trigger inside an overflow-hidden settings section', async () => {
+    render(
+      <SettingsSection title="Preferences">
+        <SettingsRow
+          label="Timezone"
+          tooltip="Used for incident timestamps, on-call schedules, and quiet hours"
+        >
+          <input aria-label="Timezone value" />
+        </SettingsRow>
+      </SettingsSection>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'More information about Timezone' });
+    fireEvent.focus(trigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Used for incident timestamps, on-call schedules, and quiet hours'
+    );
+  });
+});


### PR DESCRIPTION
## 📝 Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## 🧪 Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## 🛡️ How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Check (please describe)

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved settings help tooltips with keyboard-focusable buttons and accessible labels.
  * Added consistent tooltip positioning and a brief display delay.

* **Bug Fixes**
  * Updated field and settings-row tooltips for more reliable rendering and interaction.

* **Tests**
  * Added coverage verifying that help text appears when the tooltip trigger receives focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->