### PR TITLE
fix(incident): keep War Room available when Jira is disabled

### DIFF
--- a/src/components/incident/detail/IncidentCommandBar.tsx
+++ b/src/components/incident/detail/IncidentCommandBar.tsx
@@ -177,6 +177,7 @@ export default function IncidentCommandBar({
   const isWarRoomArchived = Boolean(warRoom?.warRoomArchivedAt);
   const hasActiveWarRoom = Boolean(warRoom?.slackChannelId) && !isWarRoomArchived;
   const warRoomEnabled = warRoom?.enabled ?? false;
+  const hasVisibleWarRoom = hasActiveWarRoom || (warRoomEnabled && canManage);
 
   const jiraLinks = jira?.links || [];
   const primaryJira = jiraLinks[0];
@@ -188,7 +189,7 @@ export default function IncidentCommandBar({
     jiraCapability.canCreate ||
     jiraCapability.canLink;
   const hasAnyIntegrations =
-    hasActiveWarRoom || Boolean(primaryJira) || jiraCapability.showOperationalJira;
+    hasVisibleWarRoom || Boolean(primaryJira) || jiraCapability.showOperationalJira;
 
   const handleCreateWarRoom = () => {
     setWarRoomError(null);

--- a/tests/components/war-room-jira-independence.test.tsx
+++ b/tests/components/war-room-jira-independence.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import IncidentCommandBar from '@/components/incident/detail/IncidentCommandBar';
+import { deriveJiraCapability } from '@/lib/jira-capabilities';
+
+vi.mock('@/components/incident/ResolveIncidentModal', () => ({ default: () => null }));
+vi.mock('@/components/incident/detail/SnoozeDurationDialog', () => ({ default: () => null }));
+vi.mock('@/components/incident/detail/IncidentTags', () => ({ default: () => null }));
+vi.mock('@/app/(app)/incidents/snooze-actions', () => ({ snoozeIncidentWithDuration: vi.fn() }));
+vi.mock('@/app/(app)/incidents/jira/actions', () => ({
+  createJiraIssueFromIncident: vi.fn().mockResolvedValue({ success: true }),
+  linkJiraIssueToIncident: vi.fn().mockResolvedValue({ success: true }),
+  unlinkJiraIssueFromIncident: vi.fn().mockResolvedValue({ success: true }),
+  syncIncidentJiraIssue: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+const disabledJira = deriveJiraCapability({
+  workspaceState: 'DISABLED',
+  canManage: true,
+  serviceMapped: true,
+  syncEnabled: true,
+  rawEnabled: false,
+});
+
+describe('IncidentCommandBar integration independence', () => {
+  it('keeps Create War-Room available when Jira is disabled', () => {
+    render(
+      <IncidentCommandBar
+        incidentId="incident-1"
+        currentStatus="OPEN"
+        canManage
+        canAcknowledge={false}
+        snoozedUntil={null}
+        onAcknowledge={vi.fn()}
+        onUnacknowledge={vi.fn()}
+        onUnsnooze={vi.fn()}
+        onSuppress={vi.fn()}
+        onUnsuppress={vi.fn()}
+        resolvingIncident={{} as never}
+        postmortemHref="/postmortems/incident-1"
+        postmortemExists={false}
+        warRoom={{
+          slackChannelId: null,
+          slackChannelName: null,
+          warRoomUrl: null,
+          warRoomArchivedAt: null,
+          enabled: true,
+        }}
+        jira={{
+          links: [],
+          enabled: false,
+          serviceMapped: true,
+          serviceSettingsHref: '/services/service-1?tab=settings',
+        }}
+        tags={[]}
+        jiraCapability={disabledJira}
+      />
+    );
+
+    expect(screen.getByText('Create War-Room')).toBeInTheDocument();
+    expect(screen.queryByText('Link Jira Issue')).not.toBeInTheDocument();
+
+    const moreButtons = screen.getAllByLabelText('More incident actions');
+    fireEvent.click(moreButtons[moreButtons.length - 1]);
+    expect(screen.getByText('Create Slack War-Room')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a regression where disabling Jira could make the desktop **Create War-Room** action disappear from the incident command bar even though Slack War Room remained enabled.

## Root cause

The desktop integrations wrapper used this visibility contract:

- active War Room, or
- existing Jira link, or
- operational Jira capability.

It did **not** count an enabled-but-not-yet-created War Room. When Jira was disabled and no War Room channel existed yet, the wrapper disappeared before the nested `Create War-Room` button could render.

Mobile did not have the same coupling because its action sheet checks `warRoomEnabled` directly.

## Fix

- Introduces `hasVisibleWarRoom = hasActiveWarRoom || (warRoomEnabled && canManage)`.
- Uses that independent Slack/War Room visibility signal when deciding whether the desktop integrations section should render.
- Jira capability continues to control Jira UI only; disabling Jira no longer affects Slack War Room visibility.
- Keeps the section hidden for users who cannot manage and have no active room, avoiding an empty integrations header.

## Regression coverage

Adds a component-level test for the exact production state:

- Jira workspace disabled
- Slack War Room enabled
- no War Room created yet
- manager/responder with manage capability

The test verifies both:

- desktop: `Create War-Room` remains visible;
- mobile action sheet: `Create Slack War-Room` remains visible;
- Jira operational controls remain absent.

## Scope

No server/API behavior, Slack creation logic, Jira policy, database schema, or migration behavior is changed.