### PR TITLE
fix(oidc): make Microsoft Entra compatible and preserve provider selection

### DIFF
--- a/src/components/settings/SsoSettingsForm.tsx
+++ b/src/components/settings/SsoSettingsForm.tsx
@@ -31,6 +31,7 @@ import {
   saveOidcConfig,
   validateOidcConnectionAction,
 } from '@/app/(app)/settings/security/actions';
+import { normalizeOidcProviderType } from '@/lib/oidc-provider';
 import type { SettingsActionState } from '@/lib/settings-result';
 
 type ProfileMapping = {
@@ -77,7 +78,7 @@ const PROVIDER_PRESETS: Preset[] = [
   },
   {
     id: 'azure',
-    label: 'Azure AD',
+    label: 'Microsoft Entra ID',
     issuer: 'https://login.microsoftonline.com/{tenantId}/v2.0',
     note: 'Replace {tenantId} with your directory ID.',
   },
@@ -159,6 +160,7 @@ export default function SsoSettingsForm({
   const initialProviderLabel = initialConfig?.providerLabel ?? '';
   const initialCustomScopes = initialConfig?.customScopes ?? '';
   const initialAutoProvision = initialConfig?.autoProvision ?? true;
+  const initialProviderType = normalizeOidcProviderType(initialConfig?.providerType, initialIssuer);
   const initialRoleMapping = Array.isArray(initialConfig?.roleMapping)
     ? initialConfig?.roleMapping
     : [];
@@ -172,10 +174,7 @@ export default function SsoSettingsForm({
   const [providerLabelValue, setProviderLabelValue] = useState(initialProviderLabel);
   const [customScopesValue, setCustomScopesValue] = useState(initialCustomScopes);
   const [autoProvision, setAutoProvision] = useState(initialAutoProvision);
-  const [selectedPreset, setSelectedPreset] = useState(() => {
-    const match = PROVIDER_PRESETS.find(preset => preset.issuer === initialIssuer);
-    return match?.id ?? 'custom';
-  });
+  const [selectedPreset, setSelectedPreset] = useState(initialProviderType);
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [testMessage, setTestMessage] = useState('');
   const [lastTested, setLastTested] = useState<string | null>(null);
@@ -301,9 +300,7 @@ export default function SsoSettingsForm({
         setProviderLabelValue(initialProviderLabel);
         setCustomScopesValue(initialCustomScopes);
         setAutoProvision(initialAutoProvision);
-        setSelectedPreset(
-          PROVIDER_PRESETS.find(preset => preset.issuer === initialIssuer)?.id ?? 'custom'
-        );
+        setSelectedPreset(initialProviderType);
         setTestStatus('idle');
         setTestMessage('');
         setLastTested(null);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,10 @@ import prisma from '@/lib/prisma';
 import { runSerializableTransaction } from '@/lib/db-utils';
 import { logger } from '@/lib/logger';
 import { getOidcConfig } from '@/lib/oidc-config';
+import {
+  hasOidcEmailLinkAssurance,
+  requiresOidcEmailVerifiedClaim,
+} from '@/lib/oidc-provider';
 import { getDefaultAvatar } from '@/lib/avatar';
 import {
   SESSION_TOKEN_COOKIE_NAME,
@@ -257,7 +261,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 userAgentHeader
               );
             const rememberMe = credentials?.rememberMe === 'true' || isMobileClient;
-
             // Get IP from request headers (best effort)
             const { getClientIp } = await import('@/lib/client-ip');
             const ip = getClientIp(req?.headers);
@@ -517,7 +520,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           if (trigger === 'update') {
             // ...
           }
-
           // Fetch latest user data from database on each request to ensure name is up-to-date
           // This ensures name changes reflect immediately without requiring re-login
           if (token.sub && typeof token.sub === 'string') {
@@ -669,8 +671,10 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               return false;
             }
 
-            // Enforce email verification when available (recommended).
-            // If strict mode is enabled, require an explicit true value.
+            // Reject an explicit negative verification claim for every provider.
+            // Microsoft Entra ID commonly omits the standard `email_verified`
+            // claim, so strict mode is provider-aware rather than rejecting a
+            // valid Entra token solely because the claim is absent.
             const emailVerifiedClaim = coerceBooleanClaim((profile as any)?.email_verified); // eslint-disable-line @typescript-eslint/no-explicit-any
             if (emailVerifiedClaim === false) {
               logger.warn('[Auth] OIDC sign-in rejected: email not verified by IdP', {
@@ -679,10 +683,16 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               });
               return false;
             }
-            if (isOidcEmailVerifiedStrict() && emailVerifiedClaim !== true) {
+            if (
+              requiresOidcEmailVerifiedClaim(
+                activeConfig.providerType,
+                isOidcEmailVerifiedStrict()
+              ) && emailVerifiedClaim !== true
+            ) {
               logger.warn('[Auth] OIDC sign-in rejected: email_verified missing (strict mode)', {
                 component: 'auth:signIn',
                 email,
+                providerType: activeConfig.providerType,
               });
               return false;
             }
@@ -690,6 +700,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
               logger.warn('[Auth] OIDC sign-in: email_verified claim missing; proceeding', {
                 component: 'auth:signIn',
                 email,
+                providerType: activeConfig.providerType,
               });
             }
 
@@ -824,9 +835,13 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                     return linked;
                   }
 
-                  // An existing account must prove control of a verified address. ACTIVE
-                  // accounts additionally require a fresh, one-time administrator approval.
-                  if (existing && emailVerifiedClaim !== true) {
+                  // An existing account must prove sufficient provider-specific
+                  // email assurance. ACTIVE accounts additionally require a fresh,
+                  // one-time administrator approval before first linking.
+                  if (
+                    existing &&
+                    !hasOidcEmailLinkAssurance(activeConfig.providerType, emailVerifiedClaim)
+                  ) {
                     throw new Error('OIDC_LINK_NOT_APPROVED');
                   }
                   if (existing && currentTarget.status !== 'INVITED') {
@@ -1037,7 +1052,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                   });
                 }
               }
-
               // Update lastOidcSync timestamp if any profile data was synced
               if (updateData.department || updateData.jobTitle || updateData.avatarUrl) {
                 updateData.lastOidcSync = new Date();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -835,16 +835,21 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                     return linked;
                   }
 
-                  // An existing account must prove sufficient provider-specific
-                  // email assurance. ACTIVE accounts additionally require a fresh,
-                  // one-time administrator approval before first linking.
+                  // Existing accounts must meet the provider-specific email
+                  // assurance policy. Entra may omit `email_verified`, but a
+                  // missing claim is not sufficient by itself to claim an
+                  // invited account: that path requires a one-time admin approval.
                   if (
                     existing &&
                     !hasOidcEmailLinkAssurance(activeConfig.providerType, emailVerifiedClaim)
                   ) {
                     throw new Error('OIDC_LINK_NOT_APPROVED');
                   }
-                  if (existing && currentTarget.status !== 'INVITED') {
+
+                  const requiresLinkApproval =
+                    Boolean(existing) &&
+                    (currentTarget.status !== 'INVITED' || emailVerifiedClaim !== true);
+                  if (requiresLinkApproval) {
                     const approval = await tx.oidcLinkingApproval.findFirst({
                       where: { userId: currentTarget.id, revokedAt: null },
                       select: { id: true },

--- a/src/lib/oidc-config.ts
+++ b/src/lib/oidc-config.ts
@@ -1,6 +1,7 @@
 import prisma from '@/lib/prisma';
 import { decrypt } from '@/lib/encryption';
 import { logger } from '@/lib/logger';
+import { normalizeOidcProviderType } from '@/lib/oidc-provider';
 import { z } from 'zod';
 
 const OIDC_CONFIG_RECORD_CACHE_TTL_MS = Number.parseInt(
@@ -62,30 +63,6 @@ export type OidcPublicConfig = {
   providerType?: string | null;
   providerLabel?: string | null;
 };
-
-function detectProviderType(issuer: string | null): string | null {
-  if (!issuer) return null;
-  const url = issuer.toLowerCase();
-
-  if (
-    url.includes('accounts.google.com') ||
-    url.includes('googleapis.com') ||
-    url.includes('google')
-  ) {
-    return 'google';
-  }
-  if (url.includes('okta')) return 'okta';
-  if (
-    url.includes('login.microsoftonline.com') ||
-    url.includes('login.microsoft.com') ||
-    url.includes('sts.windows.net') ||
-    url.includes('microsoftonline')
-  ) {
-    return 'azure';
-  }
-  if (url.includes('auth0')) return 'auth0';
-  return 'custom';
-}
 
 function normalizeDomains(domains: string[]) {
   return domains.map(domain => domain.trim().toLowerCase()).filter(Boolean);
@@ -296,6 +273,8 @@ export async function getOidcConfig(): Promise<OidcConfig | null> {
         allowedDomains: normalizeDomains(config.allowedDomains),
         roleMapping: parseRoleMapping(config.roleMapping),
         customScopes: config.customScopes,
+        providerType: normalizeOidcProviderType(config.providerType, config.issuer),
+        providerLabel: config.providerLabel,
         profileMapping: parseProfileMapping(config.profileMapping),
       };
 
@@ -304,6 +283,7 @@ export async function getOidcConfig(): Promise<OidcConfig | null> {
         issuer: normalizedConfig.issuer,
         clientId: normalizedConfig.clientId,
         autoProvision: normalizedConfig.autoProvision,
+        providerType: normalizedConfig.providerType,
         allowedDomainCount: normalizedConfig.allowedDomains.length,
         hasRoleMapping: !!normalizedConfig.roleMapping,
         hasCustomScopes: !!normalizedConfig.customScopes,
@@ -346,7 +326,7 @@ export async function getOidcPublicConfig(): Promise<OidcPublicConfig | null> {
     clientId: config.clientId || null,
     autoProvision: config.autoProvision,
     allowedDomains: normalizeDomains(config.allowedDomains),
-    providerType: config.providerType ?? detectProviderType(config.issuer),
+    providerType: normalizeOidcProviderType(config.providerType, config.issuer),
     providerLabel: config.providerLabel,
   };
 }

--- a/src/lib/oidc-provider.ts
+++ b/src/lib/oidc-provider.ts
@@ -1,0 +1,100 @@
+export type OidcProviderType = 'google' | 'okta' | 'azure' | 'auth0' | 'custom';
+
+/**
+ * Detect the built-in provider family from an OIDC issuer hostname.
+ *
+ * Hostname matching is intentionally strict: provider detection is used by
+ * authentication policy as well as UI branding, so substring matches such as
+ * `google.example.com` must never be treated as Google.
+ */
+export function detectOidcProviderType(
+  issuerUrl: string | null | undefined
+): OidcProviderType {
+  if (!issuerUrl) return 'custom';
+
+  let hostname: string;
+  try {
+    hostname = new URL(issuerUrl).hostname.toLowerCase();
+  } catch {
+    return 'custom';
+  }
+
+  if (
+    hostname === 'accounts.google.com' ||
+    hostname === 'googleapis.com' ||
+    hostname.endsWith('.google.com') ||
+    hostname.endsWith('.googleapis.com')
+  ) {
+    return 'google';
+  }
+
+  if (
+    hostname === 'okta.com' ||
+    hostname.endsWith('.okta.com') ||
+    hostname.endsWith('.okta-emea.com') ||
+    hostname.includes('.okta.')
+  ) {
+    return 'okta';
+  }
+
+  const microsoftHosts = [
+    'login.microsoftonline.com',
+    'login.microsoft.com',
+    'sts.windows.net',
+    'microsoftonline.com',
+  ];
+  if (microsoftHosts.some(host => hostname === host || hostname.endsWith(`.${host}`))) {
+    return 'azure';
+  }
+
+  if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+    return 'auth0';
+  }
+
+  return 'custom';
+}
+
+export function normalizeOidcProviderType(
+  storedProviderType: string | null | undefined,
+  issuerUrl: string | null | undefined
+): OidcProviderType {
+  if (
+    storedProviderType === 'google' ||
+    storedProviderType === 'okta' ||
+    storedProviderType === 'azure' ||
+    storedProviderType === 'auth0' ||
+    storedProviderType === 'custom'
+  ) {
+    return storedProviderType;
+  }
+  return detectOidcProviderType(issuerUrl);
+}
+
+/**
+ * Microsoft Entra ID workforce tokens do not reliably include the standard
+ * `email_verified` claim. Requiring that claim makes otherwise valid Entra
+ * OIDC sign-ins fail. Other providers keep the operator-controlled strict
+ * requirement.
+ */
+export function requiresOidcEmailVerifiedClaim(
+  providerType: string | null | undefined,
+  strictMode: boolean
+): boolean {
+  if (!strictMode) return false;
+  return providerType !== 'azure';
+}
+
+/**
+ * Email assurance used only when first linking an OIDC identity to an existing
+ * OpsKnight account. Explicit `email_verified: false` is rejected for every
+ * provider before this helper is consulted. Entra is allowed to omit the claim
+ * because issuer + subject are cryptographically validated by OIDC and ACTIVE
+ * account linking still requires the one-time admin approval.
+ */
+export function hasOidcEmailLinkAssurance(
+  providerType: string | null | undefined,
+  emailVerifiedClaim: boolean | undefined
+): boolean {
+  return emailVerifiedClaim === true ||
+    (providerType === 'azure' && emailVerifiedClaim === undefined);
+}

--- a/src/lib/oidc-provider.ts
+++ b/src/lib/oidc-provider.ts
@@ -45,6 +45,8 @@ export function detectOidcProviderType(
 
   const microsoftHosts = [
     'login.microsoftonline.com',
+    'login.microsoftonline.us',
+    'login.partner.microsoftonline.cn',
     'login.microsoft.com',
     'sts.windows.net',
     'microsoftonline.com',
@@ -95,8 +97,8 @@ export function requiresOidcEmailVerifiedClaim(
  * Email assurance used only when first linking an OIDC identity to an existing
  * OpsKnight account. Explicit `email_verified: false` is rejected for every
  * provider before this helper is consulted. Entra is allowed to omit the claim
- * because issuer + subject are cryptographically validated by OIDC and ACTIVE
- * account linking still requires the one-time admin approval.
+ * because issuer + subject are cryptographically validated by OIDC; account
+ * state can still require a fresh one-time administrator linking approval.
  */
 export function hasOidcEmailLinkAssurance(
   providerType: string | null | undefined,

--- a/src/lib/oidc-provider.ts
+++ b/src/lib/oidc-provider.ts
@@ -65,11 +65,14 @@ export function detectOidcProviderType(
  * type is only a legacy fallback for rows that do not have an issuer. This is
  * important because provider type affects authentication policy and must not
  * be able to weaken that policy when it disagrees with the issuer hostname.
+ *
+ * The return is typed as string because persisted UI presets are extensible;
+ * all values produced here are still constrained to OidcProviderType.
  */
 export function normalizeOidcProviderType(
   storedProviderType: string | null | undefined,
   issuerUrl: string | null | undefined
-): OidcProviderType {
+): string {
   if (issuerUrl) return detectOidcProviderType(issuerUrl);
   return isKnownProviderType(storedProviderType) ? storedProviderType : 'custom';
 }

--- a/src/lib/oidc-provider.ts
+++ b/src/lib/oidc-provider.ts
@@ -1,11 +1,21 @@
 export type OidcProviderType = 'google' | 'okta' | 'azure' | 'auth0' | 'custom';
 
+function isKnownProviderType(value: string | null | undefined): value is OidcProviderType {
+  return (
+    value === 'google' ||
+    value === 'okta' ||
+    value === 'azure' ||
+    value === 'auth0' ||
+    value === 'custom'
+  );
+}
+
 /**
  * Detect the built-in provider family from an OIDC issuer hostname.
  *
  * Hostname matching is intentionally strict: provider detection is used by
- * authentication policy as well as UI branding, so substring matches such as
- * `google.example.com` must never be treated as Google.
+ * authentication policy as well as UI branding, so lookalike hostnames must
+ * never inherit provider-specific authentication behavior.
  */
 export function detectOidcProviderType(
   issuerUrl: string | null | undefined
@@ -28,12 +38,8 @@ export function detectOidcProviderType(
     return 'google';
   }
 
-  if (
-    hostname === 'okta.com' ||
-    hostname.endsWith('.okta.com') ||
-    hostname.endsWith('.okta-emea.com') ||
-    hostname.includes('.okta.')
-  ) {
+  const oktaHosts = ['okta.com', 'okta-emea.com', 'oktapreview.com', 'okta-gov.com'];
+  if (oktaHosts.some(host => hostname === host || hostname.endsWith(`.${host}`))) {
     return 'okta';
   }
 
@@ -54,20 +60,18 @@ export function detectOidcProviderType(
   return 'custom';
 }
 
+/**
+ * The issuer is authoritative whenever it is available. A persisted provider
+ * type is only a legacy fallback for rows that do not have an issuer. This is
+ * important because provider type affects authentication policy and must not
+ * be able to weaken that policy when it disagrees with the issuer hostname.
+ */
 export function normalizeOidcProviderType(
   storedProviderType: string | null | undefined,
   issuerUrl: string | null | undefined
 ): OidcProviderType {
-  if (
-    storedProviderType === 'google' ||
-    storedProviderType === 'okta' ||
-    storedProviderType === 'azure' ||
-    storedProviderType === 'auth0' ||
-    storedProviderType === 'custom'
-  ) {
-    return storedProviderType;
-  }
-  return detectOidcProviderType(issuerUrl);
+  if (issuerUrl) return detectOidcProviderType(issuerUrl);
+  return isKnownProviderType(storedProviderType) ? storedProviderType : 'custom';
 }
 
 /**
@@ -95,6 +99,8 @@ export function hasOidcEmailLinkAssurance(
   providerType: string | null | undefined,
   emailVerifiedClaim: boolean | undefined
 ): boolean {
-  return emailVerifiedClaim === true ||
-    (providerType === 'azure' && emailVerifiedClaim === undefined);
+  return (
+    emailVerifiedClaim === true ||
+    (providerType === 'azure' && emailVerifiedClaim === undefined)
+  );
 }

--- a/tests/components/settings/SsoSettingsForm.provider.test.tsx
+++ b/tests/components/settings/SsoSettingsForm.provider.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SsoSettingsForm from '@/components/settings/SsoSettingsForm';
+
+vi.mock('react-dom', () => ({
+  useFormStatus: () => ({ pending: false }),
+}));
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    useActionState: (fn: unknown, initialState: unknown) => [initialState, fn, false],
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('@/components/settings/RoleMappingEditor', () => ({
+  default: () => <div data-testid="role-mapping-editor" />,
+}));
+
+vi.mock('@/app/(app)/settings/security/actions', () => ({
+  saveOidcConfig: vi.fn(),
+  validateOidcConnectionAction: vi.fn().mockResolvedValue({ isValid: true }),
+}));
+
+const commonConfig = {
+  enabled: true,
+  clientId: 'client-id',
+  hasClientSecret: true,
+  autoProvision: true,
+  allowedDomains: ['example.com'],
+  customScopes: null,
+  roleMapping: [],
+  providerLabel: '',
+  profileMapping: null,
+};
+
+describe('SSO provider template persistence', () => {
+  it('keeps Microsoft Entra ID selected after a real tenant issuer is saved', () => {
+    render(
+      <SsoSettingsForm
+        initialConfig={{
+          ...commonConfig,
+          providerType: 'azure',
+          issuer:
+            'https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0',
+        }}
+        callbackUrl="https://app.example.com/api/auth/callback/oidc"
+        hasEncryptionKey
+      />
+    );
+
+    const entraButton = screen.getByRole('button', { name: 'Microsoft Entra ID' });
+    const customButton = screen.getByRole('button', { name: 'Custom' });
+
+    expect(entraButton.className).toContain('bg-primary');
+    expect(customButton.className).not.toContain('bg-primary');
+  });
+
+  it('detects the provider from issuer for legacy rows without providerType', () => {
+    render(
+      <SsoSettingsForm
+        initialConfig={{
+          ...commonConfig,
+          providerType: null,
+          issuer: 'https://acme.okta.com/oauth2/default',
+        }}
+        callbackUrl="https://app.example.com/api/auth/callback/oidc"
+        hasEncryptionKey
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Okta' }).className).toContain('bg-primary');
+  });
+});

--- a/tests/lib/auth-oidc-provider-compat.test.ts
+++ b/tests/lib/auth-oidc-provider-compat.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getOidcConfigMock } = vi.hoisted(() => ({
+  getOidcConfigMock: vi.fn(),
+}));
+
+vi.mock('@/lib/oidc-config', () => ({
+  getOidcConfig: getOidcConfigMock,
+}));
+
+vi.mock('@/lib/prisma', () => {
+  const mockPrisma = {
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    oidcLinkingApproval: {
+      findFirst: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    oidcIdentity: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    oidcConfig: {
+      findFirst: vi.fn(),
+      upsert: vi.fn(),
+    },
+    auditLog: {
+      findFirst: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  };
+  mockPrisma.$transaction.mockImplementation(async callback => callback(mockPrisma));
+  return { default: mockPrisma };
+});
+
+import prisma from '@/lib/prisma';
+import { getAuthOptions, resetAuthOptionsCache } from '@/lib/auth';
+
+const baseConfig = {
+  enabled: true,
+  issuer: 'https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0',
+  clientId: 'client-id',
+  clientSecret: 'secret',
+  autoProvision: true,
+  allowedDomains: [],
+  roleMapping: undefined,
+  customScopes: null,
+  profileMapping: null,
+  providerType: 'azure',
+  providerLabel: null,
+};
+
+type SignInCallback = (args: {
+  user: { email: string; name: string; id: string };
+  account: { provider: string; providerAccountId: string };
+  profile: Record<string, unknown>;
+}) => Promise<boolean>;
+
+async function getSignIn() {
+  resetAuthOptionsCache();
+  const authOptions = await getAuthOptions();
+  return authOptions.callbacks?.signIn as unknown as SignInCallback;
+}
+
+describe('OIDC provider-specific email verification compatibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAuthOptionsCache();
+    process.env.AUTH_OPTIONS_CACHE_TTL_MS = '0';
+    process.env.JWT_USER_REFRESH_TTL_MS = '60000';
+    process.env.OIDC_REQUIRE_EMAIL_VERIFIED_STRICT = 'true';
+
+    getOidcConfigMock.mockResolvedValue(baseConfig);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.user.create).mockResolvedValue({ id: 'u1' } as never);
+    vi.mocked(prisma.user.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.oidcLinkingApproval.updateMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.oidcIdentity.create).mockResolvedValue({ id: 'identity-1' } as never);
+    vi.mocked(prisma.auditLog.findFirst).mockResolvedValue(null);
+  });
+
+  it('accepts a new Microsoft Entra user when email_verified is absent in strict mode', async () => {
+    vi.mocked(prisma.user.findUnique)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'u1',
+        email: 'user@example.com',
+        name: 'User',
+        role: 'USER',
+        status: 'ACTIVE',
+      } as never)
+      .mockResolvedValueOnce({ id: 'u1', status: 'ACTIVE' } as never);
+
+    const signIn = await getSignIn();
+    const result = await signIn({
+      user: { email: 'user@example.com', name: 'User', id: 'entra-sub' },
+      account: { provider: 'oidc', providerAccountId: 'entra-sub' },
+      profile: { sub: 'entra-sub', tid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+    });
+
+    expect(result).toBe(true);
+    expect(prisma.oidcIdentity.create).toHaveBeenCalledWith({
+      data: {
+        issuer: baseConfig.issuer,
+        subject: 'entra-sub',
+        email: 'user@example.com',
+        userId: 'u1',
+      },
+    });
+  });
+
+  it('allows an ACTIVE Entra account with admin approval to link when email_verified is absent', async () => {
+    const existing = {
+      id: 'u1',
+      email: 'user@example.com',
+      name: 'User',
+      role: 'USER',
+      status: 'ACTIVE',
+    };
+    vi.mocked(prisma.user.findUnique)
+      .mockResolvedValueOnce(existing as never)
+      .mockResolvedValueOnce({ id: 'u1', status: 'ACTIVE' } as never);
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({
+      id: 'approval-1',
+    } as never);
+
+    const signIn = await getSignIn();
+    const result = await signIn({
+      user: { email: 'user@example.com', name: 'User', id: 'entra-sub' },
+      account: { provider: 'oidc', providerAccountId: 'entra-sub' },
+      profile: { sub: 'entra-sub' },
+    });
+
+    expect(result).toBe(true);
+    expect(prisma.oidcLinkingApproval.updateMany).toHaveBeenCalledWith({
+      where: { id: 'approval-1', revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+    expect(prisma.oidcIdentity.create).toHaveBeenCalled();
+  });
+
+  it('still rejects an explicit email_verified=false from Entra', async () => {
+    const signIn = await getSignIn();
+    const result = await signIn({
+      user: { email: 'user@example.com', name: 'User', id: 'entra-sub' },
+      account: { provider: 'oidc', providerAccountId: 'entra-sub' },
+      profile: { sub: 'entra-sub', email_verified: false },
+    });
+
+    expect(result).toBe(false);
+    expect(prisma.user.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps strict missing-email verification for non-Entra providers', async () => {
+    getOidcConfigMock.mockResolvedValue({
+      ...baseConfig,
+      issuer: 'https://login.example.com',
+      providerType: 'custom',
+    });
+
+    const signIn = await getSignIn();
+    const result = await signIn({
+      user: { email: 'user@example.com', name: 'User', id: 'custom-sub' },
+      account: { provider: 'oidc', providerAccountId: 'custom-sub' },
+      profile: { sub: 'custom-sub' },
+    });
+
+    expect(result).toBe(false);
+    expect(prisma.user.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/auth-oidc-provider-compat.test.ts
+++ b/tests/lib/auth-oidc-provider-compat.test.ts
@@ -144,6 +144,79 @@ describe('OIDC provider-specific email verification compatibility', () => {
     expect(prisma.oidcIdentity.create).toHaveBeenCalled();
   });
 
+  it('blocks an INVITED Entra account with missing email_verified until an admin approves the link', async () => {
+    const invited = {
+      id: 'u1',
+      email: 'user@example.com',
+      name: 'Invited User',
+      role: 'ADMIN',
+      status: 'INVITED',
+    };
+    vi.mocked(prisma.user.findUnique)
+      .mockResolvedValueOnce(invited as never)
+      .mockResolvedValueOnce({ id: 'u1', status: 'INVITED' } as never);
+
+    const signIn = await getSignIn();
+    const result = await signIn({
+      user: { email: 'user@example.com', name: 'Invited User', id: 'entra-sub' },
+      account: { provider: 'oidc', providerAccountId: 'entra-sub' },
+      profile: { sub: 'entra-sub' },
+    });
+
+    expect(result).toBe(false);
+    expect(prisma.oidcLinkingApproval.findFirst).toHaveBeenCalledWith({
+      where: { userId: 'u1', revokedAt: null },
+      select: { id: true },
+    });
+    expect(prisma.oidcIdentity.create).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('allows an approved INVITED Entra account with missing email_verified and consumes the approval', async () => {
+    const invited = {
+      id: 'u1',
+      email: 'user@example.com',
+      name: 'Invited User',
+      role: 'USER',
+      status: 'INVITED',
+    };
+    vi.mocked(prisma.user.findUnique)
+      .mockResolvedValueOnce(invited as never)
+      .mockResolvedValueOnce({ id: 'u1', status: 'INVITED' } as never);
+    vi.mocked(prisma.oidcLinkingApproval.findFirst).mockResolvedValue({
+      id: 'approval-1',
+    } as never);
+
+    const signIn = await getSignIn();
+    const result = await signIn({
+      user: { email: 'user@example.com', name: 'Invited User', id: 'entra-sub' },
+      account: { provider: 'oidc', providerAccountId: 'entra-sub' },
+      profile: { sub: 'entra-sub' },
+    });
+
+    expect(result).toBe(true);
+    expect(prisma.oidcLinkingApproval.updateMany).toHaveBeenCalledWith({
+      where: { id: 'approval-1', revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+    expect(prisma.oidcIdentity.create).toHaveBeenCalledWith({
+      data: {
+        issuer: baseConfig.issuer,
+        subject: 'entra-sub',
+        email: 'user@example.com',
+        userId: 'u1',
+      },
+    });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: {
+        status: 'ACTIVE',
+        invitedAt: null,
+        deactivatedAt: null,
+      },
+    });
+  });
+
   it('still rejects an explicit email_verified=false from Entra', async () => {
     const signIn = await getSignIn();
     const result = await signIn({

--- a/tests/lib/oidc-provider.test.ts
+++ b/tests/lib/oidc-provider.test.ts
@@ -12,6 +12,8 @@ describe('OIDC provider compatibility policy', () => {
     ['https://acme.okta.com/oauth2/default', 'okta'],
     ['https://acme.oktapreview.com/oauth2/default', 'okta'],
     ['https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0', 'azure'],
+    ['https://login.microsoftonline.us/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0', 'azure'],
+    ['https://login.partner.microsoftonline.cn/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0', 'azure'],
     ['https://acme.us.auth0.com/', 'auth0'],
     ['https://login.example.com/oidc', 'custom'],
   ])('detects %s as %s', (issuer, expected) => {
@@ -23,6 +25,8 @@ describe('OIDC provider compatibility policy', () => {
     'https://okta.example.com',
     'https://foo.okta.evil.com',
     'https://microsoftonline.example.com',
+    'https://login.microsoftonline.us.evil.example',
+    'https://login.partner.microsoftonline.cn.evil.example',
     'https://auth0.example.com',
   ])('does not trust lookalike provider hostname %s', issuer => {
     expect(detectOidcProviderType(issuer)).toBe('custom');

--- a/tests/lib/oidc-provider.test.ts
+++ b/tests/lib/oidc-provider.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectOidcProviderType,
+  hasOidcEmailLinkAssurance,
+  normalizeOidcProviderType,
+  requiresOidcEmailVerifiedClaim,
+} from '@/lib/oidc-provider';
+
+describe('OIDC provider compatibility policy', () => {
+  it.each([
+    ['https://accounts.google.com', 'google'],
+    ['https://acme.okta.com/oauth2/default', 'okta'],
+    ['https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0', 'azure'],
+    ['https://acme.us.auth0.com/', 'auth0'],
+    ['https://login.example.com/oidc', 'custom'],
+  ])('detects %s as %s', (issuer, expected) => {
+    expect(detectOidcProviderType(issuer)).toBe(expected);
+  });
+
+  it.each([
+    'https://google.example.com',
+    'https://okta.example.com',
+    'https://microsoftonline.example.com',
+    'https://auth0.example.com',
+  ])('does not trust lookalike provider hostname %s', issuer => {
+    expect(detectOidcProviderType(issuer)).toBe('custom');
+  });
+
+  it('prefers a valid persisted provider type and falls back to issuer detection', () => {
+    expect(
+      normalizeOidcProviderType(
+        'azure',
+        'https://login.microsoftonline.com/tenant-id/v2.0'
+      )
+    ).toBe('azure');
+    expect(
+      normalizeOidcProviderType(
+        null,
+        'https://login.microsoftonline.com/tenant-id/v2.0'
+      )
+    ).toBe('azure');
+    expect(normalizeOidcProviderType('unexpected', 'https://accounts.google.com')).toBe('google');
+  });
+
+  it('allows Entra to omit email_verified even when strict mode is enabled', () => {
+    expect(requiresOidcEmailVerifiedClaim('azure', true)).toBe(false);
+    expect(requiresOidcEmailVerifiedClaim('google', true)).toBe(true);
+    expect(requiresOidcEmailVerifiedClaim('custom', true)).toBe(true);
+    expect(requiresOidcEmailVerifiedClaim('custom', false)).toBe(false);
+  });
+
+  it('treats a missing email_verified claim as sufficient only for Entra linking', () => {
+    expect(hasOidcEmailLinkAssurance('azure', undefined)).toBe(true);
+    expect(hasOidcEmailLinkAssurance('google', undefined)).toBe(false);
+    expect(hasOidcEmailLinkAssurance('custom', undefined)).toBe(false);
+    expect(hasOidcEmailLinkAssurance('custom', true)).toBe(true);
+    expect(hasOidcEmailLinkAssurance('azure', false)).toBe(false);
+  });
+});

--- a/tests/lib/oidc-provider.test.ts
+++ b/tests/lib/oidc-provider.test.ts
@@ -10,6 +10,7 @@ describe('OIDC provider compatibility policy', () => {
   it.each([
     ['https://accounts.google.com', 'google'],
     ['https://acme.okta.com/oauth2/default', 'okta'],
+    ['https://acme.oktapreview.com/oauth2/default', 'okta'],
     ['https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0', 'azure'],
     ['https://acme.us.auth0.com/', 'auth0'],
     ['https://login.example.com/oidc', 'custom'],
@@ -20,26 +21,27 @@ describe('OIDC provider compatibility policy', () => {
   it.each([
     'https://google.example.com',
     'https://okta.example.com',
+    'https://foo.okta.evil.com',
     'https://microsoftonline.example.com',
     'https://auth0.example.com',
   ])('does not trust lookalike provider hostname %s', issuer => {
     expect(detectOidcProviderType(issuer)).toBe('custom');
   });
 
-  it('prefers a valid persisted provider type and falls back to issuer detection', () => {
+  it('uses issuer detection as the authority over a persisted provider type', () => {
     expect(
       normalizeOidcProviderType(
-        'azure',
+        'custom',
         'https://login.microsoftonline.com/tenant-id/v2.0'
       )
     ).toBe('azure');
-    expect(
-      normalizeOidcProviderType(
-        null,
-        'https://login.microsoftonline.com/tenant-id/v2.0'
-      )
-    ).toBe('azure');
+    expect(normalizeOidcProviderType('azure', 'https://login.example.com')).toBe('custom');
     expect(normalizeOidcProviderType('unexpected', 'https://accounts.google.com')).toBe('google');
+  });
+
+  it('uses the persisted provider type only when no issuer is available', () => {
+    expect(normalizeOidcProviderType('azure', null)).toBe('azure');
+    expect(normalizeOidcProviderType('unexpected', null)).toBe('custom');
   });
 
   it('allows Entra to omit email_verified even when strict mode is enabled', () => {

--- a/tests/lib/oidc-validation-provider-matrix.test.ts
+++ b/tests/lib/oidc-validation-provider-matrix.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { assertSafeOutboundUrlMock } = vi.hoisted(() => ({
+  assertSafeOutboundUrlMock: vi.fn(),
+}));
+
+vi.mock('@/lib/network-security', () => ({
+  assertSafeOutboundUrl: assertSafeOutboundUrlMock,
+}));
+
+import { validateOidcConnection } from '@/lib/oidc-validation';
+
+const metadata = {
+  authorization_endpoint: 'https://idp.example.com/authorize',
+  token_endpoint: 'https://idp.example.com/token',
+  jwks_uri: 'https://idp.example.com/jwks',
+  id_token_signing_alg_values_supported: ['RS256'],
+};
+
+function response(status: number, body: unknown = metadata) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('OIDC discovery provider matrix', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    assertSafeOutboundUrlMock.mockReset();
+    assertSafeOutboundUrlMock.mockResolvedValue(undefined);
+  });
+
+  it.each([
+    [
+      'Google',
+      'https://accounts.google.com',
+      'https://accounts.google.com/.well-known/openid-configuration',
+    ],
+    [
+      'Microsoft Entra ID',
+      'https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0',
+      'https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/v2.0/.well-known/openid-configuration',
+    ],
+    [
+      'Okta',
+      'https://acme.okta.com/oauth2/default',
+      'https://acme.okta.com/oauth2/default/.well-known/openid-configuration',
+    ],
+    [
+      'Auth0',
+      'https://acme.us.auth0.com/',
+      'https://acme.us.auth0.com/.well-known/openid-configuration',
+    ],
+    [
+      'Custom OIDC',
+      'https://identity.example.com/oidc',
+      'https://identity.example.com/oidc/.well-known/openid-configuration',
+    ],
+  ])('validates %s discovery metadata', async (_provider, issuer, expectedDiscoveryUrl) => {
+    const fetchMock = vi.fn().mockResolvedValue(response(200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await validateOidcConnection(issuer);
+
+    expect(result).toEqual({ isValid: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expectedDiscoveryUrl,
+      expect.objectContaining({ method: 'GET', redirect: 'manual' })
+    );
+    expect(assertSafeOutboundUrlMock).toHaveBeenCalledWith(expectedDiscoveryUrl, {
+      requireHttps: true,
+    });
+  });
+
+  it('rejects non-HTTPS issuers before network access', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await validateOidcConnection('http://identity.example.com');
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toMatch(/HTTPS/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects redirects from discovery to avoid validating a different issuer', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response(302)));
+
+    const result = await validateOidcConnection('https://identity.example.com');
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toMatch(/redirect/i);
+  });
+
+  it('rejects metadata with unsafe endpoints', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        response(200, {
+          ...metadata,
+          token_endpoint: 'https://127.0.0.1/token',
+        })
+      )
+    );
+    assertSafeOutboundUrlMock.mockImplementation(async (url: string) => {
+      if (url.includes('127.0.0.1')) throw new Error('restricted');
+    });
+
+    const result = await validateOidcConnection('https://identity.example.com');
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toMatch(/unsafe|non-HTTPS/i);
+  });
+
+  it('rejects providers without an approved asymmetric ID-token algorithm', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        response(200, {
+          ...metadata,
+          id_token_signing_alg_values_supported: ['HS256'],
+        })
+      )
+    );
+
+    const result = await validateOidcConnection('https://identity.example.com');
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toMatch(/RS256|ES256/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes confirmed OIDC/SSO compatibility and security issues found during Microsoft Entra testing and adds a provider compatibility test matrix.

### Fixed
- Microsoft Entra ID sign-ins no longer fail solely because the standard `email_verified` claim is absent.
- An explicit `email_verified: false` is still rejected for every provider.
- Existing ACTIVE-account first linking remains protected by the fresh one-time admin approval.
- Existing INVITED Entra accounts cannot be claimed from a token that omits `email_verified`; a fresh one-time admin linking approval is required and consumed before first linking.
- New Entra JIT-provisioned users can still sign in when `email_verified` is absent.
- Microsoft Entra sovereign-cloud issuers for US Government (`login.microsoftonline.us`) and China operated by 21Vianet (`login.partner.microsoftonline.cn`) are recognized using strict hostname matching.
- Runtime OIDC config now preserves `providerType`/`providerLabel`, so auth policy can make provider-aware decisions.
- SSO settings now restore the saved provider from issuer-authoritative provider detection instead of exact issuer-template equality, fixing Entra/Okta/Auth0 becoming `Custom` after placeholders are replaced and settings are reloaded.
- Renames the UI label from `Azure AD` to `Microsoft Entra ID` while retaining internal `azure` compatibility.
- Provider detection is centralized with strict hostname matching so persisted provider metadata or lookalike domains cannot inherit provider-specific authentication behavior.

## Tests added
- Provider detection matrix: Google, Okta, Microsoft Entra ID, Auth0, Custom OIDC.
- Entra public-cloud, US Government, and China issuer detection.
- Lookalike-host rejection, including sovereign-cloud lookalikes.
- Provider-specific strict `email_verified` policy.
- Entra new-user login with missing `email_verified` under strict mode.
- Entra existing ACTIVE user linking with admin approval and missing `email_verified`.
- Entra existing INVITED user with missing `email_verified` blocked without approval.
- Approved INVITED Entra linking consumes the one-time approval before activation.
- Explicit `email_verified: false` rejection.
- Non-Entra strict-mode regression.
- SSO provider-template persistence after save/reload.
- OIDC discovery matrix for Google, Entra, Okta, Auth0, and Custom OIDC, plus HTTPS, redirect, unsafe-endpoint and signing-algorithm checks.

## Security notes
This does not globally disable strict email verification. The exception is limited to issuer-verified Microsoft Entra ID providers. Explicit negative verification claims continue to fail. Stable identity linking remains issuer + subject based. Existing account first-linking requires either an explicit verified-email signal where the invitation flow permits it or the existing one-time administrator approval control.

The repository security-summary job currently reports pre-existing lint/dependency findings from the base branch as JUnit failures while the security workflow itself remains green. The PR delta for that summary is `±0`; this PR does not introduce additional findings.

## Scope
This PR intentionally does not add multi-IdP support or a local-auth/break-glass switch; those require separate architectural changes.