### PR TITLE
feat(status): establish enterprise status and notification contract

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -65,6 +65,7 @@ jobs:
           mkdir -p reports
           npx prisma migrate deploy
           npx prisma generate
+          npm run prisma:indexes:status-platform
           npm run prisma:validate
           npm run prisma:health
           node scripts/ci-db-smoke.cjs
@@ -102,6 +103,7 @@ jobs:
             DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_upgrade?schema=public' npx prisma migrate deploy
           )
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_upgrade?schema=public' npx prisma migrate deploy
+          DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_upgrade?schema=public' npm run prisma:indexes:status-platform
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_upgrade?schema=public' npm run prisma:health
 
       - name: Backup and restore contract
@@ -115,6 +117,7 @@ jobs:
           docker exec "$POSTGRES_CONTAINER" createdb -U postgres opsknight_restore
           docker exec "$POSTGRES_CONTAINER" pg_restore -U postgres --no-owner \
             -d opsknight_restore /tmp/opsknight-release.dump
+          DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_restore?schema=public' npm run prisma:indexes:status-platform
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_restore?schema=public' npm run prisma:health
           DATABASE_URL='postgresql://postgres:postgres@localhost:5432/opsknight_restore?schema=public' node scripts/ci-db-smoke.cjs
 

--- a/.github/workflows/enterprise-readiness.yml
+++ b/.github/workflows/enterprise-readiness.yml
@@ -89,7 +89,9 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - name: Build representative database
-        run: npx prisma migrate deploy
+        run: |
+          npx prisma migrate deploy
+          npm run prisma:indexes:status-platform
       - name: Create backup
         run: |
           mkdir -p reports

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate
 
+      - name: Enforce idempotent status platform indexes
+        run: |
+          npm run prisma:indexes:status-platform
+          npm run prisma:indexes:status-platform
+
       - name: DB smoke test (post-migrations)
         run: |
           mkdir -p reports

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,6 +16,16 @@ run_migrations() {
     return 1
 }
 
