### PR TITLE
fix(jira): hide empty action-item Jira surfaces when disabled

### DIFF
--- a/src/components/action-items/ActionItemJiraContext.tsx
+++ b/src/components/action-items/ActionItemJiraContext.tsx
@@ -27,9 +27,9 @@ export default function ActionItemJiraContext({
   labelClassName = 'text-[10px]',
 }: ActionItemJiraContextProps) {
   const hasHistoricalLink = Boolean(externalIssue);
-  const hasOperationalActions = jiraCapability.showOperationalJira;
+  const canStartJiraTracking = jiraCapability.canCreate || jiraCapability.canLink;
 
-  if (!hasHistoricalLink && !hasOperationalActions) return null;
+  if (!hasHistoricalLink && !canStartJiraTracking) return null;
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">

--- a/src/components/action-items/ActionItemJiraContext.tsx
+++ b/src/components/action-items/ActionItemJiraContext.tsx
@@ -1,0 +1,50 @@
+import type { ActionItemExternalIssue } from '@/lib/action-items';
+import type { JiraCapability } from '@/lib/jira-capabilities';
+import ActionItemJiraBadge from '@/components/action-items/ActionItemJiraBadge';
+
+interface ActionItemJiraContextProps {
+  actionItemId: string;
+  externalIssue?: ActionItemExternalIssue;
+  canManage: boolean;
+  compact?: boolean;
+  jiraCapability: JiraCapability;
+  labelClassName?: string;
+}
+
+/**
+ * Canonical action-item Jira surface.
+ *
+ * Disabled/unconfigured Jira must not leave an empty "Action Item Jira" shell.
+ * Historical links remain useful read-only context, so the section stays visible
+ * when an action item already owns a Jira link.
+ */
+export default function ActionItemJiraContext({
+  actionItemId,
+  externalIssue,
+  canManage,
+  compact = false,
+  jiraCapability,
+  labelClassName = 'text-[10px]',
+}: ActionItemJiraContextProps) {
+  const hasHistoricalLink = Boolean(externalIssue);
+  const hasOperationalActions = jiraCapability.showOperationalJira;
+
+  if (!hasHistoricalLink && !hasOperationalActions) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span
+        className={`font-semibold uppercase tracking-wide text-muted-foreground ${labelClassName}`}
+      >
+        Action Item Jira
+      </span>
+      <ActionItemJiraBadge
+        actionItemId={actionItemId}
+        externalIssue={externalIssue}
+        canManage={canManage}
+        compact={compact}
+        jiraCapability={jiraCapability}
+      />
+    </div>
+  );
+}

--- a/src/components/action-items/ActionItemsBoard.tsx
+++ b/src/components/action-items/ActionItemsBoard.tsx
@@ -25,7 +25,7 @@ import type { ActionItem } from '@/lib/action-items';
 import type { JiraCapability } from '@/lib/jira-capabilities';
 import type { JiraIssueReference } from '@/lib/jira-references';
 import { ActionItemStatus } from '@prisma/client';
-import ActionItemJiraBadge from '@/components/action-items/ActionItemJiraBadge';
+import ActionItemJiraContext from '@/components/action-items/ActionItemJiraContext';
 import IncidentJiraContext from '@/components/jira/IncidentJiraContext';
 import DueDateBadge from '@/components/action-items/DueDateBadge';
 import SearchFilterBar from '@/components/ui/SearchFilterBar';
