### PR TITLE
fix(status): harden public incident and postmortem privacy

### DIFF
--- a/src/app/(public)/status/postmortems/[incidentId]/page.tsx
+++ b/src/app/(public)/status/postmortems/[incidentId]/page.tsx
@@ -6,6 +6,7 @@ import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
 import { resolveStatusPage } from '@/lib/status-page-resolver';
 import { canPublishIncidentToStatusPage } from '@/lib/status-page-publication';
+import { serializePublicPostmortem } from '@/lib/status-pages/public-postmortem';
 import { deriveJiraCapability } from '@/lib/jira-capabilities';
 
 const PUBLIC_READ_ONLY_JIRA_CAPABILITY = deriveJiraCapability({
@@ -49,19 +50,23 @@ export async function renderPublicPostmortem(incidentId: string, slug?: string) 
       status: 'PUBLISHED',
       isPublic: true,
     },
-    include: {
+    select: {
+      title: true,
+      summary: true,
+      timeline: true,
+      impact: true,
+      rootCause: true,
+      resolution: true,
+      lessons: true,
+      status: true,
+      isPublic: true,
+      createdAt: true,
+      publishedAt: true,
       incident: {
         select: {
           id: true,
           title: true,
           resolvedAt: true,
-        },
-      },
-      createdBy: {
-        select: {
-          id: true,
-          name: true,
-          email: true,
         },
       },
     },
@@ -71,14 +76,7 @@ export async function renderPublicPostmortem(incidentId: string, slug?: string) 
     notFound();
   }
 
-  const sanitizedPostmortem = {
-    ...postmortem,
-    createdBy: {
-      id: postmortem.createdBy?.id ?? 'deleted-user',
-      name: postmortem.createdBy?.name ?? 'OpsKnight Team',
-      email: '',
-    },
-  };
+  const sanitizedPostmortem = serializePublicPostmortem(postmortem);
 
   return (
     <main style={{ padding: 'var(--spacing-6)' }}>

--- a/src/lib/status-page-public-data.ts
+++ b/src/lib/status-page-public-data.ts
@@ -1,10 +1,13 @@
 import type {
   PublicIncident,
   PublicIncidentStatus,
-  PublicIncidentUpdateType,
+  PublicIncidentUpdate,
   PublicIncidentUrgency,
 } from '@/lib/status-pages/public-contract';
-import { publicStatusIncidentEventId } from '@/lib/status-pages/public-event-id';
+import {
+  publicStatusIncidentEventId,
+  publicStatusIncidentUpdateEventId,
+} from '@/lib/status-pages/public-event-id';
 import { publicStatusForIncidentUrgency } from '@/lib/status-pages/status-presentation';
 
 export type StatusPagePublicSettings = {
@@ -79,6 +82,40 @@ function serializeDate(value: string | Date | null | undefined): string | undefi
   return value instanceof Date ? value.toISOString() : value;
 }
 
+/**
+ * IncidentEvent is an internal audit stream. Never forward its free-text message to the public
+ * status page: assignment, escalation, Jira, notification, and responder identity details can be
+ * embedded in those messages. Only lifecycle facts with customer-safe fixed copy are projected.
+ */
+function serializePublicIncidentUpdate(
+  incidentId: string,
+  event: NonNullable<PublicIncidentInput['events']>[number],
+  pageId: string | undefined,
+  showTimestamp: boolean
+): PublicIncidentUpdate | null {
+  let update: Pick<PublicIncidentUpdate, 'type' | 'message'> | null = null;
+  switch (event.type) {
+    case 'ACKNOWLEDGED':
+      update = { type: 'ACKNOWLEDGED', message: 'Incident acknowledged' };
+      break;
+    case 'AUTO_RESOLVED':
+    case 'MANUAL_RESOLVED':
+      update = { type: 'RESOLVED', message: 'Incident resolved' };
+      break;
+    case 'REOPENED':
+      update = { type: 'UPDATE', message: 'Incident reopened' };
+      break;
+    default:
+      return null;
+  }
+
+  return {
+    id: publicStatusIncidentUpdateEventId(pageId ?? 'unscoped', incidentId, event.id),
+    ...update,
+    ...(showTimestamp ? { createdAt: serializeDate(event.createdAt) } : {}),
+  };
+}
+
 /** Shape every public endpoint from the same status-page visibility controls. */
 export function serializePublicStatusIncident(
   incident: PublicIncidentInput,
@@ -123,12 +160,16 @@ export function serializePublicStatusIncident(
     };
   }
   if (visibility.showIncidentId && visibility.showIncidentDescription && incident.events?.length) {
-    result.updates = incident.events.map(event => ({
-      id: event.id,
-      type: publicUpdateType(event.type),
-      message: event.message,
-      ...(visibility.showIncidentTimestamp ? { createdAt: serializeDate(event.createdAt) } : {}),
-    }));
+    const updates = incident.events.flatMap(event => {
+      const update = serializePublicIncidentUpdate(
+        incident.id,
+        event,
+        context?.pageId,
+        visibility.showIncidentTimestamp
+      );
+      return update ? [update] : [];
+    });
+    if (updates.length > 0) result.updates = updates;
   }
   if (
     visibility.showPostIncidentReview &&
@@ -150,21 +191,6 @@ export function serializePublicStatusIncident(
   }
 
   return result;
-}
-
-function publicUpdateType(type: string | null | undefined): PublicIncidentUpdateType {
-  if (
-    type === 'INVESTIGATING' ||
-    type === 'IDENTIFIED' ||
-    type === 'MONITORING' ||
-    type === 'ACKNOWLEDGED' ||
-    type === 'RESOLVED' ||
-    type === 'UPDATE'
-  ) {
-    return type;
-  }
-  if (type === 'AUTO_RESOLVED' || type === 'MANUAL_RESOLVED') return 'RESOLVED';
-  return 'UPDATE';
 }
 
 /**

--- a/src/lib/status-pages/public-event-id.ts
+++ b/src/lib/status-pages/public-event-id.ts
@@ -1,12 +1,25 @@
 import { createHmac } from 'node:crypto';
 
-/** Domain-separated HMAC so feed GUIDs stay stable without disclosing the internal incident id. */
-const EVENT_ID_DOMAIN = 'opsknight:public-status-event:v1';
+/** Domain-separated HMACs keep public identifiers stable without disclosing internal ids. */
+const INCIDENT_EVENT_ID_DOMAIN = 'opsknight:public-status-event:v1';
+const INCIDENT_UPDATE_ID_DOMAIN = 'opsknight:public-status-update:v1';
 
-export function publicStatusIncidentEventId(pageId: string, incidentId: string): string {
-  const digest = createHmac('sha256', EVENT_ID_DOMAIN)
-    .update(`${pageId}:${incidentId}`)
+function publicStatusId(domain: string, ...parts: string[]): string {
+  const digest = createHmac('sha256', domain)
+    .update(parts.join(':'))
     .digest('hex')
     .slice(0, 32);
   return `evt_${digest}`;
+}
+
+export function publicStatusIncidentEventId(pageId: string, incidentId: string): string {
+  return publicStatusId(INCIDENT_EVENT_ID_DOMAIN, pageId, incidentId);
+}
+
+export function publicStatusIncidentUpdateEventId(
+  pageId: string,
+  incidentId: string,
+  eventId: string
+): string {
+  return publicStatusId(INCIDENT_UPDATE_ID_DOMAIN, pageId, incidentId, eventId);
 }

--- a/src/lib/status-pages/public-postmortem.ts
+++ b/src/lib/status-pages/public-postmortem.ts
@@ -1,0 +1,132 @@
+type PublicTimelineEvent = {
+  id: string;
+  timestamp: string;
+  type: 'DETECTION' | 'ESCALATION' | 'MITIGATION' | 'RESOLUTION';
+  title: string;
+  description: string;
+};
+
+type PublicImpactMetrics = {
+  usersAffected?: number;
+  downtimeMinutes?: number;
+  errorRate?: number;
+  servicesAffected?: string[];
+  apiErrors?: number;
+  performanceDegradation?: number;
+};
+
+export type PublicPostmortemSource = {
+  title: string;
+  summary?: string | null;
+  timeline?: unknown;
+  impact?: unknown;
+  rootCause?: string | null;
+  resolution?: string | null;
+  lessons?: string | null;
+  status: string;
+  isPublic: boolean | null;
+  createdAt: Date;
+  publishedAt?: Date | null;
+  incident: {
+    id: string;
+    title: string;
+    resolvedAt?: Date | null;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function publicTimeline(value: unknown): PublicTimelineEvent[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const rows = value.flatMap((entry, index) => {
+    if (!isRecord(entry)) return [];
+    const timestamp = typeof entry.timestamp === 'string' ? entry.timestamp : undefined;
+    const title = typeof entry.title === 'string' ? entry.title : undefined;
+    const description = typeof entry.description === 'string' ? entry.description : undefined;
+    const type = entry.type;
+    if (!timestamp || !title || !description) return [];
+    if (
+      type !== 'DETECTION' &&
+      type !== 'ESCALATION' &&
+      type !== 'MITIGATION' &&
+      type !== 'RESOLUTION'
+    ) {
+      return [];
+    }
+    return [
+      {
+        id: `public-timeline-${index}`,
+        timestamp,
+        type,
+        title,
+        description,
+      } satisfies PublicTimelineEvent,
+    ];
+  });
+  return rows.length > 0 ? rows : undefined;
+}
+
+function publicImpact(value: unknown): PublicImpactMetrics | undefined {
+  if (!isRecord(value)) return undefined;
+  const metrics: PublicImpactMetrics = {};
+  const usersAffected = finiteNumber(value.usersAffected);
+  const downtimeMinutes = finiteNumber(value.downtimeMinutes);
+  const errorRate = finiteNumber(value.errorRate);
+  const apiErrors = finiteNumber(value.apiErrors);
+  const performanceDegradation = finiteNumber(value.performanceDegradation);
+  if (usersAffected !== undefined) metrics.usersAffected = usersAffected;
+  if (downtimeMinutes !== undefined) metrics.downtimeMinutes = downtimeMinutes;
+  if (errorRate !== undefined) metrics.errorRate = errorRate;
+  if (apiErrors !== undefined) metrics.apiErrors = apiErrors;
+  if (performanceDegradation !== undefined) {
+    metrics.performanceDegradation = performanceDegradation;
+  }
+  if (Array.isArray(value.servicesAffected)) {
+    metrics.servicesAffected = value.servicesAffected.filter(
+      (service): service is string => typeof service === 'string'
+    );
+  }
+  return Object.keys(metrics).length > 0 ? metrics : undefined;
+}
+
+/**
+ * Public postmortem DTO. Internal responder identities, action items, Jira state,
+ * SLA breach counts, revenue impact, and arbitrary extra JSON never cross the
+ * server boundary to the public page.
+ */
+export function serializePublicPostmortem(postmortem: PublicPostmortemSource) {
+  const timeline = publicTimeline(postmortem.timeline);
+  const impact = publicImpact(postmortem.impact);
+
+  return {
+    // The public route is incident-addressed; do not expose the internal postmortem id.
+    id: postmortem.incident.id,
+    title: postmortem.title,
+    summary: postmortem.summary ?? null,
+    ...(timeline ? { timeline } : {}),
+    ...(impact ? { impact } : {}),
+    rootCause: postmortem.rootCause ?? null,
+    resolution: postmortem.resolution ?? null,
+    lessons: postmortem.lessons ?? null,
+    status: 'PUBLISHED',
+    isPublic: true,
+    createdAt: postmortem.createdAt,
+    publishedAt: postmortem.publishedAt ?? null,
+    createdBy: {
+      id: 'public-incident-response-team',
+      name: 'Incident Response Team',
+      email: '',
+    },
+    incident: {
+      id: postmortem.incident.id,
+      title: postmortem.incident.title,
+      resolvedAt: postmortem.incident.resolvedAt ?? null,
+    },
+  };
+}

--- a/src/lib/status-pages/view-model.ts
+++ b/src/lib/status-pages/view-model.ts
@@ -58,8 +58,16 @@ export function createStatusPageViewModel(
         incident.service && typeof incident.service === 'object' && !Array.isArray(incident.service)
           ? (incident.service as { name?: unknown; regions?: unknown })
           : {};
+      const hasLinkablePostmortem = Boolean(
+        incident.postmortem?.available === true && typeof incident.postmortem.id === 'string'
+      );
       return {
-        id: typeof incident.id === 'string' ? incident.id : `public-${index}`,
+        id:
+          typeof incident.id === 'string'
+            ? incident.id
+            : typeof incident.publicEventId === 'string'
+              ? incident.publicEventId
+              : `public-${index}`,
         title: typeof incident.title === 'string' ? incident.title : 'Status update',
         description: typeof incident.description === 'string' ? incident.description : null,
         status: typeof incident.status === 'string' ? incident.status : 'OPEN',
@@ -74,7 +82,10 @@ export function createStatusPageViewModel(
           region: Array.isArray(service.regions) ? service.regions.join(', ') : null,
         },
         events: snapshotIncidentEvents(incident.updates),
-        postIncidentReview: incident.postIncidentReview === true,
+        // The legacy renderer turns this marker into a clickable link using `id`. Only preserve
+        // it when the V3 projection also provided a real public postmortem id; otherwise a
+        // privacy-hidden incident id would become a fabricated /postmortems/public-N URL.
+        postIncidentReview: incident.postIncidentReview === true && hasLinkablePostmortem,
       };
     }),
     announcements: snapshot.announcements.map(item => ({
@@ -82,12 +93,22 @@ export function createStatusPageViewModel(
       startDate: new Date(item.startDate),
       endDate: item.endDate ? new Date(item.endDate) : null,
     })),
-    uptime: Object.fromEntries(snapshot.services.flatMap(service =>
-      service.uptime?.days90.percentage == null ? [] : [[service.id, service.uptime.days90.percentage]]
-    )),
-    uptime30: Object.fromEntries(snapshot.services.flatMap(service =>
-      service.uptime?.days30.percentage == null ? [] : [[service.id, service.uptime.days30.percentage]]
-    )),
-    statusHistory: Object.fromEntries(snapshot.services.map(service => [service.id, service.history ?? []])),
+    uptime: Object.fromEntries(
+      snapshot.services.flatMap(service =>
+        service.uptime?.days90.percentage == null
+          ? []
+          : [[service.id, service.uptime.days90.percentage]]
+      )
+    ),
+    uptime30: Object.fromEntries(
+      snapshot.services.flatMap(service =>
+        service.uptime?.days30.percentage == null
+          ? []
+          : [[service.id, service.uptime.days30.percentage]]
+      )
+    ),
+    statusHistory: Object.fromEntries(
+      snapshot.services.map(service => [service.id, service.history ?? []])
+    ),
   };
 }

--- a/tests/lib/status-page-public-data.test.ts
+++ b/tests/lib/status-page-public-data.test.ts
@@ -107,4 +107,70 @@ describe('status page public-data policy', () => {
       )
     ).not.toHaveProperty('postIncidentReview');
   });
+
+  it('never forwards internal IncidentEvent free text to public incident updates', () => {
+    const at = new Date('2026-08-30T10:05:00.000Z');
+    const result = serializePublicStatusIncident(
+      {
+        id: 'inc-1',
+        title: 'Database latency',
+        description: 'Customer-visible description',
+        status: 'RESOLVED',
+        urgency: 'HIGH',
+        createdAt: new Date('2026-08-30T10:00:00.000Z'),
+        resolvedAt: new Date('2026-08-30T11:00:00.000Z'),
+        events: [
+          {
+            id: 'event-assignment',
+            type: 'ASSIGNMENT',
+            message: 'Incident assigned to Alice from the Payments team',
+            createdAt: at,
+          },
+          {
+            id: 'event-status-change',
+            type: 'STATUS_CHANGE',
+            message: 'Jira OPS-123 linked and war room #secret-channel created',
+            createdAt: at,
+          },
+          {
+            id: 'event-ack',
+            type: 'ACKNOWLEDGED',
+            message: 'Incident acknowledged by Alice',
+            createdAt: at,
+          },
+          {
+            id: 'event-resolved',
+            type: 'MANUAL_RESOLVED',
+            message: 'Resolved: rotated secret credential from internal runbook',
+            createdAt: at,
+          },
+        ],
+      },
+      {
+        ...privateSettings,
+        showIncidentDetails: true,
+        showIncidentDescriptions: true,
+        showIncidentTimestamps: true,
+      },
+      { pageId: 'page-1' }
+    );
+
+    expect(result.updates).toEqual([
+      {
+        id: expect.stringMatching(/^evt_[0-9a-f]{32}$/),
+        type: 'ACKNOWLEDGED',
+        message: 'Incident acknowledged',
+        createdAt: at.toISOString(),
+      },
+      {
+        id: expect.stringMatching(/^evt_[0-9a-f]{32}$/),
+        type: 'RESOLVED',
+        message: 'Incident resolved',
+        createdAt: at.toISOString(),
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('Alice');
+    expect(JSON.stringify(result)).not.toContain('OPS-123');
+    expect(JSON.stringify(result)).not.toContain('secret credential');
+  });
 });

--- a/tests/lib/status-page-public-postmortem.test.ts
+++ b/tests/lib/status-page-public-postmortem.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { serializePublicPostmortem } from '@/lib/status-pages/public-postmortem';
+
+describe('public postmortem projection', () => {
+  it('keeps customer-safe content and strips internal-only fields before the browser boundary', () => {
+    const result = serializePublicPostmortem({
+      title: 'Checkout outage review',
+      summary: 'Checkout requests failed for a subset of users.',
+      timeline: [
+        {
+          id: 'internal-event-1',
+          timestamp: '2026-09-10T10:00:00.000Z',
+          type: 'DETECTION',
+          title: 'Detected',
+          description: 'Error rate increased.',
+          actor: 'Alice Responder',
+        },
+      ],
+      impact: {
+        usersAffected: 1200,
+        downtimeMinutes: 18,
+        errorRate: 12.5,
+        servicesAffected: ['Checkout'],
+        slaBreaches: 3,
+        revenueImpact: 45000,
+        apiErrors: 5000,
+        performanceDegradation: 20,
+      },
+      rootCause: 'A bad deployment exhausted the connection pool.',
+      resolution: 'Rolled back the deployment.',
+      lessons: 'Add a connection-pool saturation alert.',
+      status: 'PUBLISHED',
+      isPublic: true,
+      createdAt: new Date('2026-09-10T12:00:00.000Z'),
+      publishedAt: new Date('2026-09-10T13:00:00.000Z'),
+      incident: {
+        id: 'incident-public-id',
+        title: 'Checkout errors',
+        resolvedAt: new Date('2026-09-10T10:18:00.000Z'),
+      },
+    });
+
+    expect(result.id).toBe('incident-public-id');
+    expect(result.createdBy).toEqual({
+      id: 'public-incident-response-team',
+      name: 'Incident Response Team',
+      email: '',
+    });
+    expect(result.timeline).toEqual([
+      {
+        id: 'public-timeline-0',
+        timestamp: '2026-09-10T10:00:00.000Z',
+        type: 'DETECTION',
+        title: 'Detected',
+        description: 'Error rate increased.',
+      },
+    ]);
+    expect(result.impact).toEqual({
+      usersAffected: 1200,
+      downtimeMinutes: 18,
+      errorRate: 12.5,
+      servicesAffected: ['Checkout'],
+      apiErrors: 5000,
+      performanceDegradation: 20,
+    });
+    expect(JSON.stringify(result)).not.toContain('Alice Responder');
+    expect(JSON.stringify(result)).not.toContain('slaBreaches');
+    expect(JSON.stringify(result)).not.toContain('revenueImpact');
+    expect(JSON.stringify(result)).not.toContain('internal-event-1');
+  });
+});

--- a/tests/lib/status-page-view-model.test.ts
+++ b/tests/lib/status-page-view-model.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { createStatusPageViewModel } from '@/lib/status-pages/view-model';
+import type { PublicStatusPageSnapshot } from '@/lib/status-pages/public-contract';
+
+function snapshotWithIncident(
+  incident: PublicStatusPageSnapshot['incidents'][number]
+): PublicStatusPageSnapshot {
+  return {
+    schemaVersion: 3,
+    pageId: 'page-1',
+    revision: '1',
+    generatedAt: '2026-09-10T00:00:00.000Z',
+    page: {
+      id: 'page-1',
+      name: 'Status',
+      showSubscribe: false,
+      showServicesByRegion: false,
+      showRegionHeatmap: false,
+      showPostIncidentReview: true,
+      showChangelog: false,
+      enableUptimeExports: false,
+      isDefault: true,
+      requireAuth: false,
+      enabled: true,
+      statusApiRequireToken: false,
+      statusApiRateLimitEnabled: false,
+      statusApiRateLimitMax: 120,
+      statusApiRateLimitWindowSec: 60,
+    },
+    status: 'OPERATIONAL',
+    services: [],
+    regions: [],
+    incidents: [incident],
+    announcements: [],
+    historyDays: 90,
+  } as PublicStatusPageSnapshot;
+}
+
+describe('status page legacy compatibility view model', () => {
+  it('uses the opaque event id for rendering but does not fabricate a postmortem link', () => {
+    const view = createStatusPageViewModel(
+      { id: 'page-1', name: 'Status', showPostIncidentReview: true },
+      snapshotWithIncident({
+        publicEventId: 'evt_1234567890abcdef1234567890abcdef',
+        status: 'RESOLVED',
+        postIncidentReview: true,
+      })
+    );
+
+    expect(view.incidents[0]?.id).toBe('evt_1234567890abcdef1234567890abcdef');
+    expect(view.incidents[0]?.postIncidentReview).toBe(false);
+  });
+
+  it('keeps the postmortem link marker only when V3 supplied a real public postmortem id', () => {
+    const view = createStatusPageViewModel(
+      { id: 'page-1', name: 'Status', showPostIncidentReview: true },
+      snapshotWithIncident({
+        id: 'incident-1',
+        publicEventId: 'evt_1234567890abcdef1234567890abcdef',
+        status: 'RESOLVED',
+        postIncidentReview: true,
+        postmortem: { available: true, id: 'incident-1' },
+      })
+    );
+
+    expect(view.incidents[0]?.id).toBe('incident-1');
+    expect(view.incidents[0]?.postIncidentReview).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens Status Page publication boundaries for incidents and postmortems.

### Changes
- project public postmortems through a server-side DTO before passing data to the client
- strip responder identities, internal action items/Jira state, SLA breach counts, revenue impact, arbitrary extra JSON, and internal postmortem ids from the public browser payload
- stop forwarding arbitrary internal `IncidentEvent.message` text to public incident timelines
- publish only safe lifecycle facts (`ACKNOWLEDGED`, `RESOLVED`, `REOPENED`) with fixed customer-safe copy
- use opaque stable ids for public incident timeline updates
- prevent the legacy compatibility adapter from manufacturing broken `/postmortems/public-N` links when incident ids are intentionally hidden
- use the existing opaque incident event id as the legacy renderer key when the raw incident id is suppressed

## Why

`IncidentEvent` is an internal audit stream and can contain responder names, team assignments, Jira details, Slack/war-room data, notification details, and other operational text. Public status surfaces should never treat that free text as customer-facing content.

The public postmortem page also previously fetched the full postmortem object and relied on the client component to hide some fields. This PR moves that redaction to the server boundary so the browser only receives approved public fields.

## Tests
- public incident update projection rejects internal event free text
- safe lifecycle updates use fixed copy and opaque ids
- public postmortem projection strips internal-only fields
- legacy adapter does not create a postmortem link when V3 withholds the incident/postmortem id