+install_status_platform_indexes() {
+    if [ -f "scripts/create-status-platform-online-indexes.cjs" ]; then
+        node scripts/create-status-platform-online-indexes.cjs
+        return $?
+    fi
+
+    echo "❌ Status platform index installer not found"
+    return 1
+}
+
 run_auto_recovery() {
     echo "🔧 Attempting migration recovery..."
 
@@ -56,6 +66,13 @@ if [ $MIGRATION_SUCCESS -eq 0 ]; then
     exit 1
 fi
 
+echo "🔄 Enforcing status platform indexes..."
+if ! install_status_platform_indexes; then
+    echo "❌ Status platform index enforcement failed. Refusing to start without required indexes."
+    exit 1
+fi
+
+echo "✅ Status platform indexes are ready."
 echo "✅ Database is ready."
 echo "🚀 Starting application..."
 export NEXT_RUNTIME=nodejs

--- a/docs/status-notification-scaling.md
+++ b/docs/status-notification-scaling.md
@@ -23,6 +23,18 @@ The operations page shows effective capacity, leases, campaigns, and bulk pause 
 delivery leaves critical and transactional workers running. Provider credentials remain in the
 encrypted provider store.
 
+Provider/account overrides use
+`NOTIFICATION_<CHANNEL>_<PROVIDER_ACCOUNT>_RATE_PER_SECOND` and
+`NOTIFICATION_<CHANNEL>_<PROVIDER_ACCOUNT>_MAX_IN_FLIGHT`. Non-alphanumeric characters in the
+provider account key become underscores. The precedence is provider account, channel, then the
+built-in system default. Queue claims cap each tenant within each traffic class so a large public
+campaign cannot consume an entire worker batch.
+
+Subscriber delivery state is explicit: pending, active, unsubscribed, suppressed, bounced, or
+complained. Provider feedback is idempotent by provider event ID. Hard bounces, complaints,
+invalid recipients, and provider suppressions stop later delivery; three soft bounces transition a
+subscriber to bounced. The worker revalidates this state immediately before provider submission.
+
 Public HTML, JSON, and RSS serve published snapshots only. Set
 `STATUS_PAGE_SERVING_STORE_URL` and `STATUS_PAGE_SERVING_STORE_TOKEN` for an external store and
 opt in with `STATUS_PAGE_EXTERNAL_SERVING_STORE=true`. Privacy changes revoke the manifest before
@@ -42,9 +54,17 @@ k6 run -e BASE_URL=https://staging.example.com -e PUBLIC_RPS=1000 \
   scripts/load/status-notification-scaling.js
 ```
 
-Execute subscriber campaigns at 1k, 10k, and 100k while recording PostgreSQL CPU, connections,
+Execute subscriber campaigns at 1k, 10k, 100k, and 1M while recording PostgreSQL CPU, connections,
 query rate, queue depth/age, provider throughput, worker memory, public latency, and internal p95.
 Repeat with provider 429, 500, two-second latency, a 30-minute outage, PostgreSQL pressure, and a
 bulk-worker termination. Acceptance requires internal p95 degradation below 15%, uninterrupted
 critical paging, crash-safe campaign resume, and correct Retry-After behavior at 250/s, 500/s, and
 1,000/s test ceilings.
+
+Release SLOs are: public availability 99.99%, public p95 below 250 ms, critical queue p95 below two
+seconds, transactional queue p95 below ten seconds, snapshot publication p95 below 60 seconds,
+zero false-green responses, and zero duplicate lifecycle deliveries. Run public traffic at 100,
+500, 1,000, and 5,000 RPS. The final mixed test combines 1,000 public RPS, a 1M-recipient campaign,
+critical responder traffic, and internal incident traffic. Store the dated k6 output and database,
+worker, provider, bounce, complaint, and queue telemetry with the release record; targets without
+recorded evidence do not count as certification.

--- a/docs/status-notification-scaling.md
+++ b/docs/status-notification-scaling.md
@@ -46,6 +46,12 @@ rolled back by deploying the previous compatible application/worker version, not
 runtime flags. Roll forward by applying additive schema first, then workers, then web processes.
 Keep snapshot-only public serving fail-closed during rollback.
 
+After applying the status-platform schema migration, run
+`npm run prisma:indexes:status-platform` before enabling the new workers. This installs the
+Notification and StatusPageSubscription indexes with PostgreSQL's online concurrent build, outside
+Prisma's migration transaction. The command is idempotent and must complete on every production
+database before the rollout proceeds.
+
 Run combined load validation with:
 
 ```sh

--- a/docs/v1.5/deployment/database-migrations.md
+++ b/docs/v1.5/deployment/database-migrations.md
@@ -10,7 +10,7 @@ OpsKnight stores application state in PostgreSQL and ships ordered Prisma migrat
 
 ## Startup behavior
 
-The production container entrypoint in this repository revision runs `prisma migrate deploy` before starting the Next.js server. It attempts migration up to three times, waits five seconds between attempts, and invokes the packaged auto-recovery helper after a failed attempt. If migration still fails, the container exits non-zero instead of serving against an unknown schema.
+The production container entrypoint in this repository revision runs `prisma migrate deploy` before starting the Next.js server. It attempts migration up to three times, waits five seconds between attempts, and invokes the packaged auto-recovery helper after a failed attempt. After migrations succeed, it runs `npm run prisma:indexes:status-platform` to enforce the large-table indexes that PostgreSQL must build concurrently outside Prisma's migration transaction. Both steps are idempotent and fail closed: the application does not start if either migrations or required index enforcement fails.
 
 The `1.4.0` image and later fail closed instead of starting after an unrecovered migration failure. Confirm the exact image release before relying on startup behavior. For every release:
 
@@ -39,7 +39,7 @@ For a controlled manual deployment, the repository's combined command is:
 npm run prisma:migrate:safe
 ```
 
-That command validates files, checks database history, and runs `prisma migrate deploy`. Do not use `prisma db push` as a production upgrade method: it bypasses the reviewed migration history and does not provide the same deployment record.
+That command validates files, checks database history, applies migrations, and enforces the online indexes. Index enforcement uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, so repeating the command is safe and avoids a blocking table rewrite. Do not use `prisma db push` as a production upgrade method: it bypasses the reviewed migration history and does not provide the same deployment record.
 
 ## Release procedure
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prisma:validate": "node scripts/validate-migrations.cjs",
     "prisma:health": "node scripts/check-migration-health.cjs",
     "prisma:auto-recover": "node --loader ts-node/esm scripts/auto-recover-migrations.ts",
-    "prisma:migrate:safe": "npm run prisma:validate && npm run prisma:health && npx prisma migrate deploy",
+    "prisma:migrate:safe": "npm run prisma:validate && npm run prisma:health && npx prisma migrate deploy && npm run prisma:indexes:status-platform",
     "prisma:indexes:status-platform": "node scripts/create-status-platform-online-indexes.cjs",
     "prepare": "husky install",
     "security:check": "npm audit && npm run lint:check",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "prisma:health": "node scripts/check-migration-health.cjs",
     "prisma:auto-recover": "node --loader ts-node/esm scripts/auto-recover-migrations.ts",
     "prisma:migrate:safe": "npm run prisma:validate && npm run prisma:health && npx prisma migrate deploy",
+    "prisma:indexes:status-platform": "node scripts/create-status-platform-online-indexes.cjs",
     "prepare": "husky install",
     "security:check": "npm audit && npm run lint:check",
     "lint:report": "eslint . --format @microsoft/eslint-formatter-sarif --output-file reports/security.sarif",

--- a/prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql
+++ b/prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql
@@ -1,7 +1,9 @@
 CREATE TYPE "StatusPageSubscriptionState" AS ENUM ('PENDING', 'ACTIVE', 'UNSUBSCRIBED', 'SUPPRESSED', 'BOUNCED', 'COMPLAINED');
 
 ALTER TABLE "Notification" ADD COLUMN "tenantKey" TEXT NOT NULL DEFAULT 'system';
-CREATE INDEX "idx_notification_tenant_fair_delivery" ON "Notification"("trafficClass", "tenantKey", "status", "nextAttemptAt", "createdAt");
+-- These indexes cover existing, write-heavy tables. Prisma applies PostgreSQL
+-- migrations without an implicit transaction, which permits online creation.
+CREATE INDEX CONCURRENTLY "idx_notification_tenant_fair_delivery" ON "Notification"("trafficClass", "tenantKey", "status", "nextAttemptAt", "createdAt");
 
 ALTER TABLE "StatusPageSubscription"
   ADD COLUMN "state" "StatusPageSubscriptionState" NOT NULL DEFAULT 'PENDING',
@@ -19,7 +21,7 @@ SET "state" = CASE
   ELSE 'PENDING'::"StatusPageSubscriptionState"
 END;
 
-CREATE INDEX "StatusPageSubscription_statusPageId_state_idx" ON "StatusPageSubscription"("statusPageId", "state");
+CREATE INDEX CONCURRENTLY "StatusPageSubscription_statusPageId_state_idx" ON "StatusPageSubscription"("statusPageId", "state");
 
 CREATE TABLE "NotificationProviderFeedback" (
   "id" TEXT NOT NULL,

--- a/prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql
+++ b/prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql
@@ -1,0 +1,37 @@
+CREATE TYPE "StatusPageSubscriptionState" AS ENUM ('PENDING', 'ACTIVE', 'UNSUBSCRIBED', 'SUPPRESSED', 'BOUNCED', 'COMPLAINED');
+
+ALTER TABLE "Notification" ADD COLUMN "tenantKey" TEXT NOT NULL DEFAULT 'system';
+CREATE INDEX "idx_notification_tenant_fair_delivery" ON "Notification"("trafficClass", "tenantKey", "status", "nextAttemptAt", "createdAt");
+
+ALTER TABLE "StatusPageSubscription"
+  ADD COLUMN "state" "StatusPageSubscriptionState" NOT NULL DEFAULT 'PENDING',
+  ADD COLUMN "suppressionReason" TEXT,
+  ADD COLUMN "lastBounceAt" TIMESTAMP(3),
+  ADD COLUMN "bounceCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "complainedAt" TIMESTAMP(3),
+  ADD COLUMN "lastDeliveredAt" TIMESTAMP(3),
+  ADD COLUMN "lastFailedAt" TIMESTAMP(3);
+
+UPDATE "StatusPageSubscription"
+SET "state" = CASE
+  WHEN "unsubscribedAt" IS NOT NULL THEN 'UNSUBSCRIBED'::"StatusPageSubscriptionState"
+  WHEN "verified" = TRUE THEN 'ACTIVE'::"StatusPageSubscriptionState"
+  ELSE 'PENDING'::"StatusPageSubscriptionState"
+END;
+
+CREATE INDEX "StatusPageSubscription_statusPageId_state_idx" ON "StatusPageSubscription"("statusPageId", "state");
+
+CREATE TABLE "NotificationProviderFeedback" (
+  "id" TEXT NOT NULL,
+  "provider" TEXT NOT NULL,
+  "providerEventId" TEXT NOT NULL,
+  "providerMessageId" TEXT,
+  "eventType" TEXT NOT NULL,
+  "recipientHash" TEXT,
+  "occurredAt" TIMESTAMP(3) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "NotificationProviderFeedback_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "NotificationProviderFeedback_provider_providerEventId_key" ON "NotificationProviderFeedback"("provider", "providerEventId");
+CREATE INDEX "NotificationProviderFeedback_providerMessageId_idx" ON "NotificationProviderFeedback"("providerMessageId");
+CREATE INDEX "NotificationProviderFeedback_eventType_occurredAt_idx" ON "NotificationProviderFeedback"("eventType", "occurredAt");

--- a/prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql
+++ b/prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql
@@ -1,9 +1,9 @@
 CREATE TYPE "StatusPageSubscriptionState" AS ENUM ('PENDING', 'ACTIVE', 'UNSUBSCRIBED', 'SUPPRESSED', 'BOUNCED', 'COMPLAINED');
 
 ALTER TABLE "Notification" ADD COLUMN "tenantKey" TEXT NOT NULL DEFAULT 'system';
--- These indexes cover existing, write-heavy tables. Prisma applies PostgreSQL
--- migrations without an implicit transaction, which permits online creation.
-CREATE INDEX CONCURRENTLY "idx_notification_tenant_fair_delivery" ON "Notification"("trafficClass", "tenantKey", "status", "nextAttemptAt", "createdAt");
+-- Indexes on existing write-heavy tables are installed by
+-- `npm run prisma:indexes:status-platform` after this transactional migration.
+-- PostgreSQL concurrent index builds cannot run inside Prisma's migration transaction.
 
 ALTER TABLE "StatusPageSubscription"
   ADD COLUMN "state" "StatusPageSubscriptionState" NOT NULL DEFAULT 'PENDING',
@@ -20,8 +20,6 @@ SET "state" = CASE
   WHEN "verified" = TRUE THEN 'ACTIVE'::"StatusPageSubscriptionState"
   ELSE 'PENDING'::"StatusPageSubscriptionState"
 END;
-
-CREATE INDEX CONCURRENTLY "StatusPageSubscription_statusPageId_state_idx" ON "StatusPageSubscription"("statusPageId", "state");
 
 CREATE TABLE "NotificationProviderFeedback" (
   "id" TEXT NOT NULL,

--- a/prisma/migrations/20260909200000_status_page_history_timezone/migration.sql
+++ b/prisma/migrations/20260909200000_status_page_history_timezone/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "StatusPage"
+ADD COLUMN "timeZone" TEXT NOT NULL DEFAULT 'UTC';

--- a/prisma/migrations/20260909200000_status_page_history_timezone/migration.sql
+++ b/prisma/migrations/20260909200000_status_page_history_timezone/migration.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "StatusPage"
-ADD COLUMN "timeZone" TEXT NOT NULL DEFAULT 'UTC';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1500,7 +1500,6 @@ model StatusPage {
   slug             String? @unique
   isDefault        Boolean @default(false)
   organizationName String? // Dedicated organization name for email branding
-  timeZone         String  @default("UTC") // IANA timezone used for public history day boundaries
   subdomain        String? @unique // Custom subdomain (e.g., status.yourcompany.com)
   customDomain     String? @unique // Custom domain (e.g., status.yourcompany.com)
   enabled          Boolean @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1500,6 +1500,7 @@ model StatusPage {
   slug             String? @unique
   isDefault        Boolean @default(false)
   organizationName String? // Dedicated organization name for email branding
+  timeZone         String  @default("UTC") // IANA timezone used for public history day boundaries
   subdomain        String? @unique // Custom subdomain (e.g., status.yourcompany.com)
   customDomain     String? @unique // Custom domain (e.g., status.yourcompany.com)
   enabled          Boolean @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,15 @@ enum NotificationTrafficClass {
   BULK
 }
 
+enum StatusPageSubscriptionState {
+  PENDING
+  ACTIVE
+  UNSUBSCRIBED
+  SUPPRESSED
+  BOUNCED
+  COMPLAINED
+}
+
 enum NotificationCategory {
   INCIDENT
   SECURITY
@@ -1144,6 +1153,7 @@ model Notification {
   contentId         String?
   fanoutId          String?
   trafficClass      NotificationTrafficClass  @default(TRANSACTIONAL)
+  tenantKey         String                    @default("system")
   priority          Int                       @default(5)
   scheduledAt       DateTime                  @default(now())
   nextAttemptAt     DateTime                  @default(now())
@@ -1176,6 +1186,7 @@ model Notification {
   @@index([incidentId, userId, status], name: "idx_notification_incident_user_status") // For per-incident per-user dedup checks
   @@index([status, nextAttemptAt, priority, createdAt], name: "idx_notification_delivery_due")
   @@index([trafficClass, status, nextAttemptAt, priority, createdAt], name: "idx_notification_traffic_delivery_due")
+  @@index([trafficClass, tenantKey, status, nextAttemptAt, createdAt], name: "idx_notification_tenant_fair_delivery")
   @@index([category, createdAt], name: "idx_notification_category_created")
   @@index([recipientHash, createdAt], name: "idx_notification_recipient_created")
   @@index([sourceType, sourceId, createdAt], name: "idx_notification_source_created")
@@ -1240,6 +1251,21 @@ model NotificationDeliveryAttempt {
   @@unique([notificationId, ordinal])
   @@index([notificationId, startedAt])
   @@index([outcome, startedAt])
+}
+
+model NotificationProviderFeedback {
+  id                String   @id @default(cuid())
+  provider          String
+  providerEventId   String
+  providerMessageId String?
+  eventType         String
+  recipientHash     String?
+  occurredAt        DateTime
+  createdAt         DateTime @default(now())
+
+  @@unique([provider, providerEventId])
+  @@index([providerMessageId])
+  @@index([eventType, occurredAt])
 }
 
 model InAppNotification {
@@ -1630,6 +1656,13 @@ model StatusPageSubscription {
   subscribedAt      DateTime  @default(now())
   unsubscribedAt    DateTime?
   verified          Boolean   @default(false)
+  state             StatusPageSubscriptionState @default(PENDING)
+  suppressionReason String?
+  lastBounceAt      DateTime?
+  bounceCount       Int       @default(0)
+  complainedAt      DateTime?
+  lastDeliveredAt   DateTime?
+  lastFailedAt      DateTime?
   verificationToken String?
   preferences       Json? // Notification preferences (all incidents, major only, etc.)
 

--- a/scripts/create-status-platform-online-indexes.cjs
+++ b/scripts/create-status-platform-online-indexes.cjs
@@ -1,6 +1,15 @@
 const { PrismaClient } = require('@prisma/client');
 
-const prisma = new PrismaClient();
+const databaseUrl = new URL(process.env.DATABASE_URL);
+// Session-level advisory locks require every statement to use the same backend.
+// A dedicated one-connection Prisma pool provides that guarantee during startup.
+databaseUrl.searchParams.set('connection_limit', '1');
+
+const prisma = new PrismaClient({
+  datasourceUrl: databaseUrl.toString(),
+});
+
+const INSTALL_LOCK_ID = 1448233807;
 
 const indexes = [
   `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_notification_tenant_fair_delivery"
@@ -10,8 +19,19 @@ const indexes = [
 ];
 
 async function main() {
-  for (const statement of indexes) {
-    await prisma.$executeRawUnsafe(statement);
+  let lockAcquired = false;
+
+  try {
+    await prisma.$queryRawUnsafe(`SELECT pg_advisory_lock(${INSTALL_LOCK_ID})`);
+    lockAcquired = true;
+
+    for (const statement of indexes) {
+      await prisma.$executeRawUnsafe(statement);
+    }
+  } finally {
+    if (lockAcquired) {
+      await prisma.$queryRawUnsafe(`SELECT pg_advisory_unlock(${INSTALL_LOCK_ID})`);
+    }
   }
 }
 

--- a/scripts/create-status-platform-online-indexes.cjs
+++ b/scripts/create-status-platform-online-indexes.cjs
@@ -22,7 +22,10 @@ async function main() {
   let lockAcquired = false;
 
   try {
-    await prisma.$queryRawUnsafe(`SELECT pg_advisory_lock(${INSTALL_LOCK_ID})`);
+    // Cast PostgreSQL's void result so Prisma can deserialize the row.
+    await prisma.$queryRawUnsafe(
+      `SELECT pg_advisory_lock(${INSTALL_LOCK_ID})::text AS "lockResult"`
+    );
     lockAcquired = true;
 
     for (const statement of indexes) {

--- a/scripts/create-status-platform-online-indexes.cjs
+++ b/scripts/create-status-platform-online-indexes.cjs
@@ -1,0 +1,25 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+const indexes = [
+  `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_notification_tenant_fair_delivery"
+   ON "Notification"("trafficClass", "tenantKey", "status", "nextAttemptAt", "createdAt")`,
+  `CREATE INDEX CONCURRENTLY IF NOT EXISTS "StatusPageSubscription_statusPageId_state_idx"
+   ON "StatusPageSubscription"("statusPageId", "state")`,
+];
+
+async function main() {
+  for (const statement of indexes) {
+    await prisma.$executeRawUnsafe(statement);
+  }
+}
+
+main()
+  .catch(error => {
+    console.error('Status platform online index installation failed.', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/(app)/settings/notifications/operations/page.tsx
+++ b/src/app/(app)/settings/notifications/operations/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/shadcn/badge';
 import NotificationCapacityOverview from '@/components/settings/NotificationCapacityOverview';
 import { getProviderCapacity } from '@/lib/provider-capacity';
 import prisma from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 
 export default async function NotificationOperationsPage() {
   let user: Awaited<ReturnType<typeof getCurrentUser>>;
@@ -38,12 +39,12 @@ export default async function NotificationOperationsPage() {
     }),
     prisma.systemConfig.findUnique({ where: { key: 'notification_capacity_control' } }),
     prisma.statusPageSubscription.groupBy({ by: ['state'], _count: { _all: true } }),
-    prisma.notificationProviderFeedback.groupBy({
-      by: ['eventType'],
-      // eslint-disable-next-line react-hooks/purity -- server request timestamp bounds live telemetry.
-      where: { occurredAt: { gte: new Date(Date.now() - 24 * 60 * 60_000) } },
-      _count: { _all: true },
-    }),
+    prisma.$queryRaw<Array<{ eventType: string; count: number }>>(Prisma.sql`
+      SELECT "eventType", COUNT(*)::integer AS "count"
+      FROM "NotificationProviderFeedback"
+      WHERE "occurredAt" >= CURRENT_TIMESTAMP - INTERVAL '24 hours'
+      GROUP BY "eventType"
+    `),
   ]);
   const controlValue =
     control?.value && typeof control.value === 'object' && !Array.isArray(control.value)
@@ -131,7 +132,7 @@ export default async function NotificationOperationsPage() {
         {feedbackTypes.map(item => (
           <div key={item.eventType} className="rounded-xl border bg-card p-4">
             <p className="text-xs font-semibold uppercase text-muted-foreground">24h {item.eventType.toLowerCase()}</p>
-            <p className="text-2xl font-bold">{item._count._all}</p>
+            <p className="text-2xl font-bold">{item.count}</p>
           </div>
         ))}
       </section>

--- a/src/app/(app)/settings/notifications/operations/page.tsx
+++ b/src/app/(app)/settings/notifications/operations/page.tsx
@@ -40,6 +40,7 @@ export default async function NotificationOperationsPage() {
     prisma.statusPageSubscription.groupBy({ by: ['state'], _count: { _all: true } }),
     prisma.notificationProviderFeedback.groupBy({
       by: ['eventType'],
+      // eslint-disable-next-line react-hooks/purity -- server request timestamp bounds live telemetry.
       where: { occurredAt: { gte: new Date(Date.now() - 24 * 60 * 60_000) } },
       _count: { _all: true },
     }),

--- a/src/app/(app)/settings/notifications/operations/page.tsx
+++ b/src/app/(app)/settings/notifications/operations/page.tsx
@@ -22,7 +22,7 @@ export default async function NotificationOperationsPage() {
     redirect('/settings');
   }
   const channels = ['EMAIL', 'SMS', 'WHATSAPP', 'PUSH', 'SLACK', 'WEBHOOK'] as const;
-  const [leases, campaigns, control] = await Promise.all([
+  const [leases, campaigns, control, subscriptionStates, feedbackTypes] = await Promise.all([
     prisma.providerWorkerLease.count({ where: { expiresAt: { gt: new Date() } } }),
     prisma.notificationFanout.findMany({
       orderBy: { createdAt: 'desc' },
@@ -37,6 +37,12 @@ export default async function NotificationOperationsPage() {
       },
     }),
     prisma.systemConfig.findUnique({ where: { key: 'notification_capacity_control' } }),
+    prisma.statusPageSubscription.groupBy({ by: ['state'], _count: { _all: true } }),
+    prisma.notificationProviderFeedback.groupBy({
+      by: ['eventType'],
+      where: { occurredAt: { gte: new Date(Date.now() - 24 * 60 * 60_000) } },
+      _count: { _all: true },
+    }),
   ]);
   const controlValue =
     control?.value && typeof control.value === 'object' && !Array.isArray(control.value)
@@ -113,6 +119,21 @@ export default async function NotificationOperationsPage() {
         initialPaused={controlValue.bulkPaused === true}
         canManage={user.role === 'ADMIN'}
       />
+      <section aria-labelledby="deliverability-heading" className="grid gap-3 md:grid-cols-3">
+        <h2 id="deliverability-heading" className="sr-only">Subscriber deliverability</h2>
+        {subscriptionStates.map(item => (
+          <div key={item.state} className="rounded-xl border bg-card p-4">
+            <p className="text-xs font-semibold uppercase text-muted-foreground">{item.state.toLowerCase()}</p>
+            <p className="text-2xl font-bold">{item._count._all}</p>
+          </div>
+        ))}
+        {feedbackTypes.map(item => (
+          <div key={item.eventType} className="rounded-xl border bg-card p-4">
+            <p className="text-xs font-semibold uppercase text-muted-foreground">24h {item.eventType.toLowerCase()}</p>
+            <p className="text-2xl font-bold">{item._count._all}</p>
+          </div>
+        ))}
+      </section>
       <NotificationOperations canRetry={user.role === 'ADMIN'} />
     </div>
   );

--- a/src/app/(public)/status/unsubscribe/[token]/page.tsx
+++ b/src/app/(public)/status/unsubscribe/[token]/page.tsx
@@ -21,7 +21,7 @@ async function confirmUnsubscribe(formData: FormData) {
       await prisma.$transaction([
         prisma.statusPageSubscription.updateMany({
           where: { id: subscription.id, unsubscribedAt: null },
-          data: { unsubscribedAt: new Date() },
+          data: { unsubscribedAt: new Date(), state: 'UNSUBSCRIBED' },
         }),
         prisma.notification.updateMany({
           where: {

--- a/src/app/(public)/status/verify/[token]/page.tsx
+++ b/src/app/(public)/status/verify/[token]/page.tsx
@@ -28,7 +28,7 @@ export async function confirmStatusSubscription(form: FormData) {
       verificationToken: hashSubscriptionToken(input.token),
       unsubscribedAt: null,
     },
-    data: { verified: true, verificationToken: null },
+    data: { verified: true, state: 'ACTIVE', verificationToken: null },
   });
   redirect(getStatusPagePublicUrl(subscription.statusPage));
 }

--- a/src/app/api/settings/status-page/route.ts
+++ b/src/app/api/settings/status-page/route.ts
@@ -61,6 +61,7 @@ export async function POST(req: NextRequest) {
       name,
       slug,
       organizationName,
+      timeZone,
       subdomain,
       customDomain,
       enabled,
@@ -134,6 +135,7 @@ export async function POST(req: NextRequest) {
     const updateData: Prisma.StatusPageUpdateInput = {
       slug: hasField('slug') ? slug || null : undefined,
       organizationName: hasField('organizationName') ? nullableText(organizationName) : undefined,
+      timeZone: hasField('timeZone') ? timeZone : undefined,
       subdomain: hasField('subdomain') ? nullableText(subdomain) : undefined,
       customDomain: hasField('customDomain') ? nullableText(customDomain) : undefined,
       enabled: hasField('enabled') ? enabled : undefined,

--- a/src/app/api/settings/status-page/route.ts
+++ b/src/app/api/settings/status-page/route.ts
@@ -61,7 +61,6 @@ export async function POST(req: NextRequest) {
       name,
       slug,
       organizationName,
-      timeZone,
       subdomain,
       customDomain,
       enabled,
@@ -135,7 +134,6 @@ export async function POST(req: NextRequest) {
     const updateData: Prisma.StatusPageUpdateInput = {
       slug: hasField('slug') ? slug || null : undefined,
       organizationName: hasField('organizationName') ? nullableText(organizationName) : undefined,
-      timeZone: hasField('timeZone') ? timeZone : undefined,
       subdomain: hasField('subdomain') ? nullableText(subdomain) : undefined,
       customDomain: hasField('customDomain') ? nullableText(customDomain) : undefined,
       enabled: hasField('enabled') ? enabled : undefined,

--- a/src/app/api/settings/status-page/route.ts
+++ b/src/app/api/settings/status-page/route.ts
@@ -243,6 +243,16 @@ export async function POST(req: NextRequest) {
       return saved;
     });
 
+    const store = getStatusPageServingStore();
+    await Promise.all([
+      ...(statusPage.slug && statusPage.slug !== updated.slug
+        ? [store.removeRoute(statusPage.slug)] : []),
+      ...(statusPage.customDomain && statusPage.customDomain !== updated.customDomain
+        ? [store.removeRoute(`domain:${statusPage.customDomain.toLowerCase()}`)] : []),
+      ...(statusPage.subdomain && statusPage.subdomain !== updated.subdomain
+        ? [store.removeRoute(`subdomain:${statusPage.subdomain.toLowerCase()}`)] : []),
+    ]);
+
     revalidatePath('/status');
     revalidatePath('/');
 

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -37,12 +37,14 @@ export async function getStatusResponse(req: NextRequest, slug?: string) {
       });
     }
 
-    const authResult = await authorizeStatusApiRequest(req, statusPage.id, {
+    const needsApiControl = statusPage.statusApiRequireToken === true ||
+      statusPage.statusApiRateLimitEnabled === true || req.headers.has('authorization');
+    const authResult = needsApiControl ? await authorizeStatusApiRequest(req, statusPage.id, {
       requireToken: statusPage.statusApiRequireToken === true,
       rateLimitEnabled: statusPage.statusApiRateLimitEnabled === true,
       rateLimitMax: statusPage.statusApiRateLimitMax ?? 120,
       rateLimitWindowSec: statusPage.statusApiRateLimitWindowSec ?? 60,
-    });
+    }) : { allowed: true };
     if (!authResult.allowed) {
       if (authResult.status === 429) {
         return NextResponse.json(
@@ -73,9 +75,10 @@ export async function getStatusResponse(req: NextRequest, slug?: string) {
         services: snapshot.services,
         incidents: snapshot.incidents,
         metrics: {
-          uptime: Object.entries(snapshot.uptime).map(([serviceId, uptime]) => ({
-            serviceId,
-            uptime: Number(uptime.toFixed(3)),
+          uptime: snapshot.services.map(service => ({
+            serviceId: service.id,
+            days30: service.uptime?.days30 ?? null,
+            days90: service.uptime?.days90 ?? null,
           })),
         },
         retention: { historyDays: snapshot.historyDays },

--- a/src/app/api/webhooks/notifications/provider-feedback/route.ts
+++ b/src/app/api/webhooks/notifications/provider-feedback/route.ts
@@ -1,0 +1,39 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { jsonError, jsonOk } from '@/lib/api-response';
+import { ingestNotificationProviderFeedback } from '@/lib/notification-provider-feedback';
+
+const feedbackSchema = z.object({
+  provider: z.string().trim().min(1).max(80),
+  providerEventId: z.string().trim().min(1).max(191),
+  providerMessageId: z.string().trim().min(1).max(191).optional(),
+  type: z.enum(['DELIVERED', 'HARD_BOUNCE', 'SOFT_BOUNCE', 'COMPLAINT', 'SUPPRESSION', 'INVALID_RECIPIENT']),
+  occurredAt: z.string().datetime({ offset: true }),
+}).strict();
+
+function validSignature(body: string, supplied: string | null, secret: string) {
+  if (!supplied) return false;
+  const expected = createHmac('sha256', secret).update(body).digest('hex');
+  const actualBuffer = Buffer.from(supplied.replace(/^sha256=/, ''), 'hex');
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.NOTIFICATION_PROVIDER_FEEDBACK_SECRET?.trim();
+  if (!secret) return jsonError('Provider feedback is not configured.', 503);
+  const body = await request.text();
+  if (!validSignature(body, request.headers.get('x-opsknight-signature'), secret)) {
+    return jsonError('Invalid provider feedback signature.', 401);
+  }
+  let value: unknown;
+  try { value = JSON.parse(body); } catch { return jsonError('Invalid JSON.', 400); }
+  const parsed = feedbackSchema.safeParse(value);
+  if (!parsed.success) return jsonError('Invalid provider feedback event.', 400);
+  const result = await ingestNotificationProviderFeedback({
+    ...parsed.data,
+    occurredAt: new Date(parsed.data.occurredAt),
+  });
+  return jsonOk(result, 202);
+}

--- a/src/components/StatusPageConfig.tsx
+++ b/src/components/StatusPageConfig.tsx
@@ -19,6 +19,7 @@ import StatusPageWebhooksSettings from '@/components/status-page/StatusPageWebho
 import StatusPageSubscribers from '@/components/status-page/StatusPageSubscribers';
 import StatusPageEmailConfig from '@/components/status-page/StatusPageEmailConfig';
 import { Badge } from '@/components/ui/shadcn/badge';
+import TimeZoneSelect from '@/components/TimeZoneSelect';
 import {
   STATUS_PAGE_FONTS,
   STATUS_PAGE_COLOR_PRESETS,
@@ -56,6 +57,7 @@ type StatusPageConfigProps = {
   statusPage: {
     id: string;
     name: string;
+    timeZone?: string;
     slug?: string | null;
     isDefault?: boolean;
     organizationName?: string | null;
@@ -726,6 +728,7 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
 
   const [formData, setFormData] = useState({
     name: statusPage.name,
+    timeZone: statusPage.timeZone || 'UTC',
     slug: statusPage.slug || '',
     isDefault: statusPage.isDefault ?? false,
     organizationName: statusPage.organizationName || '',
@@ -1018,6 +1021,7 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                 id: statusPage.id,
                 expectedUpdatedAt: revision,
                 name: formData.name,
+                timeZone: formData.timeZone,
                 slug: formData.slug || null,
                 organizationName: formData.organizationName || null,
                 subdomain: formData.subdomain || null,
@@ -1686,6 +1690,24 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                             helperText="Used in email headers (e.g., 'OpsKnight'). Overrides Status Page Name if set."
                             placeholder="e.g. OpsKnight"
                           />
+
+                          <div className="space-y-2">
+                            <label
+                              htmlFor="status-page-time-zone"
+                              className="text-sm font-medium text-gray-900"
+                            >
+                              History time zone
+                            </label>
+                            <TimeZoneSelect
+                              id="status-page-time-zone"
+                              name="timeZone"
+                              defaultValue={formData.timeZone}
+                              onChange={timeZone => setFormData(prev => ({ ...prev, timeZone }))}
+                            />
+                            <p className="text-sm text-gray-600">
+                              Defines calendar-day boundaries for uptime and incident history.
+                            </p>
+                          </div>
                         </div>
                       </div>
                     </Card>

--- a/src/components/StatusPageConfig.tsx
+++ b/src/components/StatusPageConfig.tsx
@@ -19,7 +19,6 @@ import StatusPageWebhooksSettings from '@/components/status-page/StatusPageWebho
 import StatusPageSubscribers from '@/components/status-page/StatusPageSubscribers';
 import StatusPageEmailConfig from '@/components/status-page/StatusPageEmailConfig';
 import { Badge } from '@/components/ui/shadcn/badge';
-import TimeZoneSelect from '@/components/TimeZoneSelect';
 import {
   STATUS_PAGE_FONTS,
   STATUS_PAGE_COLOR_PRESETS,
@@ -57,7 +56,6 @@ type StatusPageConfigProps = {
   statusPage: {
     id: string;
     name: string;
-    timeZone?: string;
     slug?: string | null;
     isDefault?: boolean;
     organizationName?: string | null;
@@ -728,7 +726,6 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
 
   const [formData, setFormData] = useState({
     name: statusPage.name,
-    timeZone: statusPage.timeZone || 'UTC',
     slug: statusPage.slug || '',
     isDefault: statusPage.isDefault ?? false,
     organizationName: statusPage.organizationName || '',
@@ -1021,7 +1018,6 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                 id: statusPage.id,
                 expectedUpdatedAt: revision,
                 name: formData.name,
-                timeZone: formData.timeZone,
                 slug: formData.slug || null,
                 organizationName: formData.organizationName || null,
                 subdomain: formData.subdomain || null,
@@ -1691,23 +1687,6 @@ export default function StatusPageConfig({ statusPage, allServices }: StatusPage
                             placeholder="e.g. OpsKnight"
                           />
 
-                          <div className="space-y-2">
-                            <label
-                              htmlFor="status-page-time-zone"
-                              className="text-sm font-medium text-gray-900"
-                            >
-                              History time zone
-                            </label>
-                            <TimeZoneSelect
-                              id="status-page-time-zone"
-                              name="timeZone"
-                              defaultValue={formData.timeZone}
-                              onChange={timeZone => setFormData(prev => ({ ...prev, timeZone }))}
-                            />
-                            <p className="text-sm text-gray-600">
-                              Defines calendar-day boundaries for uptime and incident history.
-                            </p>
-                          </div>
                         </div>
                       </div>
                     </Card>

--- a/src/components/status-page/PublicStatusServices.tsx
+++ b/src/components/status-page/PublicStatusServices.tsx
@@ -12,7 +12,13 @@ function historyLabel(service: PublicStatusService, day: PublicStatusHistoryDay)
   return `${day.date}, ${service.name}, ${presentation.label}, ${availability}, ${day.incidentCount} incidents`;
 }
 
-export default function PublicStatusServices({ services }: { services: PublicStatusService[] }) {
+export default function PublicStatusServices({
+  services,
+  groupByRegion = false,
+}: {
+  services: PublicStatusService[];
+  groupByRegion?: boolean;
+}) {
   const [open, setOpen] = useState<{ serviceId: string; date: string } | null>(null);
   useEffect(() => {
     const close = (event: KeyboardEvent) => event.key === 'Escape' && setOpen(null);
@@ -20,11 +26,7 @@ export default function PublicStatusServices({ services }: { services: PublicSta
     return () => window.removeEventListener('keydown', close);
   }, []);
 
-  if (services.length === 0) return null;
-  return (
-    <section aria-labelledby="service-health-heading" className="public-service-health">
-      <h2 id="service-health-heading">Services</h2>
-      {services.map(service => {
+  const renderServices = (items: PublicStatusService[]) => items.map(service => {
         const current = statusPresentation(service.status);
         return (
           <article key={service.id} className="public-service-card">
@@ -86,7 +88,20 @@ export default function PublicStatusServices({ services }: { services: PublicSta
             ) : null}
           </article>
         );
-      })}
+      });
+  if (services.length === 0) return null;
+  const regions = [...new Set(services.flatMap(service => service.regions ?? []))].sort();
+  return (
+    <section aria-labelledby="service-health-heading" className="public-service-health">
+      <h2 id="service-health-heading">Services</h2>
+      {groupByRegion && regions.length > 0
+        ? regions.map(region => (
+          <section key={region} aria-label={`${region} services`} className="public-service-region">
+            <h3>{region}</h3>
+            {renderServices(services.filter(service => service.regions?.includes(region)))}
+          </section>
+        ))
+        : renderServices(services)}
     </section>
   );
 }

--- a/src/components/status-page/PublicStatusServices.tsx
+++ b/src/components/status-page/PublicStatusServices.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import type { PublicStatusHistoryDay, PublicStatusService } from '@/lib/status-pages/public-contract';
 import { statusPresentation } from '@/lib/status-pages/status-presentation';
+import { buildPublicHistoryDays } from '@/lib/status-pages/history-presentation';
 
-function historyLabel(service: PublicStatusService, day: PublicStatusHistoryDay) {
+const subscribeToBrowserTimeZone = () => () => {};
+const getBrowserTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+const getServerTimeZone = () => null;
+
+function historyLabel(service: Pick<PublicStatusService, 'name'>, day: PublicStatusHistoryDay) {
   const presentation = statusPresentation(day.status);
   const availability = day.availabilityPercent == null
     ? 'availability unavailable'
@@ -20,6 +25,11 @@ export default function PublicStatusServices({
   groupByRegion?: boolean;
 }) {
   const [open, setOpen] = useState<{ serviceId: string; date: string } | null>(null);
+  const browserTimeZone = useSyncExternalStore(
+    subscribeToBrowserTimeZone,
+    getBrowserTimeZone,
+    getServerTimeZone
+  );
   const pointerSelection = useRef<{
     serviceId: string;
     date: string;
@@ -31,7 +41,19 @@ export default function PublicStatusServices({
     return () => window.removeEventListener('keydown', close);
   }, []);
 
-  const renderServices = (items: PublicStatusService[]) => items.map(service => {
+  const displayServices = useMemo(
+    () => services.map(service => ({
+      ...service,
+      history: browserTimeZone && service.history
+        ? buildPublicHistoryDays(service.history, browserTimeZone)
+        : undefined,
+    })),
+    [browserTimeZone, services]
+  );
+
+  const renderServices = (
+    items: Array<Omit<PublicStatusService, 'history'> & { history?: PublicStatusHistoryDay[] }>
+  ) => items.map(service => {
         const current = statusPresentation(service.status);
         return (
           <article key={service.id} className="public-service-card">
@@ -116,18 +138,23 @@ export default function PublicStatusServices({
         );
       });
   if (services.length === 0) return null;
-  const regions = [...new Set(services.flatMap(service => service.regions ?? []))].sort();
+  const regions = [...new Set(displayServices.flatMap(service => service.regions ?? []))].sort();
   return (
     <section aria-labelledby="service-health-heading" className="public-service-health">
       <h2 id="service-health-heading">Services</h2>
+      <p className="public-service-health__timezone" aria-live="polite">
+        {browserTimeZone
+          ? `Daily history is shown in your browser timezone (${browserTimeZone}).`
+          : 'Loading daily history in your browser timezone…'}
+      </p>
       {groupByRegion && regions.length > 0
         ? regions.map(region => (
           <section key={region} aria-label={`${region} services`} className="public-service-region">
             <h3>{region}</h3>
-            {renderServices(services.filter(service => service.regions?.includes(region)))}
+            {renderServices(displayServices.filter(service => service.regions?.includes(region)))}
           </section>
         ))
-        : renderServices(services)}
+        : renderServices(displayServices)}
     </section>
   );
 }

--- a/src/components/status-page/PublicStatusServices.tsx
+++ b/src/components/status-page/PublicStatusServices.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { PublicStatusHistoryDay, PublicStatusService } from '@/lib/status-pages/public-contract';
+import { statusPresentation } from '@/lib/status-pages/status-presentation';
+
+function historyLabel(service: PublicStatusService, day: PublicStatusHistoryDay) {
+  const presentation = statusPresentation(day.status);
+  const availability = day.availabilityPercent == null
+    ? 'availability unavailable'
+    : `${day.availabilityPercent.toFixed(2)}% availability`;
+  return `${day.date}, ${service.name}, ${presentation.label}, ${availability}, ${day.incidentCount} incidents`;
+}
+
+export default function PublicStatusServices({ services }: { services: PublicStatusService[] }) {
+  const [open, setOpen] = useState<{ serviceId: string; date: string } | null>(null);
+  useEffect(() => {
+    const close = (event: KeyboardEvent) => event.key === 'Escape' && setOpen(null);
+    window.addEventListener('keydown', close);
+    return () => window.removeEventListener('keydown', close);
+  }, []);
+
+  if (services.length === 0) return null;
+  return (
+    <section aria-labelledby="service-health-heading" className="public-service-health">
+      <h2 id="service-health-heading">Services</h2>
+      {services.map(service => {
+        const current = statusPresentation(service.status);
+        return (
+          <article key={service.id} className="public-service-card">
+            <header className="public-service-card__header">
+              <div>
+                <h3>{service.name}</h3>
+                {service.description && <p>{service.description}</p>}
+                {service.regions?.length ? <p>{service.regions.join(' · ')}</p> : null}
+                {service.slaTier && <p>Service tier: {service.slaTier}</p>}
+                {service.team && <p>Owned by {service.team.name}</p>}
+              </div>
+              <span className={`status-badge status-${current.token}`}>
+                <span aria-hidden="true">{current.icon}</span> {current.label}
+              </span>
+            </header>
+            {service.uptime && (
+              <dl className="public-service-metrics">
+                {(['days30', 'days90'] as const).map(window => {
+                  const value = window === 'days30' ? service.uptime?.days30 : service.uptime?.days90;
+                  const label = window === 'days30' ? '30-day uptime' : '90-day uptime';
+                  return <div key={window}><dt>{label}</dt><dd>{value?.percentage == null
+                    ? `Unavailable (${Math.floor(value?.measuredDays ?? 0)} days retained)`
+                    : `${value.percentage.toFixed(3)}% (${value.incidentCount} incidents)`}</dd></div>;
+                })}
+              </dl>
+            )}
+            {service.history?.length ? (
+              <div className="public-history" aria-label={`${service.name} status history`}>
+                {service.history.map(day => {
+                  const presentation = statusPresentation(day.status);
+                  const selected = open?.serviceId === service.id && open.date === day.date;
+                  return (
+                    <div key={day.date} className="public-history__item">
+                      <button
+                        type="button"
+                        className={`public-history__cell status-${presentation.token}`}
+                        aria-label={historyLabel(service, day)}
+                        aria-expanded={selected}
+                        onClick={() => setOpen(selected ? null : { serviceId: service.id, date: day.date })}
+                        onFocus={() => setOpen({ serviceId: service.id, date: day.date })}
+                      ><span className="sr-only">{presentation.label}</span></button>
+                      {selected && <div role="tooltip" className="public-history__tooltip">
+                        <strong>{day.date}: {presentation.label}</strong>
+                        <span>{day.availabilityPercent == null ? 'Availability unavailable' : `${day.availabilityPercent.toFixed(2)}% availability`}</span>
+                        <span>{day.incidentCount} incidents</span>
+                        {day.timeline && <div className="public-history__timeline" aria-label="Intraday status timeline">
+                          {day.timeline.map(slice => <span
+                            key={`${slice.startMinute}-${slice.endMinute}-${slice.status}`}
+                            className={`status-${statusPresentation(slice.status).token}`}
+                            style={{ flexGrow: slice.endMinute - slice.startMinute }}
+                            title={`${slice.startMinute}-${slice.endMinute}: ${statusPresentation(slice.status).label}`}
+                          />)}
+                        </div>}
+                      </div>}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : null}
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/components/status-page/PublicStatusServices.tsx
+++ b/src/components/status-page/PublicStatusServices.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { PublicStatusHistoryDay, PublicStatusService } from '@/lib/status-pages/public-contract';
 import { statusPresentation } from '@/lib/status-pages/status-presentation';
 
@@ -20,6 +20,11 @@ export default function PublicStatusServices({
   groupByRegion?: boolean;
 }) {
   const [open, setOpen] = useState<{ serviceId: string; date: string } | null>(null);
+  const pointerSelection = useRef<{
+    serviceId: string;
+    date: string;
+    wasSelected: boolean;
+  } | null>(null);
   useEffect(() => {
     const close = (event: KeyboardEvent) => event.key === 'Escape' && setOpen(null);
     window.addEventListener('keydown', close);
@@ -58,6 +63,7 @@ export default function PublicStatusServices({
                 {service.history.map(day => {
                   const presentation = statusPresentation(day.status);
                   const selected = open?.serviceId === service.id && open.date === day.date;
+                  const tooltipId = `status-history-${service.id}-${day.date}`;
                   return (
                     <div key={day.date} className="public-history__item">
                       <button
@@ -65,10 +71,30 @@ export default function PublicStatusServices({
                         className={`public-history__cell status-${presentation.token}`}
                         aria-label={historyLabel(service, day)}
                         aria-expanded={selected}
-                        onClick={() => setOpen(selected ? null : { serviceId: service.id, date: day.date })}
-                        onFocus={() => setOpen({ serviceId: service.id, date: day.date })}
+                        aria-describedby={selected ? tooltipId : undefined}
+                        onPointerDown={() => {
+                          pointerSelection.current = {
+                            serviceId: service.id,
+                            date: day.date,
+                            wasSelected: selected,
+                          };
+                        }}
+                        onClick={() => {
+                          const pointer = pointerSelection.current;
+                          pointerSelection.current = null;
+                          const wasSelected = pointer?.serviceId === service.id && pointer.date === day.date
+                            ? pointer.wasSelected
+                            : selected;
+                          setOpen(wasSelected ? null : { serviceId: service.id, date: day.date });
+                        }}
+                        onFocus={() => {
+                          const pointer = pointerSelection.current;
+                          if (pointer?.serviceId !== service.id || pointer.date !== day.date) {
+                            setOpen({ serviceId: service.id, date: day.date });
+                          }
+                        }}
                       ><span className="sr-only">{presentation.label}</span></button>
-                      {selected && <div role="tooltip" className="public-history__tooltip">
+                      {selected && <div id={tooltipId} role="tooltip" className="public-history__tooltip">
                         <strong>{day.date}: {presentation.label}</strong>
                         <span>{day.availabilityPercent == null ? 'Availability unavailable' : `${day.availabilityPercent.toFixed(2)}% availability`}</span>
                         <span>{day.incidentCount} incidents</span>

--- a/src/components/status-page/StatusPageHeader.tsx
+++ b/src/components/status-page/StatusPageHeader.tsx
@@ -10,7 +10,7 @@ interface StatusPageHeaderProps {
     contactEmail?: string | null;
     contactUrl?: string | null;
   };
-  overallStatus: 'operational' | 'maintenance' | 'degraded' | 'outage';
+  overallStatus: 'operational' | 'maintenance' | 'degraded' | 'outage' | 'unknown';
   branding?: Record<string, unknown>;
   lastUpdated?: string;
 }
@@ -48,6 +48,10 @@ const STATUS_CONFIG = {
     border: '#fca5a5',
     pulse: true,
   },
+  unknown: {
+    badge: 'Unknown', text: 'Current status is unavailable', color: '#475569',
+    background: 'linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%)', border: '#94a3b8', pulse: false,
+  },
 };
 
 export default function StatusPageHeader({
@@ -63,7 +67,7 @@ export default function StatusPageHeader({
         ? STATUS_CONFIG.degraded
         : overallStatus === 'outage'
           ? STATUS_CONFIG.outage
-          : STATUS_CONFIG.operational;
+          : overallStatus === 'unknown' ? STATUS_CONFIG.unknown : STATUS_CONFIG.operational;
   const logoUrl =
     (typeof branding.logoUrl === 'string' && branding.logoUrl) ||
     (typeof branding.logo === 'string' && branding.logo) ||
@@ -199,7 +203,8 @@ export default function StatusPageHeader({
                   e.currentTarget.style.boxShadow = '0 1px 2px rgba(0, 0, 0, 0.05)';
                 }}
               >
-                <img
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                   src={logoUrl}
                   alt={statusPage.name}
                   style={{

--- a/src/components/status-page/StatusPageIncidents.tsx
+++ b/src/components/status-page/StatusPageIncidents.tsx
@@ -7,7 +7,7 @@ import { formatDateTime } from '@/lib/timezone';
 interface IncidentEvent {
   id: string;
   message: string;
-  createdAt: Date;
+  createdAt?: Date;
 }
 
 interface Incident {
@@ -16,7 +16,7 @@ interface Incident {
   description?: string | null;
   status: string;
   urgency: string;
-  createdAt: Date;
+  createdAt?: Date;
   acknowledgedAt?: Date | null;
   resolvedAt?: Date | null;
   service: {
@@ -460,7 +460,7 @@ export default function StatusPageIncidents({
                                   <polyline points="12 6 12 12 16 14"></polyline>
                                 </svg>
                                 Started{' '}
-                                {formatDateTime(incident.createdAt, browserTimeZone, {
+                                {incident.createdAt && formatDateTime(incident.createdAt, browserTimeZone, {
                                   format: 'datetime',
                                 })}
                               </span>
@@ -693,7 +693,7 @@ export default function StatusPageIncidents({
                         >
                           <span>Detected</span>
                           <span>
-                            {formatDateTime(incident.createdAt, browserTimeZone, {
+                            {incident.createdAt && formatDateTime(incident.createdAt, browserTimeZone, {
                               format: 'short',
                             })}
                           </span>
@@ -857,7 +857,7 @@ export default function StatusPageIncidents({
                               >
                                 {event.message}
                               </p>
-                              <span
+                              {event.createdAt && <span
                                 style={{
                                   fontSize: '0.8125rem',
                                   color: 'var(--status-text-subtle, #9ca3af)',
@@ -880,7 +880,7 @@ export default function StatusPageIncidents({
                                 {formatDateTime(event.createdAt, browserTimeZone, {
                                   format: 'short',
                                 })}
-                              </span>
+                              </span>}
                             </div>
                           </div>
                         ))}

--- a/src/components/status-page/StatusPageSnapshotView.tsx
+++ b/src/components/status-page/StatusPageSnapshotView.tsx
@@ -93,10 +93,10 @@ export default function StatusPageSnapshotView({
             })}
           </section>
         )}
-        {page.showServicesByRegion === true && snapshot.regions.map(region => (
-          <section key={region.name} aria-label={`${region.name} services`} />
-        ))}
-        <PublicStatusServices services={snapshot.services} />
+        <PublicStatusServices
+          services={snapshot.services}
+          groupByRegion={page.showServicesByRegion === true}
+        />
         <StatusPageIncidents
           incidents={view.incidents}
           privacySettings={{

--- a/src/components/status-page/StatusPageSnapshotView.tsx
+++ b/src/components/status-page/StatusPageSnapshotView.tsx
@@ -3,8 +3,7 @@ import StatusPageAnnouncements from './StatusPageAnnouncements';
 import StatusPageAutoRefresh from './StatusPageAutoRefresh';
 import StatusPageHeader from './StatusPageHeader';
 import StatusPageIncidents from './StatusPageIncidents';
-import StatusPageMetrics from './StatusPageMetrics';
-import StatusPageServices from './StatusPageServices';
+import PublicStatusServices from './PublicStatusServices';
 import StatusPageSubscribe from './StatusPageSubscribe';
 import type { StatusPageSnapshot } from '@/lib/status-pages/snapshot';
 import {
@@ -13,6 +12,7 @@ import {
 } from '@/lib/status-pages/view-model';
 import { toSafeStyleTagContent } from '@/lib/status-page-content';
 import { computeStatusPageTheme } from '@/lib/status-page-theme';
+import { statusPresentation } from '@/lib/status-pages/status-presentation';
 
 export default function StatusPageSnapshotView({
   page,
@@ -44,10 +44,6 @@ export default function StatusPageSnapshotView({
     page.slug && !page.isDefault ? `/status/${encodeURIComponent(page.slug)}` : '/status';
   const apiPath =
     page.slug && !page.isDefault ? `/api/status/${encodeURIComponent(page.slug)}` : '/api/status';
-  const thirtyDaysAgo = new Date(snapshot.generatedAt);
-  thirtyDaysAgo.setUTCDate(thirtyDaysAgo.getUTCDate() - 30);
-  const ninetyDaysAgo = new Date(snapshot.generatedAt);
-  ninetyDaysAgo.setUTCDate(ninetyDaysAgo.getUTCDate() - 90);
   const customCss = toSafeStyleTagContent(branding.customCss);
 
   return (
@@ -70,7 +66,10 @@ export default function StatusPageSnapshotView({
         {branding.showHeader !== false && (
           <StatusPageHeader
             statusPage={page}
-            overallStatus={snapshot.status}
+            overallStatus={snapshot.status === 'OPERATIONAL' ? 'operational'
+              : snapshot.status === 'MAINTENANCE' ? 'maintenance'
+                : snapshot.status === 'MAJOR_OUTAGE' || snapshot.status === 'PARTIAL_OUTAGE' ? 'outage'
+                  : snapshot.status === 'UNKNOWN' ? 'unknown' : 'degraded'}
             branding={branding}
             lastUpdated={snapshot.generatedAt}
           />
@@ -78,64 +77,26 @@ export default function StatusPageSnapshotView({
         {stale && <p role="note">Showing the last verified status update.</p>}
         <StatusPageAnnouncements
           announcements={view.announcements.filter(item => item.type !== 'UPDATE')}
-          showServiceRegions={snapshot.services.some(service => service.region !== undefined)}
+          showServiceRegions={snapshot.services.some(service => service.regions !== undefined)}
         />
-        {page.showRegionHeatmap === true && (
-          <section aria-labelledby="region-health-heading">
+        {page.showRegionHeatmap === true && snapshot.regions.length > 0 && (
+          <section aria-labelledby="region-health-heading" className="public-regions">
             <h2 id="region-health-heading">Region health</h2>
-            {Array.from(
-              new Set(
-                snapshot.services.flatMap(service =>
-                  (service.region || '')
-                    .split(',')
-                    .map(region => region.trim())
-                    .filter(Boolean)
-                )
-              )
-            ).map(region => (
-              <p key={region}>{region}</p>
-            ))}
+            {snapshot.regions.map(region => {
+              const presentation = statusPresentation(region.status);
+              return <article key={region.name} className="public-region-card">
+                <strong>{region.name}</strong>
+                <span className={`status-badge status-${presentation.token}`}>{presentation.icon} {presentation.label}</span>
+                <span>{region.totalServices} services · {region.impactedServices} impacted</span>
+                <span>{region.operationalServices} operational · {region.degradedServices} degraded · {region.maintenanceServices} maintenance · {region.partialOutageServices} partial · {region.majorOutageServices} major · {region.unknownServices} unknown</span>
+              </article>;
+            })}
           </section>
         )}
-        {page.showServicesByRegion === true &&
-          Array.from(
-            new Set(
-              snapshot.services.flatMap(service =>
-                (service.region || '')
-                  .split(',')
-                  .map(region => region.trim())
-                  .filter(Boolean)
-              )
-            )
-          ).map(region => <section key={region} aria-label={`${region} services`} />)}
-        <StatusPageServices
-          services={view.services}
-          statusPageServices={view.mappings}
-          uptime90={view.uptime}
-          incidents={[]}
-          statusHistory={view.statusHistory}
-          groupByRegionDefault={page.showServicesByRegion}
-          showServiceOwners={snapshot.services.some(service => service.team !== undefined)}
-          showServiceSlaTier={snapshot.services.some(service => service.slaTier !== undefined)}
-          privacySettings={{
-            showServiceDescriptions: snapshot.services.some(
-              service => service.description !== undefined
-            ),
-            showServiceRegions: snapshot.services.some(service => service.region !== undefined),
-            showTeamInformation: snapshot.services.some(service => service.team !== undefined),
-            showUptimeHistory: snapshot.statusHistory !== undefined,
-          }}
-        />
-        {Object.keys(view.uptime).length > 0 && (
-          <StatusPageMetrics
-            services={view.services}
-            incidents={[]}
-            thirtyDaysAgo={thirtyDaysAgo}
-            ninetyDaysAgo={ninetyDaysAgo}
-            precomputedUptime={view.uptime}
-            precomputedUptime30={view.uptime30}
-          />
-        )}
+        {page.showServicesByRegion === true && snapshot.regions.map(region => (
+          <section key={region.name} aria-label={`${region.name} services`} />
+        ))}
+        <PublicStatusServices services={snapshot.services} />
         <StatusPageIncidents
           incidents={view.incidents}
           privacySettings={{

--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -30,6 +30,7 @@ import {
   notificationAgingFloor,
   NOTIFICATION_AGING_FLOOR,
 } from './notification-priority';
+import { z } from 'zod';
 
 const MAX_ENCRYPTED_PAYLOAD_BYTES = 768 * 1024;
 const MAX_ERROR_LENGTH = 1_000;
@@ -177,6 +178,30 @@ export type CentralNotificationInput = {
   tenantKey?: string;
 };
 
+const centralNotificationInputSchema = z.object({
+  category: z.enum(['INCIDENT', 'SECURITY', 'STATUS_PAGE', 'SLA', 'ADMINISTRATION', 'SYSTEM']),
+  channel: z.enum(['EMAIL', 'SMS', 'PUSH', 'SLACK', 'WEBHOOK', 'WHATSAPP']),
+  recipientType: z.enum(['USER', 'EMAIL', 'PHONE', 'SUBSCRIBER', 'SLACK_CHANNEL', 'WEBHOOK']),
+  recipientId: z.string().max(191).optional(),
+  recipientAddress: z.string().max(2_048),
+  userId: z.string().max(191).optional(),
+  incidentId: z.string().max(191).optional(),
+  templateKey: z.string().max(191),
+  sourceType: z.string().max(191),
+  sourceId: z.string().max(191),
+  eventKey: z.string().max(512),
+  displayMessage: z.string().max(2_000),
+  payload: z.unknown(),
+  priority: z.number().int().optional(),
+  trafficClass: z.enum(['CRITICAL', 'TRANSACTIONAL', 'PUBLIC_INCIDENT', 'BULK']).optional(),
+  scheduledAt: z.date().optional(),
+  expiresAt: z.date().optional(),
+  maxAttempts: z.number().int().optional(),
+  contentId: z.string().max(191).optional(),
+  fanoutId: z.string().max(191).optional(),
+  tenantKey: z.string().trim().min(1).max(191).optional(),
+}).strict();
+
 type NotificationStore = Pick<Prisma.TransactionClient, 'notification'>;
 
 type DeliveryResult = {
@@ -305,6 +330,9 @@ function isCentralNotificationPayload(value: unknown): value is CentralNotificat
 }
 
 function assertValidInput(input: CentralNotificationInput): void {
+  if (!centralNotificationInputSchema.safeParse(input).success) {
+    throw new Error('Notification input is invalid');
+  }
   if (!isCentralNotificationPayload(input.payload)) {
     throw new Error('Notification payload is incomplete or unsupported');
   }

--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -174,6 +174,7 @@ export type CentralNotificationInput = {
   maxAttempts?: number;
   contentId?: string;
   fanoutId?: string;
+  tenantKey?: string;
 };
 
 type NotificationStore = Pick<Prisma.TransactionClient, 'notification'>;
@@ -322,6 +323,18 @@ function assertValidInput(input: CentralNotificationInput): void {
   }
 }
 
+function tenantKeyForInput(input: CentralNotificationInput): string {
+  if (input.tenantKey?.trim()) return input.tenantKey.trim().slice(0, 191);
+  const payload = input.payload;
+  if (payload.kind === 'EMAIL' && payload.providerScope?.statusPageId) {
+    return `status-page:${payload.providerScope.statusPageId}`;
+  }
+  if (payload.kind === 'STATUS_PAGE_WEBHOOK' && payload.statusPageId) {
+    return `status-page:${payload.statusPageId}`;
+  }
+  return input.userId ? `user:${input.userId}` : 'system';
+}
+
 function isUniqueConstraintError(error: unknown): boolean {
   return Boolean(
     error &&
@@ -388,6 +401,7 @@ export async function createCentralNotificationIntent(
         fanoutId: input.fanoutId,
         priority,
         trafficClass,
+        tenantKey: tenantKeyForInput(input),
         scheduledAt,
         nextAttemptAt: scheduledAt,
         maxAttempts,
@@ -457,6 +471,7 @@ export async function createCentralNotificationIntentsBatch(
           9
         ),
         trafficClass,
+        tenantKey: tenantKeyForInput(input),
         scheduledAt,
         nextAttemptAt: scheduledAt,
         maxAttempts: Math.min(
@@ -1201,6 +1216,7 @@ async function statusSubscriberDeliveryRevoked(
       email: normalizedRecipient('EMAIL', payload.to),
       verified: true,
       unsubscribedAt: null,
+      state: 'ACTIVE',
       statusPage: { enabled: true },
     },
     select: { id: true },
@@ -1833,9 +1849,10 @@ export async function processCentralNotificationQueue(
   const claimToken = crypto.randomUUID();
   const claimedBy = process.env.OPSKNIGHT_WORKER_ID?.slice(0, 128) || 'integrated-worker';
   const candidates = await prisma.$queryRaw<Array<{ id: string; claimToken: string }>>(Prisma.sql`
-    WITH candidates AS (
-      SELECT "id"
-      FROM "Notification"
+    WITH ranked AS MATERIALIZED (
+        SELECT "id", "trafficClass", "priority", "nextAttemptAt", "createdAt",
+          ROW_NUMBER() OVER (PARTITION BY "trafficClass", "tenantKey" ORDER BY "priority", "nextAttemptAt", "createdAt") AS tenant_rank
+        FROM "Notification"
     WHERE "payloadEncrypted" IS NOT NULL
       AND "attempts" < "maxAttempts"
       AND "scheduledAt" <= ${now}
@@ -1849,17 +1866,23 @@ export async function processCentralNotificationQueue(
           AND ("lastAttemptAt" IS NULL OR "lastAttemptAt" < ${staleClaimBefore})
         )
       )
-    -- Aging cannot promote customer broadcasts into responder precedence.
+    ), candidates AS (
+      SELECT notification."id"
+      FROM "Notification" notification
+      JOIN ranked ON ranked."id" = notification."id"
+      WHERE ranked.tenant_rank <= ${Math.max(1, Math.ceil(batchSize / 10))}
+    -- Aging cannot promote customer broadcasts into responder precedence; the
+    -- per-tenant cap prevents a large campaign from consuming the full claim.
     ORDER BY GREATEST(
-      CASE "trafficClass"
+      CASE ranked."trafficClass"
         WHEN 'CRITICAL' THEN ${NOTIFICATION_AGING_FLOOR.CRITICAL}
         WHEN 'TRANSACTIONAL' THEN ${NOTIFICATION_AGING_FLOOR.TRANSACTIONAL}
         WHEN 'PUBLIC_INCIDENT' THEN ${NOTIFICATION_AGING_FLOOR.PUBLIC_INCIDENT}
         ELSE ${NOTIFICATION_AGING_FLOOR.BULK}
       END,
-      "priority" - FLOOR(EXTRACT(EPOCH FROM (${now} - "createdAt")) / 300)
-    ) ASC, "nextAttemptAt" ASC, "createdAt" ASC
-    FOR UPDATE SKIP LOCKED
+      ranked."priority" - FLOOR(EXTRACT(EPOCH FROM (${now} - ranked."createdAt")) / 300)
+    ) ASC, ranked."nextAttemptAt" ASC, ranked."createdAt" ASC
+    FOR UPDATE OF notification SKIP LOCKED
     LIMIT ${batchSize}
     )
     UPDATE "Notification" AS notification

--- a/src/lib/notification-control-plane.ts
+++ b/src/lib/notification-control-plane.ts
@@ -1870,10 +1870,11 @@ export async function processCentralNotificationQueue(
       SELECT notification."id"
       FROM "Notification" notification
       JOIN ranked ON ranked."id" = notification."id"
-      WHERE ranked.tenant_rank <= ${Math.max(1, Math.ceil(batchSize / 10))}
-    -- Aging cannot promote customer broadcasts into responder precedence; the
-    -- per-tenant cap prevents a large campaign from consuming the full claim.
-    ORDER BY GREATEST(
+    -- Prefer each tenant's initial share, then redistribute unused slots so
+    -- small tenant sets can still fill the worker batch. Traffic-class floors
+    -- keep aged customer broadcasts behind responder notifications.
+    ORDER BY CASE WHEN ranked.tenant_rank <= ${Math.max(1, Math.ceil(batchSize / 10))} THEN 0 ELSE 1 END,
+    GREATEST(
       CASE ranked."trafficClass"
         WHEN 'CRITICAL' THEN ${NOTIFICATION_AGING_FLOOR.CRITICAL}
         WHEN 'TRANSACTIONAL' THEN ${NOTIFICATION_AGING_FLOOR.TRANSACTIONAL}

--- a/src/lib/notification-provider-feedback.ts
+++ b/src/lib/notification-provider-feedback.ts
@@ -1,0 +1,70 @@
+import 'server-only';
+import { Prisma } from '@prisma/client';
+import prisma from './prisma';
+
+export type ProviderFeedbackType =
+  | 'DELIVERED'
+  | 'HARD_BOUNCE'
+  | 'SOFT_BOUNCE'
+  | 'COMPLAINT'
+  | 'SUPPRESSION'
+  | 'INVALID_RECIPIENT';
+
+export interface ProviderFeedback {
+  provider: string;
+  providerEventId: string;
+  providerMessageId?: string;
+  type: ProviderFeedbackType;
+  occurredAt: Date;
+}
+
+export async function ingestNotificationProviderFeedback(event: ProviderFeedback) {
+  return prisma.$transaction(async tx => {
+    try {
+      await tx.notificationProviderFeedback.create({
+        data: {
+          provider: event.provider,
+          providerEventId: event.providerEventId,
+          providerMessageId: event.providerMessageId,
+          eventType: event.type,
+          occurredAt: event.occurredAt,
+        },
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        return { processed: false, reason: 'duplicate' as const };
+      }
+      throw error;
+    }
+    if (!event.providerMessageId) return { processed: true, subscriptionId: null };
+    const notification = await tx.notification.findUnique({
+      where: { providerMessageId: event.providerMessageId },
+      select: { recipientType: true, recipientId: true },
+    });
+    if (notification?.recipientType !== 'SUBSCRIBER' || !notification.recipientId) {
+      return { processed: true, subscriptionId: null };
+    }
+    const id = notification.recipientId;
+    if (event.type === 'DELIVERED') {
+      await tx.statusPageSubscription.updateMany({ where: { id }, data: { lastDeliveredAt: event.occurredAt } });
+    } else if (event.type === 'SOFT_BOUNCE') {
+      const subscription = await tx.statusPageSubscription.update({
+        where: { id }, data: { lastBounceAt: event.occurredAt, lastFailedAt: event.occurredAt, bounceCount: { increment: 1 } },
+        select: { bounceCount: true },
+      });
+      if (subscription.bounceCount >= 3) {
+        await tx.statusPageSubscription.update({ where: { id }, data: { state: 'BOUNCED', suppressionReason: 'Repeated soft bounce' } });
+      }
+    } else {
+      const state = event.type === 'COMPLAINT' ? 'COMPLAINED' : event.type === 'HARD_BOUNCE' ? 'BOUNCED' : 'SUPPRESSED';
+      await tx.statusPageSubscription.updateMany({ where: { id }, data: {
+        state,
+        suppressionReason: event.type,
+        lastFailedAt: event.occurredAt,
+        ...(event.type === 'COMPLAINT' ? { complainedAt: event.occurredAt } : {}),
+        ...(event.type === 'HARD_BOUNCE' ? { lastBounceAt: event.occurredAt, bounceCount: { increment: 1 } } : {}),
+      } });
+    }
+    return { processed: true, subscriptionId: id };
+  });
+}

--- a/src/lib/provider-capacity.ts
+++ b/src/lib/provider-capacity.ts
@@ -104,8 +104,12 @@ export function getProviderCapacity(
   providerKey = 'default',
   env: NodeJS.ProcessEnv = process.env
 ): ProviderCapacity {
+  const providerEnvKey = providerKey.toUpperCase().replace(/[^A-Z0-9]+/g, '_').slice(0, 80);
+  const scoped = (suffix: string) =>
+    envValue(env, `NOTIFICATION_${scope}_${providerEnvKey}_${suffix}`) ??
+    envValue(env, `NOTIFICATION_${scope}_${suffix}`);
   const configuredRatePerSecond = integerSetting(
-    envValue(env, `NOTIFICATION_${scope}_RATE_PER_SECOND`),
+    scoped('RATE_PER_SECOND'),
     defaultRate(scope),
     1,
     ABSOLUTE_RATE_CEILING
@@ -126,7 +130,7 @@ export function getProviderCapacity(
   const bulkShare = shareSetting(env.NOTIFICATION_BULK_SHARE);
   const bulkRatePerSecond = Math.max(1, Math.floor(effectiveRatePerSecond * bulkShare));
   const maxInFlight = integerSetting(
-    envValue(env, `NOTIFICATION_${scope}_MAX_IN_FLIGHT`),
+    scoped('MAX_IN_FLIGHT'),
     defaultInFlight(scope),
     1,
     ABSOLUTE_IN_FLIGHT_CEILING

--- a/src/lib/status-page-public-data.ts
+++ b/src/lib/status-page-public-data.ts
@@ -1,3 +1,10 @@
+import type {
+  PublicIncident,
+  PublicIncidentStatus,
+  PublicIncidentUpdateType,
+  PublicIncidentUrgency,
+} from '@/lib/status-pages/public-contract';
+
 export type StatusPagePublicSettings = {
   showServices: boolean;
   showIncidents: boolean;
@@ -48,17 +55,19 @@ type PublicIncidentInput = {
   urgency?: string;
   createdAt: string | Date;
   resolvedAt: string | Date | null;
-  service?: { name?: string; region?: string | null } | null;
+  acknowledgedAt?: string | Date | null;
+  service?: { id?: string; name?: string; region?: string | null } | null;
   postmortem?: { status?: string; isPublic?: boolean | null } | null;
   events?: Array<{
     id: string;
+    type?: string | null;
     message: string;
     createdAt: string | Date;
   }>;
 };
 
-function serializeDate(value: string | Date | null): string | null {
-  if (value === null) return null;
+function serializeDate(value: string | Date | null | undefined): string | undefined {
+  if (value == null) return undefined;
   return value instanceof Date ? value.toISOString() : value;
 }
 
@@ -66,24 +75,32 @@ function serializeDate(value: string | Date | null): string | null {
 export function serializePublicStatusIncident(
   incident: PublicIncidentInput,
   settings: StatusPagePublicSettings
-): Record<string, unknown> {
+): PublicIncident {
   const visibility = publicStatusVisibility(settings);
-  const result: Record<string, unknown> = { status: incident.status };
+  const result: PublicIncident = { status: incident.status as PublicIncidentStatus };
 
   if (visibility.showIncidentId) result.id = incident.id;
   if (visibility.showIncidentTitle) result.title = incident.title;
   if (visibility.showIncidentDescription && incident.description) {
     result.description = incident.description;
   }
-  if (visibility.showIncidentUrgency && incident.urgency) result.urgency = incident.urgency;
+  if (visibility.showIncidentUrgency && incident.urgency) {
+    result.urgency = incident.urgency as PublicIncidentUrgency;
+  }
   if (visibility.showIncidentTimestamp) {
     result.createdAt = serializeDate(incident.createdAt);
-    result.resolvedAt = serializeDate(incident.resolvedAt);
+    const acknowledgedAt = serializeDate(incident.acknowledgedAt);
+    const resolvedAt = serializeDate(incident.resolvedAt);
+    if (acknowledgedAt) result.acknowledgedAt = acknowledgedAt;
+    if (resolvedAt) result.resolvedAt = resolvedAt;
   }
   if (visibility.showAffectedService && incident.service) {
     result.service = {
+      ...(incident.service.id ? { id: incident.service.id } : {}),
       ...(incident.service.name ? { name: incident.service.name } : {}),
-      ...(visibility.showServiceRegion ? { region: incident.service.region ?? null } : {}),
+      ...(visibility.showServiceRegion && incident.service.region
+        ? { regions: incident.service.region.split(',').map(value => value.trim()).filter(Boolean) }
+        : {}),
     };
   }
   if (
@@ -91,8 +108,9 @@ export function serializePublicStatusIncident(
     visibility.showIncidentDescription &&
     incident.events?.length
   ) {
-    result.events = incident.events.map(event => ({
+    result.updates = incident.events.map(event => ({
       id: event.id,
+      type: publicUpdateType(event.type),
       message: event.message,
       ...(visibility.showIncidentTimestamp ? { createdAt: serializeDate(event.createdAt) } : {}),
     }));
@@ -109,6 +127,14 @@ export function serializePublicStatusIncident(
   return result;
 }
 
+function publicUpdateType(type: string | null | undefined): PublicIncidentUpdateType {
+  if (type === 'ACKNOWLEDGED') return 'ACKNOWLEDGED';
+  if (type === 'RESOLVED' || type === 'AUTO_RESOLVED' || type === 'MANUAL_RESOLVED') {
+    return 'RESOLVED';
+  }
+  return 'UPDATE';
+}
+
 /**
  * Keep the long-standing `/api/status` incident shape while applying the
  * same visibility policy used by the other public status endpoints.
@@ -117,15 +143,15 @@ export function serializePublicStatusApiIncident(
   incident: PublicIncidentInput,
   settings: StatusPagePublicSettings
 ): Record<string, unknown> {
-  const result = serializePublicStatusIncident(incident, settings);
+  const result = { ...serializePublicStatusIncident(incident, settings) } as Record<string, unknown>;
   const service = result.service;
   if (!service || typeof service !== 'object' || Array.isArray(service)) return result;
 
   const { service: _service, ...withoutService } = result;
-  const publicService = service as { name?: unknown; region?: unknown };
+  const publicService = service as { name?: unknown; regions?: unknown };
   return {
     ...withoutService,
     ...(typeof publicService.name === 'string' ? { service: publicService.name } : {}),
-    ...('region' in publicService ? { serviceRegion: publicService.region } : {}),
+    ...('regions' in publicService ? { serviceRegions: publicService.regions } : {}),
   };
 }

--- a/src/lib/status-pages/admin.ts
+++ b/src/lib/status-pages/admin.ts
@@ -63,7 +63,7 @@ export async function makeDefaultStatusPage(statusPageId: string) {
 }
 
 export async function deleteStatusPage(statusPageId: string, replacementDefaultId?: string) {
-  await prisma.$transaction(async tx => {
+  const page = await prisma.$transaction(async tx => {
     await lockLifecycle(tx);
     const page = await requireStatusPageForAdmin(statusPageId, tx);
     const count = await tx.statusPage.count();
@@ -89,7 +89,27 @@ export async function deleteStatusPage(statusPageId: string, replacementDefaultI
       });
     }
 
-    await tx.statusPage.delete({ where: { id: statusPageId } });
+    await tx.statusPage.update({ where: { id: statusPageId }, data: { enabled: false } });
+    await tx.$executeRaw`UPDATE "StatusPageSnapshot" SET "revision" = "revision" + 1 WHERE "statusPageId" = ${statusPageId}`;
+    return page;
   });
-  await getStatusPageServingStore().revoke(statusPageId);
+  const store = getStatusPageServingStore();
+  await store.revoke(statusPageId);
+  await Promise.all([
+    ...(page.slug ? [store.removeRoute(page.slug)] : []),
+    ...(page.customDomain ? [store.removeRoute(`domain:${page.customDomain.toLowerCase()}`)] : []),
+    ...(page.subdomain ? [store.removeRoute(`subdomain:${page.subdomain.toLowerCase()}`)] : []),
+    ...(page.isDefault ? [store.removeRoute('default')] : []),
+  ]);
+  await prisma.$transaction(async tx => {
+    await lockLifecycle(tx);
+    await tx.notification.updateMany({
+      where: { sourceType: 'STATUS_PAGE', sourceId: statusPageId, status: 'PENDING' },
+      data: { status: 'SKIPPED', errorMsg: 'Status page deleted' },
+    });
+    await tx.statusPage.delete({ where: { id: statusPageId } });
+    await tx.auditLog.create({
+      data: { action: 'STATUS_PAGE_DELETED', entityType: 'STATUS_PAGE', entityId: statusPageId },
+    });
+  });
 }

--- a/src/lib/status-pages/admin.ts
+++ b/src/lib/status-pages/admin.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import type { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
+import { emitAuditEvent } from '@/lib/audit';
 import { getStatusPageServingStore } from './serving-store';
 
 const STATUS_PAGE_LIFECYCLE_LOCK = 'opsknight:status-pages:lifecycle:v1';
@@ -104,12 +105,17 @@ export async function deleteStatusPage(statusPageId: string, replacementDefaultI
   await prisma.$transaction(async tx => {
     await lockLifecycle(tx);
     await tx.notification.updateMany({
-      where: { sourceType: 'STATUS_PAGE', sourceId: statusPageId, status: 'PENDING' },
+      where: {
+        tenantKey: `status-page:${statusPageId}`,
+        status: { in: ['PENDING', 'FAILED'] },
+      },
       data: { status: 'SKIPPED', errorMsg: 'Status page deleted' },
     });
     await tx.statusPage.delete({ where: { id: statusPageId } });
-    await tx.auditLog.create({
-      data: { action: 'STATUS_PAGE_DELETED', entityType: 'STATUS_PAGE', entityId: statusPageId },
-    });
+    await emitAuditEvent({
+      action: 'STATUS_PAGE_DELETED',
+      source: 'UI',
+      target: { type: 'STATUS_PAGE', id: statusPageId },
+    }, tx);
   });
 }

--- a/src/lib/status-pages/admin.ts
+++ b/src/lib/status-pages/admin.ts
@@ -4,6 +4,7 @@ import type { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { emitAuditEvent } from '@/lib/audit';
 import { getStatusPageServingStore } from './serving-store';
+import { rebuildStatusPageSnapshot } from './snapshot';
 
 const STATUS_PAGE_LIFECYCLE_LOCK = 'opsknight:status-pages:lifecycle:v1';
 
@@ -64,7 +65,7 @@ export async function makeDefaultStatusPage(statusPageId: string) {
 }
 
 export async function deleteStatusPage(statusPageId: string, replacementDefaultId?: string) {
-  const page = await prisma.$transaction(async tx => {
+  const { page, replacementId } = await prisma.$transaction(async tx => {
     await lockLifecycle(tx);
     const page = await requireStatusPageForAdmin(statusPageId, tx);
     const count = await tx.statusPage.count();
@@ -82,7 +83,13 @@ export async function deleteStatusPage(statusPageId: string, replacementDefaultI
           'The replacement default must be a different status page.'
         );
       }
-      await requireStatusPageForAdmin(replacementDefaultId, tx);
+      const replacement = await requireStatusPageForAdmin(replacementDefaultId, tx);
+      if (!replacement.enabled) {
+        throw new StatusPageAdminError(
+          'STATUS_PAGE_DEFAULT_REPLACEMENT_INVALID',
+          'The replacement default status page must be public.'
+        );
+      }
       await tx.statusPage.update({ where: { id: statusPageId }, data: { isDefault: false } });
       await tx.statusPage.update({
         where: { id: replacementDefaultId },
@@ -90,20 +97,47 @@ export async function deleteStatusPage(statusPageId: string, replacementDefaultI
       });
     }
 
-    await tx.statusPage.update({ where: { id: statusPageId }, data: { enabled: false } });
-    await tx.$executeRaw`UPDATE "StatusPageSnapshot" SET "revision" = "revision" + 1 WHERE "statusPageId" = ${statusPageId}`;
-    return page;
+    return {
+      page,
+      replacementId: page.isDefault && count > 1 ? replacementDefaultId : undefined,
+    };
   });
   const store = getStatusPageServingStore();
+  // Publish the replacement and switch the default route before revoking the
+  // old page. This keeps /status continuously available during replacement.
+  if (replacementId) {
+    try {
+      if (!(await rebuildStatusPageSnapshot(replacementId))) {
+        throw new Error('Failed to publish the replacement default status page.');
+      }
+    } catch (error) {
+      // Keep the operation retryable if publication fails. The old route still
+      // points to a healthy page because revocation has not started yet.
+      await prisma.$transaction(async tx => {
+        await lockLifecycle(tx);
+        await tx.statusPage.updateMany({
+          where: { id: replacementId },
+          data: { isDefault: false },
+        });
+        await tx.statusPage.updateMany({
+          where: { id: statusPageId },
+          data: { isDefault: true },
+        });
+      });
+      throw error;
+    }
+  }
   await store.revoke(statusPageId);
   await Promise.all([
     ...(page.slug ? [store.removeRoute(page.slug)] : []),
     ...(page.customDomain ? [store.removeRoute(`domain:${page.customDomain.toLowerCase()}`)] : []),
     ...(page.subdomain ? [store.removeRoute(`subdomain:${page.subdomain.toLowerCase()}`)] : []),
-    ...(page.isDefault ? [store.removeRoute('default')] : []),
+    ...(page.isDefault && !replacementId ? [store.removeRoute('default')] : []),
   ]);
   await prisma.$transaction(async tx => {
     await lockLifecycle(tx);
+    await tx.statusPage.update({ where: { id: statusPageId }, data: { enabled: false } });
+    await tx.$executeRaw`UPDATE "StatusPageSnapshot" SET "revision" = "revision" + 1 WHERE "statusPageId" = ${statusPageId}`;
     await tx.notification.updateMany({
       where: {
         tenantKey: `status-page:${statusPageId}`,

--- a/src/lib/status-pages/history-presentation.ts
+++ b/src/lib/status-pages/history-presentation.ts
@@ -1,0 +1,95 @@
+import type {
+  PublicHistorySlice,
+  PublicServiceStatus,
+  PublicStatusHistory,
+  PublicStatusHistoryDay,
+} from '@/lib/status-pages/public-contract';
+import {
+  addDaysToDateKey,
+  formatDateKeyInTimeZone,
+  startOfDayFromDateKey,
+  startOfNextDayFromDateKey,
+} from '@/lib/timezone';
+import { getWorstPublicStatus } from './status-presentation';
+
+function worstStatus(statuses: PublicServiceStatus[]): PublicServiceStatus {
+  return getWorstPublicStatus(statuses);
+}
+
+export function buildPublicHistoryDays(
+  history: PublicStatusHistory,
+  timeZone: string
+): PublicStatusHistoryDay[] {
+  const rangeStart = new Date(history.rangeStart);
+  const rangeEnd = new Date(history.rangeEnd);
+  if (!Number.isFinite(rangeStart.getTime()) || !Number.isFinite(rangeEnd.getTime()) || rangeEnd <= rangeStart) {
+    return [];
+  }
+
+  const days: PublicStatusHistoryDay[] = [];
+  let date = formatDateKeyInTimeZone(rangeStart, timeZone);
+  const lastDate = formatDateKeyInTimeZone(new Date(rangeEnd.getTime() - 1), timeZone);
+  while (date <= lastDate) {
+    const dayStart = startOfDayFromDateKey(date, timeZone);
+    const dayEnd = startOfNextDayFromDateKey(date, timeZone);
+    const measuredStart = Math.max(dayStart.getTime(), rangeStart.getTime());
+    const measuredEnd = Math.min(dayEnd.getTime(), rangeEnd.getTime());
+    const dayMinutes = Math.round((dayEnd.getTime() - dayStart.getTime()) / 60_000);
+    const startMinute = Math.floor((measuredStart - dayStart.getTime()) / 60_000);
+    const endMinute = Math.ceil((measuredEnd - dayStart.getTime()) / 60_000);
+    const points = new Set([startMinute, endMinute]);
+    const overlaps = history.segments.flatMap(segment => {
+      const start = Math.max(measuredStart, new Date(segment.startAt).getTime());
+      const end = Math.min(measuredEnd, new Date(segment.endAt).getTime());
+      if (end <= start) return [];
+      const slice = {
+        startMinute: Math.max(0, Math.floor((start - dayStart.getTime()) / 60_000)),
+        endMinute: Math.min(dayMinutes, Math.ceil((end - dayStart.getTime()) / 60_000)),
+        status: segment.status,
+      };
+      points.add(slice.startMinute);
+      points.add(slice.endMinute);
+      return [slice];
+    });
+    const sorted = [...points].sort((left, right) => left - right);
+    const timeline: PublicHistorySlice[] = [];
+    for (let index = 0; index < sorted.length - 1; index += 1) {
+      const from = sorted.at(index);
+      const to = sorted.at(index + 1);
+      if (from === undefined || to === undefined || from >= to) continue;
+      const covering = overlaps
+        .filter(slice => slice.startMinute < to && slice.endMinute > from)
+        .map(slice => slice.status);
+      const status = covering.length > 0
+        ? worstStatus(covering)
+        : history.coverage === 'COMPLETE' ? 'OPERATIONAL' : 'UNKNOWN';
+      const previous = timeline.at(-1);
+      if (previous?.status === status) previous.endMinute = to;
+      else timeline.push({ startMinute: from, endMinute: to, status });
+    }
+    const measuredMinutes = Math.max(1, endMinute - startMinute);
+    const unavailableMinutes = timeline.reduce(
+      (total, slice) =>
+        total +
+        (slice.status === 'DEGRADED' ||
+        slice.status === 'PARTIAL_OUTAGE' ||
+        slice.status === 'MAJOR_OUTAGE' ||
+        slice.status === 'UNKNOWN'
+          ? slice.endMinute - slice.startMinute
+          : 0),
+      0
+    );
+    days.push({
+      date,
+      status: worstStatus(timeline.map(slice => slice.status)),
+      incidentCount: overlaps.filter(slice => slice.status !== 'MAINTENANCE').length,
+      availabilityPercent:
+        history.coverage === 'COMPLETE'
+          ? Number((((measuredMinutes - unavailableMinutes) / measuredMinutes) * 100).toFixed(3))
+          : null,
+      timeline,
+    });
+    date = addDaysToDateKey(date, 1);
+  }
+  return days;
+}

--- a/src/lib/status-pages/history-query.ts
+++ b/src/lib/status-pages/history-query.ts
@@ -1,0 +1,55 @@
+import 'server-only';
+import prisma from '@/lib/prisma';
+
+export const HISTORY_INCIDENT_PAGE_SIZE = 1_000;
+
+export type HistoryIncident = {
+  id: string;
+  serviceId: string;
+  createdAt: Date;
+  resolvedAt: Date | null;
+  urgency: string;
+  status: string;
+};
+
+/** Reads the complete window in bounded pages or rejects without returning partial history. */
+export async function loadHistoryIncidentsByService(
+  serviceIds: string[],
+  earliestRequiredStart: Date,
+  now: Date
+): Promise<Map<string, HistoryIncident[]>> {
+  const byService = new Map<string, HistoryIncident[]>();
+  let cursor: string | undefined;
+
+  while (true) {
+    const page = await prisma.incident.findMany({
+      where: {
+        serviceId: { in: serviceIds },
+        visibility: 'PUBLIC',
+        status: { notIn: ['SUPPRESSED', 'SNOOZED'] },
+        createdAt: { lt: now },
+        OR: [{ resolvedAt: { gte: earliestRequiredStart } }, { resolvedAt: null }],
+      },
+      orderBy: { id: 'asc' },
+      take: HISTORY_INCIDENT_PAGE_SIZE,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      select: {
+        id: true,
+        serviceId: true,
+        createdAt: true,
+        resolvedAt: true,
+        urgency: true,
+        status: true,
+      },
+    });
+
+    for (const incident of page) {
+      const serviceIncidents = byService.get(incident.serviceId) ?? [];
+      serviceIncidents.push(incident);
+      byService.set(incident.serviceId, serviceIncidents);
+    }
+    if (page.length < HISTORY_INCIDENT_PAGE_SIZE) return byService;
+    cursor = page.at(-1)?.id;
+    if (!cursor) throw new Error('Status history pagination did not advance');
+  }
+}

--- a/src/lib/status-pages/history.ts
+++ b/src/lib/status-pages/history.ts
@@ -1,0 +1,163 @@
+import type {
+  PublicHistorySlice,
+  PublicServiceStatus,
+  PublicStatusHistoryDay,
+} from './public-contract';
+import { getWorstPublicStatus } from './status-presentation';
+
+const DAY_MS = 86_400_000;
+
+export interface PublicHistoryIncident {
+  serviceId: string;
+  createdAt: Date;
+  resolvedAt: Date | null;
+  urgency: string;
+  status: string;
+}
+
+export interface PublicHistoryMaintenance {
+  startDate: Date;
+  endDate: Date | null;
+  affectedServiceIds: string[];
+}
+
+function incidentStatus(urgency: string): PublicServiceStatus {
+  if (urgency === 'HIGH') return 'MAJOR_OUTAGE';
+  if (urgency === 'MEDIUM') return 'DEGRADED';
+  if (urgency === 'LOW') return 'PARTIAL_OUTAGE';
+  return 'UNKNOWN';
+}
+
+function overlapMinutes(start: Date, end: Date, dayStart: Date, dayEnd: Date) {
+  const from = Math.max(start.getTime(), dayStart.getTime());
+  const to = Math.min(end.getTime(), dayEnd.getTime());
+  return {
+    startMinute: Math.max(0, Math.floor((from - dayStart.getTime()) / 60_000)),
+    endMinute: Math.min(1440, Math.ceil((to - dayStart.getTime()) / 60_000)),
+  };
+}
+
+function mergeSlices(slices: PublicHistorySlice[]): PublicHistorySlice[] {
+  const points = new Set([0, 1440]);
+  for (const slice of slices) {
+    points.add(slice.startMinute);
+    points.add(slice.endMinute);
+  }
+  const sorted = [...points].sort((a, b) => a - b);
+  const result: PublicHistorySlice[] = [];
+  for (let index = 0; index < sorted.length - 1; index++) {
+    const startMinute = sorted.at(index);
+    const endMinute = sorted.at(index + 1);
+    if (startMinute === undefined || endMinute === undefined) continue;
+    const covering = slices.filter(
+      slice => slice.startMinute < endMinute && slice.endMinute > startMinute
+    );
+    const status = covering.length
+      ? getWorstPublicStatus(covering.map(slice => slice.status))
+      : 'OPERATIONAL';
+    const previous = result.at(-1);
+    if (previous?.status === status) previous.endMinute = endMinute;
+    else result.push({ startMinute, endMinute, status });
+  }
+  return result;
+}
+
+export function buildPublicServiceHistory({
+  serviceId,
+  incidents,
+  maintenance,
+  start,
+  end,
+}: {
+  serviceId: string;
+  incidents: PublicHistoryIncident[];
+  maintenance: PublicHistoryMaintenance[];
+  timezone?: string;
+  start: Date;
+  end: Date;
+}): PublicStatusHistoryDay[] {
+  const days: PublicStatusHistoryDay[] = [];
+  const cursor = new Date(start);
+  cursor.setUTCHours(0, 0, 0, 0);
+  const last = new Date(end);
+  last.setUTCHours(0, 0, 0, 0);
+
+  while (cursor <= last) {
+    const dayStart = new Date(cursor);
+    const dayEnd = new Date(dayStart.getTime() + DAY_MS);
+    const incidentSlices = incidents
+      .filter(
+        incident =>
+          incident.serviceId === serviceId &&
+          incident.status !== 'SUPPRESSED' &&
+          incident.status !== 'SNOOZED' &&
+          incident.createdAt < dayEnd &&
+          (incident.resolvedAt ?? end) > dayStart
+      )
+      .map(incident => ({
+        ...overlapMinutes(incident.createdAt, incident.resolvedAt ?? end, dayStart, dayEnd),
+        status: incidentStatus(incident.urgency),
+      }));
+    const maintenanceSlices = maintenance
+      .filter(
+        item =>
+          (item.affectedServiceIds.length === 0 || item.affectedServiceIds.includes(serviceId)) &&
+          item.startDate < dayEnd &&
+          (item.endDate ?? end) > dayStart
+      )
+      .map(item => ({
+        ...overlapMinutes(item.startDate, item.endDate ?? end, dayStart, dayEnd),
+        status: 'MAINTENANCE' as const,
+      }));
+    const timeline = mergeSlices([...incidentSlices, ...maintenanceSlices]);
+    const elapsedMinutes = dayStart.getTime() === last.getTime()
+      ? Math.max(1, Math.min(1440, Math.ceil((end.getTime() - dayStart.getTime()) / 60_000)))
+      : 1440;
+    const relevant = timeline
+      .map(slice => ({ ...slice, endMinute: Math.min(slice.endMinute, elapsedMinutes) }))
+      .filter(slice => slice.startMinute < slice.endMinute);
+    const status = getWorstPublicStatus(relevant.map(slice => slice.status));
+    const unavailable = relevant.reduce(
+      (total, slice) => total + (slice.status === 'OPERATIONAL' ? 0 : slice.endMinute - slice.startMinute),
+      0
+    );
+    days.push({
+      date: dayStart.toISOString().slice(0, 10),
+      status,
+      incidentCount: incidentSlices.length,
+      availabilityPercent: Number((((elapsedMinutes - unavailable) / elapsedMinutes) * 100).toFixed(3)),
+      timeline: relevant,
+    });
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return days;
+}
+
+export function aggregatePublicRegions(
+  services: Array<{ id: string; regions?: string[]; status: PublicServiceStatus }>
+) {
+  const regionServices = new Map<string, typeof services>();
+  for (const service of services) {
+    for (const region of service.regions ?? []) {
+      const current = regionServices.get(region) ?? [];
+      current.push(service);
+      regionServices.set(region, current);
+    }
+  }
+  return [...regionServices.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([name, members]) => {
+    const count = (status: PublicServiceStatus) => members.filter(item => item.status === status).length;
+    return {
+      name,
+      status: getWorstPublicStatus(members.map(item => item.status)),
+      totalServices: members.length,
+      operationalServices: count('OPERATIONAL'),
+      degradedServices: count('DEGRADED'),
+      maintenanceServices: count('MAINTENANCE'),
+      partialOutageServices: count('PARTIAL_OUTAGE'),
+      majorOutageServices: count('MAJOR_OUTAGE'),
+      unknownServices: count('UNKNOWN'),
+      impactedServices: members.filter(item => item.status !== 'OPERATIONAL').length,
+      serviceIds: members.map(item => item.id),
+    };
+  });
+}

--- a/src/lib/status-pages/history.ts
+++ b/src/lib/status-pages/history.ts
@@ -118,7 +118,12 @@ export function buildPublicServiceHistory({
       .filter(slice => slice.startMinute < slice.endMinute);
     const status = getWorstPublicStatus(relevant.map(slice => slice.status));
     const unavailable = relevant.reduce(
-      (total, slice) => total + (slice.status === 'OPERATIONAL' ? 0 : slice.endMinute - slice.startMinute),
+      (total, slice) => total + (
+        slice.status === 'DEGRADED' || slice.status === 'PARTIAL_OUTAGE' ||
+        slice.status === 'MAJOR_OUTAGE' || slice.status === 'UNKNOWN'
+          ? slice.endMinute - slice.startMinute
+          : 0
+      ),
       0
     );
     days.push({

--- a/src/lib/status-pages/history.ts
+++ b/src/lib/status-pages/history.ts
@@ -3,9 +3,13 @@ import type {
   PublicServiceStatus,
   PublicStatusHistoryDay,
 } from './public-contract';
-import { getWorstPublicStatus } from './status-presentation';
-
-const DAY_MS = 86_400_000;
+import { getWorstPublicStatus, publicStatusForIncidentUrgency } from './status-presentation';
+import {
+  addDaysToDateKey,
+  formatDateKeyInTimeZone,
+  startOfDayFromDateKey,
+  startOfNextDayFromDateKey,
+} from '@/lib/timezone';
 
 export interface PublicHistoryIncident {
   serviceId: string;
@@ -21,24 +25,20 @@ export interface PublicHistoryMaintenance {
   affectedServiceIds: string[];
 }
 
-function incidentStatus(urgency: string): PublicServiceStatus {
-  if (urgency === 'HIGH') return 'MAJOR_OUTAGE';
-  if (urgency === 'MEDIUM') return 'DEGRADED';
-  if (urgency === 'LOW') return 'PARTIAL_OUTAGE';
-  return 'UNKNOWN';
-}
-
 function overlapMinutes(start: Date, end: Date, dayStart: Date, dayEnd: Date) {
   const from = Math.max(start.getTime(), dayStart.getTime());
   const to = Math.min(end.getTime(), dayEnd.getTime());
   return {
     startMinute: Math.max(0, Math.floor((from - dayStart.getTime()) / 60_000)),
-    endMinute: Math.min(1440, Math.ceil((to - dayStart.getTime()) / 60_000)),
+    endMinute: Math.min(
+      Math.round((dayEnd.getTime() - dayStart.getTime()) / 60_000),
+      Math.ceil((to - dayStart.getTime()) / 60_000)
+    ),
   };
 }
 
-function mergeSlices(slices: PublicHistorySlice[]): PublicHistorySlice[] {
-  const points = new Set([0, 1440]);
+function mergeSlices(slices: PublicHistorySlice[], dayMinutes: number): PublicHistorySlice[] {
+  const points = new Set([0, dayMinutes]);
   for (const slice of slices) {
     points.add(slice.startMinute);
     points.add(slice.endMinute);
@@ -66,6 +66,7 @@ export function buildPublicServiceHistory({
   serviceId,
   incidents,
   maintenance,
+  timezone,
   start,
   end,
 }: {
@@ -76,45 +77,81 @@ export function buildPublicServiceHistory({
   start: Date;
   end: Date;
 }): PublicStatusHistoryDay[] {
-  const days: PublicStatusHistoryDay[] = [];
-  const cursor = new Date(start);
-  cursor.setUTCHours(0, 0, 0, 0);
-  const last = new Date(end);
-  last.setUTCHours(0, 0, 0, 0);
+  if (end <= start) return [];
 
-  while (cursor <= last) {
-    const dayStart = new Date(cursor);
-    const dayEnd = new Date(dayStart.getTime() + DAY_MS);
-    const incidentSlices = incidents
-      .filter(
-        incident =>
-          incident.serviceId === serviceId &&
-          incident.status !== 'SUPPRESSED' &&
-          incident.status !== 'SNOOZED' &&
-          incident.createdAt < dayEnd &&
-          (incident.resolvedAt ?? end) > dayStart
-      )
-      .map(incident => ({
-        ...overlapMinutes(incident.createdAt, incident.resolvedAt ?? end, dayStart, dayEnd),
-        status: incidentStatus(incident.urgency),
-      }));
-    const maintenanceSlices = maintenance
-      .filter(
-        item =>
-          (item.affectedServiceIds.length === 0 || item.affectedServiceIds.includes(serviceId)) &&
-          item.startDate < dayEnd &&
-          (item.endDate ?? end) > dayStart
-      )
-      .map(item => ({
-        ...overlapMinutes(item.startDate, item.endDate ?? end, dayStart, dayEnd),
-        status: 'MAINTENANCE' as const,
-      }));
-    const timeline = mergeSlices([...incidentSlices, ...maintenanceSlices]);
-    const elapsedMinutes = dayStart.getTime() === last.getTime()
-      ? Math.max(1, Math.min(1440, Math.ceil((end.getTime() - dayStart.getTime()) / 60_000)))
-      : 1440;
+  const days: PublicStatusHistoryDay[] = [];
+  const historyTimeZone = timezone || 'UTC';
+  let dateKey = formatDateKeyInTimeZone(start, historyTimeZone);
+  // The history range is half-open. An end exactly at local midnight belongs to
+  // the preceding day and must not create a zero-length trailing cell.
+  const lastDateKey = formatDateKeyInTimeZone(new Date(end.getTime() - 1), historyTimeZone);
+  const incidentSlicesByDate = new Map<string, PublicHistorySlice[]>();
+  const maintenanceSlicesByDate = new Map<string, PublicHistorySlice[]>();
+
+  const addInterval = (
+    intervalStart: Date,
+    intervalEnd: Date,
+    status: PublicServiceStatus,
+    target: Map<string, PublicHistorySlice[]>
+  ) => {
+    const boundedStart = new Date(Math.max(start.getTime(), intervalStart.getTime()));
+    const boundedEnd = new Date(Math.min(end.getTime(), intervalEnd.getTime()));
+    if (boundedEnd <= boundedStart) return;
+    let intervalDateKey = formatDateKeyInTimeZone(boundedStart, historyTimeZone);
+    const intervalLastDateKey = formatDateKeyInTimeZone(
+      new Date(boundedEnd.getTime() - 1),
+      historyTimeZone
+    );
+    while (intervalDateKey <= intervalLastDateKey) {
+      const dayStart = startOfDayFromDateKey(intervalDateKey, historyTimeZone);
+      const dayEnd = startOfNextDayFromDateKey(intervalDateKey, historyTimeZone);
+      const slices = target.get(intervalDateKey) ?? [];
+      slices.push({ ...overlapMinutes(boundedStart, boundedEnd, dayStart, dayEnd), status });
+      target.set(intervalDateKey, slices);
+      intervalDateKey = addDaysToDateKey(intervalDateKey, 1);
+    }
+  };
+
+  for (const incident of incidents) {
+    if (
+      incident.serviceId !== serviceId ||
+      incident.status === 'SUPPRESSED' ||
+      incident.status === 'SNOOZED'
+    ) continue;
+    addInterval(
+      incident.createdAt,
+      incident.resolvedAt ?? end,
+      publicStatusForIncidentUrgency(incident.urgency),
+      incidentSlicesByDate
+    );
+  }
+  for (const item of maintenance) {
+    if (item.affectedServiceIds.length > 0 && !item.affectedServiceIds.includes(serviceId)) continue;
+    addInterval(item.startDate, item.endDate ?? end, 'MAINTENANCE', maintenanceSlicesByDate);
+  }
+
+  while (dateKey <= lastDateKey) {
+    const dayStart = startOfDayFromDateKey(dateKey, historyTimeZone);
+    const dayEnd = startOfNextDayFromDateKey(dateKey, historyTimeZone);
+    const dayMinutes = Math.round((dayEnd.getTime() - dayStart.getTime()) / 60_000);
+    const incidentSlices = incidentSlicesByDate.get(dateKey) ?? [];
+    const maintenanceSlices = maintenanceSlicesByDate.get(dateKey) ?? [];
+    const timeline = mergeSlices([...incidentSlices, ...maintenanceSlices], dayMinutes);
+    const measuredStartMinute = Math.max(
+      0,
+      Math.min(dayMinutes, Math.floor((start.getTime() - dayStart.getTime()) / 60_000))
+    );
+    const measuredEndMinute = Math.max(
+      measuredStartMinute + 1,
+      Math.min(dayMinutes, Math.ceil((end.getTime() - dayStart.getTime()) / 60_000))
+    );
+    const elapsedMinutes = measuredEndMinute - measuredStartMinute;
     const relevant = timeline
-      .map(slice => ({ ...slice, endMinute: Math.min(slice.endMinute, elapsedMinutes) }))
+      .map(slice => ({
+        ...slice,
+        startMinute: Math.max(slice.startMinute, measuredStartMinute),
+        endMinute: Math.min(slice.endMinute, measuredEndMinute),
+      }))
       .filter(slice => slice.startMinute < slice.endMinute);
     const status = getWorstPublicStatus(relevant.map(slice => slice.status));
     const unavailable = relevant.reduce(
@@ -127,13 +164,13 @@ export function buildPublicServiceHistory({
       0
     );
     days.push({
-      date: dayStart.toISOString().slice(0, 10),
+      date: dateKey,
       status,
       incidentCount: incidentSlices.length,
       availabilityPercent: Number((((elapsedMinutes - unavailable) / elapsedMinutes) * 100).toFixed(3)),
       timeline: relevant,
     });
-    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    dateKey = addDaysToDateKey(dateKey, 1);
   }
   return days;
 }

--- a/src/lib/status-pages/history.ts
+++ b/src/lib/status-pages/history.ts
@@ -1,15 +1,8 @@
 import type {
-  PublicHistorySlice,
   PublicServiceStatus,
-  PublicStatusHistoryDay,
+  PublicStatusHistorySegment,
 } from './public-contract';
 import { getWorstPublicStatus, publicStatusForIncidentUrgency } from './status-presentation';
-import {
-  addDaysToDateKey,
-  formatDateKeyInTimeZone,
-  startOfDayFromDateKey,
-  startOfNextDayFromDateKey,
-} from '@/lib/timezone';
 
 export interface PublicHistoryIncident {
   serviceId: string;
@@ -25,90 +18,26 @@ export interface PublicHistoryMaintenance {
   affectedServiceIds: string[];
 }
 
-function overlapMinutes(start: Date, end: Date, dayStart: Date, dayEnd: Date) {
-  const from = Math.max(start.getTime(), dayStart.getTime());
-  const to = Math.min(end.getTime(), dayEnd.getTime());
-  return {
-    startMinute: Math.max(0, Math.floor((from - dayStart.getTime()) / 60_000)),
-    endMinute: Math.min(
-      Math.round((dayEnd.getTime() - dayStart.getTime()) / 60_000),
-      Math.ceil((to - dayStart.getTime()) / 60_000)
-    ),
-  };
-}
-
-function mergeSlices(slices: PublicHistorySlice[], dayMinutes: number): PublicHistorySlice[] {
-  const points = new Set([0, dayMinutes]);
-  for (const slice of slices) {
-    points.add(slice.startMinute);
-    points.add(slice.endMinute);
-  }
-  const sorted = [...points].sort((a, b) => a - b);
-  const result: PublicHistorySlice[] = [];
-  for (let index = 0; index < sorted.length - 1; index++) {
-    const startMinute = sorted.at(index);
-    const endMinute = sorted.at(index + 1);
-    if (startMinute === undefined || endMinute === undefined) continue;
-    const covering = slices.filter(
-      slice => slice.startMinute < endMinute && slice.endMinute > startMinute
-    );
-    const status = covering.length
-      ? getWorstPublicStatus(covering.map(slice => slice.status))
-      : 'OPERATIONAL';
-    const previous = result.at(-1);
-    if (previous?.status === status) previous.endMinute = endMinute;
-    else result.push({ startMinute, endMinute, status });
-  }
-  return result;
-}
-
-export function buildPublicServiceHistory({
+export function buildPublicHistorySegments({
   serviceId,
   incidents,
   maintenance,
-  timezone,
   start,
   end,
 }: {
   serviceId: string;
   incidents: PublicHistoryIncident[];
   maintenance: PublicHistoryMaintenance[];
-  timezone?: string;
   start: Date;
   end: Date;
-}): PublicStatusHistoryDay[] {
+}): PublicStatusHistorySegment[] {
   if (end <= start) return [];
-
-  const days: PublicStatusHistoryDay[] = [];
-  const historyTimeZone = timezone || 'UTC';
-  let dateKey = formatDateKeyInTimeZone(start, historyTimeZone);
-  // The history range is half-open. An end exactly at local midnight belongs to
-  // the preceding day and must not create a zero-length trailing cell.
-  const lastDateKey = formatDateKeyInTimeZone(new Date(end.getTime() - 1), historyTimeZone);
-  const incidentSlicesByDate = new Map<string, PublicHistorySlice[]>();
-  const maintenanceSlicesByDate = new Map<string, PublicHistorySlice[]>();
-
-  const addInterval = (
-    intervalStart: Date,
-    intervalEnd: Date,
-    status: PublicServiceStatus,
-    target: Map<string, PublicHistorySlice[]>
-  ) => {
-    const boundedStart = new Date(Math.max(start.getTime(), intervalStart.getTime()));
-    const boundedEnd = new Date(Math.min(end.getTime(), intervalEnd.getTime()));
-    if (boundedEnd <= boundedStart) return;
-    let intervalDateKey = formatDateKeyInTimeZone(boundedStart, historyTimeZone);
-    const intervalLastDateKey = formatDateKeyInTimeZone(
-      new Date(boundedEnd.getTime() - 1),
-      historyTimeZone
-    );
-    while (intervalDateKey <= intervalLastDateKey) {
-      const dayStart = startOfDayFromDateKey(intervalDateKey, historyTimeZone);
-      const dayEnd = startOfNextDayFromDateKey(intervalDateKey, historyTimeZone);
-      const slices = target.get(intervalDateKey) ?? [];
-      slices.push({ ...overlapMinutes(boundedStart, boundedEnd, dayStart, dayEnd), status });
-      target.set(intervalDateKey, slices);
-      intervalDateKey = addDaysToDateKey(intervalDateKey, 1);
+  const intervals: Array<{ start: number; end: number; status: PublicServiceStatus }> = [];
+  const addInterval = (intervalStart: Date, intervalEnd: Date, status: PublicServiceStatus) => {
+    const boundedStart = Math.max(start.getTime(), intervalStart.getTime());
+    const boundedEnd = Math.min(end.getTime(), intervalEnd.getTime());
+    if (boundedEnd > boundedStart && status !== 'OPERATIONAL') {
+      intervals.push({ start: boundedStart, end: boundedEnd, status });
     }
   };
 
@@ -121,58 +50,32 @@ export function buildPublicServiceHistory({
     addInterval(
       incident.createdAt,
       incident.resolvedAt ?? end,
-      publicStatusForIncidentUrgency(incident.urgency),
-      incidentSlicesByDate
+      publicStatusForIncidentUrgency(incident.urgency)
     );
   }
   for (const item of maintenance) {
     if (item.affectedServiceIds.length > 0 && !item.affectedServiceIds.includes(serviceId)) continue;
-    addInterval(item.startDate, item.endDate ?? end, 'MAINTENANCE', maintenanceSlicesByDate);
+    addInterval(item.startDate, item.endDate ?? end, 'MAINTENANCE');
   }
 
-  while (dateKey <= lastDateKey) {
-    const dayStart = startOfDayFromDateKey(dateKey, historyTimeZone);
-    const dayEnd = startOfNextDayFromDateKey(dateKey, historyTimeZone);
-    const dayMinutes = Math.round((dayEnd.getTime() - dayStart.getTime()) / 60_000);
-    const incidentSlices = incidentSlicesByDate.get(dateKey) ?? [];
-    const maintenanceSlices = maintenanceSlicesByDate.get(dateKey) ?? [];
-    const timeline = mergeSlices([...incidentSlices, ...maintenanceSlices], dayMinutes);
-    const measuredStartMinute = Math.max(
-      0,
-      Math.min(dayMinutes, Math.floor((start.getTime() - dayStart.getTime()) / 60_000))
-    );
-    const measuredEndMinute = Math.max(
-      measuredStartMinute + 1,
-      Math.min(dayMinutes, Math.ceil((end.getTime() - dayStart.getTime()) / 60_000))
-    );
-    const elapsedMinutes = measuredEndMinute - measuredStartMinute;
-    const relevant = timeline
-      .map(slice => ({
-        ...slice,
-        startMinute: Math.max(slice.startMinute, measuredStartMinute),
-        endMinute: Math.min(slice.endMinute, measuredEndMinute),
-      }))
-      .filter(slice => slice.startMinute < slice.endMinute);
-    const status = getWorstPublicStatus(relevant.map(slice => slice.status));
-    const unavailable = relevant.reduce(
-      (total, slice) => total + (
-        slice.status === 'DEGRADED' || slice.status === 'PARTIAL_OUTAGE' ||
-        slice.status === 'MAJOR_OUTAGE' || slice.status === 'UNKNOWN'
-          ? slice.endMinute - slice.startMinute
-          : 0
-      ),
-      0
-    );
-    days.push({
-      date: dateKey,
-      status,
-      incidentCount: incidentSlices.length,
-      availabilityPercent: Number((((elapsedMinutes - unavailable) / elapsedMinutes) * 100).toFixed(3)),
-      timeline: relevant,
-    });
-    dateKey = addDaysToDateKey(dateKey, 1);
+  const points = [...new Set(intervals.flatMap(interval => [interval.start, interval.end]))]
+    .sort((a, b) => a - b);
+  const segments: PublicStatusHistorySegment[] = [];
+  for (let index = 0; index < points.length - 1; index++) {
+    const segmentStart = points.at(index);
+    const segmentEnd = points.at(index + 1);
+    if (segmentStart === undefined || segmentEnd === undefined) continue;
+    const covering = intervals.filter(item => item.start < segmentEnd && item.end > segmentStart);
+    if (covering.length === 0) continue;
+    const status = getWorstPublicStatus(covering.map(item => item.status));
+    if (status === 'OPERATIONAL') continue;
+    const previous = segments.at(-1);
+    const startAt = new Date(segmentStart).toISOString();
+    const endAt = new Date(segmentEnd).toISOString();
+    if (previous?.status === status && previous.endAt === startAt) previous.endAt = endAt;
+    else segments.push({ startAt, endAt, status });
   }
-  return days;
+  return segments;
 }
 
 export function aggregatePublicRegions(

--- a/src/lib/status-pages/public-contract-schema.ts
+++ b/src/lib/status-pages/public-contract-schema.ts
@@ -84,6 +84,7 @@ export const publicStatusPageSnapshotSchema = z.object({
     slaTier: z.string().nullable().optional(),
     uptime: z.object({ days30: uptimeWindow, days90: uptimeWindow }).strict().optional(),
     history: z.array(historyDay).optional(),
+    historyComplete: z.boolean().optional(),
   }).strict()),
   regions: z.array(z.object({
     name: z.string(), status, totalServices: z.number().int().nonnegative(),

--- a/src/lib/status-pages/public-contract-schema.ts
+++ b/src/lib/status-pages/public-contract-schema.ts
@@ -1,0 +1,177 @@
+import { z } from 'zod';
+import type { Prisma } from '@prisma/client';
+import type { PublicStatusPageSnapshot } from './public-contract';
+import { aggregatePublicRegions } from './history';
+import { normalizePublicStatus } from './status-presentation';
+
+const status = z.enum([
+  'OPERATIONAL',
+  'DEGRADED',
+  'MAINTENANCE',
+  'PARTIAL_OUTAGE',
+  'MAJOR_OUTAGE',
+  'UNKNOWN',
+]);
+const dateTime = z.string().datetime({ offset: true });
+
+const uptimeWindow = z.object({
+  percentage: z.number().min(0).max(100).nullable(),
+  incidentCount: z.number().int().nonnegative(),
+  measuredDays: z.number().nonnegative(),
+  complete: z.boolean(),
+}).strict();
+
+const historyDay = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  status,
+  incidentCount: z.number().int().nonnegative(),
+  availabilityPercent: z.number().min(0).max(100).nullable(),
+  timeline: z.array(z.object({
+    startMinute: z.number().int().min(0).max(1440),
+    endMinute: z.number().int().min(0).max(1440),
+    status,
+  }).strict()).optional(),
+}).strict();
+
+const incidentUpdate = z.object({
+  id: z.string(),
+  type: z.enum(['INVESTIGATING', 'IDENTIFIED', 'MONITORING', 'ACKNOWLEDGED', 'RESOLVED', 'UPDATE']),
+  message: z.string(),
+  createdAt: dateTime.optional(),
+}).strict();
+
+export const publicStatusPageSnapshotSchema = z.object({
+  schemaVersion: z.literal(3),
+  pageId: z.string(),
+  revision: z.string(),
+  generatedAt: dateTime,
+  page: z.object({
+    id: z.string(),
+    name: z.string(),
+    organizationName: z.string().nullable().optional(),
+    branding: z.unknown().optional(),
+    showSubscribe: z.boolean(),
+    showServicesByRegion: z.boolean(),
+    showRegionHeatmap: z.boolean(),
+    showPostIncidentReview: z.boolean(),
+    showChangelog: z.boolean(),
+    enableUptimeExports: z.boolean(),
+    footerText: z.string().nullable().optional(),
+    contactEmail: z.string().nullable().optional(),
+    contactUrl: z.string().nullable().optional(),
+    slug: z.string().nullable().optional(),
+    customDomain: z.string().nullable().optional(),
+    subdomain: z.string().nullable().optional(),
+    isDefault: z.boolean(),
+    requireAuth: z.boolean(),
+    enabled: z.boolean(),
+    statusApiRequireToken: z.boolean(),
+    statusApiRateLimitEnabled: z.boolean(),
+    statusApiRateLimitMax: z.number().int().positive(),
+    statusApiRateLimitWindowSec: z.number().int().positive(),
+  }).strict(),
+  status,
+  services: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullable().optional(),
+    regions: z.array(z.string()).optional(),
+    status,
+    activeIncidentCount: z.number().int().nonnegative(),
+    team: z.object({ id: z.string(), name: z.string() }).strict().nullable().optional(),
+    slaTier: z.string().nullable().optional(),
+    uptime: z.object({ days30: uptimeWindow, days90: uptimeWindow }).strict().optional(),
+    history: z.array(historyDay).optional(),
+  }).strict()),
+  regions: z.array(z.object({
+    name: z.string(), status, totalServices: z.number().int().nonnegative(),
+    operationalServices: z.number().int().nonnegative(), degradedServices: z.number().int().nonnegative(),
+    maintenanceServices: z.number().int().nonnegative(), partialOutageServices: z.number().int().nonnegative(),
+    majorOutageServices: z.number().int().nonnegative(), unknownServices: z.number().int().nonnegative(),
+    impactedServices: z.number().int().nonnegative(), serviceIds: z.array(z.string()),
+  }).strict()),
+  incidents: z.array(z.object({
+    id: z.string().optional(), title: z.string().optional(), description: z.string().optional(),
+    status: z.enum(['OPEN', 'ACKNOWLEDGED', 'RESOLVED', 'SNOOZED', 'SUPPRESSED']),
+    urgency: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
+    createdAt: dateTime.optional(), acknowledgedAt: dateTime.optional(), resolvedAt: dateTime.optional(),
+    service: z.object({ id: z.string().optional(), name: z.string().optional(), regions: z.array(z.string()).optional() }).strict().optional(),
+    updates: z.array(incidentUpdate).optional(), postIncidentReview: z.boolean().optional(),
+  }).strict()),
+  announcements: z.array(z.object({
+    id: z.string(), title: z.string(), message: z.string(), type: z.string(),
+    startDate: dateTime, endDate: dateTime.nullable(),
+  }).strict()),
+  historyDays: z.number().int().positive(),
+}).strict();
+
+export function parsePublicStatusPageSnapshot(
+  pageId: string,
+  payload: Prisma.JsonValue | null | undefined
+): PublicStatusPageSnapshot | null {
+  const parsed = publicStatusPageSnapshotSchema.safeParse(payload);
+  if (parsed.success && parsed.data.pageId === pageId) return parsed.data as PublicStatusPageSnapshot;
+  const legacy = legacySnapshotSchema.safeParse(payload);
+  if (!legacy.success || legacy.data.pageId !== pageId) return null;
+  const services = legacy.data.services.map(service => ({
+    id: service.id,
+    name: service.name,
+    ...(service.description !== undefined ? { description: service.description } : {}),
+    ...(service.region ? { regions: service.region.split(',').map(value => value.trim()).filter(Boolean) } : {}),
+    status: normalizePublicStatus(service.status),
+    activeIncidentCount: service.activeIncidentCount ?? 0,
+    ...(legacy.data.uptime || legacy.data.uptime30 ? { uptime: {
+      days30: { percentage: legacy.data.uptime30?.[service.id] ?? null, incidentCount: 0, measuredDays: 30, complete: true },
+      days90: { percentage: legacy.data.uptime?.[service.id] ?? null, incidentCount: 0, measuredDays: 90, complete: true },
+    } } : {}),
+  }));
+  const candidate = {
+    schemaVersion: 3 as const, pageId, revision: legacy.data.revision,
+    generatedAt: legacy.data.generatedAt,
+    page: legacy.data.page,
+    status: normalizePublicStatus(legacy.data.status),
+    services,
+    regions: aggregatePublicRegions(services),
+    incidents: legacy.data.incidents.map(incident => ({
+      status: incident.status,
+      ...(incident.id ? { id: incident.id } : {}),
+      ...(incident.title ? { title: incident.title } : {}),
+      ...(incident.description ? { description: incident.description } : {}),
+      ...(incident.urgency ? { urgency: incident.urgency } : {}),
+      ...(incident.createdAt ? { createdAt: incident.createdAt } : {}),
+      ...(incident.resolvedAt ? { resolvedAt: incident.resolvedAt } : {}),
+      ...(incident.postIncidentReview ? { postIncidentReview: true } : {}),
+      ...(incident.service ? { service: {
+        ...(incident.service.name ? { name: incident.service.name } : {}),
+        ...(incident.service.region ? { regions: incident.service.region.split(',').map(value => value.trim()).filter(Boolean) } : {}),
+      } } : {}),
+    })),
+    announcements: legacy.data.announcements,
+    historyDays: legacy.data.historyDays,
+  };
+  const migrated = publicStatusPageSnapshotSchema.safeParse(candidate);
+  return migrated.success ? migrated.data as PublicStatusPageSnapshot : null;
+}
+
+const legacySnapshotSchema = z.object({
+  schemaVersion: z.union([z.literal(1), z.literal(2)]), pageId: z.string(), revision: z.string(),
+  generatedAt: dateTime, status: z.string(),
+  page: publicStatusPageSnapshotSchema.shape.page,
+  services: z.array(z.object({
+    id: z.string(), name: z.string(), description: z.string().nullable().optional(),
+    region: z.string().nullable().optional(), status: z.string(),
+    activeIncidentCount: z.number().int().nonnegative().optional(),
+  }).passthrough()),
+  incidents: z.array(z.object({
+    id: z.string().optional(), title: z.string().optional(), description: z.string().optional(),
+    status: z.enum(['OPEN', 'ACKNOWLEDGED', 'RESOLVED', 'SNOOZED', 'SUPPRESSED']),
+    urgency: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(), createdAt: dateTime.optional(),
+    resolvedAt: dateTime.nullable().optional(),
+    service: z.object({ name: z.string().optional(), region: z.string().nullable().optional() }).optional(),
+    postIncidentReview: z.boolean().optional(),
+  }).passthrough()),
+  uptime: z.record(z.string(), z.number()).optional(),
+  uptime30: z.record(z.string(), z.number()).optional(),
+  announcements: publicStatusPageSnapshotSchema.shape.announcements,
+  historyDays: z.number().int().positive(),
+}).passthrough();

--- a/src/lib/status-pages/public-contract-schema.ts
+++ b/src/lib/status-pages/public-contract-schema.ts
@@ -21,18 +21,13 @@ const uptimeWindow = z.object({
   complete: z.boolean(),
 }).strict();
 
-const historyDay = z.object({
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  status,
-  incidentCount: z.number().int().nonnegative(),
-  availabilityPercent: z.number().min(0).max(100).nullable(),
-  timeline: z.array(z.object({
-    // A local day can contain 25 hours when daylight-saving time ends.
-    startMinute: z.number().int().min(0).max(1500),
-    endMinute: z.number().int().min(0).max(1500),
-    status,
-  }).strict()).optional(),
-}).strict();
+const historySegment = z.object({
+  startAt: dateTime,
+  endAt: dateTime,
+  status: status.exclude(['OPERATIONAL']),
+}).strict().refine(segment => Date.parse(segment.startAt) < Date.parse(segment.endAt), {
+  message: 'History segment end must follow its start',
+});
 
 const incidentUpdate = z.object({
   id: z.string(),
@@ -50,7 +45,6 @@ export const publicStatusPageSnapshotSchema = z.object({
     id: z.string(),
     name: z.string(),
     organizationName: z.string().nullable().optional(),
-    timeZone: z.string().min(1),
     branding: z.unknown().optional(),
     showSubscribe: z.boolean(),
     showServicesByRegion: z.boolean(),
@@ -83,8 +77,14 @@ export const publicStatusPageSnapshotSchema = z.object({
     team: z.object({ id: z.string(), name: z.string() }).strict().nullable().optional(),
     slaTier: z.string().nullable().optional(),
     uptime: z.object({ days30: uptimeWindow, days90: uptimeWindow }).strict().optional(),
-    history: z.array(historyDay).optional(),
-    historyComplete: z.boolean().optional(),
+    history: z.object({
+      rangeStart: dateTime,
+      rangeEnd: dateTime,
+      coverage: z.enum(['COMPLETE', 'PARTIAL']),
+      segments: z.array(historySegment),
+    }).strict().refine(history => Date.parse(history.rangeStart) < Date.parse(history.rangeEnd), {
+      message: 'History range end must follow its start',
+    }).optional(),
   }).strict()),
   regions: z.array(z.object({
     name: z.string(), status, totalServices: z.number().int().nonnegative(),

--- a/src/lib/status-pages/public-contract-schema.ts
+++ b/src/lib/status-pages/public-contract-schema.ts
@@ -27,8 +27,9 @@ const historyDay = z.object({
   incidentCount: z.number().int().nonnegative(),
   availabilityPercent: z.number().min(0).max(100).nullable(),
   timeline: z.array(z.object({
-    startMinute: z.number().int().min(0).max(1440),
-    endMinute: z.number().int().min(0).max(1440),
+    // A local day can contain 25 hours when daylight-saving time ends.
+    startMinute: z.number().int().min(0).max(1500),
+    endMinute: z.number().int().min(0).max(1500),
     status,
   }).strict()).optional(),
 }).strict();
@@ -49,6 +50,7 @@ export const publicStatusPageSnapshotSchema = z.object({
     id: z.string(),
     name: z.string(),
     organizationName: z.string().nullable().optional(),
+    timeZone: z.string().min(1),
     branding: z.unknown().optional(),
     showSubscribe: z.boolean(),
     showServicesByRegion: z.boolean(),

--- a/src/lib/status-pages/public-contract.ts
+++ b/src/lib/status-pages/public-contract.ts
@@ -42,6 +42,8 @@ export interface PublicStatusService {
   slaTier?: string | null;
   uptime?: { days30: PublicUptimeWindow; days90: PublicUptimeWindow };
   history?: PublicStatusHistoryDay[];
+  /** True only after the complete authoritative history window has been read. */
+  historyComplete?: boolean;
 }
 
 export interface PublicRegionStatus {

--- a/src/lib/status-pages/public-contract.ts
+++ b/src/lib/status-pages/public-contract.ts
@@ -103,6 +103,7 @@ export interface PublicStatusPageSnapshot {
     id: string;
     name: string;
     organizationName?: string | null;
+    timeZone: string;
     branding?: unknown;
     showSubscribe: boolean;
     showServicesByRegion: boolean;

--- a/src/lib/status-pages/public-contract.ts
+++ b/src/lib/status-pages/public-contract.ts
@@ -1,0 +1,140 @@
+export const PUBLIC_SERVICE_STATUSES = [
+  'OPERATIONAL',
+  'DEGRADED',
+  'MAINTENANCE',
+  'PARTIAL_OUTAGE',
+  'MAJOR_OUTAGE',
+  'UNKNOWN',
+] as const;
+
+export type PublicServiceStatus = (typeof PUBLIC_SERVICE_STATUSES)[number];
+export type PublicHistoryStatus = PublicServiceStatus;
+
+export interface PublicHistorySlice {
+  startMinute: number;
+  endMinute: number;
+  status: PublicHistoryStatus;
+}
+
+export interface PublicStatusHistoryDay {
+  date: string;
+  status: PublicHistoryStatus;
+  incidentCount: number;
+  availabilityPercent: number | null;
+  timeline?: PublicHistorySlice[];
+}
+
+export interface PublicUptimeWindow {
+  percentage: number | null;
+  incidentCount: number;
+  measuredDays: number;
+  complete: boolean;
+}
+
+export interface PublicStatusService {
+  id: string;
+  name: string;
+  description?: string | null;
+  regions?: string[];
+  status: PublicServiceStatus;
+  activeIncidentCount: number;
+  team?: { id: string; name: string } | null;
+  slaTier?: string | null;
+  uptime?: { days30: PublicUptimeWindow; days90: PublicUptimeWindow };
+  history?: PublicStatusHistoryDay[];
+}
+
+export interface PublicRegionStatus {
+  name: string;
+  status: PublicServiceStatus;
+  totalServices: number;
+  operationalServices: number;
+  degradedServices: number;
+  maintenanceServices: number;
+  partialOutageServices: number;
+  majorOutageServices: number;
+  unknownServices: number;
+  impactedServices: number;
+  serviceIds: string[];
+}
+
+export type PublicIncidentStatus =
+  | 'OPEN'
+  | 'ACKNOWLEDGED'
+  | 'RESOLVED'
+  | 'SNOOZED'
+  | 'SUPPRESSED';
+export type PublicIncidentUrgency = 'LOW' | 'MEDIUM' | 'HIGH';
+export type PublicIncidentUpdateType =
+  | 'INVESTIGATING'
+  | 'IDENTIFIED'
+  | 'MONITORING'
+  | 'ACKNOWLEDGED'
+  | 'RESOLVED'
+  | 'UPDATE';
+
+export interface PublicIncidentUpdate {
+  id: string;
+  type: PublicIncidentUpdateType;
+  message: string;
+  createdAt?: string;
+}
+
+export interface PublicIncident {
+  id?: string;
+  title?: string;
+  description?: string;
+  status: PublicIncidentStatus;
+  urgency?: PublicIncidentUrgency;
+  createdAt?: string;
+  acknowledgedAt?: string;
+  resolvedAt?: string;
+  service?: { id?: string; name?: string; regions?: string[] };
+  updates?: PublicIncidentUpdate[];
+  postIncidentReview?: boolean;
+}
+
+export interface PublicStatusPageSnapshot {
+  schemaVersion: 3;
+  pageId: string;
+  revision: string;
+  generatedAt: string;
+  page: {
+    id: string;
+    name: string;
+    organizationName?: string | null;
+    branding?: unknown;
+    showSubscribe: boolean;
+    showServicesByRegion: boolean;
+    showRegionHeatmap: boolean;
+    showPostIncidentReview: boolean;
+    showChangelog: boolean;
+    enableUptimeExports: boolean;
+    footerText?: string | null;
+    contactEmail?: string | null;
+    contactUrl?: string | null;
+    slug?: string | null;
+    customDomain?: string | null;
+    subdomain?: string | null;
+    isDefault: boolean;
+    requireAuth: boolean;
+    enabled: boolean;
+    statusApiRequireToken: boolean;
+    statusApiRateLimitEnabled: boolean;
+    statusApiRateLimitMax: number;
+    statusApiRateLimitWindowSec: number;
+  };
+  status: PublicServiceStatus;
+  services: PublicStatusService[];
+  regions: PublicRegionStatus[];
+  incidents: PublicIncident[];
+  announcements: Array<{
+    id: string;
+    title: string;
+    message: string;
+    type: string;
+    startDate: string;
+    endDate: string | null;
+  }>;
+  historyDays: number;
+}

--- a/src/lib/status-pages/public-contract.ts
+++ b/src/lib/status-pages/public-contract.ts
@@ -24,6 +24,19 @@ export interface PublicStatusHistoryDay {
   timeline?: PublicHistorySlice[];
 }
 
+export interface PublicStatusHistorySegment {
+  startAt: string;
+  endAt: string;
+  status: Exclude<PublicServiceStatus, 'OPERATIONAL'>;
+}
+
+export interface PublicStatusHistory {
+  rangeStart: string;
+  rangeEnd: string;
+  coverage: 'COMPLETE' | 'PARTIAL';
+  segments: PublicStatusHistorySegment[];
+}
+
 export interface PublicUptimeWindow {
   percentage: number | null;
   incidentCount: number;
@@ -41,9 +54,7 @@ export interface PublicStatusService {
   team?: { id: string; name: string } | null;
   slaTier?: string | null;
   uptime?: { days30: PublicUptimeWindow; days90: PublicUptimeWindow };
-  history?: PublicStatusHistoryDay[];
-  /** True only after the complete authoritative history window has been read. */
-  historyComplete?: boolean;
+  history?: PublicStatusHistory;
 }
 
 export interface PublicRegionStatus {
@@ -105,7 +116,6 @@ export interface PublicStatusPageSnapshot {
     id: string;
     name: string;
     organizationName?: string | null;
-    timeZone: string;
     branding?: unknown;
     showSubscribe: boolean;
     showServicesByRegion: boolean;

--- a/src/lib/status-pages/serving-store.ts
+++ b/src/lib/status-pages/serving-store.ts
@@ -6,6 +6,8 @@ import {
   observeOperationalHistogram,
 } from '@/lib/metrics/operational/registry';
 import { scalingFeatureEnabled } from '@/lib/scaling-feature-flags';
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
 
 export interface StatusServingManifest {
   pageId: string;
@@ -13,10 +15,24 @@ export interface StatusServingManifest {
   enabled: boolean;
   revoked: boolean;
   snapshotKey: string;
+  publishedAt: string;
+  schemaVersion: number;
+  integrityHash: string;
+}
+
+const manifestSchema = z.object({
+  pageId: z.string(), revision: z.string(), enabled: z.boolean(), revoked: z.boolean(),
+  snapshotKey: z.string(), publishedAt: z.string().datetime({ offset: true }),
+  schemaVersion: z.number().int().positive(), integrityHash: z.string().regex(/^[a-f0-9]{64}$/),
+}).strict();
+
+export function statusSnapshotIntegrity(snapshot: Prisma.JsonValue) {
+  return createHash('sha256').update(JSON.stringify(snapshot)).digest('hex');
 }
 
 export interface StatusPageServingStore {
   publishRoute(routeKey: string, pageId: string): Promise<void>;
+  removeRoute(routeKey: string): Promise<void>;
   resolveRoute(routeKey: string): Promise<string | null>;
   publishManifest(manifest: StatusServingManifest): Promise<void>;
   publishSnapshot(pageId: string, revision: string, snapshot: Prisma.JsonValue): Promise<void>;
@@ -43,6 +59,7 @@ async function observed<T>(operation: string, task: () => Promise<T>): Promise<T
 
 class PostgreSqlStatusPageServingStore implements StatusPageServingStore {
   async publishRoute(): Promise<void> {}
+  async removeRoute(): Promise<void> {}
   async resolveRoute(routeKey: string): Promise<string | null> {
     const page = await prisma.statusPage.findFirst({
       where: routeKey === 'default' ? { isDefault: true } : { slug: routeKey },
@@ -63,6 +80,9 @@ class PostgreSqlStatusPageServingStore implements StatusPageServingStore {
         enabled: true,
         revoked: row.publishedRevision !== row.revision || !row.payload,
         snapshotKey: `${row.publishedRevision}.json`,
+        publishedAt: row.generatedAt?.toISOString() ?? new Date(0).toISOString(),
+        schemaVersion: 3,
+        integrityHash: row.payload ? statusSnapshotIntegrity(row.payload) : '0'.repeat(64),
       };
     });
   }
@@ -131,6 +151,17 @@ class HttpStatusPageServingStore implements StatusPageServingStore {
     });
   }
 
+  async removeRoute(routeKey: string): Promise<void> {
+    await observed('remove_route', async () => {
+      const response = await this.request(`status-pages/routes/${encodeURIComponent(routeKey)}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok && response.status !== 404) {
+        throw new Error(`Serving store route removal failed (${response.status})`);
+      }
+    });
+  }
+
   async resolveRoute(routeKey: string): Promise<string | null> {
     return observed('resolve_route', async () => {
       const response = await this.request(`status-pages/routes/${encodeURIComponent(routeKey)}`);
@@ -172,7 +203,8 @@ class HttpStatusPageServingStore implements StatusPageServingStore {
       const response = await this.request(`status-pages/${pageId}/manifest`);
       if (response.status === 404) return null;
       if (!response.ok) throw new Error(`Serving store manifest read failed (${response.status})`);
-      return (await response.json()) as StatusServingManifest;
+      const parsed = manifestSchema.safeParse(await response.json());
+      return parsed.success ? parsed.data : null;
     });
   }
 
@@ -192,6 +224,9 @@ class HttpStatusPageServingStore implements StatusPageServingStore {
       enabled: false,
       revoked: true,
       snapshotKey: '',
+      publishedAt: new Date().toISOString(),
+      schemaVersion: 3,
+      integrityHash: '0'.repeat(64),
     });
   }
 }

--- a/src/lib/status-pages/serving-store.ts
+++ b/src/lib/status-pages/serving-store.ts
@@ -8,6 +8,7 @@ import {
 import { scalingFeatureEnabled } from '@/lib/scaling-feature-flags';
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
+import { logger } from '@/lib/logger';
 
 export interface StatusServingManifest {
   pageId: string;
@@ -20,20 +21,42 @@ export interface StatusServingManifest {
   integrityHash: string;
 }
 
+export interface StatusServingRoute {
+  pageId: string;
+  slug: string | null;
+  requireAuth: boolean;
+  revision: string;
+}
+
+function isSafeStatusSlug(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= 128 &&
+    value.split('-').every(part => part.length > 0 && /^[a-z0-9]+$/.test(part))
+  );
+}
+
+const routeSchema = z.object({
+  pageId: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/),
+  slug: z.string().refine(isSafeStatusSlug).nullable(),
+  requireAuth: z.boolean(),
+  revision: z.string().min(1).max(128).regex(/^[A-Za-z0-9._:-]+$/),
+}).strict();
+
 const manifestSchema = z.object({
   pageId: z.string(), revision: z.string(), enabled: z.boolean(), revoked: z.boolean(),
   snapshotKey: z.string(), publishedAt: z.string().datetime({ offset: true }),
   schemaVersion: z.number().int().positive(), integrityHash: z.string().regex(/^[a-f0-9]{64}$/),
-}).strict();
+});
 
 export function statusSnapshotIntegrity(snapshot: Prisma.JsonValue) {
   return createHash('sha256').update(JSON.stringify(snapshot)).digest('hex');
 }
 
 export interface StatusPageServingStore {
-  publishRoute(routeKey: string, pageId: string): Promise<void>;
+  publishRoute(routeKey: string, route: StatusServingRoute): Promise<void>;
   removeRoute(routeKey: string): Promise<void>;
-  resolveRoute(routeKey: string): Promise<string | null>;
+  resolveRoute(routeKey: string): Promise<StatusServingRoute | null>;
   publishManifest(manifest: StatusServingManifest): Promise<void>;
   publishSnapshot(pageId: string, revision: string, snapshot: Prisma.JsonValue): Promise<void>;
   readManifest(pageId: string): Promise<StatusServingManifest | null>;
@@ -60,12 +83,24 @@ async function observed<T>(operation: string, task: () => Promise<T>): Promise<T
 class PostgreSqlStatusPageServingStore implements StatusPageServingStore {
   async publishRoute(): Promise<void> {}
   async removeRoute(): Promise<void> {}
-  async resolveRoute(routeKey: string): Promise<string | null> {
+  async resolveRoute(routeKey: string): Promise<StatusServingRoute | null> {
     const page = await prisma.statusPage.findFirst({
       where: routeKey === 'default' ? { isDefault: true } : { slug: routeKey },
-      select: { id: true },
+      select: {
+        id: true,
+        slug: true,
+        requireAuth: true,
+        snapshot: { select: { publishedRevision: true } },
+      },
     });
-    return page?.id ?? null;
+    return page
+      ? {
+          pageId: page.id,
+          slug: page.slug,
+          requireAuth: page.requireAuth,
+          revision: page.snapshot?.publishedRevision.toString() ?? '-1',
+        }
+      : null;
   }
   async publishManifest(): Promise<void> {}
   async publishSnapshot(): Promise<void> {}
@@ -141,11 +176,11 @@ class HttpStatusPageServingStore implements StatusPageServingStore {
     });
   }
 
-  async publishRoute(routeKey: string, pageId: string): Promise<void> {
+  async publishRoute(routeKey: string, route: StatusServingRoute): Promise<void> {
     await observed('publish_route', async () => {
       const response = await this.request(`status-pages/routes/${encodeURIComponent(routeKey)}`, {
         method: 'PUT',
-        body: JSON.stringify({ pageId }),
+        body: JSON.stringify(route),
       });
       if (!response.ok) throw new Error(`Serving store route publish failed (${response.status})`);
     });
@@ -162,13 +197,13 @@ class HttpStatusPageServingStore implements StatusPageServingStore {
     });
   }
 
-  async resolveRoute(routeKey: string): Promise<string | null> {
+  async resolveRoute(routeKey: string): Promise<StatusServingRoute | null> {
     return observed('resolve_route', async () => {
       const response = await this.request(`status-pages/routes/${encodeURIComponent(routeKey)}`);
       if (response.status === 404) return null;
       if (!response.ok) throw new Error(`Serving store route lookup failed (${response.status})`);
-      const payload = (await response.json()) as { pageId?: unknown };
-      return typeof payload.pageId === 'string' ? payload.pageId : null;
+      const parsed = routeSchema.safeParse(await response.json());
+      return parsed.success ? parsed.data : null;
     });
   }
 
@@ -204,7 +239,14 @@ class HttpStatusPageServingStore implements StatusPageServingStore {
       if (response.status === 404) return null;
       if (!response.ok) throw new Error(`Serving store manifest read failed (${response.status})`);
       const parsed = manifestSchema.safeParse(await response.json());
-      return parsed.success ? parsed.data : null;
+      if (!parsed.success) {
+        logger.error('status.serving_store.manifest_invalid', {
+          pageId,
+          issues: parsed.error.issues.map(issue => issue.path.join('.')),
+        });
+        return null;
+      }
+      return parsed.data;
     });
   }
 

--- a/src/lib/status-pages/settings-sections.ts
+++ b/src/lib/status-pages/settings-sections.ts
@@ -1,7 +1,16 @@
 const sectionFields = new Map<string, readonly string[]>([
   [
     'general',
-    ['name', 'slug', 'organizationName', 'subdomain', 'customDomain', 'enabled', 'requireAuth'],
+    [
+      'name',
+      'timeZone',
+      'slug',
+      'organizationName',
+      'subdomain',
+      'customDomain',
+      'enabled',
+      'requireAuth',
+    ],
   ],
   ['appearance', ['branding']],
   ['customization', ['branding']],

--- a/src/lib/status-pages/settings-sections.ts
+++ b/src/lib/status-pages/settings-sections.ts
@@ -3,7 +3,6 @@ const sectionFields = new Map<string, readonly string[]>([
     'general',
     [
       'name',
-      'timeZone',
       'slug',
       'organizationName',
       'subdomain',

--- a/src/lib/status-pages/snapshot.ts
+++ b/src/lib/status-pages/snapshot.ts
@@ -8,85 +8,22 @@ import {
 } from '@/lib/status-page-public-data';
 import { activeIncidentStatuses } from '@/lib/incident-status';
 import { getReportingWindowForDays } from '@/lib/retention-policy';
-import {
-  projectOverallStatus,
-  projectServiceStatus,
-  visibleMaintenanceServiceIds,
-} from '@/lib/status-page-projection';
+import { projectServiceStatus, visibleMaintenanceServiceIds } from '@/lib/status-page-projection';
 import { calculateMultiServiceUptime } from '@/lib/sla-server';
 import { addOperationalMetric, setOperationalGauge } from '@/lib/metrics/operational/registry';
-import { getStatusPageServingStore } from './serving-store';
+import { getStatusPageServingStore, statusSnapshotIntegrity } from './serving-store';
+import type { PublicStatusPageSnapshot } from './public-contract';
+import { aggregatePublicRegions, buildPublicServiceHistory } from './history';
+import { getWorstPublicStatus, normalizePublicStatus } from './status-presentation';
+import { parsePublicStatusPageSnapshot } from './public-contract-schema';
 
-export type StatusHistoryDay = {
-  date: string;
-  status: 'operational' | 'degraded' | 'outage';
-};
-
-export type StatusPageSnapshot = {
-  schemaVersion: 1 | 2;
-  pageId: string;
-  revision: string;
-  generatedAt: string;
-  page?: {
-    id: string;
-    name: string;
-    organizationName: string | null;
-    branding: Prisma.JsonValue | null;
-    showSubscribe: boolean;
-    showServicesByRegion: boolean;
-    showRegionHeatmap: boolean;
-    showPostIncidentReview: boolean;
-    showChangelog: boolean;
-    enableUptimeExports: boolean;
-    footerText: string | null;
-    contactEmail: string | null;
-    contactUrl: string | null;
-    slug: string | null;
-    customDomain: string | null;
-    subdomain: string | null;
-    isDefault: boolean;
-    requireAuth: boolean;
-    enabled?: boolean;
-    statusApiRequireToken?: boolean;
-    statusApiRateLimitEnabled?: boolean;
-    statusApiRateLimitMax?: number;
-    statusApiRateLimitWindowSec?: number;
-  };
-  status: 'operational' | 'degraded' | 'maintenance' | 'outage';
-  services: Array<{
-    id: string;
-    name: string;
-    description?: string | null;
-    region?: string | null;
-    slaTier?: string | null;
-    team?: { id: string; name: string } | null;
-    status: string;
-    activeIncidentCount?: number;
-  }>;
-  incidents: Array<Record<string, unknown>>;
-  uptime: Record<string, number>;
-  uptime30?: Record<string, number>;
-  statusHistory?: Record<string, StatusHistoryDay[]>;
-  announcements: Array<{
-    id: string;
-    title: string;
-    message: string;
-    type: string;
-    startDate: string;
-    endDate: string | null;
-  }>;
-  historyDays: number;
-};
+export type StatusPageSnapshot = PublicStatusPageSnapshot;
 
 function parseStatusPageSnapshot(
   pageId: string,
   payload: Prisma.JsonValue | null | undefined
 ): StatusPageSnapshot | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
-  const record = payload as Prisma.JsonObject;
-  if ((record.schemaVersion !== 1 && record.schemaVersion !== 2) || record.pageId !== pageId)
-    return null;
-  return payload as unknown as StatusPageSnapshot;
+  return parsePublicStatusPageSnapshot(pageId, payload);
 }
 
 /** All public data is explicitly projected; no Prisma records are spread into the payload. */
@@ -122,11 +59,13 @@ export async function buildStatusPageSnapshot(
   const limits = statusPagePublicationLimits(page);
   const visibility = publicStatusVisibility(page);
   const ids = page.services.map(mapping => mapping.serviceId);
-  const window = await getReportingWindowForDays(limits.historyDays, 'incident', now);
-  const thirtyDayStart = new Date(
-    Math.max(window.start.getTime(), now.getTime() - 30 * 86_400_000)
-  );
-  const [groups, incidents, uptime, uptime30, affectedHistoryDays] = ids.length
+  const [window, window30, window90] = await Promise.all([
+    getReportingWindowForDays(limits.historyDays, 'incident', now),
+    getReportingWindowForDays(30, 'incident', now),
+    getReportingWindowForDays(90, 'incident', now),
+  ]);
+  const earliestRequiredStart = new Date(Math.min(window.start.getTime(), window90.start.getTime()));
+  const [groups, incidents, uptime90, uptime30, historyIncidents, historyMaintenance] = ids.length
     ? await Promise.all([
         prisma.incident.groupBy({
           by: ['serviceId', 'urgency'],
@@ -153,41 +92,38 @@ export async function buildStatusPageSnapshot(
                 status: true,
                 urgency: true,
                 createdAt: true,
+                acknowledgedAt: true,
                 resolvedAt: true,
-                service: { select: { name: true, region: true } },
+                service: { select: { id: true, name: true, region: true } },
                 events: {
                   orderBy: { createdAt: 'asc' },
                   take: 50,
-                  select: { id: true, message: true, createdAt: true },
+                  select: { id: true, type: true, message: true, createdAt: true },
                 },
                 postmortem: { select: { status: true, isPublic: true } },
               },
             })
           : [],
-        visibility.showUptime ? calculateMultiServiceUptime(ids, window.start, now, 'PUBLIC') : {},
+        visibility.showUptime ? calculateMultiServiceUptime(ids, window90.start, now, 'PUBLIC') : {},
         visibility.showUptime
-          ? calculateMultiServiceUptime(ids, thirtyDayStart, now, 'PUBLIC')
+          ? calculateMultiServiceUptime(ids, window30.start, now, 'PUBLIC')
           : {},
-        visibility.showUptime
-          ? prisma.$queryRaw<Array<{ serviceId: string; date: Date; outage: boolean }>>`
-              SELECT i."serviceId", d.day AS date,
-                BOOL_OR(i.urgency = 'HIGH') AS outage
-              FROM generate_series(
-                date_trunc('day', ${window.start}::timestamp),
-                date_trunc('day', ${now}::timestamp),
-                interval '1 day'
-              ) AS d(day)
-              JOIN "Incident" i ON i."serviceId" IN (${Prisma.join(ids)})
-                AND i.visibility = 'PUBLIC'
-                AND i.status NOT IN ('SUPPRESSED', 'SNOOZED')
-                AND i."createdAt" < d.day + interval '1 day'
-                AND COALESCE(i."resolvedAt", ${now}) > d.day
-              GROUP BY i."serviceId", d.day
-              ORDER BY i."serviceId", d.day
-            `
-          : [],
+        visibility.showUptime ? prisma.incident.findMany({
+          where: {
+            serviceId: { in: ids }, visibility: 'PUBLIC', createdAt: { lte: now },
+            OR: [{ resolvedAt: { gte: earliestRequiredStart } }, { resolvedAt: null }],
+          },
+          select: { serviceId: true, createdAt: true, resolvedAt: true, urgency: true, status: true },
+        }) : [],
+        visibility.showUptime ? prisma.statusPageAnnouncement.findMany({
+          where: {
+            statusPageId: pageId, type: 'MAINTENANCE', startDate: { lte: now },
+            OR: [{ endDate: { gte: earliestRequiredStart } }, { endDate: null }],
+          },
+          select: { startDate: true, endDate: true, affectedServiceIds: true },
+        }) : [],
       ])
-    : [[], [], {}, {}, []];
+    : [[], [], {}, {}, [], []];
 
   const impactByService = new Map<string, { active: number; critical: boolean }>();
   for (const group of groups) {
@@ -198,46 +134,58 @@ export async function buildStatusPageSnapshot(
   }
 
   const maintenance = visibleMaintenanceServiceIds(page.announcements, ids, now);
+  const measuredDays30 = (now.getTime() - window30.start.getTime()) / 86_400_000;
+  const measuredDays90 = (now.getTime() - window90.start.getTime()) / 86_400_000;
+  const maintenanceHistory = historyMaintenance.map(item => ({
+    startDate: item.startDate,
+    endDate: item.endDate,
+    affectedServiceIds: Array.isArray(item.affectedServiceIds)
+      ? item.affectedServiceIds.filter((value): value is string => typeof value === 'string')
+      : [],
+  }));
+  const uptime30Values = uptime30 as Record<string, number>;
+  const uptime90Values = uptime90 as Record<string, number>;
   const services = page.services.map(mapping => {
     const impact = impactByService.get(mapping.serviceId);
     const state = impact?.critical ? 'MAJOR_OUTAGE' : impact?.active ? 'DEGRADED' : 'OPERATIONAL';
+    const history = visibility.showUptime ? buildPublicServiceHistory({
+      serviceId: mapping.serviceId,
+      incidents: historyIncidents,
+      maintenance: maintenanceHistory,
+      start: window.start,
+      end: now,
+    }).slice(-90) : undefined;
+    const status = normalizePublicStatus(projectServiceStatus(mapping.serviceId, state, maintenance));
     return {
       id: mapping.serviceId,
       name: mapping.displayName || mapping.service.name,
       ...(page.showServiceDescriptions ? { description: mapping.service.description } : {}),
-      ...(page.showServiceRegions ? { region: mapping.service.region } : {}),
+      ...(page.showServiceRegions && mapping.service.region
+        ? { regions: mapping.service.region.split(',').map(value => value.trim()).filter(Boolean) }
+        : {}),
       ...(visibility.showServiceSlaTier ? { slaTier: mapping.service.slaTier } : {}),
       ...(visibility.showTeam ? { team: mapping.service.team } : {}),
-      status: projectServiceStatus(mapping.serviceId, state, maintenance),
+      status,
       activeIncidentCount: impact?.active ?? 0,
+      ...(visibility.showUptime ? {
+        uptime: {
+          days30: {
+            percentage: measuredDays30 >= 30 ? (uptime30Values[mapping.serviceId] ?? null) : null,
+            incidentCount: historyIncidents.filter(item => item.serviceId === mapping.serviceId && item.createdAt <= now && (item.resolvedAt ?? now) >= window30.start).length,
+            measuredDays: Math.min(30, measuredDays30), complete: measuredDays30 >= 30,
+          },
+          days90: {
+            percentage: measuredDays90 >= 90 ? (uptime90Values[mapping.serviceId] ?? null) : null,
+            incidentCount: historyIncidents.filter(item => item.serviceId === mapping.serviceId && item.createdAt <= now && (item.resolvedAt ?? now) >= window90.start).length,
+            measuredDays: Math.min(90, measuredDays90), complete: measuredDays90 >= 90,
+          },
+        },
+        history,
+      } : {}),
     };
   });
-  const impactStates = Array.from(impactByService.values());
-
-  const statusHistory = visibility.showUptime ? Object.fromEntries(
-    ids.map(serviceId => {
-      const affected = new Map(
-        affectedHistoryDays
-          .filter(day => day.serviceId === serviceId)
-          .map(day => [
-            day.date.toISOString().slice(0, 10),
-            day.outage ? ('outage' as const) : ('degraded' as const),
-          ])
-      );
-      const cursor = new Date(window.start);
-      cursor.setUTCHours(0, 0, 0, 0);
-      const days: StatusHistoryDay[] = [];
-      while (cursor <= now) {
-        const date = cursor.toISOString().slice(0, 10);
-        days.push({ date, status: affected.get(date) ?? 'operational' });
-        cursor.setUTCDate(cursor.getUTCDate() + 1);
-      }
-      return [serviceId, days.slice(-90)];
-    })
-  ) as Record<string, StatusHistoryDay[]> : undefined;
-
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     pageId,
     revision,
     generatedAt: now.toISOString(),
@@ -266,16 +214,10 @@ export async function buildStatusPageSnapshot(
       statusApiRateLimitMax: page.statusApiRateLimitMax,
       statusApiRateLimitWindowSec: page.statusApiRateLimitWindowSec,
     },
-    status: projectOverallStatus(
-      impactStates.some(impact => impact.critical),
-      impactStates.some(impact => impact.active > 0),
-      maintenance
-    ),
+    status: getWorstPublicStatus(services.map(service => service.status)),
     services: visibility.showServices ? services : [],
+    regions: visibility.showServices ? aggregatePublicRegions(services) : [],
     incidents: incidents.map(incident => serializePublicStatusIncident(incident, page)),
-    uptime,
-    uptime30,
-    statusHistory,
     announcements: page.announcements
       .filter(item => item.startDate <= now && (!item.endDate || item.endDate > now))
       .map(item => ({
@@ -327,10 +269,19 @@ export async function rebuildStatusPageSnapshot(pageId: string) {
     enabled: true,
     revoked: false,
     snapshotKey: `${result.revision}.json`,
+    publishedAt: result.snapshot.generatedAt,
+    schemaVersion: result.snapshot.schemaVersion,
+    integrityHash: statusSnapshotIntegrity(result.snapshot as unknown as Prisma.JsonValue),
   });
   const slug = result.snapshot.page?.slug;
   if (slug) await store.publishRoute(slug, pageId);
   if (result.snapshot.page?.isDefault) await store.publishRoute('default', pageId);
+  if (result.snapshot.page.customDomain) {
+    await store.publishRoute(`domain:${result.snapshot.page.customDomain.toLowerCase()}`, pageId);
+  }
+  if (result.snapshot.page.subdomain) {
+    await store.publishRoute(`subdomain:${result.snapshot.page.subdomain.toLowerCase()}`, pageId);
+  }
   return true;
 }
 
@@ -397,17 +348,10 @@ export async function getStatusPageSnapshot(pageId: string): Promise<{
   const store = getStatusPageServingStore();
   const manifest = await store.readManifest(pageId);
   if (!manifest?.enabled || manifest.revoked) return { snapshot: null, stale: true };
-  const [revision] = await prisma.$queryRaw<
-    Array<{ revision: bigint; publishedRevision: bigint }>
-  >`SELECT "revision", "publishedRevision" FROM "StatusPageSnapshot" WHERE "statusPageId" = ${pageId}`;
-  if (
-    !revision ||
-    revision.revision !== revision.publishedRevision ||
-    manifest.revision !== revision.publishedRevision.toString()
-  ) {
+  const payload = await store.readSnapshot(pageId, manifest.revision);
+  if (!payload || statusSnapshotIntegrity(payload) !== manifest.integrityHash) {
     return { snapshot: null, stale: true };
   }
-  const payload = await store.readSnapshot(pageId, manifest.revision);
   const current = parseStatusPageSnapshot(pageId, payload);
   return current ? { snapshot: current, stale: false } : { snapshot: null, stale: true };
 }

--- a/src/lib/status-pages/snapshot.ts
+++ b/src/lib/status-pages/snapshot.ts
@@ -17,7 +17,7 @@ import {
   type StatusServingRoute,
 } from './serving-store';
 import type { PublicStatusPageSnapshot } from './public-contract';
-import { aggregatePublicRegions, buildPublicServiceHistory } from './history';
+import { aggregatePublicRegions, buildPublicHistorySegments } from './history';
 import {
   getWorstPublicStatus,
   normalizePublicStatus,
@@ -156,14 +156,18 @@ export async function buildStatusPageSnapshot(
       ? getWorstPublicStatus(impact.statuses)
       : 'OPERATIONAL';
     const serviceHistoryIncidents = historyIncidentsByService.get(mapping.serviceId) ?? [];
-    const history = visibility.showUptime ? buildPublicServiceHistory({
+    const history = visibility.showUptime ? {
+      rangeStart: window.start.toISOString(),
+      rangeEnd: now.toISOString(),
+      coverage: 'COMPLETE' as const,
+      segments: buildPublicHistorySegments({
       serviceId: mapping.serviceId,
       incidents: serviceHistoryIncidents,
       maintenance: maintenanceHistory,
-      timezone: page.timeZone,
       start: window.start,
       end: now,
-    }).slice(-90) : undefined;
+      }),
+    } : undefined;
     const status = normalizePublicStatus(projectServiceStatus(mapping.serviceId, state, maintenance));
     return {
       id: mapping.serviceId,
@@ -190,7 +194,6 @@ export async function buildStatusPageSnapshot(
           },
         },
         history,
-        historyComplete: true,
       } : {}),
     };
   });
@@ -203,7 +206,6 @@ export async function buildStatusPageSnapshot(
       id: page.id,
       name: page.name,
       organizationName: page.organizationName,
-      timeZone: page.timeZone,
       branding: page.branding,
       showSubscribe: page.showSubscribe,
       showServicesByRegion: page.showServicesByRegion,

--- a/src/lib/status-pages/snapshot.ts
+++ b/src/lib/status-pages/snapshot.ts
@@ -24,6 +24,7 @@ import {
   publicStatusForIncidentUrgency,
 } from './status-presentation';
 import { parsePublicStatusPageSnapshot } from './public-contract-schema';
+import { loadHistoryIncidentsByService, type HistoryIncident } from './history-query';
 
 export type StatusPageSnapshot = PublicStatusPageSnapshot;
 
@@ -73,7 +74,7 @@ export async function buildStatusPageSnapshot(
     getReportingWindowForDays(90, 'incident', now),
   ]);
   const earliestRequiredStart = new Date(Math.min(window.start.getTime(), window90.start.getTime()));
-  const [groups, incidents, uptime90, uptime30, historyIncidents, historyMaintenance] = ids.length
+  const [groups, incidents, uptime90, uptime30, historyIncidentsByService, historyMaintenance] = ids.length
     ? await Promise.all([
         prisma.incident.groupBy({
           by: ['serviceId', 'urgency'],
@@ -116,16 +117,9 @@ export async function buildStatusPageSnapshot(
         visibility.showUptime
           ? calculateMultiServiceUptime(ids, window30.start, now, 'PUBLIC')
           : {},
-        visibility.showUptime ? prisma.incident.findMany({
-          where: {
-            serviceId: { in: ids },
-            visibility: 'PUBLIC',
-            status: { notIn: ['SUPPRESSED', 'SNOOZED'] },
-            createdAt: { lt: now },
-            OR: [{ resolvedAt: { gte: earliestRequiredStart } }, { resolvedAt: null }],
-          },
-          select: { serviceId: true, createdAt: true, resolvedAt: true, urgency: true, status: true },
-        }) : [],
+        visibility.showUptime
+          ? loadHistoryIncidentsByService(ids, earliestRequiredStart, now)
+          : new Map<string, HistoryIncident[]>(),
         visibility.showUptime ? prisma.statusPageAnnouncement.findMany({
           where: {
             statusPageId: pageId, type: 'MAINTENANCE', startDate: { lte: now },
@@ -134,7 +128,7 @@ export async function buildStatusPageSnapshot(
           select: { startDate: true, endDate: true, affectedServiceIds: true },
         }) : [],
       ])
-    : [[], [], {}, {}, [], []];
+    : [[], [], {}, {}, new Map<string, HistoryIncident[]>(), []];
 
   const impactByService = new Map<string, { active: number; statuses: PublicStatusPageSnapshot['status'][] }>();
   for (const group of groups) {
@@ -142,15 +136,6 @@ export async function buildStatusPageSnapshot(
     current.active += group._count._all;
     current.statuses.push(publicStatusForIncidentUrgency(group.urgency));
     impactByService.set(group.serviceId, current);
-  }
-
-  // Partition once so each service only scans its own incidents while building
-  // daily history and 30/90-day counts.
-  const historyIncidentsByService = new Map<string, typeof historyIncidents>();
-  for (const incident of historyIncidents) {
-    const serviceIncidents = historyIncidentsByService.get(incident.serviceId) ?? [];
-    serviceIncidents.push(incident);
-    historyIncidentsByService.set(incident.serviceId, serviceIncidents);
   }
 
   const maintenance = visibleMaintenanceServiceIds(page.announcements, ids, now);
@@ -205,6 +190,7 @@ export async function buildStatusPageSnapshot(
           },
         },
         history,
+        historyComplete: true,
       } : {}),
     };
   });

--- a/src/lib/status-pages/snapshot.ts
+++ b/src/lib/status-pages/snapshot.ts
@@ -11,10 +11,18 @@ import { getReportingWindowForDays } from '@/lib/retention-policy';
 import { projectServiceStatus, visibleMaintenanceServiceIds } from '@/lib/status-page-projection';
 import { calculateMultiServiceUptime } from '@/lib/sla-server';
 import { addOperationalMetric, setOperationalGauge } from '@/lib/metrics/operational/registry';
-import { getStatusPageServingStore, statusSnapshotIntegrity } from './serving-store';
+import {
+  getStatusPageServingStore,
+  statusSnapshotIntegrity,
+  type StatusServingRoute,
+} from './serving-store';
 import type { PublicStatusPageSnapshot } from './public-contract';
 import { aggregatePublicRegions, buildPublicServiceHistory } from './history';
-import { getWorstPublicStatus, normalizePublicStatus } from './status-presentation';
+import {
+  getWorstPublicStatus,
+  normalizePublicStatus,
+  publicStatusForIncidentUrgency,
+} from './status-presentation';
 import { parsePublicStatusPageSnapshot } from './public-contract-schema';
 
 export type StatusPageSnapshot = PublicStatusPageSnapshot;
@@ -110,7 +118,10 @@ export async function buildStatusPageSnapshot(
           : {},
         visibility.showUptime ? prisma.incident.findMany({
           where: {
-            serviceId: { in: ids }, visibility: 'PUBLIC', createdAt: { lte: now },
+            serviceId: { in: ids },
+            visibility: 'PUBLIC',
+            status: { notIn: ['SUPPRESSED', 'SNOOZED'] },
+            createdAt: { lt: now },
             OR: [{ resolvedAt: { gte: earliestRequiredStart } }, { resolvedAt: null }],
           },
           select: { serviceId: true, createdAt: true, resolvedAt: true, urgency: true, status: true },
@@ -125,12 +136,21 @@ export async function buildStatusPageSnapshot(
       ])
     : [[], [], {}, {}, [], []];
 
-  const impactByService = new Map<string, { active: number; critical: boolean }>();
+  const impactByService = new Map<string, { active: number; statuses: PublicStatusPageSnapshot['status'][] }>();
   for (const group of groups) {
-    const current = impactByService.get(group.serviceId) || { active: 0, critical: false };
+    const current = impactByService.get(group.serviceId) || { active: 0, statuses: [] };
     current.active += group._count._all;
-    if (group.urgency === 'HIGH') current.critical = true;
+    current.statuses.push(publicStatusForIncidentUrgency(group.urgency));
     impactByService.set(group.serviceId, current);
+  }
+
+  // Partition once so each service only scans its own incidents while building
+  // daily history and 30/90-day counts.
+  const historyIncidentsByService = new Map<string, typeof historyIncidents>();
+  for (const incident of historyIncidents) {
+    const serviceIncidents = historyIncidentsByService.get(incident.serviceId) ?? [];
+    serviceIncidents.push(incident);
+    historyIncidentsByService.set(incident.serviceId, serviceIncidents);
   }
 
   const maintenance = visibleMaintenanceServiceIds(page.announcements, ids, now);
@@ -147,11 +167,15 @@ export async function buildStatusPageSnapshot(
   const uptime90Values = uptime90 as Record<string, number>;
   const services = page.services.map(mapping => {
     const impact = impactByService.get(mapping.serviceId);
-    const state = impact?.critical ? 'MAJOR_OUTAGE' : impact?.active ? 'DEGRADED' : 'OPERATIONAL';
+    const state = impact?.active
+      ? getWorstPublicStatus(impact.statuses)
+      : 'OPERATIONAL';
+    const serviceHistoryIncidents = historyIncidentsByService.get(mapping.serviceId) ?? [];
     const history = visibility.showUptime ? buildPublicServiceHistory({
       serviceId: mapping.serviceId,
-      incidents: historyIncidents,
+      incidents: serviceHistoryIncidents,
       maintenance: maintenanceHistory,
+      timezone: page.timeZone,
       start: window.start,
       end: now,
     }).slice(-90) : undefined;
@@ -171,12 +195,12 @@ export async function buildStatusPageSnapshot(
         uptime: {
           days30: {
             percentage: measuredDays30 >= 30 ? (uptime30Values[mapping.serviceId] ?? null) : null,
-            incidentCount: historyIncidents.filter(item => item.serviceId === mapping.serviceId && item.createdAt <= now && (item.resolvedAt ?? now) >= window30.start).length,
+            incidentCount: serviceHistoryIncidents.filter(item => item.createdAt <= now && (item.resolvedAt ?? now) >= window30.start).length,
             measuredDays: Math.min(30, measuredDays30), complete: measuredDays30 >= 30,
           },
           days90: {
             percentage: measuredDays90 >= 90 ? (uptime90Values[mapping.serviceId] ?? null) : null,
-            incidentCount: historyIncidents.filter(item => item.serviceId === mapping.serviceId && item.createdAt <= now && (item.resolvedAt ?? now) >= window90.start).length,
+            incidentCount: serviceHistoryIncidents.filter(item => item.createdAt <= now && (item.resolvedAt ?? now) >= window90.start).length,
             measuredDays: Math.min(90, measuredDays90), complete: measuredDays90 >= 90,
           },
         },
@@ -193,6 +217,7 @@ export async function buildStatusPageSnapshot(
       id: page.id,
       name: page.name,
       organizationName: page.organizationName,
+      timeZone: page.timeZone,
       branding: page.branding,
       showSubscribe: page.showSubscribe,
       showServicesByRegion: page.showServicesByRegion,
@@ -274,13 +299,19 @@ export async function rebuildStatusPageSnapshot(pageId: string) {
     integrityHash: statusSnapshotIntegrity(result.snapshot as unknown as Prisma.JsonValue),
   });
   const slug = result.snapshot.page?.slug;
-  if (slug) await store.publishRoute(slug, pageId);
-  if (result.snapshot.page?.isDefault) await store.publishRoute('default', pageId);
+  const route: StatusServingRoute = {
+    pageId,
+    slug: slug ?? null,
+    requireAuth: result.snapshot.page.requireAuth,
+    revision: result.revision,
+  };
+  if (slug) await store.publishRoute(slug, route);
+  if (result.snapshot.page?.isDefault) await store.publishRoute('default', route);
   if (result.snapshot.page.customDomain) {
-    await store.publishRoute(`domain:${result.snapshot.page.customDomain.toLowerCase()}`, pageId);
+    await store.publishRoute(`domain:${result.snapshot.page.customDomain.toLowerCase()}`, route);
   }
   if (result.snapshot.page.subdomain) {
-    await store.publishRoute(`subdomain:${result.snapshot.page.subdomain.toLowerCase()}`, pageId);
+    await store.publishRoute(`subdomain:${result.snapshot.page.subdomain.toLowerCase()}`, route);
   }
   return true;
 }
@@ -358,8 +389,8 @@ export async function getStatusPageSnapshot(pageId: string): Promise<{
 
 export async function getStatusPageSnapshotByRoute(routeKey: string) {
   const store = getStatusPageServingStore();
-  const pageId = await store.resolveRoute(routeKey || 'default');
-  return pageId
-    ? { pageId, ...(await getStatusPageSnapshot(pageId)) }
+  const route = await store.resolveRoute(routeKey || 'default');
+  return route
+    ? { pageId: route.pageId, ...(await getStatusPageSnapshot(route.pageId)) }
     : { pageId: null, snapshot: null, stale: true };
 }

--- a/src/lib/status-pages/status-presentation.ts
+++ b/src/lib/status-pages/status-presentation.ts
@@ -1,5 +1,15 @@
 import type { PublicServiceStatus } from './public-contract';
 
+/** Canonical product policy for projecting incident urgency onto every public status surface. */
+export function publicStatusForIncidentUrgency(urgency: string): PublicServiceStatus {
+  switch (urgency) {
+    case 'LOW': return 'DEGRADED';
+    case 'MEDIUM': return 'PARTIAL_OUTAGE';
+    case 'HIGH': return 'MAJOR_OUTAGE';
+    default: return 'UNKNOWN';
+  }
+}
+
 function statusRank(status: PublicServiceStatus): number {
   switch (status) {
     case 'OPERATIONAL': return 0;

--- a/src/lib/status-pages/status-presentation.ts
+++ b/src/lib/status-pages/status-presentation.ts
@@ -1,0 +1,39 @@
+import type { PublicServiceStatus } from './public-contract';
+
+const RANK: Record<PublicServiceStatus, number> = {
+  UNKNOWN: -1,
+  OPERATIONAL: 0,
+  MAINTENANCE: 1,
+  DEGRADED: 2,
+  PARTIAL_OUTAGE: 3,
+  MAJOR_OUTAGE: 4,
+};
+
+export const STATUS_PRESENTATION: Record<
+  PublicServiceStatus,
+  { label: string; token: string; icon: string }
+> = {
+  OPERATIONAL: { label: 'Operational', token: 'operational', icon: '✓' },
+  DEGRADED: { label: 'Degraded', token: 'degraded', icon: '⚠' },
+  MAINTENANCE: { label: 'Maintenance', token: 'maintenance', icon: '⚙' },
+  PARTIAL_OUTAGE: { label: 'Partial outage', token: 'partial-outage', icon: '◐' },
+  MAJOR_OUTAGE: { label: 'Major outage', token: 'major-outage', icon: '✕' },
+  UNKNOWN: { label: 'Status unknown', token: 'unknown', icon: '?' },
+};
+
+export function normalizePublicStatus(value: unknown): PublicServiceStatus {
+  return typeof value === 'string' && value in STATUS_PRESENTATION
+    ? (value as PublicServiceStatus)
+    : 'UNKNOWN';
+}
+
+export function getWorstPublicStatus(
+  statuses: readonly PublicServiceStatus[]
+): PublicServiceStatus {
+  if (statuses.length === 0) return 'UNKNOWN';
+  return statuses.reduce((worst, status) => (RANK[status] > RANK[worst] ? status : worst));
+}
+
+export function statusPresentation(status: PublicServiceStatus) {
+  return STATUS_PRESENTATION[status];
+}

--- a/src/lib/status-pages/status-presentation.ts
+++ b/src/lib/status-pages/status-presentation.ts
@@ -1,13 +1,15 @@
 import type { PublicServiceStatus } from './public-contract';
 
-const RANK: Record<PublicServiceStatus, number> = {
-  UNKNOWN: -1,
-  OPERATIONAL: 0,
-  MAINTENANCE: 1,
-  DEGRADED: 2,
-  PARTIAL_OUTAGE: 3,
-  MAJOR_OUTAGE: 4,
-};
+function statusRank(status: PublicServiceStatus): number {
+  switch (status) {
+    case 'OPERATIONAL': return 0;
+    case 'UNKNOWN': return 1;
+    case 'MAINTENANCE': return 2;
+    case 'DEGRADED': return 3;
+    case 'PARTIAL_OUTAGE': return 4;
+    case 'MAJOR_OUTAGE': return 5;
+  }
+}
 
 export const STATUS_PRESENTATION: Record<
   PublicServiceStatus,
@@ -22,18 +24,29 @@ export const STATUS_PRESENTATION: Record<
 };
 
 export function normalizePublicStatus(value: unknown): PublicServiceStatus {
-  return typeof value === 'string' && value in STATUS_PRESENTATION
-    ? (value as PublicServiceStatus)
-    : 'UNKNOWN';
+  switch (value) {
+    case 'OPERATIONAL': case 'DEGRADED': case 'MAINTENANCE':
+    case 'PARTIAL_OUTAGE': case 'MAJOR_OUTAGE': case 'UNKNOWN': return value;
+    default: return 'UNKNOWN';
+  }
 }
 
 export function getWorstPublicStatus(
   statuses: readonly PublicServiceStatus[]
 ): PublicServiceStatus {
   if (statuses.length === 0) return 'UNKNOWN';
-  return statuses.reduce((worst, status) => (RANK[status] > RANK[worst] ? status : worst));
+  return statuses.reduce((worst, status) => (
+    statusRank(status) > statusRank(worst) ? status : worst
+  ));
 }
 
 export function statusPresentation(status: PublicServiceStatus) {
-  return STATUS_PRESENTATION[status];
+  switch (status) {
+    case 'OPERATIONAL': return STATUS_PRESENTATION.OPERATIONAL;
+    case 'DEGRADED': return STATUS_PRESENTATION.DEGRADED;
+    case 'MAINTENANCE': return STATUS_PRESENTATION.MAINTENANCE;
+    case 'PARTIAL_OUTAGE': return STATUS_PRESENTATION.PARTIAL_OUTAGE;
+    case 'MAJOR_OUTAGE': return STATUS_PRESENTATION.MAJOR_OUTAGE;
+    case 'UNKNOWN': return STATUS_PRESENTATION.UNKNOWN;
+  }
 }

--- a/src/lib/status-pages/subscription-policy.ts
+++ b/src/lib/status-pages/subscription-policy.ts
@@ -1,0 +1,25 @@
+import type { StatusPageSubscriptionState } from '@prisma/client';
+
+export type SubscriptionRequestAction = 'ACCEPT' | 'REACTIVATE' | 'REFRESH_VERIFICATION';
+
+const VERIFICATION_RESEND_DELAY_MS = 60_000;
+
+export function subscriptionRequestAction(
+  state: StatusPageSubscriptionState,
+  subscribedAt: Date,
+  nowMs: number
+): SubscriptionRequestAction {
+  switch (state) {
+    case 'UNSUBSCRIBED':
+      return 'REACTIVATE';
+    case 'PENDING':
+      return nowMs - subscribedAt.getTime() < VERIFICATION_RESEND_DELAY_MS
+        ? 'ACCEPT'
+        : 'REFRESH_VERIFICATION';
+    case 'ACTIVE':
+    case 'COMPLAINED':
+    case 'SUPPRESSED':
+    case 'BOUNCED':
+      return 'ACCEPT';
+  }
+}

--- a/src/lib/status-pages/subscriptions.ts
+++ b/src/lib/status-pages/subscriptions.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { hashSubscriptionToken } from './subscription-tokens';
+import { subscriptionRequestAction } from './subscription-policy';
 import {
   getStatusPageLogoUrl,
   getStatusPagePublicUrl,
@@ -106,9 +107,17 @@ export async function subscribeStatusPageRequest(req: NextRequest) {
     });
 
     if (existing) {
-      if (existing.unsubscribedAt) {
-        await prisma.statusPageSubscription.update({
-          where: { id: existing.id },
+      const action = subscriptionRequestAction(existing.state, existing.subscribedAt, Date.now());
+      // Deliverability state is authoritative. Provider suppressions can arrive
+      // after an unsubscribe, so unsubscribedAt alone must never reactivate a
+      // complained, bounced, or suppressed address.
+      if (action === 'ACCEPT') {
+        return subscriptionAccepted();
+      }
+
+      if (action === 'REACTIVATE') {
+        const reactivated = await prisma.statusPageSubscription.updateMany({
+          where: { id: existing.id, state: 'UNSUBSCRIBED' },
           data: {
             unsubscribedAt: null,
             state: 'PENDING',
@@ -118,18 +127,19 @@ export async function subscribeStatusPageRequest(req: NextRequest) {
             verified: false,
           },
         });
-      } else if (existing.verified) {
-        return subscriptionAccepted();
-      } else if (Date.now() - existing.subscribedAt.getTime() < 60_000) {
-        return subscriptionAccepted();
+
+        // A provider callback may have applied a stronger suppression after the
+        // initial read. Preserve that state and avoid queueing verification.
+        if (reactivated.count === 0) return subscriptionAccepted();
       } else {
-        await prisma.statusPageSubscription.update({
-          where: { id: existing.id },
+        const refreshed = await prisma.statusPageSubscription.updateMany({
+          where: { id: existing.id, state: 'PENDING' },
           data: {
             token: hashSubscriptionToken(token),
             verificationToken: hashSubscriptionToken(verificationToken),
           },
         });
+        if (refreshed.count === 0) return subscriptionAccepted();
       }
     } else {
       await prisma.statusPageSubscription.create({

--- a/src/lib/status-pages/subscriptions.ts
+++ b/src/lib/status-pages/subscriptions.ts
@@ -111,6 +111,8 @@ export async function subscribeStatusPageRequest(req: NextRequest) {
           where: { id: existing.id },
           data: {
             unsubscribedAt: null,
+            state: 'PENDING',
+            suppressionReason: null,
             token: hashSubscriptionToken(token),
             verificationToken: hashSubscriptionToken(verificationToken),
             verified: false,
@@ -137,6 +139,7 @@ export async function subscribeStatusPageRequest(req: NextRequest) {
           token: hashSubscriptionToken(token),
           verificationToken: hashSubscriptionToken(verificationToken),
           verified: false,
+          state: 'PENDING',
         },
       });
     }

--- a/src/lib/status-pages/view-model.ts
+++ b/src/lib/status-pages/view-model.ts
@@ -18,7 +18,7 @@ export type StatusPageSnapshotPage = {
   isDefault?: boolean;
 };
 
-function snapshotIncidentEvents(value: unknown, generatedAt: string) {
+function snapshotIncidentEvents(value: unknown) {
   if (!Array.isArray(value)) return [];
   return value.flatMap((entry, index) => {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
@@ -28,8 +28,7 @@ function snapshotIncidentEvents(value: unknown, generatedAt: string) {
       {
         id: typeof event.id === 'string' ? event.id : `public-event-${index}`,
         message: event.message,
-        createdAt:
-          typeof event.createdAt === 'string' ? new Date(event.createdAt) : new Date(generatedAt),
+        createdAt: typeof event.createdAt === 'string' ? new Date(event.createdAt) : undefined,
       },
     ];
   });
@@ -41,6 +40,7 @@ export function createStatusPageViewModel(
 ) {
   const services = snapshot.services.map(service => ({
     ...service,
+    region: service.regions?.join(', ') ?? null,
     _count: { incidents: service.activeIncidentCount ?? 0 },
   }));
   return {
@@ -56,7 +56,7 @@ export function createStatusPageViewModel(
     incidents: snapshot.incidents.map((incident, index) => {
       const service =
         incident.service && typeof incident.service === 'object' && !Array.isArray(incident.service)
-          ? (incident.service as { name?: unknown; region?: unknown })
+          ? (incident.service as { name?: unknown; regions?: unknown })
           : {};
       return {
         id: typeof incident.id === 'string' ? incident.id : `public-${index}`,
@@ -64,17 +64,16 @@ export function createStatusPageViewModel(
         description: typeof incident.description === 'string' ? incident.description : null,
         status: typeof incident.status === 'string' ? incident.status : 'OPEN',
         urgency: typeof incident.urgency === 'string' ? incident.urgency : 'MEDIUM',
-        createdAt:
-          typeof incident.createdAt === 'string'
-            ? new Date(incident.createdAt)
-            : new Date(snapshot.generatedAt),
+        createdAt: typeof incident.createdAt === 'string' ? new Date(incident.createdAt) : undefined,
+        acknowledgedAt:
+          typeof incident.acknowledgedAt === 'string' ? new Date(incident.acknowledgedAt) : undefined,
         resolvedAt: typeof incident.resolvedAt === 'string' ? new Date(incident.resolvedAt) : null,
         service: {
           id: '',
           name: typeof service.name === 'string' ? service.name : 'Service',
-          region: typeof service.region === 'string' ? service.region : null,
+          region: Array.isArray(service.regions) ? service.regions.join(', ') : null,
         },
-        events: snapshotIncidentEvents(incident.events, snapshot.generatedAt),
+        events: snapshotIncidentEvents(incident.updates),
         postIncidentReview: incident.postIncidentReview === true,
       };
     }),
@@ -83,8 +82,12 @@ export function createStatusPageViewModel(
       startDate: new Date(item.startDate),
       endDate: item.endDate ? new Date(item.endDate) : null,
     })),
-    uptime: snapshot.uptime,
-    uptime30: snapshot.uptime30 ?? snapshot.uptime,
-    statusHistory: snapshot.statusHistory ?? {},
+    uptime: Object.fromEntries(snapshot.services.flatMap(service =>
+      service.uptime?.days90.percentage == null ? [] : [[service.id, service.uptime.days90.percentage]]
+    )),
+    uptime30: Object.fromEntries(snapshot.services.flatMap(service =>
+      service.uptime?.days30.percentage == null ? [] : [[service.id, service.uptime.days30.percentage]]
+    )),
+    statusHistory: Object.fromEntries(snapshot.services.map(service => [service.id, service.history ?? []])),
   };
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -168,6 +168,14 @@ export const StatusPageSettingsSchema = z
       .optional()
       .nullable(),
     organizationName: z.string().trim().max(200).optional().nullable(),
+    timeZone: z.string().trim().refine(value => {
+      try {
+        new Intl.DateTimeFormat('en-US', { timeZone: value }).format();
+        return true;
+      } catch {
+        return false;
+      }
+    }, 'Use a valid IANA timezone.').optional(),
     subdomain: statusPageHostname.optional().nullable(),
     customDomain: statusPageHostname.optional().nullable(),
     enabled: z.boolean().optional(),

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -168,14 +168,6 @@ export const StatusPageSettingsSchema = z
       .optional()
       .nullable(),
     organizationName: z.string().trim().max(200).optional().nullable(),
-    timeZone: z.string().trim().refine(value => {
-      try {
-        new Intl.DateTimeFormat('en-US', { timeZone: value }).format();
-        return true;
-      } catch {
-        return false;
-      }
-    }, 'Use a valid IANA timezone.').optional(),
     subdomain: statusPageHostname.optional().nullable(),
     customDomain: statusPageHostname.optional().nullable(),
     enabled: z.boolean().optional(),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -52,6 +52,10 @@ const CORS_ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || '')
   .map(value => value.trim())
   .filter(Boolean);
 const STATUS_DOMAIN_CACHE_TTL = Number(process.env.STATUS_PAGE_DOMAIN_CACHE_TTL || 60);
+const STATUS_ROUTE_POSITIVE_TTL_MS = 60_000;
+const STATUS_ROUTE_NEGATIVE_TTL_MS = 10_000;
+const STATUS_ROUTE_MAX_STALE_MS = 5 * 60_000;
+const STATUS_ROUTE_CACHE_MAX_ENTRIES = 1_000;
 
 function isPublicPath(pathname: string) {
   // Exact matches for public paths
@@ -92,7 +96,13 @@ function isStatusDomainPath(pathname: string) {
 
 function normalizeHostname(value?: string | null) {
   if (!value) return '';
-  return value.split(':')[0]?.trim().toLowerCase() || '';
+  const candidate = value.trim().toLowerCase().replace(/\.$/, '');
+  if (!candidate || candidate.length > 253 || /[^a-z0-9.:[\]-]/.test(candidate)) return '';
+  try {
+    return new URL(`http://${candidate}`).hostname.replace(/^\[|\]$/g, '');
+  } catch {
+    return '';
+  }
 }
 
 function parseHostname(value?: string | null) {
@@ -123,6 +133,14 @@ function buildSubdomainHost(subdomain: string, appHost: string) {
 const INTERNAL_API_BASE =
   process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
 
+function usesExternalStatusServingStore(): boolean {
+  return (
+    process.env.STATUS_PAGE_EXTERNAL_SERVING_STORE === 'true' &&
+    Boolean(process.env.STATUS_PAGE_SERVING_STORE_URL?.trim()) &&
+    Boolean(process.env.STATUS_PAGE_SERVING_STORE_TOKEN?.trim())
+  );
+}
+
 type StatusDomainPage = {
     id: string;
     slug?: string | null;
@@ -130,6 +148,12 @@ type StatusDomainPage = {
     subdomain?: string | null;
     customDomain?: string | null;
     requireAuth?: boolean;
+};
+type PublishedStatusRoute = {
+  pageId: string;
+  slug: string | null;
+  requireAuth: boolean;
+  revision: string;
 };
 type StatusDomainConfig = {
   enabled: boolean;
@@ -192,30 +216,116 @@ async function fetchStatusDomainConfig(): Promise<StatusDomainConfig | null> {
   return inflightStatusDomainFetch;
 }
 
-async function fetchPublishedStatusDomain(hostname: string): Promise<StatusDomainPage | null> {
+type CachedPublishedRoute = {
+  value: PublishedStatusRoute | null;
+  expiresAt: number;
+  staleUntil: number;
+};
+const publishedRouteCache = new Map<string, CachedPublishedRoute>();
+const publishedRouteInflight = new Map<string, Promise<PublishedStatusRoute | null>>();
+
+function cachePublishedRoute(routeKey: string, entry: CachedPublishedRoute): void {
+  if (!publishedRouteCache.has(routeKey) && publishedRouteCache.size >= STATUS_ROUTE_CACHE_MAX_ENTRIES) {
+    const oldestKey = publishedRouteCache.keys().next().value;
+    if (oldestKey) publishedRouteCache.delete(oldestKey);
+  }
+  publishedRouteCache.set(routeKey, entry);
+}
+
+function isSafeStatusSlug(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= 128 &&
+    value.split('-').every(part => part.length > 0 && /^[a-z0-9]+$/.test(part))
+  );
+}
+
+export function parsePublishedStatusRoute(value: unknown): PublishedStatusRoute | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).some(key => !['pageId', 'slug', 'requireAuth', 'revision'].includes(key))) {
+    return null;
+  }
+  const slug = record.slug === null ? null : record.slug;
+  if (
+    typeof record.pageId !== 'string' ||
+    !/^[A-Za-z0-9_-]{1,128}$/.test(record.pageId) ||
+    (typeof slug !== 'string' && slug !== null) ||
+    (typeof slug === 'string' && !isSafeStatusSlug(slug)) ||
+    typeof record.requireAuth !== 'boolean' ||
+    typeof record.revision !== 'string' ||
+    !/^[A-Za-z0-9._:-]{1,128}$/.test(record.revision)
+  ) {
+    return null;
+  }
+  return { pageId: record.pageId, slug, requireAuth: record.requireAuth, revision: record.revision };
+}
+
+export function externalRouteKey(hostname: string): string {
+  const appHostname = parseHostname(INTERNAL_API_BASE);
+  if (appHostname && hostname.endsWith(`.${appHostname}`)) {
+    const subdomain = hostname.slice(0, -(appHostname.length + 1));
+    if (isSafeStatusSlug(subdomain)) return `subdomain:${subdomain}`;
+  }
+  return `domain:${hostname}`;
+}
+
+export async function fetchPublishedStatusDomain(
+  hostname: string
+): Promise<PublishedStatusRoute | null> {
   const base = process.env.STATUS_PAGE_SERVING_STORE_URL?.trim();
   const token = process.env.STATUS_PAGE_SERVING_STORE_TOKEN?.trim();
   if (!base || !token || process.env.STATUS_PAGE_EXTERNAL_SERVING_STORE !== 'true') return null;
-  try {
-    const origin = new URL(base);
-    if (origin.protocol !== 'https:' || origin.username || origin.password) return null;
-    const storeBase = origin.pathname.endsWith('/') ? origin : new URL(`${origin.pathname}/`, origin);
-    const headers = { Authorization: `Bearer ${token}` };
-    const route = await fetch(new URL(`status-pages/routes/${encodeURIComponent(`domain:${hostname}`)}`, storeBase), { headers, cache: 'no-store', signal: AbortSignal.timeout(2000) });
-    if (!route.ok) return null;
-    const routeData = await route.json() as { pageId?: unknown };
-    if (typeof routeData.pageId !== 'string') return null;
-    const manifestResponse = await fetch(new URL(`status-pages/${routeData.pageId}/manifest`, storeBase), { headers, cache: 'no-store', signal: AbortSignal.timeout(2000) });
-    if (!manifestResponse.ok) return null;
-    const manifest = await manifestResponse.json() as { enabled?: unknown; revoked?: unknown; revision?: unknown };
-    if (manifest.enabled !== true || manifest.revoked === true || typeof manifest.revision !== 'string') return null;
-    const snapshotResponse = await fetch(new URL(`status-pages/${routeData.pageId}/${manifest.revision}.json`, storeBase), { headers, cache: 'no-store', signal: AbortSignal.timeout(2000) });
-    if (!snapshotResponse.ok) return null;
-    const snapshot = await snapshotResponse.json() as { page?: StatusDomainPage };
-    return snapshot.page ?? null;
-  } catch {
-    return null;
-  }
+  const routeKey = externalRouteKey(hostname);
+  const now = Date.now();
+  const cached = publishedRouteCache.get(routeKey);
+  if (cached && cached.expiresAt > now) return cached.value;
+  const inflight = publishedRouteInflight.get(routeKey);
+  if (inflight) return inflight;
+
+  const request = (async () => {
+    try {
+      const origin = new URL(base);
+      if (origin.protocol !== 'https:' || origin.username || origin.password) return null;
+      const storeBase = origin.pathname.endsWith('/') ? origin : new URL(`${origin.pathname}/`, origin);
+      const response = await fetch(
+        new URL(`status-pages/routes/${encodeURIComponent(routeKey)}`, storeBase),
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          cache: 'no-store',
+          signal: AbortSignal.timeout(2000),
+        }
+      );
+      if (!response.ok && response.status !== 404) throw new Error('Status route lookup failed');
+      const value = response.status === 404
+        ? null
+        : parsePublishedStatusRoute(await response.json());
+      if (response.status !== 404 && !value) throw new Error('Invalid status route payload');
+      const cachedAt = Date.now();
+      cachePublishedRoute(routeKey, {
+        value,
+        expiresAt: cachedAt + (value ? STATUS_ROUTE_POSITIVE_TTL_MS : STATUS_ROUTE_NEGATIVE_TTL_MS),
+        staleUntil: cachedAt + (value ? STATUS_ROUTE_MAX_STALE_MS : STATUS_ROUTE_NEGATIVE_TTL_MS),
+      });
+      return value;
+    } catch {
+      // Retain the last known route briefly when the serving store is unavailable.
+      if (cached?.value && cached.staleUntil > Date.now()) {
+        cachePublishedRoute(routeKey, {
+          value: cached.value,
+          expiresAt: Math.min(Date.now() + STATUS_ROUTE_NEGATIVE_TTL_MS, cached.staleUntil),
+          staleUntil: cached.staleUntil,
+        });
+        return cached.value;
+      }
+      publishedRouteCache.delete(routeKey);
+      return null;
+    } finally {
+      publishedRouteInflight.delete(routeKey);
+    }
+  })();
+  publishedRouteInflight.set(routeKey, request);
+  return request;
 }
 
 /**
@@ -299,9 +409,11 @@ export default async function middleware(req: NextRequest) {
       .at(-1);
     const hostname = normalizeHostname(forwardedHost || req.headers.get('host'));
     const publishedPage = hostname ? await fetchPublishedStatusDomain(hostname) : null;
-    const statusConfig = publishedPage ? { enabled: true, pages: [publishedPage] } : await fetchStatusDomainConfig();
+    const statusConfig = publishedPage || usesExternalStatusServingStore()
+      ? null
+      : await fetchStatusDomainConfig();
     if (statusConfig?.enabled) {
-      const matchedPage = publishedPage ?? statusConfig.pages?.find(page => {
+      const matchedPage = statusConfig.pages?.find(page => {
         const subdomainHost =
           page.subdomain && statusConfig.appHost
             ? buildSubdomainHost(page.subdomain, statusConfig.appHost)
@@ -325,6 +437,20 @@ export default async function middleware(req: NextRequest) {
         if (matchedPage.requireAuth) rewriteResponse.headers.set('Vary', 'Cookie');
         return rewriteResponse;
       }
+    }
+    if (hostname && publishedPage && isStatusDomainPath(pathname)) {
+      const url = req.nextUrl.clone();
+      const pageRoot = publishedPage.slug ? `/status/${publishedPage.slug}` : '/status';
+      url.pathname = pathname === '/' || pathname === '' ? pageRoot : `${pageRoot}${pathname}`;
+      const rewriteResponse = NextResponse.rewrite(url);
+      Object.entries(securityHeaders).forEach(([key, value]) => rewriteResponse.headers.set(key, value));
+      rewriteResponse.headers.set('x-request-id', requestId);
+      rewriteResponse.headers.set(
+        'Cache-Control',
+        publishedPage.requireAuth ? PRIVATE_STATUS_CACHE_CONTROL : PUBLIC_STATUS_CACHE_CONTROL
+      );
+      if (publishedPage.requireAuth) rewriteResponse.headers.set('Vary', 'Cookie');
+      return rewriteResponse;
     }
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -123,16 +123,17 @@ function buildSubdomainHost(subdomain: string, appHost: string) {
 const INTERNAL_API_BASE =
   process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
 
-type StatusDomainConfig = {
-  enabled: boolean;
-  pages?: Array<{
+type StatusDomainPage = {
     id: string;
     slug?: string | null;
     isDefault?: boolean;
     subdomain?: string | null;
     customDomain?: string | null;
     requireAuth?: boolean;
-  }>;
+};
+type StatusDomainConfig = {
+  enabled: boolean;
+  pages?: StatusDomainPage[];
   appHost?: string | null;
 };
 
@@ -189,6 +190,32 @@ async function fetchStatusDomainConfig(): Promise<StatusDomainConfig | null> {
   })();
 
   return inflightStatusDomainFetch;
+}
+
+async function fetchPublishedStatusDomain(hostname: string): Promise<StatusDomainPage | null> {
+  const base = process.env.STATUS_PAGE_SERVING_STORE_URL?.trim();
+  const token = process.env.STATUS_PAGE_SERVING_STORE_TOKEN?.trim();
+  if (!base || !token || process.env.STATUS_PAGE_EXTERNAL_SERVING_STORE !== 'true') return null;
+  try {
+    const origin = new URL(base);
+    if (origin.protocol !== 'https:' || origin.username || origin.password) return null;
+    const storeBase = origin.pathname.endsWith('/') ? origin : new URL(`${origin.pathname}/`, origin);
+    const headers = { Authorization: `Bearer ${token}` };
+    const route = await fetch(new URL(`status-pages/routes/${encodeURIComponent(`domain:${hostname}`)}`, storeBase), { headers, cache: 'no-store', signal: AbortSignal.timeout(2000) });
+    if (!route.ok) return null;
+    const routeData = await route.json() as { pageId?: unknown };
+    if (typeof routeData.pageId !== 'string') return null;
+    const manifestResponse = await fetch(new URL(`status-pages/${routeData.pageId}/manifest`, storeBase), { headers, cache: 'no-store', signal: AbortSignal.timeout(2000) });
+    if (!manifestResponse.ok) return null;
+    const manifest = await manifestResponse.json() as { enabled?: unknown; revoked?: unknown; revision?: unknown };
+    if (manifest.enabled !== true || manifest.revoked === true || typeof manifest.revision !== 'string') return null;
+    const snapshotResponse = await fetch(new URL(`status-pages/${routeData.pageId}/${manifest.revision}.json`, storeBase), { headers, cache: 'no-store', signal: AbortSignal.timeout(2000) });
+    if (!snapshotResponse.ok) return null;
+    const snapshot = await snapshotResponse.json() as { page?: StatusDomainPage };
+    return snapshot.page ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -264,16 +291,17 @@ export default async function middleware(req: NextRequest) {
     /\.(jpg|jpeg|png|webp|avif|gif|svg|ico|css|js|woff|woff2|ttf|eot|webmanifest)$/i.test(pathname);
 
   if (!skipDomainCheck) {
-    const statusConfig = await fetchStatusDomainConfig();
+    const forwardedHost = req.headers
+      .get('x-forwarded-host')
+      ?.split(',')
+      .map(value => value.trim())
+      .filter(Boolean)
+      .at(-1);
+    const hostname = normalizeHostname(forwardedHost || req.headers.get('host'));
+    const publishedPage = hostname ? await fetchPublishedStatusDomain(hostname) : null;
+    const statusConfig = publishedPage ? { enabled: true, pages: [publishedPage] } : await fetchStatusDomainConfig();
     if (statusConfig?.enabled) {
-      const forwardedHost = req.headers
-        .get('x-forwarded-host')
-        ?.split(',')
-        .map(value => value.trim())
-        .filter(Boolean)
-        .at(-1);
-      const hostname = normalizeHostname(forwardedHost || req.headers.get('host'));
-      const matchedPage = statusConfig.pages?.find(page => {
+      const matchedPage = publishedPage ?? statusConfig.pages?.find(page => {
         const subdomainHost =
           page.subdomain && statusConfig.appHost
             ? buildSubdomainHost(page.subdomain, statusConfig.appHost)

--- a/src/styles/pages/status-page.css
+++ b/src/styles/pages/status-page.css
@@ -22,6 +22,18 @@
 }
 
 .status-page-container {
+  --status-operational: #047857;
+  --status-operational-bg: #ecfdf5;
+  --status-degraded: #b45309;
+  --status-degraded-bg: #fffbeb;
+  --status-maintenance: #1d4ed8;
+  --status-maintenance-bg: #eff6ff;
+  --status-partial-outage: #c2410c;
+  --status-partial-outage-bg: #fff7ed;
+  --status-major-outage: #be123c;
+  --status-major-outage-bg: #fff1f2;
+  --status-unknown: #475569;
+  --status-unknown-bg: #f1f5f9;
   color: var(--status-text, #111827);
   background-color: var(--status-bg, #ffffff);
   font-family: var(--status-font-family, inherit);
@@ -37,6 +49,26 @@
   --status-panel-muted-bg: var(--sp-panel-muted-bg, color-mix(in srgb, #f8fafc 85%, var(--status-primary, #2563eb) 15%));
   --status-panel-muted-border: var(--sp-panel-muted-border, color-mix(in srgb, #e2e8f0 80%, var(--status-primary, #2563eb) 20%));
 }
+
+.public-service-health, .public-regions { display: grid; gap: 1rem; margin: 2rem 0; }
+.public-service-card, .public-region-card { position: relative; padding: 1rem; border: 1px solid var(--status-panel-border, #e2e8f0); border-radius: .75rem; background: var(--status-panel-bg, #fff); }
+.public-service-card__header, .public-region-card { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .75rem; }
+.status-badge { display: inline-flex; align-items: center; gap: .35rem; border: 1px solid currentColor; border-radius: 999px; padding: .25rem .6rem; font-weight: 700; }
+.status-operational { color: var(--status-operational); background: var(--status-operational-bg); }
+.status-degraded { color: var(--status-degraded); background: var(--status-degraded-bg); }
+.status-maintenance { color: var(--status-maintenance); background: var(--status-maintenance-bg); }
+.status-partial-outage { color: var(--status-partial-outage); background: var(--status-partial-outage-bg); }
+.status-major-outage { color: var(--status-major-outage); background: var(--status-major-outage-bg); }
+.status-unknown { color: var(--status-unknown); background: var(--status-unknown-bg); }
+.public-service-metrics { display: flex; flex-wrap: wrap; gap: 1.5rem; margin: .75rem 0; }
+.public-service-metrics dt { font-size: .75rem; color: var(--status-text-muted, #64748b); }
+.public-history { display: flex; align-items: center; gap: 2px; min-height: 2rem; overflow-x: auto; }
+.public-history__item { position: relative; flex: 1 0 4px; }
+.public-history__cell { width: 100%; min-width: 4px; height: 1.5rem; padding: 0; border: 0; border-radius: 2px; cursor: pointer; }
+.public-history__cell:focus-visible { outline: 3px solid currentColor; outline-offset: 2px; }
+.public-history__tooltip { position: absolute; z-index: 10; bottom: 2rem; left: 50%; transform: translateX(-50%); min-width: 18rem; display: grid; gap: .35rem; padding: .75rem; color: var(--status-text, #0f172a); background: var(--status-panel-bg, #fff); border: 1px solid var(--status-panel-border, #cbd5e1); border-radius: .5rem; box-shadow: 0 10px 30px rgba(15,23,42,.2); }
+.public-history__timeline { display: flex; height: .65rem; gap: 1px; }
+.public-history__timeline > span { min-width: 1px; }
 
 .status-page-button {
   padding: 0.4rem 0.75rem;

--- a/tests/api/provider-feedback-webhook.test.ts
+++ b/tests/api/provider-feedback-webhook.test.ts
@@ -1,0 +1,39 @@
+import { createHmac } from 'node:crypto';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ingest = vi.fn();
+vi.mock('@/lib/notification-provider-feedback', () => ({
+  ingestNotificationProviderFeedback: (...args: unknown[]) => ingest(...args),
+}));
+
+describe('provider feedback webhook', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    ingest.mockReset().mockResolvedValue({ processed: true, subscriptionId: 'sub-1' });
+    process.env.NOTIFICATION_PROVIDER_FEEDBACK_SECRET = 'test-feedback-secret';
+  });
+
+  it('authenticates and ingests a typed provider event', async () => {
+    const body = JSON.stringify({
+      provider: 'sendgrid', providerEventId: 'event-1', providerMessageId: 'message-1',
+      type: 'COMPLAINT', occurredAt: '2026-09-09T12:00:00.000Z',
+    });
+    const signature = createHmac('sha256', 'test-feedback-secret').update(body).digest('hex');
+    const { POST } = await import('@/app/api/webhooks/notifications/provider-feedback/route');
+    const response = await POST(new NextRequest('https://example.test/api/webhooks/notifications/provider-feedback', {
+      method: 'POST', body, headers: { 'x-opsknight-signature': `sha256=${signature}` },
+    }));
+    expect(response.status).toBe(202);
+    expect(ingest).toHaveBeenCalledWith(expect.objectContaining({ type: 'COMPLAINT' }));
+  });
+
+  it('rejects unsigned feedback', async () => {
+    const { POST } = await import('@/app/api/webhooks/notifications/provider-feedback/route');
+    const response = await POST(new NextRequest('https://example.test/api/webhooks/notifications/provider-feedback', {
+      method: 'POST', body: '{}',
+    }));
+    expect(response.status).toBe(401);
+    expect(ingest).not.toHaveBeenCalled();
+  });
+});

--- a/tests/architecture/status-page-admin-isolation-contract.test.ts
+++ b/tests/architecture/status-page-admin-isolation-contract.test.ts
@@ -47,6 +47,18 @@ describe('status-page administration isolation contract', () => {
     expect(migration).toContain('WHERE "isDefault" = true');
   });
 
+  it('publishes a replacement default before revoking the deleted page', () => {
+    const service = fs.readFileSync('src/lib/status-pages/admin.ts', 'utf8');
+    const publishReplacement = service.indexOf('rebuildStatusPageSnapshot(replacementId)');
+    const revokeDeleted = service.indexOf('store.revoke(statusPageId)');
+
+    expect(publishReplacement).toBeGreaterThan(-1);
+    expect(revokeDeleted).toBeGreaterThan(publishReplacement);
+    expect(service).toContain('The replacement default status page must be public.');
+    expect(service).toContain('page.isDefault && !replacementId');
+    expect(service.lastIndexOf('data: { enabled: false }')).toBeGreaterThan(revokeDeleted);
+  });
+
   it('cancels stale page-owned resource requests after navigation', () => {
     const subscribers = fs.readFileSync(
       'src/components/status-page/StatusPageSubscribers.tsx',

--- a/tests/architecture/status-platform-migration-safety.test.ts
+++ b/tests/architecture/status-platform-migration-safety.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('status platform migration safety', () => {
+  it('builds indexes on existing hot tables without blocking writes', () => {
+    const migration = fs.readFileSync(
+      'prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql',
+      'utf8'
+    );
+
+    expect(migration).toContain(
+      'CREATE INDEX CONCURRENTLY "idx_notification_tenant_fair_delivery"'
+    );
+    expect(migration).toContain(
+      'CREATE INDEX CONCURRENTLY "StatusPageSubscription_statusPageId_state_idx"'
+    );
+  });
+});

--- a/tests/architecture/status-platform-migration-safety.test.ts
+++ b/tests/architecture/status-platform-migration-safety.test.ts
@@ -2,17 +2,22 @@ import fs from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 describe('status platform migration safety', () => {
-  it('builds indexes on existing hot tables without blocking writes', () => {
+  it('keeps concurrent index creation outside the transactional migration', () => {
     const migration = fs.readFileSync(
       'prisma/migrations/20260909173000_status_platform_enterprise_contract/migration.sql',
       'utf8'
     );
-
-    expect(migration).toContain(
-      'CREATE INDEX CONCURRENTLY "idx_notification_tenant_fair_delivery"'
+    const onlineInstaller = fs.readFileSync(
+      'scripts/create-status-platform-online-indexes.cjs',
+      'utf8'
     );
-    expect(migration).toContain(
-      'CREATE INDEX CONCURRENTLY "StatusPageSubscription_statusPageId_state_idx"'
+
+    expect(migration).not.toContain('CREATE INDEX CONCURRENTLY');
+    expect(onlineInstaller).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_notification_tenant_fair_delivery"'
+    );
+    expect(onlineInstaller).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "StatusPageSubscription_statusPageId_state_idx"'
     );
   });
 });

--- a/tests/components/PublicStatusServices.test.tsx
+++ b/tests/components/PublicStatusServices.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import PublicStatusServices from '@/components/status-page/PublicStatusServices';
+import type { PublicStatusService } from '@/lib/status-pages/public-contract';
+
+const services: PublicStatusService[] = [{
+  id: 'service-1',
+  name: 'API',
+  status: 'OPERATIONAL',
+  activeIncidentCount: 0,
+  history: [{
+    date: '2026-09-09',
+    status: 'DEGRADED',
+    availabilityPercent: 99.5,
+    incidentCount: 1,
+  }],
+}];
+
+describe('PublicStatusServices history interaction', () => {
+  it('opens once for a pointer click and exposes a stable tooltip relationship', () => {
+    render(<PublicStatusServices services={services} />);
+    const cell = screen.getByRole('button', { name: /2026-09-09, API/i });
+
+    fireEvent.pointerDown(cell);
+    fireEvent.focus(cell);
+    fireEvent.click(cell);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(cell).toHaveAttribute('aria-expanded', 'true');
+    expect(cell).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(tooltip.id).toBe('status-history-service-1-2026-09-09');
+
+    fireEvent.pointerDown(cell);
+    fireEvent.click(cell);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(cell).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('opens history details when reached by keyboard focus', () => {
+    render(<PublicStatusServices services={services} />);
+    const cell = screen.getByRole('button', { name: /2026-09-09, API/i });
+
+    fireEvent.focus(cell);
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(cell).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/tests/components/PublicStatusServices.test.tsx
+++ b/tests/components/PublicStatusServices.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import PublicStatusServices from '@/components/status-page/PublicStatusServices';
+import { buildPublicHistoryDays } from '@/lib/status-pages/history-presentation';
 import type { PublicStatusService } from '@/lib/status-pages/public-contract';
 
 const services: PublicStatusService[] = [{
@@ -8,12 +9,16 @@ const services: PublicStatusService[] = [{
   name: 'API',
   status: 'OPERATIONAL',
   activeIncidentCount: 0,
-  history: [{
-    date: '2026-09-09',
-    status: 'DEGRADED',
-    availabilityPercent: 99.5,
-    incidentCount: 1,
-  }],
+  history: {
+    rangeStart: '2026-09-09T00:00:00.000Z',
+    rangeEnd: '2026-09-10T00:00:00.000Z',
+    coverage: 'COMPLETE',
+    segments: [{
+      startAt: '2026-09-09T10:00:00.000Z',
+      endAt: '2026-09-09T10:30:00.000Z',
+      status: 'DEGRADED',
+    }],
+  },
 }];
 
 describe('PublicStatusServices history interaction', () => {
@@ -44,5 +49,65 @@ describe('PublicStatusServices history interaction', () => {
 
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
     expect(cell).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+describe('browser-local status history', () => {
+  const history = {
+    rangeStart: '2026-09-08T00:00:00.000Z',
+    rangeEnd: '2026-09-10T00:00:00.000Z',
+    coverage: 'COMPLETE' as const,
+    segments: [{
+      startAt: '2026-09-08T20:00:00.000Z',
+      endAt: '2026-09-08T21:00:00.000Z',
+      status: 'DEGRADED' as const,
+    }],
+  };
+
+  it('assigns UTC segments to Kolkata calendar days', () => {
+    const days = buildPublicHistoryDays(history, 'Asia/Kolkata');
+
+    expect(days.find(day => day.status === 'DEGRADED')).toMatchObject({
+      date: '2026-09-09',
+      incidentCount: 1,
+    });
+  });
+
+  it('assigns the same UTC segments to New York calendar days', () => {
+    const days = buildPublicHistoryDays(history, 'America/New_York');
+
+    expect(days.find(day => day.status === 'DEGRADED')).toMatchObject({
+      date: '2026-09-08',
+      incidentCount: 1,
+    });
+  });
+
+  it('uses the real 25-hour New York day across the DST fallback', () => {
+    const days = buildPublicHistoryDays({
+      rangeStart: '2026-11-01T04:00:00.000Z',
+      rangeEnd: '2026-11-02T05:00:00.000Z',
+      coverage: 'COMPLETE',
+      segments: [{
+        startAt: '2026-11-01T05:30:00.000Z',
+        endAt: '2026-11-01T06:30:00.000Z',
+        status: 'DEGRADED',
+      }],
+    }, 'America/New_York');
+
+    expect(days).toHaveLength(1);
+    expect(days[0]).toMatchObject({ date: '2026-11-01', availabilityPercent: 96 });
+    expect(days[0]?.timeline?.at(-1)?.endMinute).toBe(1500);
+  });
+
+  it('renders unknown gaps when source history coverage is partial', () => {
+    const days = buildPublicHistoryDays({
+      rangeStart: '2026-09-09T00:00:00.000Z',
+      rangeEnd: '2026-09-10T00:00:00.000Z',
+      coverage: 'PARTIAL',
+      segments: [],
+    }, 'Asia/Kolkata');
+
+    expect(days.every(day => day.status === 'UNKNOWN')).toBe(true);
+    expect(days.every(day => day.availabilityPercent === null)).toBe(true);
   });
 });

--- a/tests/components/status-page-snapshot-view.test.tsx
+++ b/tests/components/status-page-snapshot-view.test.tsx
@@ -17,7 +17,7 @@ const snapshot: StatusPageSnapshot = {
   generatedAt: '2026-09-07T10:00:00.000Z',
   status: 'DEGRADED',
   page: {
-    id: 'page-1', name: 'Acme status', timeZone: 'UTC', showSubscribe: false, showServicesByRegion: false,
+    id: 'page-1', name: 'Acme status', showSubscribe: false, showServicesByRegion: false,
     showRegionHeatmap: false, showPostIncidentReview: true, showChangelog: true,
     enableUptimeExports: true, isDefault: true, requireAuth: false, enabled: true,
     statusApiRequireToken: false, statusApiRateLimitEnabled: false,

--- a/tests/components/status-page-snapshot-view.test.tsx
+++ b/tests/components/status-page-snapshot-view.test.tsx
@@ -17,7 +17,7 @@ const snapshot: StatusPageSnapshot = {
   generatedAt: '2026-09-07T10:00:00.000Z',
   status: 'DEGRADED',
   page: {
-    id: 'page-1', name: 'Acme status', showSubscribe: false, showServicesByRegion: false,
+    id: 'page-1', name: 'Acme status', timeZone: 'UTC', showSubscribe: false, showServicesByRegion: false,
     showRegionHeatmap: false, showPostIncidentReview: true, showChangelog: true,
     enableUptimeExports: true, isDefault: true, requireAuth: false, enabled: true,
     statusApiRequireToken: false, statusApiRateLimitEnabled: false,

--- a/tests/components/status-page-snapshot-view.test.tsx
+++ b/tests/components/status-page-snapshot-view.test.tsx
@@ -11,20 +11,32 @@ vi.mock('@/components/status-page/StatusPageAutoRefresh', () => ({
 }));
 
 const snapshot: StatusPageSnapshot = {
-  schemaVersion: 1,
+  schemaVersion: 3,
   pageId: 'page-1',
   revision: '7',
   generatedAt: '2026-09-07T10:00:00.000Z',
-  status: 'degraded',
+  status: 'DEGRADED',
+  page: {
+    id: 'page-1', name: 'Acme status', showSubscribe: false, showServicesByRegion: false,
+    showRegionHeatmap: false, showPostIncidentReview: true, showChangelog: true,
+    enableUptimeExports: true, isDefault: true, requireAuth: false, enabled: true,
+    statusApiRequireToken: false, statusApiRateLimitEnabled: false,
+    statusApiRateLimitMax: 120, statusApiRateLimitWindowSec: 60,
+  },
   services: [
     {
       id: 'service-1',
       name: 'Payments',
       description: 'Payment processing',
-      region: 'eu-west-1',
+      regions: ['eu-west-1'],
       slaTier: 'TIER_1',
       team: { id: 'team-1', name: 'Payments team' },
       status: 'DEGRADED',
+      activeIncidentCount: 1,
+      uptime: {
+        days30: { percentage: 99.95, incidentCount: 1, measuredDays: 30, complete: true },
+        days90: { percentage: 99.95, incidentCount: 1, measuredDays: 90, complete: true },
+      },
     },
   ],
   incidents: [
@@ -35,10 +47,14 @@ const snapshot: StatusPageSnapshot = {
       status: 'OPEN',
       urgency: 'HIGH',
       createdAt: '2026-09-07T09:00:00.000Z',
-      service: { name: 'Payments', region: 'eu-west-1' },
+      service: { name: 'Payments', regions: ['eu-west-1'] },
     },
   ],
-  uptime: { 'service-1': 99.95 },
+  regions: [{
+    name: 'eu-west-1', status: 'DEGRADED', totalServices: 1, operationalServices: 0,
+    degradedServices: 1, maintenanceServices: 0, partialOutageServices: 0,
+    majorOutageServices: 0, unknownServices: 0, impactedServices: 1, serviceIds: ['service-1'],
+  }],
   announcements: [],
   historyDays: 30,
 };
@@ -71,7 +87,7 @@ describe('StatusPageSnapshotView publication parity', () => {
         snapshot={{
           ...snapshot,
           incidents: [{ status: 'OPEN' }],
-          services: [{ id: 'service-1', name: 'Payments', status: 'OPERATIONAL' }],
+          services: [{ id: 'service-1', name: 'Payments', status: 'OPERATIONAL', activeIncidentCount: 0 }],
         }}
         stale={false}
       />

--- a/tests/integration/status-page-subscription.test.ts
+++ b/tests/integration/status-page-subscription.test.ts
@@ -44,7 +44,10 @@ vi.mock('@/lib/notification-providers', async importOriginal => {
 
 import { getServerSession } from 'next-auth';
 import { sendEmail } from '@/lib/email';
-import { processCentralNotificationQueue } from '@/lib/notification-control-plane';
+import {
+  createCentralNotificationIntent,
+  processCentralNotificationQueue,
+} from '@/lib/notification-control-plane';
 import { ingestNotificationProviderFeedback } from '@/lib/notification-provider-feedback';
 
 describeIfRealDB('Status Page Subscription Integration', () => {
@@ -151,14 +154,27 @@ describeIfRealDB('Status Page Subscription Integration', () => {
         unsubscribedAt,
         verified: false,
       });
-      await testPrisma.notification.create({
-        data: {
-          channel: 'EMAIL',
-          category: 'STATUS_PAGE',
-          recipientType: 'SUBSCRIBER',
-          recipientId: sub.id,
-          providerMessageId: 'provider-message-delayed-complaint',
+      const notification = await createCentralNotificationIntent({
+        category: 'STATUS_PAGE',
+        channel: 'EMAIL',
+        recipientType: 'SUBSCRIBER',
+        recipientId: sub.id,
+        recipientAddress: 'complaint@example.com',
+        templateKey: 'status-page-update',
+        sourceType: 'STATUS_PAGE',
+        sourceId: sp.id,
+        eventKey: 'delayed-complaint',
+        displayMessage: 'Status page update',
+        payload: {
+          kind: 'EMAIL',
+          to: 'complaint@example.com',
+          subject: 'Status page update',
+          html: '<p>Status page update</p>',
         },
+      });
+      await testPrisma.notification.update({
+        where: { id: notification.id },
+        data: { providerMessageId: 'provider-message-delayed-complaint' },
       });
       const complainedAt = new Date('2026-09-09T09:05:00.000Z');
 

--- a/tests/integration/status-page-subscription.test.ts
+++ b/tests/integration/status-page-subscription.test.ts
@@ -45,6 +45,7 @@ vi.mock('@/lib/notification-providers', async importOriginal => {
 import { getServerSession } from 'next-auth';
 import { sendEmail } from '@/lib/email';
 import { processCentralNotificationQueue } from '@/lib/notification-control-plane';
+import { ingestNotificationProviderFeedback } from '@/lib/notification-provider-feedback';
 
 describeIfRealDB('Status Page Subscription Integration', () => {
   beforeAll(() => {
@@ -88,6 +89,7 @@ describeIfRealDB('Status Page Subscription Integration', () => {
       const sub = await createTestStatusPageSubscription(sp.id, 'user@example.com', {
         unsubscribedAt: new Date(),
         verified: true,
+        state: 'UNSUBSCRIBED',
       });
 
       const req = new Request('http://localhost/api/status-page/subscribe', {
@@ -103,6 +105,173 @@ describeIfRealDB('Status Page Subscription Integration', () => {
       });
       expect(updatedSub?.unsubscribedAt).toBeNull();
       expect(updatedSub?.verified).toBe(false);
+      expect(updatedSub?.state).toBe('PENDING');
+      expect(updatedSub?.suppressionReason).toBeNull();
+    });
+
+    it.each(['COMPLAINED', 'SUPPRESSED', 'BOUNCED'] as const)(
+      'does not automatically reactivate a %s subscriber',
+      async state => {
+        const sp = await createTestStatusPage();
+        const unsubscribedAt = new Date('2026-09-09T09:00:00.000Z');
+        const sub = await createTestStatusPageSubscription(sp.id, 'blocked@example.com', {
+          state,
+          unsubscribedAt,
+          suppressionReason: `provider:${state.toLowerCase()}`,
+          verified: false,
+        });
+
+        const res = await POST(
+          new Request('http://localhost/api/status-page/subscribe', {
+            method: 'POST',
+            body: JSON.stringify({ statusPageId: sp.id, email: 'blocked@example.com' }),
+          }) as NextRequest
+        );
+
+        expect(res.status).toBe(200);
+        expect(await testPrisma.statusPageSubscription.findUnique({ where: { id: sub.id } })).toMatchObject({
+          state,
+          unsubscribedAt,
+          suppressionReason: `provider:${state.toLowerCase()}`,
+          verified: false,
+        });
+        expect(
+          await testPrisma.notification.count({
+            where: { recipientType: 'SUBSCRIBER', recipientId: sub.id },
+          })
+        ).toBe(0);
+      }
+    );
+
+    it('preserves a delayed complaint received after unsubscribe', async () => {
+      const sp = await createTestStatusPage();
+      const unsubscribedAt = new Date('2026-09-09T09:00:00.000Z');
+      const sub = await createTestStatusPageSubscription(sp.id, 'complaint@example.com', {
+        state: 'UNSUBSCRIBED',
+        unsubscribedAt,
+        verified: false,
+      });
+      await testPrisma.notification.create({
+        data: {
+          channel: 'EMAIL',
+          category: 'STATUS_PAGE',
+          recipientType: 'SUBSCRIBER',
+          recipientId: sub.id,
+          providerMessageId: 'provider-message-delayed-complaint',
+        },
+      });
+      const complainedAt = new Date('2026-09-09T09:05:00.000Z');
+
+      await ingestNotificationProviderFeedback({
+        provider: 'test-provider',
+        providerEventId: 'delayed-complaint-event',
+        providerMessageId: 'provider-message-delayed-complaint',
+        type: 'COMPLAINT',
+        occurredAt: complainedAt,
+      });
+      const res = await POST(
+        new Request('http://localhost/api/status-page/subscribe', {
+          method: 'POST',
+          body: JSON.stringify({ statusPageId: sp.id, email: 'complaint@example.com' }),
+        }) as NextRequest
+      );
+
+      expect(res.status).toBe(200);
+      expect(await testPrisma.statusPageSubscription.findUnique({ where: { id: sub.id } })).toMatchObject({
+        state: 'COMPLAINED',
+        unsubscribedAt,
+        suppressionReason: 'COMPLAINT',
+        complainedAt,
+        verified: false,
+      });
+      expect(
+        await testPrisma.notification.count({
+          where: {
+            recipientType: 'SUBSCRIBER',
+            recipientId: sub.id,
+            templateKey: 'status-page-verification',
+          },
+        })
+      ).toBe(0);
+    });
+
+    it('keeps an active subscriber active without queueing verification', async () => {
+      const sp = await createTestStatusPage();
+      const sub = await createTestStatusPageSubscription(sp.id, 'active@example.com', {
+        state: 'ACTIVE',
+        verified: true,
+      });
+
+      const res = await POST(
+        new Request('http://localhost/api/status-page/subscribe', {
+          method: 'POST',
+          body: JSON.stringify({ statusPageId: sp.id, email: 'active@example.com' }),
+        }) as NextRequest
+      );
+
+      expect(res.status).toBe(200);
+      expect(await testPrisma.statusPageSubscription.findUnique({ where: { id: sub.id } })).toMatchObject({
+        state: 'ACTIVE',
+        verified: true,
+      });
+      expect(
+        await testPrisma.notification.count({ where: { recipientId: sub.id } })
+      ).toBe(0);
+    });
+
+    it('does not resend verification for a recently created pending subscriber', async () => {
+      const sp = await createTestStatusPage();
+      const sub = await createTestStatusPageSubscription(sp.id, 'recent@example.com', {
+        state: 'PENDING',
+        verified: false,
+        subscribedAt: new Date(),
+      });
+
+      const res = await POST(
+        new Request('http://localhost/api/status-page/subscribe', {
+          method: 'POST',
+          body: JSON.stringify({ statusPageId: sp.id, email: 'recent@example.com' }),
+        }) as NextRequest
+      );
+
+      expect(res.status).toBe(200);
+      expect(
+        await testPrisma.notification.count({ where: { recipientId: sub.id } })
+      ).toBe(0);
+    });
+
+    it('refreshes verification for an expired pending subscriber', async () => {
+      const sp = await createTestStatusPage();
+      const oldVerificationToken = hashSubscriptionToken('old-verification-token');
+      const sub = await createTestStatusPageSubscription(sp.id, 'pending@example.com', {
+        state: 'PENDING',
+        verified: false,
+        subscribedAt: new Date(Date.now() - 61_000),
+        verificationToken: oldVerificationToken,
+      });
+
+      const res = await POST(
+        new Request('http://localhost/api/status-page/subscribe', {
+          method: 'POST',
+          body: JSON.stringify({ statusPageId: sp.id, email: 'pending@example.com' }),
+        }) as NextRequest
+      );
+
+      expect(res.status).toBe(200);
+      const updatedSub = await testPrisma.statusPageSubscription.findUnique({
+        where: { id: sub.id },
+      });
+      expect(updatedSub).toMatchObject({ state: 'PENDING', verified: false });
+      expect(updatedSub?.verificationToken).not.toBe(oldVerificationToken);
+      expect(
+        await testPrisma.notification.count({
+          where: {
+            recipientType: 'SUBSCRIBER',
+            recipientId: sub.id,
+            templateKey: 'status-page-verification',
+          },
+        })
+      ).toBe(1);
     });
   });
 

--- a/tests/lib/deployment-config-unit.test.ts
+++ b/tests/lib/deployment-config-unit.test.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 
+/* eslint-disable security/detect-non-literal-fs-filename, security/detect-non-literal-regexp -- Deployment contract tests inspect a fixed repository-local file set. */
+
 const root = process.cwd();
 const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
 
@@ -75,6 +77,26 @@ describe('deployment configuration invariants', () => {
     expect(entrypoint).toContain('Refusing to start against an unknown database schema');
     expect(entrypoint).toMatch(/MIGRATION_SUCCESS=0[\s\S]*exit 1/);
     expect(entrypoint).toContain('scripts/dist/scripts/auto-recover-migrations.js');
+    expect(entrypoint).toMatch(
+      /MIGRATION_SUCCESS[\s\S]*install_status_platform_indexes[\s\S]*Starting application/
+    );
+    expect(entrypoint).toContain(
+      'Refusing to start without required indexes'
+    );
+    expect(read('.github/workflows/tests.yml')).toMatch(
+      /prisma migrate deploy[\s\S]*prisma:indexes:status-platform/
+    );
+    expect(read('.github/workflows/docker-image.yml')).toMatch(
+      /prisma migrate deploy[\s\S]*prisma:indexes:status-platform/
+    );
+    expect(read('package.json')).toContain(
+      'prisma migrate deploy && npm run prisma:indexes:status-platform'
+    );
+    const onlineIndexes = read('scripts/create-status-platform-online-indexes.cjs');
+    expect(onlineIndexes).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
+    expect(onlineIndexes).toContain("searchParams.set('connection_limit', '1')");
+    expect(onlineIndexes).toContain('pg_advisory_lock');
+    expect(onlineIndexes).toContain('pg_advisory_unlock');
     expect(read('package.json')).toContain(
       'scripts/auto-recover-migrations.ts --rootDir . --outDir scripts/dist'
     );

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -440,7 +440,9 @@ describe('central notification control plane', () => {
       values?: readonly unknown[];
     };
     const sql = queueQuery.strings?.join('?') ?? '';
-    expect(sql).toContain('CASE "trafficClass"');
+    expect(sql).toContain('CASE ranked."trafficClass"');
+    expect(sql).toContain('PARTITION BY "trafficClass", "tenantKey"');
+    expect(sql).toContain('tenant_rank <=');
     expect(sql).toContain("WHEN 'CRITICAL'");
     expect(sql).toContain("WHEN 'PUBLIC_INCIDENT'");
     expect(sql).toContain('ELSE');

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -152,6 +152,13 @@ describe('central notification control plane', () => {
     expect(prisma.notification.create).not.toHaveBeenCalled();
   });
 
+  it('rejects malformed runtime input before accessing typed fields', async () => {
+    await expect(
+      createCentralNotificationIntent({ ...input, sourceType: 42 } as never)
+    ).rejects.toThrow('Notification input is invalid');
+    expect(prisma.notification.create).not.toHaveBeenCalled();
+  });
+
   it('derives recipient identity from the existing session secret, not a new setting', async () => {
     const previousSessionSecret = process.env.NEXTAUTH_SECRET;
     const previousIdentitySecret = process.env.NOTIFICATION_IDENTITY_KEY;

--- a/tests/lib/notification-control-plane.test.ts
+++ b/tests/lib/notification-control-plane.test.ts
@@ -443,6 +443,7 @@ describe('central notification control plane', () => {
     expect(sql).toContain('CASE ranked."trafficClass"');
     expect(sql).toContain('PARTITION BY "trafficClass", "tenantKey"');
     expect(sql).toContain('tenant_rank <=');
+    expect(sql).not.toContain('WHERE ranked.tenant_rank <=');
     expect(sql).toContain("WHEN 'CRITICAL'");
     expect(sql).toContain("WHEN 'PUBLIC_INCIDENT'");
     expect(sql).toContain('ELSE');

--- a/tests/lib/provider-capacity.test.ts
+++ b/tests/lib/provider-capacity.test.ts
@@ -25,6 +25,18 @@ describe('provider capacity', () => {
     });
   });
 
+  it('prefers provider-account capacity over the channel default', () => {
+    const capacity = getProviderCapacity('EMAIL', 'sendgrid-prod/us', {
+      NODE_ENV: 'test',
+      NOTIFICATION_EMAIL_RATE_PER_SECOND: '100',
+      NOTIFICATION_EMAIL_MAX_IN_FLIGHT: '20',
+      NOTIFICATION_EMAIL_SENDGRID_PROD_US_RATE_PER_SECOND: '25',
+      NOTIFICATION_EMAIL_SENDGRID_PROD_US_MAX_IN_FLIGHT: '4',
+    });
+    expect(capacity.configuredRatePerSecond).toBe(25);
+    expect(capacity.maxInFlight).toBe(4);
+  });
+
   it('halves on pressure and recovers additively without exceeding configuration', () => {
     process.env.NOTIFICATION_EMAIL_RATE_PER_SECOND = '500';
     expect(recordCapacityPressure('EMAIL', 'resend')).toBe(250);

--- a/tests/lib/status-page-history-query.test.ts
+++ b/tests/lib/status-page-history-query.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ findMany: vi.fn() }));
+
+vi.mock('@/lib/prisma', () => ({
+  default: { incident: { findMany: mocks.findMany } },
+}));
+
+import {
+  HISTORY_INCIDENT_PAGE_SIZE,
+  loadHistoryIncidentsByService,
+} from '@/lib/status-pages/history-query';
+
+const start = new Date('2026-06-01T00:00:00.000Z');
+const end = new Date('2026-09-01T00:00:00.000Z');
+
+function incident(id: string, serviceId = 'service-a') {
+  return {
+    id,
+    serviceId,
+    createdAt: start,
+    resolvedAt: end,
+    urgency: 'LOW',
+    status: 'RESOLVED',
+  };
+}
+
+describe('status-page authoritative history query', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exhausts bounded keyset pages before marking history complete', async () => {
+    const firstPage = Array.from(
+      { length: HISTORY_INCIDENT_PAGE_SIZE },
+      (_, index) => incident(`incident-${String(index).padStart(4, '0')}`)
+    );
+    mocks.findMany.mockResolvedValueOnce(firstPage).mockResolvedValueOnce([
+      incident('incident-final', 'service-b'),
+    ]);
+
+    const result = await loadHistoryIncidentsByService(['service-a', 'service-b'], start, end);
+
+    expect(result.get('service-a')).toHaveLength(HISTORY_INCIDENT_PAGE_SIZE);
+    expect(result.get('service-b')?.map(item => item.id)).toEqual(['incident-final']);
+    expect(mocks.findMany).toHaveBeenCalledTimes(2);
+    expect(mocks.findMany.mock.calls[0]?.[0]).toMatchObject({
+      orderBy: { id: 'asc' },
+      take: HISTORY_INCIDENT_PAGE_SIZE,
+    });
+    expect(mocks.findMany.mock.calls[1]?.[0]).toMatchObject({
+      cursor: { id: firstPage.at(-1)?.id },
+      skip: 1,
+      take: HISTORY_INCIDENT_PAGE_SIZE,
+    });
+  });
+
+  it('rejects the whole read when a later page fails', async () => {
+    mocks.findMany
+      .mockResolvedValueOnce(Array.from(
+        { length: HISTORY_INCIDENT_PAGE_SIZE },
+        (_, index) => incident(`incident-${index}`)
+      ))
+      .mockRejectedValueOnce(new Error('database unavailable'));
+
+    await expect(loadHistoryIncidentsByService(['service-a'], start, end)).rejects.toThrow(
+      'database unavailable'
+    );
+  });
+});

--- a/tests/lib/status-page-middleware-routing.test.ts
+++ b/tests/lib/status-page-middleware-routing.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const route = {
+  pageId: 'page_123',
+  slug: 'customer-status',
+  requireAuth: false,
+  revision: '42',
+};
+
+describe('status page middleware serving routes', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-09T00:00:00Z'));
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://app.opsknight.test');
+    vi.stubEnv('STATUS_PAGE_SERVING_STORE_URL', 'https://serving.opsknight.test/v1');
+    vi.stubEnv('STATUS_PAGE_SERVING_STORE_TOKEN', 'secret');
+    vi.stubEnv('STATUS_PAGE_EXTERNAL_SERVING_STORE', 'true');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts only the minimal sanitized route contract', async () => {
+    const { parsePublishedStatusRoute } = await import('@/middleware');
+
+    expect(parsePublishedStatusRoute(route)).toEqual(route);
+    expect(parsePublishedStatusRoute({ ...route, slug: '../settings' })).toBeNull();
+    expect(parsePublishedStatusRoute({ ...route, requireAuth: 'false' })).toBeNull();
+    expect(parsePublishedStatusRoute({ ...route, extra: 'rejected' })).toBeNull();
+  });
+
+  it('uses independent custom-domain and subdomain route keys', async () => {
+    const { externalRouteKey } = await import('@/middleware');
+
+    expect(externalRouteKey('status.customer.test')).toBe('domain:status.customer.test');
+    expect(externalRouteKey('acme.app.opsknight.test')).toBe('subdomain:acme');
+    expect(externalRouteKey('nested.acme.app.opsknight.test')).toBe(
+      'domain:nested.acme.app.opsknight.test'
+    );
+  });
+
+  it('coalesces concurrent lookups and positively caches a valid route', async () => {
+    let release: ((response: Response) => void) | undefined;
+    const fetchMock = vi.fn(
+      () => new Promise<Response>(resolve => { release = resolve; })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchPublishedStatusDomain } = await import('@/middleware');
+
+    const first = fetchPublishedStatusDomain('status.customer.test');
+    const second = fetchPublishedStatusDomain('status.customer.test');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    release?.(Response.json(route));
+
+    await expect(first).resolves.toEqual(route);
+    await expect(second).resolves.toEqual(route);
+    await expect(fetchPublishedStatusDomain('status.customer.test')).resolves.toEqual(route);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('negative-caches missing routes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchPublishedStatusDomain } = await import('@/middleware');
+
+    await expect(fetchPublishedStatusDomain('missing.customer.test')).resolves.toBeNull();
+    await expect(fetchPublishedStatusDomain('missing.customer.test')).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves the last known route briefly when refresh fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json(route))
+      .mockRejectedValueOnce(new Error('serving store unavailable'));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchPublishedStatusDomain } = await import('@/middleware');
+
+    await expect(fetchPublishedStatusDomain('status.customer.test')).resolves.toEqual(route);
+    vi.advanceTimersByTime(60_001);
+    await expect(fetchPublishedStatusDomain('status.customer.test')).resolves.toEqual(route);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the last known safe route when a refresh payload is malformed', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json(route))
+      .mockResolvedValueOnce(Response.json({ ...route, slug: '../settings' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchPublishedStatusDomain } = await import('@/middleware');
+
+    await expect(fetchPublishedStatusDomain('status.customer.test')).resolves.toEqual(route);
+    vi.advanceTimersByTime(60_001);
+    await expect(fetchPublishedStatusDomain('status.customer.test')).resolves.toEqual(route);
+  });
+
+  it('does not serve a stale route beyond the bounded outage window', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json(route))
+      .mockRejectedValue(new Error('serving store unavailable'));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchPublishedStatusDomain } = await import('@/middleware');
+
+    await expect(fetchPublishedStatusDomain('status.customer.test')).resolves.toEqual(route);
+    vi.advanceTimersByTime(5 * 60_000 + 1);
+    await expect(fetchPublishedStatusDomain('status.customer.test')).resolves.toBeNull();
+  });
+
+  it('resolves a valid route with one serving-store request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json(route));
+    vi.stubGlobal('fetch', fetchMock);
+    const { default: middleware } = await import('@/middleware');
+    const { NextRequest } = await import('next/server');
+
+    const response = await middleware(
+      new NextRequest('https://status.customer.test/', {
+        headers: { host: 'status.customer.test' },
+      })
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      'status-pages/routes/domain%3Astatus.customer.test'
+    );
+    expect(response.headers.get('x-middleware-rewrite')).toBe(
+      'https://status.customer.test/status/customer-status'
+    );
+  });
+});

--- a/tests/lib/status-page-public-contract.test.ts
+++ b/tests/lib/status-page-public-contract.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { aggregatePublicRegions, buildPublicServiceHistory } from '@/lib/status-pages/history';
+import { parsePublicStatusPageSnapshot } from '@/lib/status-pages/public-contract-schema';
+import { getWorstPublicStatus, normalizePublicStatus } from '@/lib/status-pages/status-presentation';
+
+describe('canonical public status contract', () => {
+  it('never converts malformed or missing status to operational', () => {
+    expect(normalizePublicStatus(undefined)).toBe('UNKNOWN');
+    expect(normalizePublicStatus('healthy')).toBe('UNKNOWN');
+    expect(getWorstPublicStatus([])).toBe('UNKNOWN');
+  });
+
+  it('uses one precedence for service, region and history aggregation', () => {
+    expect(getWorstPublicStatus(['OPERATIONAL', 'MAINTENANCE', 'DEGRADED'])).toBe('DEGRADED');
+    expect(getWorstPublicStatus(['DEGRADED', 'MAJOR_OUTAGE'])).toBe('MAJOR_OUTAGE');
+  });
+
+  it('keeps degraded history, timeline and availability semantically aligned', () => {
+    const history = buildPublicServiceHistory({
+      serviceId: 'payments',
+      incidents: [{
+        serviceId: 'payments', status: 'RESOLVED', urgency: 'MEDIUM',
+        createdAt: new Date('2026-09-09T12:15:00.000Z'),
+        resolvedAt: new Date('2026-09-09T13:25:00.000Z'),
+      }],
+      maintenance: [],
+      start: new Date('2026-09-09T00:00:00.000Z'),
+      end: new Date('2026-09-10T00:00:00.000Z'),
+    })[0];
+    expect(history.status).toBe('DEGRADED');
+    expect(history.incidentCount).toBe(1);
+    expect(history.availabilityPercent).toBeLessThan(100);
+    expect(history.timeline).toContainEqual({ startMinute: 735, endMinute: 805, status: 'DEGRADED' });
+  });
+
+  it('preserves maintenance and aggregates multi-region services into each region', () => {
+    const maintenance = buildPublicServiceHistory({
+      serviceId: 'api', incidents: [],
+      maintenance: [{ startDate: new Date('2026-09-09T01:00:00.000Z'), endDate: new Date('2026-09-09T02:00:00.000Z'), affectedServiceIds: ['api'] }],
+      start: new Date('2026-09-09T00:00:00.000Z'), end: new Date('2026-09-10T00:00:00.000Z'),
+    })[0];
+    expect(maintenance.status).toBe('MAINTENANCE');
+    const regions = aggregatePublicRegions([
+      { id: 'api', regions: ['us-east-1', 'eu-west-1'], status: 'DEGRADED' },
+      { id: 'web', regions: ['us-east-1'], status: 'OPERATIONAL' },
+    ]);
+    expect(regions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'eu-west-1', status: 'DEGRADED', totalServices: 1 }),
+      expect.objectContaining({ name: 'us-east-1', status: 'DEGRADED', totalServices: 2, impactedServices: 1 }),
+    ]));
+  });
+
+  it('rejects malformed and legacy snapshots instead of serving false green', () => {
+    expect(parsePublicStatusPageSnapshot('page', { schemaVersion: 3, pageId: 'page' })).toBeNull();
+    expect(parsePublicStatusPageSnapshot('page', { schemaVersion: 2, pageId: 'page', status: 'operational' })).toBeNull();
+  });
+});

--- a/tests/lib/status-page-public-contract.test.ts
+++ b/tests/lib/status-page-public-contract.test.ts
@@ -1,104 +1,61 @@
 import { describe, expect, it } from 'vitest';
-import { aggregatePublicRegions, buildPublicServiceHistory } from '@/lib/status-pages/history';
+import { aggregatePublicRegions, buildPublicHistorySegments } from '@/lib/status-pages/history';
+import { buildPublicHistoryDays } from '@/lib/status-pages/history-presentation';
 import { parsePublicStatusPageSnapshot } from '@/lib/status-pages/public-contract-schema';
-import {
-  getWorstPublicStatus,
-  normalizePublicStatus,
-  publicStatusForIncidentUrgency,
-} from '@/lib/status-pages/status-presentation';
+import { getWorstPublicStatus, normalizePublicStatus, publicStatusForIncidentUrgency } from '@/lib/status-pages/status-presentation';
+
+const rangeStart = '2026-09-09T00:00:00.000Z';
+const rangeEnd = '2026-09-11T00:00:00.000Z';
 
 describe('canonical public status contract', () => {
-  it('never converts malformed or missing status to operational', () => {
+  it('never converts malformed, missing or mixed unknown status to operational', () => {
     expect(normalizePublicStatus(undefined)).toBe('UNKNOWN');
-    expect(normalizePublicStatus('healthy')).toBe('UNKNOWN');
     expect(getWorstPublicStatus([])).toBe('UNKNOWN');
-  });
-
-  it('uses one precedence for service, region and history aggregation', () => {
-    expect(getWorstPublicStatus(['OPERATIONAL', 'MAINTENANCE', 'DEGRADED'])).toBe('DEGRADED');
-    expect(getWorstPublicStatus(['DEGRADED', 'MAJOR_OUTAGE'])).toBe('MAJOR_OUTAGE');
     expect(getWorstPublicStatus(['OPERATIONAL', 'UNKNOWN'])).toBe('UNKNOWN');
   });
 
-  it('uses one monotonic urgency policy for current and historical status', () => {
+  it('uses one monotonic urgency policy', () => {
     expect(publicStatusForIncidentUrgency('LOW')).toBe('DEGRADED');
     expect(publicStatusForIncidentUrgency('MEDIUM')).toBe('PARTIAL_OUTAGE');
     expect(publicStatusForIncidentUrgency('HIGH')).toBe('MAJOR_OUTAGE');
-    expect(publicStatusForIncidentUrgency('UNRECOGNIZED')).toBe('UNKNOWN');
+    expect(publicStatusForIncidentUrgency('other')).toBe('UNKNOWN');
   });
 
-  it('keeps degraded history, timeline and availability semantically aligned', () => {
-    const history = buildPublicServiceHistory({
-      serviceId: 'payments',
-      incidents: [{
-        serviceId: 'payments', status: 'RESOLVED', urgency: 'MEDIUM',
-        createdAt: new Date('2026-09-09T12:15:00.000Z'),
-        resolvedAt: new Date('2026-09-09T13:25:00.000Z'),
-      }],
-      maintenance: [],
-      start: new Date('2026-09-09T00:00:00.000Z'),
-      end: new Date('2026-09-10T00:00:00.000Z'),
-    })[0];
-    expect(history.status).toBe('PARTIAL_OUTAGE');
-    expect(history.incidentCount).toBe(1);
-    expect(history.availabilityPercent).toBeLessThan(100);
-    expect(history.timeline).toContainEqual({ startMinute: 735, endMinute: 805, status: 'PARTIAL_OUTAGE' });
-  });
-
-  it('uses half-open history ranges without a trailing midnight day', () => {
-    const history = buildPublicServiceHistory({
-      serviceId: 'api', incidents: [], maintenance: [], timezone: 'UTC',
-      start: new Date('2026-09-09T00:00:00.000Z'),
-      end: new Date('2026-09-10T00:00:00.000Z'),
-    });
-    expect(history).toHaveLength(1);
-    expect(history[0]).toMatchObject({ date: '2026-09-09', status: 'OPERATIONAL' });
-  });
-
-  it('assigns incidents across midnight in the configured timezone', () => {
-    const history = buildPublicServiceHistory({
-      serviceId: 'api',
-      incidents: [{
-        serviceId: 'api', status: 'RESOLVED', urgency: 'LOW',
-        createdAt: new Date('2026-09-09T06:30:00.000Z'),
-        resolvedAt: new Date('2026-09-09T07:30:00.000Z'),
-      }],
-      maintenance: [],
-      timezone: 'America/Los_Angeles',
-      start: new Date('2026-09-09T06:00:00.000Z'),
-      end: new Date('2026-09-09T08:00:00.000Z'),
-    });
-    expect(history.map(day => day.date)).toEqual(['2026-09-08', '2026-09-09']);
-    expect(history[0]?.timeline).toContainEqual({ startMinute: 1410, endMinute: 1440, status: 'DEGRADED' });
-    expect(history[1]?.timeline).toContainEqual({ startMinute: 0, endMinute: 30, status: 'DEGRADED' });
-  });
-
-  it('models the 25-hour daylight-saving fallback day without truncation', () => {
-    const history = buildPublicServiceHistory({
-      serviceId: 'api', incidents: [], maintenance: [], timezone: 'America/New_York',
-      start: new Date('2026-11-01T04:00:00.000Z'),
-      end: new Date('2026-11-02T05:00:00.000Z'),
-    });
-    expect(history).toHaveLength(1);
-    expect(history[0]?.timeline).toEqual([{ startMinute: 0, endMinute: 1500, status: 'OPERATIONAL' }]);
-  });
-
-  it('preserves maintenance and aggregates multi-region services into each region', () => {
-    const maintenance = buildPublicServiceHistory({
-      serviceId: 'api', incidents: [],
-      maintenance: [{ startDate: new Date('2026-09-09T01:00:00.000Z'), endDate: new Date('2026-09-09T02:00:00.000Z'), affectedServiceIds: ['api'] }],
-      start: new Date('2026-09-09T00:00:00.000Z'), end: new Date('2026-09-10T00:00:00.000Z'),
-    })[0];
-    expect(maintenance.status).toBe('MAINTENANCE');
-    expect(maintenance.availabilityPercent).toBe(100);
-    const regions = aggregatePublicRegions([
-      { id: 'api', regions: ['us-east-1', 'eu-west-1'], status: 'DEGRADED' },
-      { id: 'web', regions: ['us-east-1'], status: 'OPERATIONAL' },
+  it('publishes merged UTC non-operational segments without incident details', () => {
+    const segments = buildPublicHistorySegments({ serviceId: 'api', start: new Date(rangeStart), end: new Date(rangeEnd), maintenance: [], incidents: [
+      { serviceId: 'api', status: 'RESOLVED', urgency: 'LOW', createdAt: new Date('2026-09-09T12:00:00Z'), resolvedAt: new Date('2026-09-09T13:00:00Z') },
+      { serviceId: 'api', status: 'RESOLVED', urgency: 'HIGH', createdAt: new Date('2026-09-09T12:30:00Z'), resolvedAt: new Date('2026-09-09T14:00:00Z') },
+    ] });
+    expect(segments).toEqual([
+      { startAt: '2026-09-09T12:00:00.000Z', endAt: '2026-09-09T12:30:00.000Z', status: 'DEGRADED' },
+      { startAt: '2026-09-09T12:30:00.000Z', endAt: '2026-09-09T14:00:00.000Z', status: 'MAJOR_OUTAGE' },
     ]);
-    expect(regions).toEqual(expect.arrayContaining([
-      expect.objectContaining({ name: 'eu-west-1', status: 'DEGRADED', totalServices: 1 }),
-      expect.objectContaining({ name: 'us-east-1', status: 'DEGRADED', totalServices: 2, impactedServices: 1 }),
-    ]));
+    expect(Object.keys(segments[0] ?? {}).sort()).toEqual(['endAt', 'startAt', 'status']);
+  });
+
+  it('projects the same UTC segment onto each viewer local calendar', () => {
+    const history = { rangeStart, rangeEnd, coverage: 'COMPLETE' as const, segments: [{ startAt: '2026-09-09T18:45:00.000Z', endAt: '2026-09-09T19:30:00.000Z', status: 'DEGRADED' as const }] };
+    expect(buildPublicHistoryDays(history, 'Asia/Kolkata').find(day => day.status === 'DEGRADED')?.date).toBe('2026-09-10');
+    expect(buildPublicHistoryDays(history, 'America/New_York').find(day => day.status === 'DEGRADED')?.date).toBe('2026-09-09');
+  });
+
+  it('supports 25-hour fallback and 23-hour spring-forward browser days', () => {
+    const complete = (start: string, end: string) => ({ rangeStart: start, rangeEnd: end, coverage: 'COMPLETE' as const, segments: [] });
+    expect(buildPublicHistoryDays(complete('2026-11-01T04:00:00Z', '2026-11-02T05:00:00Z'), 'America/New_York')[0]?.timeline).toEqual([{ startMinute: 0, endMinute: 1500, status: 'OPERATIONAL' }]);
+    expect(buildPublicHistoryDays(complete('2026-03-08T05:00:00Z', '2026-03-09T04:00:00Z'), 'America/New_York')[0]?.timeline).toEqual([{ startMinute: 0, endMinute: 1380, status: 'OPERATIONAL' }]);
+  });
+
+  it('renders partial coverage gaps as unknown', () => {
+    const day = buildPublicHistoryDays({ rangeStart, rangeEnd: '2026-09-10T00:00:00Z', coverage: 'PARTIAL', segments: [] }, 'UTC')[0];
+    expect(day).toMatchObject({ status: 'UNKNOWN', availabilityPercent: null });
+    expect(day?.timeline).toEqual([{ startMinute: 0, endMinute: 1440, status: 'UNKNOWN' }]);
+  });
+
+  it('preserves maintenance availability and region aggregation', () => {
+    const segments = buildPublicHistorySegments({ serviceId: 'api', incidents: [], maintenance: [{ startDate: new Date('2026-09-09T01:00:00Z'), endDate: new Date('2026-09-09T02:00:00Z'), affectedServiceIds: ['api'] }], start: new Date(rangeStart), end: new Date('2026-09-10T00:00:00Z') });
+    const day = buildPublicHistoryDays({ rangeStart, rangeEnd: '2026-09-10T00:00:00Z', coverage: 'COMPLETE', segments }, 'UTC')[0];
+    expect(day).toMatchObject({ status: 'MAINTENANCE', availabilityPercent: 100 });
+    expect(aggregatePublicRegions([{ id: 'api', regions: ['us', 'eu'], status: 'DEGRADED' }])).toHaveLength(2);
   });
 
   it('rejects malformed and legacy snapshots instead of serving false green', () => {

--- a/tests/lib/status-page-public-contract.test.ts
+++ b/tests/lib/status-page-public-contract.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { aggregatePublicRegions, buildPublicServiceHistory } from '@/lib/status-pages/history';
 import { parsePublicStatusPageSnapshot } from '@/lib/status-pages/public-contract-schema';
-import { getWorstPublicStatus, normalizePublicStatus } from '@/lib/status-pages/status-presentation';
+import {
+  getWorstPublicStatus,
+  normalizePublicStatus,
+  publicStatusForIncidentUrgency,
+} from '@/lib/status-pages/status-presentation';
 
 describe('canonical public status contract', () => {
   it('never converts malformed or missing status to operational', () => {
@@ -16,6 +20,13 @@ describe('canonical public status contract', () => {
     expect(getWorstPublicStatus(['OPERATIONAL', 'UNKNOWN'])).toBe('UNKNOWN');
   });
 
+  it('uses one monotonic urgency policy for current and historical status', () => {
+    expect(publicStatusForIncidentUrgency('LOW')).toBe('DEGRADED');
+    expect(publicStatusForIncidentUrgency('MEDIUM')).toBe('PARTIAL_OUTAGE');
+    expect(publicStatusForIncidentUrgency('HIGH')).toBe('MAJOR_OUTAGE');
+    expect(publicStatusForIncidentUrgency('UNRECOGNIZED')).toBe('UNKNOWN');
+  });
+
   it('keeps degraded history, timeline and availability semantically aligned', () => {
     const history = buildPublicServiceHistory({
       serviceId: 'payments',
@@ -28,10 +39,48 @@ describe('canonical public status contract', () => {
       start: new Date('2026-09-09T00:00:00.000Z'),
       end: new Date('2026-09-10T00:00:00.000Z'),
     })[0];
-    expect(history.status).toBe('DEGRADED');
+    expect(history.status).toBe('PARTIAL_OUTAGE');
     expect(history.incidentCount).toBe(1);
     expect(history.availabilityPercent).toBeLessThan(100);
-    expect(history.timeline).toContainEqual({ startMinute: 735, endMinute: 805, status: 'DEGRADED' });
+    expect(history.timeline).toContainEqual({ startMinute: 735, endMinute: 805, status: 'PARTIAL_OUTAGE' });
+  });
+
+  it('uses half-open history ranges without a trailing midnight day', () => {
+    const history = buildPublicServiceHistory({
+      serviceId: 'api', incidents: [], maintenance: [], timezone: 'UTC',
+      start: new Date('2026-09-09T00:00:00.000Z'),
+      end: new Date('2026-09-10T00:00:00.000Z'),
+    });
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({ date: '2026-09-09', status: 'OPERATIONAL' });
+  });
+
+  it('assigns incidents across midnight in the configured timezone', () => {
+    const history = buildPublicServiceHistory({
+      serviceId: 'api',
+      incidents: [{
+        serviceId: 'api', status: 'RESOLVED', urgency: 'LOW',
+        createdAt: new Date('2026-09-09T06:30:00.000Z'),
+        resolvedAt: new Date('2026-09-09T07:30:00.000Z'),
+      }],
+      maintenance: [],
+      timezone: 'America/Los_Angeles',
+      start: new Date('2026-09-09T06:00:00.000Z'),
+      end: new Date('2026-09-09T08:00:00.000Z'),
+    });
+    expect(history.map(day => day.date)).toEqual(['2026-09-08', '2026-09-09']);
+    expect(history[0]?.timeline).toContainEqual({ startMinute: 1410, endMinute: 1440, status: 'DEGRADED' });
+    expect(history[1]?.timeline).toContainEqual({ startMinute: 0, endMinute: 30, status: 'DEGRADED' });
+  });
+
+  it('models the 25-hour daylight-saving fallback day without truncation', () => {
+    const history = buildPublicServiceHistory({
+      serviceId: 'api', incidents: [], maintenance: [], timezone: 'America/New_York',
+      start: new Date('2026-11-01T04:00:00.000Z'),
+      end: new Date('2026-11-02T05:00:00.000Z'),
+    });
+    expect(history).toHaveLength(1);
+    expect(history[0]?.timeline).toEqual([{ startMinute: 0, endMinute: 1500, status: 'OPERATIONAL' }]);
   });
 
   it('preserves maintenance and aggregates multi-region services into each region', () => {

--- a/tests/lib/status-page-public-contract.test.ts
+++ b/tests/lib/status-page-public-contract.test.ts
@@ -13,6 +13,7 @@ describe('canonical public status contract', () => {
   it('uses one precedence for service, region and history aggregation', () => {
     expect(getWorstPublicStatus(['OPERATIONAL', 'MAINTENANCE', 'DEGRADED'])).toBe('DEGRADED');
     expect(getWorstPublicStatus(['DEGRADED', 'MAJOR_OUTAGE'])).toBe('MAJOR_OUTAGE');
+    expect(getWorstPublicStatus(['OPERATIONAL', 'UNKNOWN'])).toBe('UNKNOWN');
   });
 
   it('keeps degraded history, timeline and availability semantically aligned', () => {
@@ -40,6 +41,7 @@ describe('canonical public status contract', () => {
       start: new Date('2026-09-09T00:00:00.000Z'), end: new Date('2026-09-10T00:00:00.000Z'),
     })[0];
     expect(maintenance.status).toBe('MAINTENANCE');
+    expect(maintenance.availabilityPercent).toBe(100);
     const regions = aggregatePublicRegions([
       { id: 'api', regions: ['us-east-1', 'eu-west-1'], status: 'DEGRADED' },
       { id: 'web', regions: ['us-east-1'], status: 'OPERATIONAL' },

--- a/tests/lib/status-page-settings-sections.test.ts
+++ b/tests/lib/status-page-settings-sections.test.ts
@@ -18,6 +18,16 @@ describe('status page section mutation boundaries', () => {
     });
   });
 
+  it('does not persist browser-local history timezone preferences', () => {
+    expect(
+      statusPageSectionPatch('general', {
+        id: 'page',
+        name: 'Public status',
+        timeZone: 'America/New_York',
+      })
+    ).toEqual({ id: 'page', name: 'Public status' });
+  });
+
   it('rejects sections that own their own independent controls', () => {
     expect(() => statusPageSectionPatch('subscribers', {})).toThrow();
   });

--- a/tests/lib/status-page-subscription-policy.test.ts
+++ b/tests/lib/status-page-subscription-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { subscriptionRequestAction } from '@/lib/status-pages/subscription-policy';
+
+describe('status page subscription request policy', () => {
+  const now = Date.parse('2026-09-09T10:00:00.000Z');
+
+  it('only allows an unsubscribed address to restart verification', () => {
+    expect(subscriptionRequestAction('UNSUBSCRIBED', new Date(now), now)).toBe('REACTIVATE');
+  });
+
+  it.each(['COMPLAINED', 'SUPPRESSED', 'BOUNCED'] as const)(
+    'keeps %s addresses suppressed even when another subscription is requested',
+    state => {
+      expect(subscriptionRequestAction(state, new Date(now - 120_000), now)).toBe('ACCEPT');
+    }
+  );
+
+  it('keeps active subscriptions unchanged', () => {
+    expect(subscriptionRequestAction('ACTIVE', new Date(now - 120_000), now)).toBe('ACCEPT');
+  });
+
+  it('throttles recent pending verification and refreshes an expired request', () => {
+    expect(subscriptionRequestAction('PENDING', new Date(now - 59_999), now)).toBe('ACCEPT');
+    expect(subscriptionRequestAction('PENDING', new Date(now - 60_000), now)).toBe(
+      'REFRESH_VERIFICATION'
+    );
+  });
+});

--- a/tests/lib/status-page-validation.test.ts
+++ b/tests/lib/status-page-validation.test.ts
@@ -38,6 +38,16 @@ describe('Status Page Validation Schemas', () => {
       expect(result.success).toBe(true);
     });
 
+    it('does not expose browser-local timezone as a persisted setting', () => {
+      const result = StatusPageSettingsSchema.safeParse({
+        enabled: true,
+        timeZone: 'America/New_York',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toEqual({ enabled: true });
+    });
+
     it('should validate privacy mode values', () => {
       const validModes = ['PUBLIC', 'RESTRICTED', 'PRIVATE'];
 


### PR DESCRIPTION
Public status could still contradict itself across history, hover, regions, metrics, and APIs, while malformed data could appear operational and external serving still consulted the control-plane database. This PR establishes the V3 publication contract and closes the remaining enterprise status/notification gaps in one branch.

## What changed

- Adds a runtime-validated V3 public contract with `UNKNOWN`, typed incidents and updates, canonical status precedence, sanitized history slices, exact 30/90-day uptime metadata, and region aggregates.
- Replaces snapshot-mode client reconstruction with a keyboard/touch-accessible renderer that consumes published history, availability, status, and region truth directly.
- Separates semantic status tokens from customer branding and preserves maintenance/unknown presentation.
- Publishes integrity-checked immutable snapshots and authoritative manifests; public reads no longer perform a PostgreSQL revision check.
- Publishes custom-domain/subdomain routes and lets middleware resolve the external route/manifest/snapshot path directly.
- Revokes manifests and routes before status-page deletion, cancels queued public delivery, and records deletion audit history.
- Adds provider-account capacity overrides, tenant-aware fair queue claiming, explicit subscriber deliverability states, idempotent provider feedback ingestion, suppression checks, and operations visibility.
- Documents 1M fanout, mixed-workload certification, and explicit release SLOs.

## Validation

- `DATABASE_URL=postgresql://user:pass@localhost:5432/opsknight npx prisma validate`
- `npx prisma generate`
- `npx tsc --noEmit --incremental false`
- 53 focused unit/component/architecture tests across status publication and notification control plane
- ESLint on all modified TypeScript/TSX files with zero errors and warnings
- `npm run build` (production build passed)

Database-backed integration tests could not run locally because the checkout's `.env.test` credentials are rejected by local PostgreSQL; CI has the managed integration database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned public status pages with service cards, regional health, uptime metrics, incident history, maintenance timelines, and interactive daily details.
  * Added clearer status handling, including unknown status display and consistent status indicators.
  * Published status pages now support validated snapshots and improved custom-domain delivery.
  * Notification operations now show subscription states and recent provider delivery feedback.

* **Bug Fixes**
  * Improved subscription lifecycle tracking for verification, resubscription, unsubscribing, bounces, complaints, and delivery outcomes.
  * Improved status-page data compatibility and validation for legacy and invalid snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->