@@ -257,18 +257,13 @@ function ActionItemCard({
 
       <div className="mb-2.5 flex flex-col gap-1.5">
         <IncidentJiraContext issues={inheritedIssues} compact />
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span className="font-semibold text-[10px] uppercase tracking-wide text-muted-foreground">
-            Action Item Jira
-          </span>
-          <ActionItemJiraBadge
-            actionItemId={item.id}
-            externalIssue={item.externalIssue}
-            canManage={canManage}
-            compact
-            jiraCapability={jiraCapability}
-          />
-        </div>
+        <ActionItemJiraContext
+          actionItemId={item.id}
+          externalIssue={item.externalIssue}
+          canManage={canManage}
+          compact
+          jiraCapability={jiraCapability}
+        />
       </div>
 
       <div className="pt-2 border-t border-slate-100 flex flex-col gap-1 text-[11px] text-muted-foreground">
@@ -665,18 +660,13 @@ export default function ActionItemsBoard({
                       <h3 className="text-base font-semibold mb-1 text-foreground">{item.title}</h3>
                       <div className="flex flex-col gap-1.5">
                         <IncidentJiraContext issues={inheritedIssues} compact />
-                        <div className="flex flex-wrap items-center gap-1.5">
-                          <span className="font-semibold text-[10px] uppercase tracking-wide text-muted-foreground">
-                            Action Item Jira
-                          </span>
-                          <ActionItemJiraBadge
-                            actionItemId={item.id}
-                            externalIssue={item.externalIssue}
-                            canManage={canManage}
-                            compact
-                            jiraCapability={jiraCapability}
-                          />
-                        </div>
+                        <ActionItemJiraContext
+                          actionItemId={item.id}
+                          externalIssue={item.externalIssue}
+                          canManage={canManage}
+                          compact
+                          jiraCapability={jiraCapability}
+                        />
                       </div>
                       {item.description && (
                         <p className="text-sm text-muted-foreground mt-1 mb-2">{item.description}</p>

--- a/src/components/incident/detail/IncidentPostmortemTabContent.tsx
+++ b/src/components/incident/detail/IncidentPostmortemTabContent.tsx
@@ -30,7 +30,7 @@ import {
 import { normalizeLegacyActionItems, type ActionItem } from '@/lib/action-items';
 import type { JiraCapability } from '@/lib/jira-capabilities';
 import type { JiraIssueReference } from '@/lib/jira-references';
-import ActionItemJiraBadge from '@/components/action-items/ActionItemJiraBadge';
+import ActionItemJiraContext from '@/components/action-items/ActionItemJiraContext';
 import IncidentJiraContext from '@/components/jira/IncidentJiraContext';
 import DueDateBadge from '@/components/action-items/DueDateBadge';
 
@@ -312,18 +312,14 @@ export default function IncidentPostmortemTabContent({
 
                       <IncidentJiraContext issues={inheritedIssues} compact />
 
-                      <div className="flex flex-wrap items-center gap-1">
-                        <span className="font-semibold text-[9px] uppercase tracking-wide text-muted-foreground">
-                          Action Item Jira
-                        </span>
-                        <ActionItemJiraBadge
-                          actionItemId={item.id}
-                          externalIssue={item.externalIssue}
-                          canManage={canManage}
-                          compact
-                          jiraCapability={jiraCapability}
-                        />
-                      </div>
+                      <ActionItemJiraContext
+                        actionItemId={item.id}
+                        externalIssue={item.externalIssue}
+                        canManage={canManage}
+                        compact
+                        jiraCapability={jiraCapability}
+                        labelClassName="text-[9px]"
+                      />
 
                       {item.dueDate && (
                         <DueDateBadge

--- a/src/components/postmortem/PostmortemActionItems.tsx
+++ b/src/components/postmortem/PostmortemActionItems.tsx
@@ -22,7 +22,7 @@ import { Calendar, Pencil, Trash2, Plus } from 'lucide-react';
 import type { ActionItem } from '@/lib/action-items';
 import type { JiraCapability } from '@/lib/jira-capabilities';
 import type { JiraIssueReference } from '@/lib/jira-references';
-import ActionItemJiraBadge from '@/components/action-items/ActionItemJiraBadge';
+import ActionItemJiraContext from '@/components/action-items/ActionItemJiraContext';
 import IncidentJiraContext from '@/components/jira/IncidentJiraContext';
 import { ACTION_ITEM_STATUS_CONFIG, ACTION_ITEM_PRIORITY_CONFIG } from './shared';
 
@@ -280,18 +280,13 @@ export default function PostmortemActionItems({
                       <div className="my-1.5 flex flex-col gap-1.5">
                         <IncidentJiraContext issues={inheritedIssues} compact />
                         {isPersisted && (
-                          <div className="flex flex-wrap items-center gap-1.5">
-                            <span className="font-semibold text-[10px] uppercase tracking-wide text-muted-foreground">
-                              Action Item Jira
-                            </span>
-                            <ActionItemJiraBadge
-                              actionItemId={item.id}
-                              externalIssue={item.externalIssue}
-                              canManage={canManage}
-                              compact
-                              jiraCapability={jiraCapability}
-                            />
-                          </div>
+                          <ActionItemJiraContext
+                            actionItemId={item.id}
+                            externalIssue={item.externalIssue}
+                            canManage={canManage}
+                            compact
+                            jiraCapability={jiraCapability}
+                          />
                         )}
                       </div>
 

--- a/src/components/postmortem/PostmortemDetailView.tsx
+++ b/src/components/postmortem/PostmortemDetailView.tsx
@@ -21,7 +21,7 @@ import { Pencil, Globe, Eye, EyeOff, Sparkles } from 'lucide-react';
 import { normalizeLegacyActionItems } from '@/lib/action-items';
 import type { JiraCapability } from '@/lib/jira-capabilities';
 import type { JiraIssueReference } from '@/lib/jira-references';
-import ActionItemJiraBadge from '@/components/action-items/ActionItemJiraBadge';
+import ActionItemJiraContext from '@/components/action-items/ActionItemJiraContext';
 import IncidentJiraContext from '@/components/jira/IncidentJiraContext';
 import { togglePostmortemPublicStatus } from '@/app/(app)/postmortems/actions';
 import {
@@ -545,18 +545,13 @@ export default function PostmortemDetailView({
                       {!effectivePublicView && (
                         <div className="mb-2 flex flex-col gap-1.5">
                           <IncidentJiraContext issues={inheritedIssues} compact />
-                          <div className="flex flex-wrap items-center gap-1.5">
-                            <span className="font-semibold text-[10px] uppercase tracking-wide text-muted-foreground">
-                              Action Item Jira
-                            </span>
-                            <ActionItemJiraBadge
-                              actionItemId={item.id}
-                              externalIssue={item.externalIssue}
-                              canManage={canEdit}
-                              compact
-                              jiraCapability={jiraCapability}
-                            />
-                          </div>
+                          <ActionItemJiraContext
+                            actionItemId={item.id}
+                            externalIssue={item.externalIssue}
+                            canManage={canEdit}
+                            compact
+                            jiraCapability={jiraCapability}
+                          />
                         </div>
                       )}
                       {item.description && (

--- a/tests/architecture/jira-action-item-surface-contract.test.ts
+++ b/tests/architecture/jira-action-item-surface-contract.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const canonicalSurface = 'src/components/action-items/ActionItemJiraContext.tsx';
+const parentSurfaces = [
+  'src/components/postmortem/PostmortemActionItems.tsx',
+  'src/components/postmortem/PostmortemDetailView.tsx',
+  'src/components/incident/detail/IncidentPostmortemTabContent.tsx',
+  'src/components/action-items/ActionItemsBoard.tsx',
+] as const;
+
+describe('action-item Jira UX surface contract', () => {
+  it('centralizes the Action Item Jira label and capability-aware visibility', () => {
+    const canonical = readFileSync(canonicalSurface, 'utf8');
+
+    expect(canonical).toContain('Action Item Jira');
+    expect(canonical).toContain('jiraCapability.canCreate || jiraCapability.canLink');
+    expect(canonical).toContain('if (!hasHistoricalLink && !canStartJiraTracking) return null');
+  });
+
+  it('does not duplicate raw Jira labels or badge visibility logic in parent surfaces', () => {
+    for (const path of parentSurfaces) {
+      const source = readFileSync(path, 'utf8');
+
+      expect(source, path).toContain('ActionItemJiraContext');
+      expect(source, path).not.toContain('ActionItemJiraBadge');
+      expect(source, path).not.toContain('Action Item Jira');
+    }
+  });
+});

--- a/tests/architecture/jira-action-item-surface-contract.test.ts
+++ b/tests/architecture/jira-action-item-surface-contract.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
-const canonicalSurface = 'src/components/action-items/ActionItemJiraContext.tsx';
-const parentSurfaces = [
-  'src/components/postmortem/PostmortemActionItems.tsx',
-  'src/components/postmortem/PostmortemDetailView.tsx',
-  'src/components/incident/detail/IncidentPostmortemTabContent.tsx',
-  'src/components/action-items/ActionItemsBoard.tsx',
-] as const;
+function expectCentralizedParent(source: string, name: string) {
+  expect(source, name).toContain('ActionItemJiraContext');
+  expect(source, name).not.toContain('ActionItemJiraBadge');
+  expect(source, name).not.toContain('Action Item Jira');
+}
 
 describe('action-item Jira UX surface contract', () => {
   it('centralizes the Action Item Jira label and capability-aware visibility', () => {
-    const canonical = readFileSync(canonicalSurface, 'utf8');
+    const canonical = readFileSync(
+      'src/components/action-items/ActionItemJiraContext.tsx',
+      'utf8'
+    );
 
     expect(canonical).toContain('Action Item Jira');
     expect(canonical).toContain('jiraCapability.canCreate || jiraCapability.canLink');
@@ -19,12 +20,26 @@ describe('action-item Jira UX surface contract', () => {
   });
 
   it('does not duplicate raw Jira labels or badge visibility logic in parent surfaces', () => {
-    for (const path of parentSurfaces) {
-      const source = readFileSync(path, 'utf8');
+    const postmortemEditor = readFileSync(
+      'src/components/postmortem/PostmortemActionItems.tsx',
+      'utf8'
+    );
+    const postmortemDetail = readFileSync(
+      'src/components/postmortem/PostmortemDetailView.tsx',
+      'utf8'
+    );
+    const incidentPostmortemTab = readFileSync(
+      'src/components/incident/detail/IncidentPostmortemTabContent.tsx',
+      'utf8'
+    );
+    const actionItemsBoard = readFileSync(
+      'src/components/action-items/ActionItemsBoard.tsx',
+      'utf8'
+    );
 
-      expect(source, path).toContain('ActionItemJiraContext');
-      expect(source, path).not.toContain('ActionItemJiraBadge');
-      expect(source, path).not.toContain('Action Item Jira');
-    }
+    expectCentralizedParent(postmortemEditor, 'PostmortemActionItems');
+    expectCentralizedParent(postmortemDetail, 'PostmortemDetailView');
+    expectCentralizedParent(incidentPostmortemTab, 'IncidentPostmortemTabContent');
+    expectCentralizedParent(actionItemsBoard, 'ActionItemsBoard');
   });
 });

--- a/tests/components/action-item-jira-context-visibility.test.tsx
+++ b/tests/components/action-item-jira-context-visibility.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ActionItemJiraContext from '@/components/action-items/ActionItemJiraContext';
+import { deriveJiraCapability, type JiraCapability } from '@/lib/jira-capabilities';
+import type { ActionItemExternalIssue } from '@/lib/action-items';
+
+vi.mock('@/app/(app)/action-items/jira/actions', () => ({
+  createJiraIssueFromActionItem: vi.fn().mockResolvedValue({ success: true }),
+  linkJiraIssueToActionItem: vi.fn().mockResolvedValue({ success: true }),
+  unlinkJiraIssueFromActionItem: vi.fn().mockResolvedValue({ success: true }),
+  syncActionItemJiraIssue: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+const capability = (
+  overrides: Partial<Parameters<typeof deriveJiraCapability>[0]> = {}
+): JiraCapability =>
+  deriveJiraCapability({
+    workspaceState: 'ENABLED',
+    canManage: true,
+    serviceMapped: true,
+    syncEnabled: true,
+    rawEnabled: true,
+    ...overrides,
+  });
+
+const historicalIssue: ActionItemExternalIssue = {
+  linkId: 'jira-link-1',
+  provider: 'JIRA',
+  key: 'OPS-456',
+  url: 'https://example.atlassian.net/browse/OPS-456',
+  status: 'In Progress',
+  assignee: 'Responder',
+  syncState: 'SYNCED',
+};
+
+describe('ActionItemJiraContext visibility contract', () => {
+  it('hides the complete Jira surface when the workspace is disabled and no link exists', () => {
+    const { container } = render(
+      <ActionItemJiraContext
+        actionItemId="action-1"
+        canManage
+        jiraCapability={capability({ workspaceState: 'DISABLED', rawEnabled: false })}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Action Item Jira')).not.toBeInTheDocument();
+    expect(screen.queryByText('Create Jira')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Link existing Jira issue')).not.toBeInTheDocument();
+  });
+
+  it('hides the complete Jira surface when Jira is not configured and no link exists', () => {
+    const { container } = render(
+      <ActionItemJiraContext
+        actionItemId="action-1"
+        canManage
+        jiraCapability={capability({
+          workspaceState: 'NOT_CONFIGURED',
+          serviceMapped: false,
+          rawEnabled: false,
+        })}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Action Item Jira')).not.toBeInTheDocument();
+  });
+
+  it('preserves a historical action-item Jira link read-only while Jira is disabled', () => {
+    render(
+      <ActionItemJiraContext
+        actionItemId="action-1"
+        externalIssue={historicalIssue}
+        canManage
+        jiraCapability={capability({ workspaceState: 'DISABLED', rawEnabled: false })}
+      />
+    );
+
+    expect(screen.getByText('Action Item Jira')).toBeInTheDocument();
+    const link = screen.getByText('OPS-456').closest('a');
+    expect(link).toBeInTheDocument();
+
+    fireEvent.mouseEnter(link!.parentElement!);
+    expect(screen.queryByTitle('Sync status')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Unlink')).not.toBeInTheDocument();
+  });
+
+  it('shows only useful Jira actions for an enabled but unmapped service', () => {
+    render(
+      <ActionItemJiraContext
+        actionItemId="action-1"
+        canManage
+        jiraCapability={capability({ serviceMapped: false, syncEnabled: true })}
+      />
+    );
+
+    expect(screen.getByText('Action Item Jira')).toBeInTheDocument();
+    expect(screen.queryByText('Create Jira')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Link existing Jira issue')).toBeInTheDocument();
+  });
+
+  it('shows create and link actions when Jira and the service mapping are operational', () => {
+    render(
+      <ActionItemJiraContext
+        actionItemId="action-1"
+        canManage
+        jiraCapability={capability()}
+      />
+    );
+
+    expect(screen.getByText('Action Item Jira')).toBeInTheDocument();
+    expect(screen.getByText('Create Jira')).toBeInTheDocument();
+    expect(screen.getByTitle('Link existing Jira issue')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a UX regression where disabling or removing operational Jira capability could leave an orphan **Action Item Jira** label/card visible even though no Jira action or linked ticket existed.

The underlying `ActionItemJiraBadge` already failed closed correctly. The problem was duplicated parent markup rendering the static label before the badge independently returned `null`.

## Fix

Introduces a single `ActionItemJiraContext` component as the canonical action-item Jira surface.

Visibility contract:

- Jira disabled / not configured + no existing action-item Jira link → render nothing, including no label or empty shell.
- Jira disabled / not configured + historical action-item Jira link → preserve the link as read-only context; no Sync/Unlink/Create/Link controls.
- Jira enabled + service unmapped → expose Link only.
- Jira enabled + service mapped → expose Create/Link and the normal capability-controlled linked-ticket actions.
- Draft/unsaved postmortem action items continue to expose no Jira controls.

## Surfaces normalized

The duplicated wrapper has been removed from all action-item Jira surfaces:

- Postmortem edit action-item cards
- Full Postmortem detail action-item cards
- Incident → Postmortem tab action items
- Global Action Items board view
- Global Action Items list view

Each surface now delegates both the label and the badge to `ActionItemJiraContext`, preventing the visibility policy from drifting again.

## Wider UX audit

Also rechecked neighboring Jira UI contracts:

- `IncidentJiraContext` already renders nothing when there are no inherited incident Jira links.
- Existing incident/action-item Jira links intentionally remain visible read-only when Jira is disabled, preserving historical context.
- Service-level Jira mapping settings already disappear when the workspace integration is disabled.
- Settings → Integrations → Jira intentionally remains available so administrators can re-enable or remove the workspace.
- Incident Slack War Room visibility is already independent of Jira after #616.
- No production `Connect Jira` affordance leaks outside Settings.

## Regression coverage

Adds component tests covering disabled, not-configured, historical-read-only, unmapped, and fully operational action-item Jira states.

Adds an architecture contract ensuring the raw `Action Item Jira` label and badge visibility logic cannot be duplicated back into the four parent surfaces.