### PR TITLE
fix(migrations): make Jira guard rolling-update compatible

### DIFF
--- a/prisma/migrations/20260911013000_jira_action_item_link_rolling_guard/migration.sql
+++ b/prisma/migrations/20260911013000_jira_action_item_link_rolling_guard/migration.sql
@@ -1,0 +1,133 @@
+-- Rolling-compatible repair for 20260910174500_guard_jira_mapping_workspace.
+--
+-- The earlier migration rejected deployment when historical data already
+-- contained multiple Jira links for one action item. That is a valid data
+-- quality problem, but it must not make an otherwise healthy application
+-- unavailable during a rolling deploy.
+--
+-- This migration follows expand/migrate/contract semantics:
+--   1. Re-establish the workspace fences idempotently, regardless of how far
+--      the failed migration progressed.
+--   2. Preserve all historical Jira associations for operator review.
+--   3. Prevent every NEW duplicate action-item Jira association at the database
+--      boundary, including writes from older application instances.
+--   4. Allow metadata-only updates to existing legacy duplicate rows so normal
+--      Jira synchronization remains available during cleanup.
+--
+-- Once historical duplicates are reconciled, a later contract migration may
+-- add the partial unique index. Startup must never require that cleanup.
+
+CREATE OR REPLACE FUNCTION "guard_jira_service_mapping_workspace"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM pg_advisory_xact_lock_shared(9141005::bigint);
+
+  PERFORM 1
+  FROM "JiraConfig"
+  WHERE "id" = 'default'
+    AND "enabled" = TRUE
+  FOR KEY SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Jira workspace is not configured or is disabled'
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "trg_guard_jira_service_mapping_workspace" ON "JiraServiceMapping";
+
+CREATE TRIGGER "trg_guard_jira_service_mapping_workspace"
+BEFORE INSERT OR UPDATE ON "JiraServiceMapping"
+FOR EACH ROW
+EXECUTE FUNCTION "guard_jira_service_mapping_workspace"();
+
+CREATE OR REPLACE FUNCTION "guard_jira_external_issue_link_workspace"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW."provider" = 'JIRA' THEN
+    PERFORM pg_advisory_xact_lock_shared(9141005::bigint);
+
+    PERFORM 1
+    FROM "JiraConfig"
+    WHERE "id" = 'default'
+      AND "enabled" = TRUE
+    FOR KEY SHARE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Jira workspace is not configured or is disabled'
+        USING ERRCODE = '23503';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "trg_guard_jira_external_issue_link_workspace" ON "ExternalIssueLink";
+
+CREATE TRIGGER "trg_guard_jira_external_issue_link_workspace"
+BEFORE INSERT OR UPDATE ON "ExternalIssueLink"
+FOR EACH ROW
+EXECUTE FUNCTION "guard_jira_external_issue_link_workspace"();
+
+-- Preserve legacy duplicates but serialize ownership-changing writes for each
+-- action item. A 64-bit seeded PostgreSQL hash keeps the lock local to one
+-- action item while making accidental lock collisions vanishingly unlikely.
+CREATE OR REPLACE FUNCTION "guard_jira_action_item_single_link"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW."provider" <> 'JIRA' OR NEW."actionItemId" IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Existing duplicate rows must remain synchronizable. The UPDATE trigger is
+  -- scoped to provider/actionItemId columns, but keep this identity check as a
+  -- defense if the trigger definition is broadened in the future.
+  IF TG_OP = 'UPDATE'
+    AND OLD."provider" = NEW."provider"
+    AND OLD."actionItemId" IS NOT DISTINCT FROM NEW."actionItemId"
+  THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(NEW."actionItemId", 9141006::bigint)
+  );
+
+  IF EXISTS (
+    SELECT 1
+    FROM "ExternalIssueLink"
+    WHERE "provider" = 'JIRA'
+      AND "actionItemId" = NEW."actionItemId"
+      AND "id" <> NEW."id"
+  ) THEN
+    RAISE EXCEPTION 'Action item already has a Jira issue link'
+      USING ERRCODE = '23505',
+            CONSTRAINT = 'ExternalIssueLink_jira_actionItemId_guard';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "trg_guard_jira_action_item_single_link_insert" ON "ExternalIssueLink";
+DROP TRIGGER IF EXISTS "trg_guard_jira_action_item_single_link_ownership_update" ON "ExternalIssueLink";
+
+CREATE TRIGGER "trg_guard_jira_action_item_single_link_insert"
+BEFORE INSERT ON "ExternalIssueLink"
+FOR EACH ROW
+EXECUTE FUNCTION "guard_jira_action_item_single_link"();
+
+CREATE TRIGGER "trg_guard_jira_action_item_single_link_ownership_update"
+BEFORE UPDATE OF "provider", "actionItemId" ON "ExternalIssueLink"
+FOR EACH ROW
+EXECUTE FUNCTION "guard_jira_action_item_single_link"();

--- a/prisma/migrations/20260911013000_jira_action_item_link_rolling_guard/migration.sql
+++ b/prisma/migrations/20260911013000_jira_action_item_link_rolling_guard/migration.sql
@@ -91,12 +91,14 @@ BEGIN
 
   -- Existing duplicate rows must remain synchronizable. The UPDATE trigger is
   -- scoped to provider/actionItemId columns, but keep this identity check as a
-  -- defense if the trigger definition is broadened in the future.
-  IF TG_OP = 'UPDATE'
-    AND OLD."provider" = NEW."provider"
-    AND OLD."actionItemId" IS NOT DISTINCT FROM NEW."actionItemId"
-  THEN
-    RETURN NEW;
+  -- defense if the trigger definition is broadened in the future. Keep OLD
+  -- inside the UPDATE-only branch because OLD is not assigned for INSERT.
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD."provider" = NEW."provider"
+      AND OLD."actionItemId" IS NOT DISTINCT FROM NEW."actionItemId"
+    THEN
+      RETURN NEW;
+    END IF;
   END IF;
 
   PERFORM pg_advisory_xact_lock(

--- a/scripts/auto-recover-migrations.ts
+++ b/scripts/auto-recover-migrations.ts
@@ -43,6 +43,7 @@ interface RecoveryResult {
 const JIRA_ROLLING_GUARD_MIGRATION = '20260910174500_guard_jira_mapping_workspace';
 const JIRA_DUPLICATE_GUARD_FAILURE =
     'Cannot enforce one Jira issue per action item: duplicate Jira links exist.';
+const JIRA_ACTION_ITEM_UNIQUE_INDEX = 'ExternalIssueLink_jira_actionItemId_unique';
 
 function getRecoveryMode(): RecoveryMode {
     return process.env.MIGRATION_RECOVERY_MODE === 'aggressive' ? 'aggressive' : 'safe';
@@ -113,10 +114,18 @@ async function getFailedMigrations(): Promise<MigrationRecord[]> {
 }
 
 function isKnownJiraDuplicateGuardFailure(migration: MigrationRecord): boolean {
-    return (
-        migration.migration_name === JIRA_ROLLING_GUARD_MIGRATION &&
-        Boolean(migration.logs?.includes(JIRA_DUPLICATE_GUARD_FAILURE))
-    );
+    if (migration.migration_name !== JIRA_ROLLING_GUARD_MIGRATION || !migration.logs) {
+        return false;
+    }
+
+    const failedLegacyPrecondition = migration.logs.includes(JIRA_DUPLICATE_GUARD_FAILURE);
+    const failedUniqueIndexBuild =
+        migration.logs.includes(JIRA_ACTION_ITEM_UNIQUE_INDEX) &&
+        (migration.logs.includes('could not create unique index') ||
+            migration.logs.includes('is duplicated') ||
+            migration.logs.includes('duplicate key value'));
+
+    return failedLegacyPrecondition || failedUniqueIndexBuild;
 }
 
 /**
@@ -128,12 +137,14 @@ async function autoResolveMigration(migration: MigrationRecord): Promise<Recover
 
     logger.info('Analyzing migration', { component: 'auto-recover-migrations', migration: migrationName });
 
-    // This migration was shipped with a startup-time legacy-data precondition.
-    // Existing installations can legitimately contain duplicate historical Jira
-    // links, so that precondition is not rolling-deployment compatible. Resolve
-    // only the exact, known failure signature as applied; the immediately
-    // following repair migration recreates the workspace guards idempotently and
-    // installs a write-time uniqueness guard that tolerates legacy duplicates.
+    // This migration was shipped with a startup-time legacy-data precondition
+    // followed by a unique-index build. Both can fail during a rolling deploy:
+    // historical duplicates can trip the precondition, or an older application
+    // instance can create a duplicate between the check and index creation.
+    // Resolve only these exact data-conflict signatures as applied; the
+    // immediately following repair migration recreates the workspace guards
+    // idempotently and installs a write-time uniqueness guard that tolerates
+    // legacy duplicates.
     if (isKnownJiraDuplicateGuardFailure(migration)) {
         logger.warn('Recovering known Jira rolling-migration compatibility failure', {
             component: 'auto-recover-migrations',
@@ -147,7 +158,7 @@ async function autoResolveMigration(migration: MigrationRecord): Promise<Recover
                 action: 'resolved',
                 migration: migrationName,
                 reason:
-                    'Known legacy Jira duplicate precondition bypassed; forward repair migration will enforce new writes safely',
+                    'Known Jira duplicate/index conflict bypassed; forward repair migration will enforce new writes safely',
             };
         } catch (error) {
             return {

--- a/scripts/auto-recover-migrations.ts
+++ b/scripts/auto-recover-migrations.ts
@@ -40,6 +40,10 @@ interface RecoveryResult {
     reason: string;
 }
 
+const JIRA_ROLLING_GUARD_MIGRATION = '20260910174500_guard_jira_mapping_workspace';
+const JIRA_DUPLICATE_GUARD_FAILURE =
+    'Cannot enforce one Jira issue per action item: duplicate Jira links exist.';
+
 function getRecoveryMode(): RecoveryMode {
     return process.env.MIGRATION_RECOVERY_MODE === 'aggressive' ? 'aggressive' : 'safe';
 }
@@ -89,7 +93,8 @@ async function enumValueExists(enumName: string, value: string): Promise<boolean
 }
 
 /**
- * Get all failed migrations from database
+ * Get all active failed migrations from database. Rolled-back attempts remain
+ * in Prisma's history and must not be recovered a second time.
  */
 async function getFailedMigrations(): Promise<MigrationRecord[]> {
     try {
@@ -97,6 +102,7 @@ async function getFailedMigrations(): Promise<MigrationRecord[]> {
       SELECT migration_name, started_at, finished_at, logs
       FROM "_prisma_migrations"
       WHERE finished_at IS NULL
+        AND rolled_back_at IS NULL
       ORDER BY started_at ASC
     `;
         return failed;
@@ -104,6 +110,13 @@ async function getFailedMigrations(): Promise<MigrationRecord[]> {
         logger.error('Failed to query _prisma_migrations', { component: 'auto-recover-migrations', error });
         return [];
     }
+}
+
+function isKnownJiraDuplicateGuardFailure(migration: MigrationRecord): boolean {
+    return (
+        migration.migration_name === JIRA_ROLLING_GUARD_MIGRATION &&
+        Boolean(migration.logs?.includes(JIRA_DUPLICATE_GUARD_FAILURE))
+    );
 }
 
 /**
@@ -114,6 +127,37 @@ async function autoResolveMigration(migration: MigrationRecord): Promise<Recover
     const recoveryMode = getRecoveryMode();
 
     logger.info('Analyzing migration', { component: 'auto-recover-migrations', migration: migrationName });
+
+    // This migration was shipped with a startup-time legacy-data precondition.
+    // Existing installations can legitimately contain duplicate historical Jira
+    // links, so that precondition is not rolling-deployment compatible. Resolve
+    // only the exact, known failure signature as applied; the immediately
+    // following repair migration recreates the workspace guards idempotently and
+    // installs a write-time uniqueness guard that tolerates legacy duplicates.
+    if (isKnownJiraDuplicateGuardFailure(migration)) {
+        logger.warn('Recovering known Jira rolling-migration compatibility failure', {
+            component: 'auto-recover-migrations',
+            migration: migrationName,
+        });
+
+        try {
+            runPrisma(['migrate', 'resolve', '--applied', migrationName]);
+            return {
+                success: true,
+                action: 'resolved',
+                migration: migrationName,
+                reason:
+                    'Known legacy Jira duplicate precondition bypassed; forward repair migration will enforce new writes safely',
+            };
+        } catch (error) {
+            return {
+                success: false,
+                action: 'failed',
+                migration: migrationName,
+                reason: `Failed to resolve known Jira migration: ${formatExecError(error)}`,
+            };
+        }
+    }
 
     // Special handling for known enum migrations
     if (migrationName.includes('escalation_policy_enum')) {

--- a/tests/architecture/jira-rolling-migration-contract.test.ts
+++ b/tests/architecture/jira-rolling-migration-contract.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const failedMigrationPath =
+  'prisma/migrations/20260910174500_guard_jira_mapping_workspace/migration.sql';
+const repairMigrationPath =
+  'prisma/migrations/20260911013000_jira_action_item_link_rolling_guard/migration.sql';
+
+describe('Jira rolling migration contract', () => {
+  it('recovers only the exact known legacy-duplicate failure', () => {
+    const failedMigration = readFileSync(failedMigrationPath, 'utf8');
+    const recovery = readFileSync('scripts/auto-recover-migrations.ts', 'utf8');
+
+    expect(failedMigration).toContain(
+      'Cannot enforce one Jira issue per action item: duplicate Jira links exist.'
+    );
+    expect(recovery).toContain("'20260910174500_guard_jira_mapping_workspace'");
+    expect(recovery).toContain(
+      "'Cannot enforce one Jira issue per action item: duplicate Jira links exist.'"
+    );
+    expect(recovery).toContain("['migrate', 'resolve', '--applied', migrationName]");
+    expect(recovery).toContain('migration.logs?.includes(JIRA_DUPLICATE_GUARD_FAILURE)');
+    expect(recovery).toContain('AND rolled_back_at IS NULL');
+  });
+
+  it('never requires historical duplicate cleanup during application startup', () => {
+    const repairMigration = readFileSync(repairMigrationPath, 'utf8');
+
+    expect(repairMigration).not.toContain('HAVING COUNT(*) > 1');
+    expect(repairMigration).not.toContain('CREATE UNIQUE INDEX');
+    expect(repairMigration).not.toContain('DELETE FROM "ExternalIssueLink"');
+    expect(repairMigration).not.toContain('UPDATE "ExternalIssueLink" SET');
+  });
+
+  it('blocks new duplicates at write time while preserving metadata sync for legacy rows', () => {
+    const repairMigration = readFileSync(repairMigrationPath, 'utf8');
+
+    expect(repairMigration).toContain('guard_jira_action_item_single_link');
+    expect(repairMigration).toContain('hashtextextended(NEW."actionItemId", 9141006::bigint)');
+    expect(repairMigration).toContain('BEFORE INSERT ON "ExternalIssueLink"');
+    expect(repairMigration).toContain(
+      'BEFORE UPDATE OF "provider", "actionItemId" ON "ExternalIssueLink"'
+    );
+    expect(repairMigration).toContain('"id" <> NEW."id"');
+    expect(repairMigration).toContain("ERRCODE = '23505'");
+  });
+
+  it('recreates workspace lifecycle guards idempotently after partial failure', () => {
+    const repairMigration = readFileSync(repairMigrationPath, 'utf8');
+
+    expect(repairMigration).toContain(
+      'CREATE OR REPLACE FUNCTION "guard_jira_service_mapping_workspace"()'
+    );
+    expect(repairMigration).toContain(
+      'CREATE OR REPLACE FUNCTION "guard_jira_external_issue_link_workspace"()'
+    );
+    expect(repairMigration.match(/pg_advisory_xact_lock_shared\(9141005::bigint\)/g)?.length).toBe(
+      2
+    );
+  });
+});

--- a/tests/architecture/jira-rolling-migration-contract.test.ts
+++ b/tests/architecture/jira-rolling-migration-contract.test.ts
@@ -7,7 +7,7 @@ const repairMigrationPath =
   'prisma/migrations/20260911013000_jira_action_item_link_rolling_guard/migration.sql';
 
 describe('Jira rolling migration contract', () => {
-  it('recovers only the exact known legacy-duplicate failure', () => {
+  it('recovers only the exact known duplicate-data/index-build failure class', () => {
     const failedMigration = readFileSync(failedMigrationPath, 'utf8');
     const recovery = readFileSync('scripts/auto-recover-migrations.ts', 'utf8');
 
@@ -18,8 +18,9 @@ describe('Jira rolling migration contract', () => {
     expect(recovery).toContain(
       "'Cannot enforce one Jira issue per action item: duplicate Jira links exist.'"
     );
+    expect(recovery).toContain("'ExternalIssueLink_jira_actionItemId_unique'");
     expect(recovery).toContain("['migrate', 'resolve', '--applied', migrationName]");
-    expect(recovery).toContain('migration.logs?.includes(JIRA_DUPLICATE_GUARD_FAILURE)');
+    expect(recovery).toContain('failedLegacyPrecondition || failedUniqueIndexBuild');
     expect(recovery).toContain('AND rolled_back_at IS NULL');
   });
 
@@ -41,6 +42,7 @@ describe('Jira rolling migration contract', () => {
     expect(repairMigration).toContain(
       'BEFORE UPDATE OF "provider", "actionItemId" ON "ExternalIssueLink"'
     );
+    expect(repairMigration).toContain('IF TG_OP = \'UPDATE\' THEN');
     expect(repairMigration).toContain('"id" <> NEW."id"');
     expect(repairMigration).toContain("ERRCODE = '23505'");
   });

--- a/tests/unit/migration-recovery.test.ts
+++ b/tests/unit/migration-recovery.test.ts
@@ -49,7 +49,6 @@ describe('Auto Recovery Migration System', () => {
   });
 
   it('should detect failed migrations and attempt recovery', async () => {
-    // Setup failures
     mockPrisma.$queryRaw.mockResolvedValueOnce([
       {
         migration_name: '20250630_add_escalation_policy_enum',
@@ -59,7 +58,6 @@ describe('Auto Recovery Migration System', () => {
       },
     ]);
 
-    // Setup enum exists check
     mockPrisma.$queryRaw.mockResolvedValueOnce([{ enumlabel: 'ESCALATION_POLICY' }]);
 
     const result = await autoRecoverMigrations();
@@ -74,7 +72,6 @@ describe('Auto Recovery Migration System', () => {
   });
 
   it('should apply enum value if missing', async () => {
-    // Setup failures
     mockPrisma.$queryRaw.mockResolvedValueOnce([
       {
         migration_name: '20250630_add_escalation_policy_enum',
@@ -84,12 +81,11 @@ describe('Auto Recovery Migration System', () => {
       },
     ]);
 
-    // Setup enum MISSING
     mockPrisma.$queryRaw.mockResolvedValueOnce([]);
 
     const result = await autoRecoverMigrations();
 
-    expect(mockPrisma.$executeRaw).toHaveBeenCalled(); // Should ALTER TYPE
+    expect(mockPrisma.$executeRaw).toHaveBeenCalled();
     expect(execFileSync).toHaveBeenCalledWith(
       process.execPath,
       expect.arrayContaining(['migrate', 'resolve', '--applied']),
@@ -127,6 +123,35 @@ describe('Auto Recovery Migration System', () => {
     expect(result).toBe(true);
   });
 
+  it('recovers the Jira unique-index build race from an older rolling replica', async () => {
+    const migrationName = '20260910174500_guard_jira_mapping_workspace';
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      {
+        migration_name: migrationName,
+        started_at: new Date(),
+        finished_at: null,
+        logs:
+          'ERROR: could not create unique index "ExternalIssueLink_jira_actionItemId_unique" DETAIL: Key (actionItemId)=(ai_123) is duplicated.',
+      },
+    ]);
+
+    const result = await autoRecoverMigrations();
+
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      process.execPath,
+      ['node_modules/prisma/build/index.js', 'migrate', 'resolve', '--applied', migrationName],
+      expect.anything()
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      process.execPath,
+      ['node_modules/prisma/build/index.js', 'migrate', 'deploy'],
+      expect.anything()
+    );
+    expect(result).toBe(true);
+  });
+
   it('does not auto-resolve an unrelated failure in the Jira migration', async () => {
     mockPrisma.$queryRaw.mockResolvedValueOnce([
       {
@@ -144,11 +169,10 @@ describe('Auto Recovery Migration System', () => {
   });
 
   it('should deploy pending migrations if healthy', async () => {
-    mockPrisma.$queryRaw.mockResolvedValueOnce([]); // No failures
+    mockPrisma.$queryRaw.mockResolvedValueOnce([]);
 
     const result = await autoRecoverMigrations();
 
-    // Expect NO deploy call because auto-recovery returns successfully early if no failures
     expect(execFileSync).not.toHaveBeenCalled();
     expect(result).toBe(true);
   });

--- a/tests/unit/migration-recovery.test.ts
+++ b/tests/unit/migration-recovery.test.ts
@@ -55,6 +55,7 @@ describe('Auto Recovery Migration System', () => {
         migration_name: '20250630_add_escalation_policy_enum',
         started_at: new Date(),
         finished_at: null,
+        logs: null,
       },
     ]);
 
@@ -79,6 +80,7 @@ describe('Auto Recovery Migration System', () => {
         migration_name: '20250630_add_escalation_policy_enum',
         started_at: new Date(),
         finished_at: null,
+        logs: null,
       },
     ]);
 
@@ -94,6 +96,51 @@ describe('Auto Recovery Migration System', () => {
       expect.anything()
     );
     expect(result).toBe(true);
+  });
+
+  it('recovers the known Jira duplicate precondition and applies the forward repair', async () => {
+    const migrationName = '20260910174500_guard_jira_mapping_workspace';
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      {
+        migration_name: migrationName,
+        started_at: new Date(),
+        finished_at: null,
+        logs:
+          'Database error: Cannot enforce one Jira issue per action item: duplicate Jira links exist. Review and unlink duplicates before applying this migration.',
+      },
+    ]);
+
+    const result = await autoRecoverMigrations();
+
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      process.execPath,
+      ['node_modules/prisma/build/index.js', 'migrate', 'resolve', '--applied', migrationName],
+      expect.anything()
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      process.execPath,
+      ['node_modules/prisma/build/index.js', 'migrate', 'deploy'],
+      expect.anything()
+    );
+    expect(result).toBe(true);
+  });
+
+  it('does not auto-resolve an unrelated failure in the Jira migration', async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      {
+        migration_name: '20260910174500_guard_jira_mapping_workspace',
+        started_at: new Date(),
+        finished_at: null,
+        logs: 'Database error: permission denied for relation ExternalIssueLink',
+      },
+    ]);
+
+    const result = await autoRecoverMigrations();
+
+    expect(execFileSync).not.toHaveBeenCalled();
+    expect(result).toBe(false);
   });
 
   it('should deploy pending migrations if healthy', async () => {


### PR DESCRIPTION
## Summary

Hotfix for the deployment failure caused by `20260910174500_guard_jira_mapping_workspace` when an existing installation already contains multiple historical Jira links for one action item.

The previous migration treated legacy data cleanup as a startup precondition. On an existing database that precondition raises, Prisma records the migration as failed, `migrate deploy` returns `P3009` on every subsequent container start, and the application crash-loops before Next.js can start.

This PR converts the Jira link invariant to a rolling-compatible expand/migrate/contract model and adds narrowly scoped automatic recovery for databases already stuck on this exact failed migration.

## Recovery of already-failed deployments

`auto-recover-migrations.ts` now recognizes only the exact Jira migration plus one of the known duplicate-data failure signatures:

- the explicit legacy duplicate precondition; or
- the unique-index build failing because a duplicate appeared during a rolling race.

For those signatures only, it marks the failed migration as applied and immediately runs pending migrations. Unknown failures in the same migration still fail closed and require operator review.

Rolled-back Prisma migration attempts are also excluded from recovery so they are not processed repeatedly.

## Rolling-safe forward migration

Adds `20260911013000_jira_action_item_link_rolling_guard`.

The migration:

- recreates the Jira workspace mapping/link guards idempotently, so it converges whether the previous failed migration committed none, some, or all pre-index statements;
- does not scan for or delete historical duplicate Jira associations;
- does not require a unique-index build during application startup;
- installs a database trigger that serializes action-item Jira ownership writes with a per-action-item PostgreSQL advisory lock;
- rejects new duplicate Jira/action-item associations with SQLSTATE `23505`;
- scopes the update trigger to `provider` / `actionItemId` ownership changes, so metadata-only Jira sync updates continue to work even for legacy duplicate rows;
- remains compatible with older application replicas because the invariant is enforced at the database boundary.

Existing installations where the original partial unique index already exists keep that stronger constraint. Installations with historical duplicates remain online with the write-time guard until those rows are reviewed and a later contract migration can add the unique index.

## Safety

- No historical Jira link is deleted or rewritten automatically.
- No arbitrary failed migration is auto-resolved.
- No destructive Prisma flags or `db push` behavior.
- Existing migration file is left immutable; recovery is forward-only.
- Unknown permission/schema/provider failures still block startup rather than being papered over.

## Tests

Adds/updates regression coverage for:

- recovery of the exact legacy duplicate precondition;
- recovery of the unique-index rolling race;
- refusal to auto-resolve unrelated failures;
- ignoring already rolled-back attempts;
- no startup-time duplicate scan/index requirement in the repair migration;
- write-time duplicate prevention;
- preservation of metadata synchronization for legacy duplicate rows;
- idempotent restoration of Jira workspace lifecycle guards.

## Deployment behavior

For the currently crash-looping database, the new image will:

1. attempt `prisma migrate deploy` and encounter the existing `P3009` record;
2. run the built-in migration recovery path;
3. recognize the exact known Jira duplicate failure and resolve that migration as applied;
4. apply the forward rolling-safe guard migration;
5. retry/start normally without requiring a manual `prisma migrate resolve` command.

Historical duplicate Jira links remain available for later operator review instead of making application availability depend on cleanup.