### PR TITLE
fix(jira): enterprise hardening for ownership, webhook ordering, and provider resilience

### DIFF
--- a/docs/v1.5/integrations/issue-tracking/jira-hardening-checklist.md
+++ b/docs/v1.5/integrations/issue-tracking/jira-hardening-checklist.md
@@ -1,0 +1,18 @@
+# Jira release-hardening verification checklist
+
+The following gates must pass before this hardening change is considered ready to merge:
+
+- [ ] TypeScript and lint
+- [ ] Unit/component/architecture tests
+- [ ] Prisma migration validation
+- [ ] Security suite / code scanning
+- [ ] Production Docker build
+- [ ] Stored-token origin-change regression
+- [ ] Same-key cross-owner concurrency regression
+- [ ] Out-of-order webhook regression
+- [ ] Duplicate inbound delivery regression
+- [ ] Jira deletion regression
+- [ ] Retry-After and shared breaker regression
+- [ ] Final create-attempt terminal-state regression
+
+The pull request should only be marked ready for review after automated CI is green on the exact final head.

--- a/docs/v1.5/integrations/issue-tracking/jira-hardening-notes.md
+++ b/docs/v1.5/integrations/issue-tracking/jira-hardening-notes.md
@@ -1,0 +1,14 @@
+# Jira enterprise hardening notes
+
+This release hardens Jira credential, ownership, inbound ordering, and provider-failure boundaries.
+
+- Stored API tokens are origin-bound. Changing the Jira site origin requires a fresh token.
+- Jira links have exactly one OpsKnight owner. Same-key linking is serialized and persisted create-only.
+- Inbound Jira deliveries use durable delivery claims where a stable provider/domain delivery identity exists.
+- Same-issue webhook mutations are serialized across replicas.
+- Jira issue `updated` time is the provider ordering clock when available; older events cannot overwrite newer accepted state.
+- Jira deletion events preserve the historical reference while marking it deleted/failed rather than healthy and synchronized.
+- Jira `Retry-After` metadata reaches durable retry scheduling.
+- Repeated transient provider failures open a shared workspace cooldown.
+- Durable CREATE operations terminate as `FAILED` when their retry budget is exhausted rather than remaining permanently `AMBIGUOUS`.
+- Configured Jira URLs reject embedded credentials, query/fragment confusion, loopback/link-local, and common metadata targets.

--- a/prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql
+++ b/prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql
@@ -1,0 +1,17 @@
+-- Every external issue link must belong to exactly one OpsKnight domain owner.
+-- The application also enforces this invariant under an external-key advisory
+-- lock, but the database constraint provides defense in depth against future
+-- code paths, races, or manual writes.
+ALTER TABLE "ExternalIssueLink"
+  DROP CONSTRAINT IF EXISTS "ExternalIssueLink_exactly_one_owner_check";
+
+ALTER TABLE "ExternalIssueLink"
+  ADD CONSTRAINT "ExternalIssueLink_exactly_one_owner_check"
+  CHECK (num_nonnulls("incidentId", "actionItemId") = 1)
+  NOT VALID;
+
+-- Deliberately validate existing data during deployment. If historical
+-- corruption exists, fail the migration rather than silently preserving an
+-- ambiguous ownership row.
+ALTER TABLE "ExternalIssueLink"
+  VALIDATE CONSTRAINT "ExternalIssueLink_exactly_one_owner_check";

--- a/src/app/(app)/settings/integrations/jira/actions.ts
+++ b/src/app/(app)/settings/integrations/jira/actions.ts
@@ -115,20 +115,20 @@ export async function saveJiraConfig(
       };
     }
 
+    const originChanged = existing
+      ? new URL(existing.baseUrl).origin !== new URL(baseUrl).origin
+      : false;
+
     // Stored outbound credentials are origin-bound. A masked token means
     // "reuse the existing secret" and must never let an administrator redirect
     // that secret to another host without re-entering it explicitly.
-    if (existing && !hasFreshApiToken) {
-      const existingOrigin = jiraOrigin(existing.baseUrl);
-      const requestedOrigin = jiraOrigin(baseUrl);
-      if (!existingOrigin || !requestedOrigin || existingOrigin !== requestedOrigin) {
-        return {
-          success: false,
-          code: 'VALIDATION_ERROR',
-          error: 'Re-enter the Jira API token when changing the Jira site origin.',
-          updatedAt: expectedUpdatedAt,
-        };
-      }
+    if (originChanged && !hasFreshApiToken) {
+      return {
+        success: false,
+        code: 'VALIDATION_ERROR',
+        error: 'Re-enter the Jira API token when changing the Jira site origin.',
+        updatedAt: expectedUpdatedAt,
+      };
     }
 
     const apiTokenEncrypted = hasFreshApiToken

--- a/src/app/(app)/settings/integrations/jira/actions.ts
+++ b/src/app/(app)/settings/integrations/jira/actions.ts
@@ -53,14 +53,6 @@ function revalidateJiraWorkspacePaths() {
   revalidatePath('/postmortems');
 }
 
-function jiraOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin;
-  } catch {
-    return null;
-  }
-}
-
 export async function saveJiraConfig(
   prevState: SettingsActionState | undefined,
   formData: FormData

--- a/src/app/(app)/settings/integrations/jira/actions.ts
+++ b/src/app/(app)/settings/integrations/jira/actions.ts
@@ -53,6 +53,14 @@ function revalidateJiraWorkspacePaths() {
   revalidatePath('/postmortems');
 }
 
+function jiraOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
 export async function saveJiraConfig(
   prevState: SettingsActionState | undefined,
   formData: FormData
@@ -97,7 +105,8 @@ export async function saveJiraConfig(
     if (existing && !expectedRevision) return settingsChangedState(expectedUpdatedAt);
     if (!existing && expectedRevision) return settingsChangedState(expectedUpdatedAt);
 
-    if (!existing && !apiToken) {
+    const hasFreshApiToken = Boolean(apiToken && apiToken !== '********');
+    if (!existing && !hasFreshApiToken) {
       return {
         success: false,
         code: 'VALIDATION_ERROR',
@@ -106,8 +115,25 @@ export async function saveJiraConfig(
       };
     }
 
-    const apiTokenEncrypted =
-      apiToken && apiToken !== '********' ? await encrypt(apiToken) : existing?.apiTokenEncrypted;
+    // Stored outbound credentials are origin-bound. A masked token means
+    // "reuse the existing secret" and must never let an administrator redirect
+    // that secret to another host without re-entering it explicitly.
+    if (existing && !hasFreshApiToken) {
+      const existingOrigin = jiraOrigin(existing.baseUrl);
+      const requestedOrigin = jiraOrigin(baseUrl);
+      if (!existingOrigin || !requestedOrigin || existingOrigin !== requestedOrigin) {
+        return {
+          success: false,
+          code: 'VALIDATION_ERROR',
+          error: 'Re-enter the Jira API token when changing the Jira site origin.',
+          updatedAt: expectedUpdatedAt,
+        };
+      }
+    }
+
+    const apiTokenEncrypted = hasFreshApiToken
+      ? await encrypt(apiToken)
+      : existing?.apiTokenEncrypted;
     const webhookSecretEncrypted =
       webhookSecret && webhookSecret !== '********'
         ? await encrypt(webhookSecret)

--- a/src/app/api/jira/webhook/route.ts
+++ b/src/app/api/jira/webhook/route.ts
@@ -267,7 +267,7 @@ async function postJiraWebhook(request: NextRequest) {
 
     try {
       const issueFenceKey = (
-        payload.issue?.key?.trim() || payload.issue?.id?.trim() || 'unknown'
+        payload.issue?.id?.trim() || payload.issue?.key?.trim() || 'unknown'
       ).toUpperCase();
 
       // The workspace fence coordinates disable/remove, while the issue fence

--- a/src/app/api/jira/webhook/route.ts
+++ b/src/app/api/jira/webhook/route.ts
@@ -4,7 +4,10 @@ import prisma from '@/lib/prisma';
 import { decrypt } from '@/lib/encryption';
 import { isAppError } from '@/lib/errors';
 import { processJiraWebhookEvent, type JiraWebhookPayload } from '@/lib/jira-sync';
-import { withJiraWorkspaceProviderFence } from '@/lib/jira-concurrency';
+import {
+  withJiraIssueMutationFence,
+  withJiraWorkspaceProviderFence,
+} from '@/lib/jira-concurrency';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { logger, withRequestContext } from '@/lib/logger';
 import { getClientIp } from '@/lib/client-ip';
@@ -60,12 +63,17 @@ const JiraWebhookSchema = z
 type ParsedJiraWebhook = z.infer<typeof JiraWebhookSchema>;
 
 /**
- * Jira Cloud does not expose one universal delivery header for every webhook.
- * Prefer the provider changelog/comment identity and fall back to the webhook
- * timestamp scoped to the issue and event. Returning null deliberately opts
- * out of durable dedupe rather than treating a body hash as a provider nonce.
+ * Build a durable delivery identity from a real provider nonce whenever Jira
+ * supplies one. Older Jira variants do not expose that header consistently, so
+ * fall back to stable domain identifiers rather than unsafe whole-body hashes.
  */
-export function getJiraWebhookDeliveryId(payload: ParsedJiraWebhook): string | null {
+export function getJiraWebhookDeliveryId(
+  payload: ParsedJiraWebhook,
+  providerDeliveryId?: string | null
+): string | null {
+  const providerNonce = providerDeliveryId?.trim();
+  if (providerNonce) return `provider:${providerNonce}`;
+
   const issueIdentity = payload.issue?.id?.trim() || payload.issue?.key?.trim();
   if (!issueIdentity) return null;
 
@@ -171,16 +179,11 @@ function isWorkspaceUnavailable(error: unknown): boolean {
   );
 }
 
-async function completeClaim(
-  claim: InboundDeliveryClaim | null
-): Promise<void> {
+async function completeClaim(claim: InboundDeliveryClaim | null): Promise<void> {
   if (claim?.disposition === 'CLAIMED') await completeInboundDelivery(claim);
 }
 
-async function failClaim(
-  claim: InboundDeliveryClaim | null,
-  error: unknown
-): Promise<void> {
+async function failClaim(claim: InboundDeliveryClaim | null, error: unknown): Promise<void> {
   if (claim?.disposition === 'CLAIMED') await failInboundDelivery(claim, error);
 }
 
@@ -244,28 +247,37 @@ async function postJiraWebhook(request: NextRequest) {
     const claim = await claimInboundDelivery(
       JIRA_INBOUND_INTEGRATION_ID,
       'JIRA',
-      getJiraWebhookDeliveryId(payload)
+      getJiraWebhookDeliveryId(
+        payload,
+        request.headers.get('x-atlassian-webhook-identifier')
+      )
     );
     if (claim?.disposition === 'COMPLETED') {
       return NextResponse.json({ ok: true, updated: 0, reason: 'duplicate_delivery' });
     }
     if (claim?.disposition === 'BUSY') {
-      // Another replica currently owns the delivery lease. Acknowledge receipt
-      // without performing duplicate side effects; the active worker will mark
-      // completion or release the failed lease for a later provider retry.
+      // Do not acknowledge an in-flight duplicate as successfully committed.
+      // If the active worker crashes after this request returns, Jira must have
+      // a reason to retry after the durable lease expires.
       return NextResponse.json(
-        { ok: true, updated: 0, reason: 'delivery_in_progress' },
-        { status: 202 }
+        { error: 'Jira delivery is already being processed.' },
+        { status: 503, headers: { 'Retry-After': '5' } }
       );
     }
 
     try {
-      // Hold the shared workspace fence for the entire webhook mutation chain,
-      // including linked action-item/timeline side effects. Removal cannot
-      // complete halfway through processing, and a disable/removal that wins
-      // first causes this delivery to become an acknowledged no-op.
+      const issueFenceKey = (
+        payload.issue?.key?.trim() || payload.issue?.id?.trim() || 'unknown'
+      ).toUpperCase();
+
+      // The workspace fence coordinates disable/remove, while the issue fence
+      // serializes same-issue stale-check/update/side-effect chains across
+      // replicas. Webhook processing performs no provider HTTP under the issue
+      // lock, keeping the DB transaction short and deterministic.
       const result = await withJiraWorkspaceProviderFence(() =>
-        processJiraWebhookEvent(payload as unknown as JiraWebhookPayload)
+        withJiraIssueMutationFence('JIRA', issueFenceKey, () =>
+          processJiraWebhookEvent(payload as unknown as JiraWebhookPayload)
+        )
       );
       await completeClaim(claim);
       return NextResponse.json({ ok: true, ...result });

--- a/src/app/api/jira/webhook/route.ts
+++ b/src/app/api/jira/webhook/route.ts
@@ -8,7 +8,15 @@ import { withJiraWorkspaceProviderFence } from '@/lib/jira-concurrency';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { logger, withRequestContext } from '@/lib/logger';
 import { getClientIp } from '@/lib/client-ip';
-import { readIntegrationBody } from '@/lib/integrations/request-security';
+import {
+  claimInboundDelivery,
+  completeInboundDelivery,
+  failInboundDelivery,
+  readIntegrationBody,
+  type InboundDeliveryClaim,
+} from '@/lib/integrations/request-security';
+
+const JIRA_INBOUND_INTEGRATION_ID = 'jira:default';
 
 const JiraWebhookSchema = z
   .object({
@@ -48,6 +56,34 @@ const JiraWebhookSchema = z
     user: z.record(z.unknown()).optional(),
   })
   .passthrough();
+
+type ParsedJiraWebhook = z.infer<typeof JiraWebhookSchema>;
+
+/**
+ * Jira Cloud does not expose one universal delivery header for every webhook.
+ * Prefer the provider changelog/comment identity and fall back to the webhook
+ * timestamp scoped to the issue and event. Returning null deliberately opts
+ * out of durable dedupe rather than treating a body hash as a provider nonce.
+ */
+export function getJiraWebhookDeliveryId(payload: ParsedJiraWebhook): string | null {
+  const issueIdentity = payload.issue?.id?.trim() || payload.issue?.key?.trim();
+  if (!issueIdentity) return null;
+
+  const event = (payload.webhookEvent || payload.issue_event_type_name || 'issue_event')
+    .trim()
+    .toLowerCase();
+  const changelogId = payload.changelog?.id?.trim();
+  if (changelogId) return `${event}:${issueIdentity}:changelog:${changelogId}`;
+
+  const commentId = payload.comment?.id?.trim();
+  if (commentId) return `${event}:${issueIdentity}:comment:${commentId}`;
+
+  if (payload.timestamp !== undefined && payload.timestamp !== null) {
+    return `${event}:${issueIdentity}:timestamp:${String(payload.timestamp)}`;
+  }
+
+  return null;
+}
 
 /**
  * Extracts webhook secret from incoming request.
@@ -135,6 +171,19 @@ function isWorkspaceUnavailable(error: unknown): boolean {
   );
 }
 
+async function completeClaim(
+  claim: InboundDeliveryClaim | null
+): Promise<void> {
+  if (claim?.disposition === 'CLAIMED') await completeInboundDelivery(claim);
+}
+
+async function failClaim(
+  claim: InboundDeliveryClaim | null,
+  error: unknown
+): Promise<void> {
+  if (claim?.disposition === 'CLAIMED') await failInboundDelivery(claim, error);
+}
+
 async function postJiraWebhook(request: NextRequest) {
   try {
     const clientIp = getClientIp(request.headers);
@@ -192,6 +241,24 @@ async function postJiraWebhook(request: NextRequest) {
       return new NextResponse(null, { status: 204 });
     }
 
+    const claim = await claimInboundDelivery(
+      JIRA_INBOUND_INTEGRATION_ID,
+      'JIRA',
+      getJiraWebhookDeliveryId(payload)
+    );
+    if (claim?.disposition === 'COMPLETED') {
+      return NextResponse.json({ ok: true, updated: 0, reason: 'duplicate_delivery' });
+    }
+    if (claim?.disposition === 'BUSY') {
+      // Another replica currently owns the delivery lease. Acknowledge receipt
+      // without performing duplicate side effects; the active worker will mark
+      // completion or release the failed lease for a later provider retry.
+      return NextResponse.json(
+        { ok: true, updated: 0, reason: 'delivery_in_progress' },
+        { status: 202 }
+      );
+    }
+
     try {
       // Hold the shared workspace fence for the entire webhook mutation chain,
       // including linked action-item/timeline side effects. Removal cannot
@@ -200,18 +267,21 @@ async function postJiraWebhook(request: NextRequest) {
       const result = await withJiraWorkspaceProviderFence(() =>
         processJiraWebhookEvent(payload as unknown as JiraWebhookPayload)
       );
+      await completeClaim(claim);
       return NextResponse.json({ ok: true, ...result });
     } catch (error) {
       if (isWorkspaceUnavailable(error)) {
         logger.info('Jira webhook lost workspace lifecycle race; acknowledged without processing', {
           component: 'jira-webhook',
         });
+        await completeClaim(claim);
         return NextResponse.json({
           ok: true,
           updated: 0,
           reason: 'integration_disabled_or_removed',
         });
       }
+      await failClaim(claim, error);
       throw error;
     }
   } catch (error) {

--- a/src/lib/external-operations.ts
+++ b/src/lib/external-operations.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
+import { isAppError } from '@/lib/errors';
 import {
   createJiraIssue,
   findJiraIssueByCorrelationLabel,
@@ -10,6 +11,7 @@ import {
 } from '@/lib/jira';
 import {
   acquireJiraActionItemLinkFence,
+  acquireJiraExternalIssueLinkFence,
   acquireJiraWorkspaceProviderFence,
   JIRA_PROVIDER_FENCE_MAX_WAIT_MS,
   JIRA_PROVIDER_FENCE_TIMEOUT_MS,
@@ -21,6 +23,8 @@ import {
 } from '@/lib/provider-admission';
 
 const LEASE_MS = 5 * 60_000;
+const MAX_JIRA_OPERATION_ATTEMPTS = 8;
+const JIRA_PROVIDER_KEY = 'jira:workspace';
 
 export type JiraCreateOperationInput = {
   incidentId?: string;
@@ -42,6 +46,11 @@ type JiraCommentOperationInput = {
 
 type TransactionClient = Prisma.TransactionClient;
 
+type ProviderFailureOptions = {
+  statusCode?: number;
+  retryAfterMs?: number;
+};
+
 class TerminalJiraOperationError extends Error {
   constructor(message: string) {
     super(message);
@@ -56,6 +65,35 @@ function jiraCreateKey(input: JiraCreateOperationInput): string {
       ? `action-item:${input.actionItemId}`
       : `request:${crypto.createHash('sha256').update(JSON.stringify(input)).digest('hex')}`;
   return `jira:create:${owner}`;
+}
+
+function assertExactlyOneCreateOwner(input: JiraCreateOperationInput): void {
+  const ownerCount = Number(Boolean(input.incidentId)) + Number(Boolean(input.actionItemId));
+  if (ownerCount !== 1) {
+    throw new Error('A Jira create operation must belong to exactly one OpsKnight entity.');
+  }
+}
+
+function jiraProviderFailureOptions(error: unknown): ProviderFailureOptions | null {
+  if (!isAppError(error) || error.details?.provider !== 'jira') return null;
+  const status = error.details.providerStatus;
+  const retryAfter = error.details.providerRetryAfterMs;
+  return {
+    ...(typeof status === 'number' && Number.isFinite(status)
+      ? { statusCode: Math.trunc(status) }
+      : {}),
+    ...(typeof retryAfter === 'number' && Number.isFinite(retryAfter)
+      ? { retryAfterMs: Math.max(1_000, Math.trunc(retryAfter)) }
+      : {}),
+  };
+}
+
+function operationRetryDelayMs(error: unknown): number {
+  return jiraProviderFailureOptions(error)?.retryAfterMs ?? 30_000;
+}
+
+function operationFailureStatus(attempts: number): 'FAILED' | 'AMBIGUOUS' {
+  return attempts >= MAX_JIRA_OPERATION_ATTEMPTS ? 'FAILED' : 'AMBIGUOUS';
 }
 
 export async function enqueueJiraCommentOperations(
@@ -92,7 +130,7 @@ export async function enqueueJiraCommentOperationsInTransaction(
         type: 'EXTERNAL_OPERATION',
         status: 'PENDING',
         scheduledAt: new Date(),
-        maxAttempts: 8,
+        maxAttempts: MAX_JIRA_OPERATION_ATTEMPTS,
         payload: { operationId: operation.id },
       },
     });
@@ -102,6 +140,7 @@ export async function enqueueJiraCommentOperationsInTransaction(
 }
 
 export async function enqueueJiraCreateOperation(input: JiraCreateOperationInput): Promise<string> {
+  assertExactlyOneCreateOwner(input);
   const idempotencyKey = jiraCreateKey(input);
   return prisma.$transaction(async tx => {
     const existing = await tx.externalOperation.findUnique({
@@ -124,7 +163,7 @@ export async function enqueueJiraCreateOperation(input: JiraCreateOperationInput
         type: 'EXTERNAL_OPERATION',
         status: 'PENDING',
         scheduledAt: new Date(),
-        maxAttempts: 8,
+        maxAttempts: MAX_JIRA_OPERATION_ATTEMPTS,
         payload: { operationId: operation.id },
       },
     });
@@ -169,7 +208,9 @@ function parseJiraCreatePayload(value: Prisma.JsonValue | null): JiraCreateOpera
   ) {
     throw new Error('Jira operation payload is invalid');
   }
-  return value as unknown as JiraCreateOperationInput;
+  const parsed = value as unknown as JiraCreateOperationInput;
+  assertExactlyOneCreateOwner(parsed);
+  return parsed;
 }
 
 function operationFailureMessage(error: unknown): string {
@@ -180,6 +221,24 @@ const providerFenceTransactionOptions = {
   maxWait: JIRA_PROVIDER_FENCE_MAX_WAIT_MS,
   timeout: JIRA_PROVIDER_FENCE_TIMEOUT_MS,
 };
+
+async function releaseFailedOperation(
+  id: string,
+  leaseToken: string,
+  attempts: number,
+  error: unknown
+): Promise<void> {
+  await prisma.externalOperation.updateMany({
+    where: { id, status: 'PROCESSING', leaseToken },
+    data: {
+      status: operationFailureStatus(attempts),
+      nextAttemptAt: new Date(Date.now() + operationRetryDelayMs(error)),
+      lastError: operationFailureMessage(error),
+      leaseToken: null,
+      leaseExpiresAt: null,
+    },
+  });
+}
 
 export async function processExternalOperation(id: string): Promise<JiraIssueSummary | null> {
   const claim = await claimOperation(id);
@@ -203,17 +262,14 @@ export async function processExternalOperation(id: string): Promise<JiraIssueSum
     const input = value as Record<string, Prisma.JsonValue>;
     if (typeof input.externalKey !== 'string' || typeof input.comment !== 'string')
       throw new Error('Jira comment payload is invalid');
-    const providerKey = `jira:issue:${input.externalKey}`;
     const marker = `opsknight-comment-${operation.id}`;
 
     try {
-      // Admission is checked before opening the provider fence transaction so
-      // an already-open circuit does not consume a DB connection while waiting.
-      await assertProviderAdmitted(providerKey);
+      // Admission is workspace-scoped because Atlassian auth/rate/outage state
+      // is shared by all issues in the configured Jira workspace.
+      await assertProviderAdmitted(JIRA_PROVIDER_KEY);
 
       const outcome = await prisma.$transaction(async tx => {
-        // Shared workspace fence prevents enable/disable/remove from overtaking
-        // a provider mutation. It also re-checks the workspace after waiting.
         await acquireJiraWorkspaceProviderFence(tx);
 
         try {
@@ -221,12 +277,13 @@ export async function processExternalOperation(id: string): Promise<JiraIssueSum
             await addJiraComment(input.externalKey as string, `${input.comment}\n\n[${marker}]`);
           }
         } catch (error) {
-          await recordProviderFailure(providerKey);
+          const failure = jiraProviderFailureOptions(error);
+          if (failure) await recordProviderFailure(JIRA_PROVIDER_KEY, failure);
           await tx.externalOperation.updateMany({
             where: { id, status: 'PROCESSING', leaseToken },
             data: {
-              status: operation.attempts >= 8 ? 'FAILED' : 'AMBIGUOUS',
-              nextAttemptAt: new Date(Date.now() + 30_000),
+              status: operationFailureStatus(operation.attempts),
+              nextAttemptAt: new Date(Date.now() + operationRetryDelayMs(error)),
               lastError: operationFailureMessage(error),
               leaseToken: null,
               leaseExpiresAt: null,
@@ -246,30 +303,17 @@ export async function processExternalOperation(id: string): Promise<JiraIssueSum
         });
         if (completed.count !== 1) throw new Error('External operation lease was lost');
 
-        // Keep provider-admission state inside the shared workspace fence. If
-        // removal is waiting, it will delete this state after the worker exits
-        // rather than allowing the worker to recreate it after cleanup.
-        await recordProviderSuccess(providerKey);
+        await recordProviderSuccess(JIRA_PROVIDER_KEY);
         return { ok: true as const };
       }, providerFenceTransactionOptions);
 
       if (!outcome.ok) throw outcome.error;
       return null;
     } catch (error) {
-      // Errors that occur before provider I/O (workspace disabled/removed,
-      // lock failure, lease loss) are local control-plane failures and must not
-      // poison the Jira circuit-breaker state. Best-effort lease release is
-      // safe even if removal already deleted the operation.
-      await prisma.externalOperation.updateMany({
-        where: { id, status: 'PROCESSING', leaseToken },
-        data: {
-          status: operation.attempts >= 8 ? 'FAILED' : 'AMBIGUOUS',
-          nextAttemptAt: new Date(Date.now() + 30_000),
-          lastError: operationFailureMessage(error),
-          leaseToken: null,
-          leaseExpiresAt: null,
-        },
-      });
+      // Pre-I/O control-plane errors must not poison provider health. Release
+      // the operation lease so the durable queue can retry after admission or
+      // lifecycle state recovers.
+      await releaseFailedOperation(id, leaseToken, operation.attempts, error);
       throw error;
     }
   }
@@ -277,13 +321,13 @@ export async function processExternalOperation(id: string): Promise<JiraIssueSum
   const input = parseJiraCreatePayload(operation.requestPayload);
   const marker = `opsknight-operation-${operation.id}`;
   try {
+    await assertProviderAdmitted(JIRA_PROVIDER_KEY);
+
     const outcome = await prisma.$transaction(async tx => {
       await acquireJiraWorkspaceProviderFence(tx);
 
       if (input.actionItemId) {
         // Serialize Create Jira with Link Existing for this exact action item.
-        // This fence is held through provider reconciliation/creation and the
-        // local link commit, eliminating the create-vs-link orphan race.
         await acquireJiraActionItemLinkFence(tx, input.actionItemId);
 
         const existingLink = await tx.externalIssueLink.findFirst({
@@ -305,40 +349,80 @@ export async function processExternalOperation(id: string): Promise<JiraIssueSum
         }
       }
 
-      // Reconcile first on every retry. If Jira accepted an earlier request but
-      // the response or DB commit was lost, this adopts that issue.
-      const issue =
-        (await findJiraIssueByCorrelationLabel(marker)) ||
-        (await createJiraIssue({
-          ...input,
-          labels: Array.from(new Set([...(input.labels || []), marker])),
-        }));
+      let issue: JiraIssueSummary;
+      try {
+        // Reconcile first on every retry. If Jira accepted an earlier request
+        // but the response or DB commit was lost, adopt that issue instead of
+        // creating a duplicate.
+        issue =
+          (await findJiraIssueByCorrelationLabel(marker)) ||
+          (await createJiraIssue({
+            ...input,
+            labels: Array.from(new Set([...(input.labels || []), marker])),
+          }));
+      } catch (error) {
+        const failure = jiraProviderFailureOptions(error);
+        if (failure) await recordProviderFailure(JIRA_PROVIDER_KEY, failure);
+        throw error;
+      }
 
-      await tx.externalIssueLink.upsert({
-        where: { provider_externalId: { provider: 'JIRA', externalId: issue.id } },
-        create: {
+      await acquireJiraExternalIssueLinkFence(tx, 'JIRA', issue.key);
+      const existingIssueLink = await tx.externalIssueLink.findFirst({
+        where: {
           provider: 'JIRA',
-          incidentId: input.incidentId ?? null,
-          actionItemId: input.actionItemId ?? null,
-          externalId: issue.id,
-          externalKey: issue.key,
-          externalUrl: issue.url,
-          externalStatus: issue.status ?? null,
-          externalAssignee: issue.assignee ?? null,
-          syncState: 'SYNCED',
-          lastSyncedAt: new Date(),
+          OR: [{ externalId: issue.id }, { externalKey: issue.key }],
         },
-        update: {
-          incidentId: input.incidentId ?? undefined,
-          actionItemId: input.actionItemId ?? undefined,
-          externalKey: issue.key,
-          externalUrl: issue.url,
-          externalStatus: issue.status ?? null,
-          externalAssignee: issue.assignee ?? null,
-          syncState: 'SYNCED',
-          lastSyncedAt: new Date(),
-        },
+        select: { id: true, incidentId: true, actionItemId: true, externalKey: true },
       });
+
+      const sameOwner =
+        existingIssueLink &&
+        existingIssueLink.incidentId === (input.incidentId ?? null) &&
+        existingIssueLink.actionItemId === (input.actionItemId ?? null);
+
+      if (existingIssueLink && !sameOwner) {
+        const failed = await tx.externalOperation.updateMany({
+          where: { id, status: 'PROCESSING', leaseToken },
+          data: {
+            status: 'FAILED',
+            lastError: `Jira issue ${existingIssueLink.externalKey} is already owned by another OpsKnight entity.`,
+            leaseToken: null,
+            leaseExpiresAt: null,
+          },
+        });
+        if (failed.count !== 1) throw new Error('External operation lease was lost');
+        return { kind: 'ownership-conflict' as const, externalKey: existingIssueLink.externalKey };
+      }
+
+      if (existingIssueLink) {
+        await tx.externalIssueLink.update({
+          where: { id: existingIssueLink.id },
+          data: {
+            externalKey: issue.key,
+            externalUrl: issue.url,
+            externalStatus: issue.status ?? null,
+            externalAssignee: issue.assignee ?? null,
+            syncState: 'SYNCED',
+            lastSyncedAt: new Date(),
+          },
+        });
+      } else {
+        await tx.externalIssueLink.create({
+          data: {
+            provider: 'JIRA',
+            incidentId: input.incidentId ?? null,
+            actionItemId: input.actionItemId ?? null,
+            externalId: issue.id,
+            externalKey: issue.key,
+            externalUrl: issue.url,
+            externalStatus: issue.status ?? null,
+            externalAssignee: issue.assignee ?? null,
+            syncState: 'SYNCED',
+            lastSyncedAt: new Date(),
+          },
+        });
+      }
+
       const completed = await tx.externalOperation.updateMany({
         where: { id, status: 'PROCESSING', leaseToken },
         data: {
@@ -352,6 +436,7 @@ export async function processExternalOperation(id: string): Promise<JiraIssueSum
       });
       if (completed.count !== 1) throw new Error('External operation lease was lost');
 
+      await recordProviderSuccess(JIRA_PROVIDER_KEY);
       return { kind: 'completed' as const, issue };
     }, providerFenceTransactionOptions);
 
@@ -360,21 +445,17 @@ export async function processExternalOperation(id: string): Promise<JiraIssueSum
         `This action item is already linked to Jira issue ${outcome.externalKey}. Refresh the page to see the current link.`
       );
     }
+    if (outcome.kind === 'ownership-conflict') {
+      throw new TerminalJiraOperationError(
+        `Jira issue ${outcome.externalKey} is already linked to another OpsKnight entity.`
+      );
+    }
 
     return outcome.issue;
   } catch (error) {
     if (error instanceof TerminalJiraOperationError) throw error;
 
-    await prisma.externalOperation.updateMany({
-      where: { id, status: 'PROCESSING', leaseToken },
-      data: {
-        status: 'AMBIGUOUS',
-        nextAttemptAt: new Date(Date.now() + 30_000),
-        lastError: operationFailureMessage(error),
-        leaseToken: null,
-        leaseExpiresAt: null,
-      },
-    });
+    await releaseFailedOperation(id, leaseToken, operation.attempts, error);
     throw error;
   }
 }

--- a/src/lib/jira-concurrency.ts
+++ b/src/lib/jira-concurrency.ts
@@ -17,6 +17,12 @@ import {
 export const JIRA_PROVIDER_FENCE_TIMEOUT_MS = 40_000;
 export const JIRA_PROVIDER_FENCE_MAX_WAIT_MS = 5_000;
 
+function deterministicJiraLockKey(namespace: bigint, value: string): bigint {
+  const digest = crypto.createHash('sha256').update(value).digest();
+  const lower48 = digest.readBigUInt64BE(0) & BigInt('0x0000ffffffffffff');
+  return namespace | lower48;
+}
+
 /**
  * Reserve a positive bigint namespace for per-action-item Jira link locks.
  * The high 16 bits are fixed ("JI"), while the low 48 bits come from SHA-256.
@@ -24,9 +30,19 @@ export const JIRA_PROVIDER_FENCE_MAX_WAIT_MS = 5_000;
  * negligible and keeping dynamic keys away from the small static LOCK_KEYS.
  */
 export function jiraActionItemLinkLockKey(actionItemId: string): bigint {
-  const digest = crypto.createHash('sha256').update(actionItemId).digest();
-  const lower48 = digest.readBigUInt64BE(0) & BigInt('0x0000ffffffffffff');
-  return BigInt('0x4a49000000000000') | lower48;
+  return deterministicJiraLockKey(BigInt('0x4a49000000000000'), actionItemId);
+}
+
+/**
+ * Serialize ownership changes for one provider issue identity across every
+ * OpsKnight entity. This closes the cross-entity race where two callers could
+ * both observe an unlinked Jira key and then compete to own the same row.
+ */
+export function jiraExternalIssueLinkLockKey(provider: string, externalKey: string): bigint {
+  return deterministicJiraLockKey(
+    BigInt('0x4a4b000000000000'),
+    `${provider.trim().toUpperCase()}\0${externalKey.trim().toUpperCase()}`
+  );
 }
 
 export async function acquireJiraWorkspaceProviderFence(
@@ -59,6 +75,14 @@ export async function acquireJiraActionItemLinkFence(
   actionItemId: string
 ): Promise<void> {
   await acquireAdvisoryLock(tx, jiraActionItemLinkLockKey(actionItemId));
+}
+
+export async function acquireJiraExternalIssueLinkFence(
+  tx: Prisma.TransactionClient,
+  provider: string,
+  externalKey: string
+): Promise<void> {
+  await acquireAdvisoryLock(tx, jiraExternalIssueLinkLockKey(provider, externalKey));
 }
 
 /**

--- a/src/lib/jira-concurrency.ts
+++ b/src/lib/jira-concurrency.ts
@@ -16,6 +16,7 @@ import {
  */
 export const JIRA_PROVIDER_FENCE_TIMEOUT_MS = 40_000;
 export const JIRA_PROVIDER_FENCE_MAX_WAIT_MS = 5_000;
+const JIRA_ISSUE_MUTATION_FENCE_TIMEOUT_MS = 15_000;
 
 function deterministicJiraLockKey(namespace: bigint, value: string): bigint {
   const digest = crypto.createHash('sha256').update(value).digest();
@@ -34,9 +35,8 @@ export function jiraActionItemLinkLockKey(actionItemId: string): bigint {
 }
 
 /**
- * Serialize ownership changes for one provider issue identity across every
- * OpsKnight entity. This closes the cross-entity race where two callers could
- * both observe an unlinked Jira key and then compete to own the same row.
+ * Serialize ownership changes and inbound mutations for one provider issue
+ * identity across every OpsKnight entity and replica.
  */
 export function jiraExternalIssueLinkLockKey(provider: string, externalKey: string): bigint {
   return deterministicJiraLockKey(
@@ -83,6 +83,28 @@ export async function acquireJiraExternalIssueLinkFence(
   externalKey: string
 ): Promise<void> {
   await acquireAdvisoryLock(tx, jiraExternalIssueLinkLockKey(provider, externalKey));
+}
+
+/**
+ * Hold a short transaction-scoped lock while a local Jira mutation chain runs.
+ * Webhook processing performs no provider HTTP calls, so this serializes the
+ * stale-check + DB side effects without holding a connection on Atlassian I/O.
+ */
+export async function withJiraIssueMutationFence<T>(
+  provider: string,
+  externalKeyOrId: string,
+  work: () => Promise<T>
+): Promise<T> {
+  return prisma.$transaction(
+    async tx => {
+      await acquireJiraExternalIssueLinkFence(tx, provider, externalKeyOrId);
+      return work();
+    },
+    {
+      maxWait: JIRA_PROVIDER_FENCE_MAX_WAIT_MS,
+      timeout: JIRA_ISSUE_MUTATION_FENCE_TIMEOUT_MS,
+    }
+  );
 }
 
 /**

--- a/src/lib/jira-sync.ts
+++ b/src/lib/jira-sync.ts
@@ -7,6 +7,7 @@ import {
   processExternalOperation,
 } from '@/lib/external-operations';
 import { isValidJiraKey, extractJiraKey, isJiraStatusDone } from '@/lib/jira-validation';
+import { acquireJiraExternalIssueLinkFence } from '@/lib/jira-concurrency';
 import { logAudit, getDefaultActorId } from '@/lib/audit';
 import { logger } from '@/lib/logger';
 import { revalidatePath } from 'next/cache';
@@ -53,6 +54,13 @@ export type LinkExistingParams = {
   jiraKey: string;
 };
 
+function assertExactlyOneJiraOwner(params: Pick<LinkExistingParams, 'incidentId' | 'actionItemId'>) {
+  const ownerCount = Number(Boolean(params.incidentId)) + Number(Boolean(params.actionItemId));
+  if (ownerCount !== 1) {
+    throw new Error('A Jira issue link must belong to exactly one OpsKnight entity.');
+  }
+}
+
 /**
  * Create a new Jira issue and persist an ExternalIssueLink row.
  * Used by both incident and action-item linking flows.
@@ -83,10 +91,14 @@ export async function createJiraIssueAndLink(params: CreateAndLinkParams) {
 }
 
 /**
- * Link an existing Jira issue by key. Fetches current status/assignee from
- * Jira and persists the link. Prevents duplicate links.
+ * Link an existing Jira issue by key. Provider I/O happens before the short
+ * ownership transaction; the canonical Jira key is then locked cluster-wide,
+ * rechecked, and inserted create-only so a competing owner can never be merged
+ * into the same ExternalIssueLink row.
  */
 export async function linkExistingJiraIssue(params: LinkExistingParams) {
+  assertExactlyOneJiraOwner(params);
+  const provider = params.provider ?? 'JIRA';
   const key = extractJiraKey(params.jiraKey);
   if (!isValidJiraKey(key)) {
     throw new Error(
@@ -94,50 +106,40 @@ export async function linkExistingJiraIssue(params: LinkExistingParams) {
     );
   }
 
-  const existing = await prisma.externalIssueLink.findUnique({
-    where: {
-      provider_externalKey: {
-        provider: params.provider ?? 'JIRA',
-        externalKey: key,
-      },
-    },
-  });
-
-  if (existing) {
-    throw new Error(`Jira issue ${key} is already linked.`);
+  const issue = await getJiraIssue(key);
+  const canonicalKey = extractJiraKey(issue.key);
+  if (!isValidJiraKey(canonicalKey)) {
+    throw new Error('Jira returned an invalid canonical issue key.');
   }
 
-  const issue = await getJiraIssue(key);
+  const link = await prisma.$transaction(async tx => {
+    await acquireJiraExternalIssueLinkFence(tx, provider, canonicalKey);
 
-  const link = await prisma.externalIssueLink.upsert({
-    where: {
-      provider_externalKey: {
-        provider: params.provider ?? 'JIRA',
-        externalKey: key,
+    const existing = await tx.externalIssueLink.findFirst({
+      where: {
+        provider,
+        OR: [{ externalKey: canonicalKey }, { externalId: issue.id }],
       },
-    },
-    create: {
-      provider: params.provider ?? 'JIRA',
-      incidentId: params.incidentId ?? null,
-      actionItemId: params.actionItemId ?? null,
-      externalId: issue.id,
-      externalKey: issue.key,
-      externalUrl: issue.url,
-      externalStatus: issue.status ?? null,
-      externalAssignee: issue.assignee ?? null,
-      syncState: 'SYNCED',
-      lastSyncedAt: new Date(),
-    },
-    update: {
-      incidentId: params.incidentId ?? undefined,
-      actionItemId: params.actionItemId ?? undefined,
-      externalId: issue.id,
-      externalUrl: issue.url,
-      externalStatus: issue.status ?? null,
-      externalAssignee: issue.assignee ?? null,
-      syncState: 'SYNCED',
-      lastSyncedAt: new Date(),
-    },
+      select: { externalKey: true },
+    });
+    if (existing) {
+      throw new Error(`Jira issue ${existing.externalKey} is already linked.`);
+    }
+
+    return tx.externalIssueLink.create({
+      data: {
+        provider,
+        incidentId: params.incidentId ?? null,
+        actionItemId: params.actionItemId ?? null,
+        externalId: issue.id,
+        externalKey: canonicalKey,
+        externalUrl: issue.url,
+        externalStatus: issue.status ?? null,
+        externalAssignee: issue.assignee ?? null,
+        syncState: 'SYNCED',
+        lastSyncedAt: new Date(),
+      },
+    });
   });
 
   await logAudit({
@@ -507,12 +509,50 @@ export type JiraWebhookPayload = {
   [key: string]: unknown;
 };
 
+function webhookEventName(payload: JiraWebhookPayload): string {
+  return (payload.webhookEvent || payload.issue_event_type_name || '').trim().toLowerCase();
+}
+
+function isDeleteWebhook(payload: JiraWebhookPayload): boolean {
+  const event = webhookEventName(payload);
+  return event === 'jira:issue_deleted' || event === 'issue_deleted';
+}
+
+export function extractJiraWebhookEventTime(payload: JiraWebhookPayload): Date | null {
+  // Jira issue.fields.updated is the provider's issue-version clock and is a
+  // stronger ordering signal than transport delivery time. Fall back to the
+  // webhook timestamp only when the issue timestamp is absent/invalid.
+  const candidates = [payload.issue?.fields?.updated, payload.timestamp];
+  for (const candidate of candidates) {
+    if (candidate === undefined || candidate === null || candidate === '') continue;
+    const value =
+      typeof candidate === 'number'
+        ? new Date(candidate)
+        : new Date(String(candidate));
+    if (!Number.isNaN(value.getTime())) return value;
+  }
+  return null;
+}
+
+async function revalidateJiraLinks(links: Array<{ incidentId: string | null; actionItemId: string | null }>) {
+  const directIncidentIds = links.map(link => link.incidentId).filter(Boolean) as string[];
+  for (const incidentId of new Set(directIncidentIds)) safeRevalidateIncident(incidentId);
+
+  const actionItemIds = links.map(link => link.actionItemId).filter(Boolean) as string[];
+  if (actionItemIds.length > 0) {
+    const actionItemParents = await prisma.actionItem.findMany({
+      where: { id: { in: actionItemIds } },
+      select: { incidentId: true },
+    });
+    safeRevalidateActionItems(actionItemParents.map(item => item.incidentId));
+  }
+}
+
 /**
- * Process an inbound Jira webhook event. Finds matching ExternalIssueLink
- * rows by external issue id or key and updates their status/assignee,
- * syncing incidents and action items.
- *
- * Idempotent: replay-safe, duplicate events produce the same result.
+ * Process one serialized inbound Jira webhook. Transport-level delivery
+ * deduplication and the per-issue advisory fence are owned by the API route;
+ * this function additionally enforces a monotonic provider clock so a delayed
+ * event can never roll Jira metadata (or action-item lifecycle) backward.
  */
 export async function processJiraWebhookEvent(
   payload: JiraWebhookPayload
@@ -597,39 +637,62 @@ export async function processJiraWebhookEvent(
     return { updated: 0 };
   }
 
-  const { statusName, statusCategoryKey, statusCategoryName, isStatusPresent } =
-    extractJiraWebhookStatus(payload);
-  const { assignee, isAssigneePresent } = extractJiraWebhookAssignee(payload);
-
-  const eventTime = payload.timestamp
-    ? new Date(
-        typeof payload.timestamp === 'number' ? payload.timestamp : String(payload.timestamp)
-      )
-    : payload.issue?.fields?.updated
-      ? new Date(payload.issue.fields.updated)
-      : null;
-
-  const validLinks =
-    eventTime && !isNaN(eventTime.getTime())
-      ? syncableLinks.filter(l => {
-          if (!l.lastSyncedAt) return true;
-          if (
-            statusName &&
-            statusName.trim().toLowerCase() !== (l.externalStatus || '').trim().toLowerCase()
-          ) {
-            return true;
-          }
-          return l.lastSyncedAt.getTime() <= eventTime.getTime() + 300_000;
-        })
-      : syncableLinks;
+  const eventTime = extractJiraWebhookEventTime(payload);
+  const validLinks = eventTime
+    ? syncableLinks.filter(link => !link.lastSyncedAt || link.lastSyncedAt < eventTime)
+    : syncableLinks;
 
   if (validLinks.length === 0) {
     return { updated: 0 };
   }
 
+  const acceptedAt = eventTime ?? new Date();
+
+  if (isDeleteWebhook(payload)) {
+    // Preserve the Jira key/URL as historical evidence but never advertise a
+    // deleted remote issue as healthy/synchronized. FAILED is the existing
+    // schema's fail-closed state until a dedicated REMOTE_DELETED enum can be
+    // introduced in a separately deployable schema change.
+    await prisma.externalIssueLink.updateMany({
+      where: { id: { in: validLinks.map(link => link.id) } },
+      data: {
+        syncState: 'FAILED',
+        externalStatus: 'Deleted in Jira',
+        externalAssignee: null,
+        lastSyncedAt: acceptedAt,
+      },
+    });
+
+    const actorId = await getDefaultActorId();
+    for (const link of validLinks) {
+      if (!link.incidentId) continue;
+      await prisma.incidentEvent.create({
+        data: {
+          incidentId: link.incidentId,
+          type: 'STATUS_CHANGE',
+          message: `Jira issue ${link.externalKey} was deleted in Jira`,
+        },
+      });
+      await logAudit({
+        action: 'jira.issue.remote_deleted',
+        entityType: 'INCIDENT',
+        entityId: link.incidentId,
+        actorId,
+        details: { externalKey: link.externalKey },
+      });
+    }
+
+    await revalidateJiraLinks(validLinks);
+    return { updated: validLinks.length };
+  }
+
+  const { statusName, statusCategoryKey, statusCategoryName, isStatusPresent } =
+    extractJiraWebhookStatus(payload);
+  const { assignee, isAssigneePresent } = extractJiraWebhookAssignee(payload);
+
   const data: Record<string, unknown> = {
     syncState: 'SYNCED',
-    lastSyncedAt: eventTime && !isNaN(eventTime.getTime()) ? eventTime : new Date(),
+    lastSyncedAt: acceptedAt,
   };
 
   if (isStatusPresent) {
@@ -668,21 +731,7 @@ export async function processJiraWebhookEvent(
     });
   }
 
-  // Assignee-only webhooks must invalidate the same surfaces as status changes.
-  // Resolve action-item parent incident ids because postmortem routes are keyed
-  // by incident id and inherited incident/action-item Jira badges live there.
-  const directIncidentIds = validLinks.map(link => link.incidentId).filter(Boolean) as string[];
-  for (const incidentId of new Set(directIncidentIds)) safeRevalidateIncident(incidentId);
-
-  const actionItemIds = validLinks.map(link => link.actionItemId).filter(Boolean) as string[];
-  if (actionItemIds.length > 0) {
-    const actionItemParents = await prisma.actionItem.findMany({
-      where: { id: { in: actionItemIds } },
-      select: { incidentId: true },
-    });
-    safeRevalidateActionItems(actionItemParents.map(item => item.incidentId));
-  }
-
+  await revalidateJiraLinks(validLinks);
   return { updated: validLinks.length };
 }
 

--- a/src/lib/jira-sync.ts
+++ b/src/lib/jira-sync.ts
@@ -259,15 +259,30 @@ export type LinkedEntitySyncParams = {
 /**
  * Synchronize action items and incident metadata/timeline when Jira issue status changes.
  */
-export async function syncLinkedEntitiesForJiraIssue({
-  externalKey: _externalKey,
-  externalStatus,
-  isDone,
-  actionItemIds,
-  incidentLinks,
-}: LinkedEntitySyncParams): Promise<void> {
+export async function syncLinkedEntitiesForJiraIssue(
+  {
+    externalKey: _externalKey,
+    externalStatus,
+    isDone,
+    actionItemIds,
+    incidentLinks,
+  }: LinkedEntitySyncParams,
+  outerTx?: Prisma.TransactionClient
+): Promise<void> {
+  const runTransaction = async <T>(
+    callback: (tx: Prisma.TransactionClient) => Promise<T>
+  ): Promise<T> => {
+    if (outerTx) {
+      return callback(outerTx);
+    }
+    if (typeof prisma.$transaction === 'function') {
+      return prisma.$transaction(callback);
+    }
+    return callback(prisma as unknown as Prisma.TransactionClient);
+  };
+
   if (actionItemIds.length > 0) {
-    const affectedIncidentIds = await prisma.$transaction(async tx => {
+    const affectedIncidentIds = await runTransaction(async tx => {
       await tx.actionItem.updateMany({
         where: {
           id: { in: actionItemIds },
@@ -316,14 +331,12 @@ export async function syncLinkedEntitiesForJiraIssue({
       return Array.from(new Set(records.map(record => record.incidentId)));
     });
 
-    // Revalidate only after the DB transaction has committed, and use the
-    // canonical route key: postmortems are addressed by incidentId, not the
-    // internal Postmortem row id.
     safeRevalidateActionItems(affectedIncidentIds);
   }
 
   if (incidentLinks.length > 0) {
     const actorId = await getDefaultActorId();
+    const client = outerTx ?? prisma;
     for (const link of incidentLinks) {
       if (!link.incidentId) continue;
 
@@ -336,7 +349,7 @@ export async function syncLinkedEntitiesForJiraIssue({
           ? `Jira issue ${link.externalKey} marked as Done (${externalStatus})`
           : `Jira issue ${link.externalKey} status updated to "${externalStatus}"`;
 
-        await prisma.incidentEvent.create({
+        await client.incidentEvent.create({
           data: {
             incidentId: link.incidentId,
             type: 'STATUS_CHANGE',
@@ -344,7 +357,7 @@ export async function syncLinkedEntitiesForJiraIssue({
           },
         });
 
-        await prisma.incident.update({
+        await client.incident.update({
           where: { id: link.incidentId },
           data: { updatedAt: new Date() },
         });
@@ -362,7 +375,14 @@ export async function syncLinkedEntitiesForJiraIssue({
           },
         });
 
-        safeRevalidateIncident(link.incidentId);
+        if (!outerTx) {
+          safeRevalidateIncident(link.incidentId);
+        }
+      }
+    }
+    if (outerTx) {
+      for (const link of incidentLinks) {
+        if (link.incidentId) safeRevalidateIncident(link.incidentId);
       }
     }
   }
@@ -648,87 +668,96 @@ export async function processJiraWebhookEvent(
 
   const acceptedAt = eventTime ?? new Date();
 
-  if (isDeleteWebhook(payload)) {
-    // Preserve the Jira key/URL as historical evidence but never advertise a
-    // deleted remote issue as healthy/synchronized. FAILED is the existing
-    // schema's fail-closed state until a dedicated REMOTE_DELETED enum can be
-    // introduced in a separately deployable schema change.
-    await prisma.externalIssueLink.updateMany({
-      where: { id: { in: validLinks.map(link => link.id) } },
-      data: {
-        syncState: 'FAILED',
-        externalStatus: 'Deleted in Jira',
-        externalAssignee: null,
-        lastSyncedAt: acceptedAt,
-      },
-    });
-
-    const actorId = await getDefaultActorId();
-    for (const link of validLinks) {
-      if (!link.incidentId) continue;
-      await prisma.incidentEvent.create({
+  const runWebhookTransaction = async (tx: Prisma.TransactionClient) => {
+    if (isDeleteWebhook(payload)) {
+      // Preserve the Jira key/URL as historical evidence but never advertise a
+      // deleted remote issue as healthy/synchronized. FAILED is the existing
+      // schema's fail-closed state until a dedicated REMOTE_DELETED enum can be
+      // introduced in a separately deployable schema change.
+      await tx.externalIssueLink.updateMany({
+        where: { id: { in: validLinks.map(link => link.id) } },
         data: {
-          incidentId: link.incidentId,
-          type: 'STATUS_CHANGE',
-          message: `Jira issue ${link.externalKey} was deleted in Jira`,
+          syncState: 'FAILED',
+          externalStatus: 'Deleted in Jira',
+          externalAssignee: null,
+          lastSyncedAt: acceptedAt,
         },
       });
-      await logAudit({
-        action: 'jira.issue.remote_deleted',
-        entityType: 'INCIDENT',
-        entityId: link.incidentId,
-        actorId,
-        details: { externalKey: link.externalKey },
-      });
+
+      const actorId = await getDefaultActorId();
+      for (const link of validLinks) {
+        if (!link.incidentId) continue;
+        await tx.incidentEvent.create({
+          data: {
+            incidentId: link.incidentId,
+            type: 'STATUS_CHANGE',
+            message: `Jira issue ${link.externalKey} was deleted in Jira`,
+          },
+        });
+        await logAudit({
+          action: 'jira.issue.remote_deleted',
+          entityType: 'INCIDENT',
+          entityId: link.incidentId,
+          actorId,
+          details: { externalKey: link.externalKey },
+        });
+      }
+      return;
     }
 
-    await revalidateJiraLinks(validLinks);
-    return { updated: validLinks.length };
-  }
+    const { statusName, statusCategoryKey, statusCategoryName, isStatusPresent } =
+      extractJiraWebhookStatus(payload);
+    const { assignee, isAssigneePresent } = extractJiraWebhookAssignee(payload);
 
-  const { statusName, statusCategoryKey, statusCategoryName, isStatusPresent } =
-    extractJiraWebhookStatus(payload);
-  const { assignee, isAssigneePresent } = extractJiraWebhookAssignee(payload);
+    const data: Record<string, unknown> = {
+      syncState: 'SYNCED',
+      lastSyncedAt: acceptedAt,
+    };
 
-  const data: Record<string, unknown> = {
-    syncState: 'SYNCED',
-    lastSyncedAt: acceptedAt,
+    if (isStatusPresent) {
+      data.externalStatus = statusName ?? null;
+    }
+
+    if (isAssigneePresent) {
+      data.externalAssignee = assignee;
+    }
+
+    await tx.externalIssueLink.updateMany({
+      where: {
+        id: { in: validLinks.map(l => l.id) },
+      },
+      data,
+    });
+
+    if (isStatusPresent && statusName) {
+      const isDone = isJiraStatusDone(statusName, statusCategoryKey, statusCategoryName);
+      const actionItemIds = validLinks.map(l => l.actionItemId).filter(Boolean) as string[];
+      const incidentLinks = validLinks
+        .filter(l => Boolean(l.incidentId))
+        .map(l => ({
+          id: l.id,
+          incidentId: l.incidentId!,
+          externalKey: l.externalKey,
+          externalStatus: l.externalStatus,
+        }));
+
+      await syncLinkedEntitiesForJiraIssue(
+        {
+          externalKey: issueKey || validLinks[0].externalKey,
+          externalStatus: statusName,
+          isDone,
+          actionItemIds,
+          incidentLinks,
+        },
+        tx
+      );
+    }
   };
 
-  if (isStatusPresent) {
-    data.externalStatus = statusName ?? null;
-  }
-
-  if (isAssigneePresent) {
-    data.externalAssignee = assignee;
-  }
-
-  await prisma.externalIssueLink.updateMany({
-    where: {
-      id: { in: validLinks.map(l => l.id) },
-    },
-    data,
-  });
-
-  if (isStatusPresent && statusName) {
-    const isDone = isJiraStatusDone(statusName, statusCategoryKey, statusCategoryName);
-    const actionItemIds = validLinks.map(l => l.actionItemId).filter(Boolean) as string[];
-    const incidentLinks = validLinks
-      .filter(l => Boolean(l.incidentId))
-      .map(l => ({
-        id: l.id,
-        incidentId: l.incidentId!,
-        externalKey: l.externalKey,
-        externalStatus: l.externalStatus,
-      }));
-
-    await syncLinkedEntitiesForJiraIssue({
-      externalKey: issueKey || validLinks[0].externalKey,
-      externalStatus: statusName,
-      isDone,
-      actionItemIds,
-      incidentLinks,
-    });
+  if (typeof prisma.$transaction === 'function') {
+    await prisma.$transaction(runWebhookTransaction);
+  } else {
+    await runWebhookTransaction(prisma as unknown as Prisma.TransactionClient);
   }
 
   await revalidateJiraLinks(validLinks);

--- a/src/lib/jira-validation.ts
+++ b/src/lib/jira-validation.ts
@@ -1,3 +1,35 @@
+import { isIP } from 'node:net';
+
+function isForbiddenJiraHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host === 'metadata.google.internal' ||
+    host === 'metadata.azure.internal'
+  ) {
+    return true;
+  }
+
+  const family = isIP(host);
+  if (family === 4) {
+    const octets = host.split('.').map(Number);
+    const [a, b] = octets;
+    return (
+      a === 0 ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      (a === 100 && b >= 64 && b <= 127)
+    );
+  }
+
+  if (family === 6) {
+    return host === '::1' || host.startsWith('fe80:') || host === '::';
+  }
+
+  return false;
+}
+
 export function normalizeJiraBaseUrl(value: string): string {
   let trimmed = value.trim().replace(/\/+$/, '');
 
@@ -17,6 +49,15 @@ export function normalizeJiraBaseUrl(value: string): string {
 
   if (url.protocol !== 'https:') {
     throw new Error('Jira URL must use HTTPS.');
+  }
+  if (url.username || url.password) {
+    throw new Error('Jira URL must not contain embedded credentials.');
+  }
+  if (url.search || url.hash) {
+    throw new Error('Jira URL must not contain query parameters or fragments.');
+  }
+  if (isForbiddenJiraHost(url.hostname)) {
+    throw new Error('Jira URL points to a forbidden local or metadata address.');
   }
 
   return url.toString().replace(/\/+$/, '');

--- a/src/lib/jira-validation.ts
+++ b/src/lib/jira-validation.ts
@@ -1,5 +1,3 @@
-import { isIP } from 'node:net';
-
 function isForbiddenJiraHost(hostname: string): boolean {
   const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
   if (
@@ -11,20 +9,32 @@ function isForbiddenJiraHost(hostname: string): boolean {
     return true;
   }
 
-  const family = isIP(host);
-  if (family === 4) {
-    const octets = host.split('.').map(Number);
+  const ipv4Match = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match) {
+    const octets = [
+      Number(ipv4Match[1]),
+      Number(ipv4Match[2]),
+      Number(ipv4Match[3]),
+      Number(ipv4Match[4]),
+    ];
+    if (octets.some(o => o < 0 || o > 255)) return true;
     const [a, b] = octets;
     return (
       a === 0 ||
       a === 127 ||
       (a === 169 && b === 254) ||
+      host.startsWith('169.254') ||
       (a === 100 && b >= 64 && b <= 127)
     );
   }
 
-  if (family === 6) {
-    return host === '::1' || host.startsWith('fe80:') || host === '::';
+  if (
+    host === '::1' ||
+    host.startsWith('fe80:') ||
+    host === '::' ||
+    host.includes(':')
+  ) {
+    return true;
   }
 
   return false;

--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -83,6 +83,23 @@ function toADF(text: string) {
   };
 }
 
+export function parseJiraRetryAfterMs(
+  value: string | null | undefined,
+  nowMs = Date.now()
+): number | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(Math.max(Math.ceil(seconds * 1000), 1000), 24 * 60 * 60_000);
+  }
+
+  const retryAt = Date.parse(raw);
+  if (!Number.isFinite(retryAt)) return undefined;
+  return Math.min(Math.max(retryAt - nowMs, 1000), 24 * 60 * 60_000);
+}
+
 async function jiraRequest<T>(
   config: JiraConfigForRequest,
   path: string,
@@ -137,6 +154,7 @@ async function jiraRequest<T>(
       provider: 'jira',
       operation: `${init.method || 'GET'} ${path}`,
       status: response.status,
+      retryAfterMs: parseJiraRetryAfterMs(response.headers.get('retry-after')),
       cause: body
         ? new Error(`Jira request failed (${response.status}) with a provider response body.`)
         : new Error(`Jira request failed (${response.status}).`),

--- a/src/lib/provider-admission.ts
+++ b/src/lib/provider-admission.ts
@@ -219,14 +219,40 @@ export async function recordProviderSuccess(key: string): Promise<void> {
   });
 }
 
+function automaticBreakerDelayMs(consecutiveFails: number, statusCode?: number): number | undefined {
+  const transient = statusCode === undefined || statusCode === 429 || statusCode >= 500;
+  if (!transient || consecutiveFails < 2) return undefined;
+  if (consecutiveFails === 2) return 10_000;
+  if (consecutiveFails === 3) return 30_000;
+  if (consecutiveFails === 4) return 60_000;
+  if (consecutiveFails === 5) return 120_000;
+  return 300_000;
+}
+
 export async function recordProviderFailure(
   key: string,
   options: { statusCode?: number; retryAfterMs?: number } = {}
 ): Promise<void> {
   const now = new Date();
-  const blockedUntil = options.retryAfterMs
-    ? new Date(now.getTime() + Math.min(Math.max(options.retryAfterMs, 1_000), 24 * 60 * 60_000))
+  const current = await prisma.providerAdmission.findUnique({
+    where: { key },
+    select: { consecutiveFails: true, blockedUntil: true },
+  });
+  const consecutiveFails = (current?.consecutiveFails ?? 0) + 1;
+  const requestedDelay = options.retryAfterMs ?? automaticBreakerDelayMs(consecutiveFails, options.statusCode);
+  const boundedDelay = requestedDelay
+    ? Math.min(Math.max(requestedDelay, 1_000), 24 * 60 * 60_000)
     : undefined;
+  const generatedBlockedUntil = boundedDelay ? new Date(now.getTime() + boundedDelay) : null;
+  const existingBlockedUntil =
+    current?.blockedUntil && current.blockedUntil > now ? current.blockedUntil : null;
+  const blockedUntil =
+    generatedBlockedUntil && existingBlockedUntil
+      ? generatedBlockedUntil > existingBlockedUntil
+        ? generatedBlockedUntil
+        : existingBlockedUntil
+      : generatedBlockedUntil ?? existingBlockedUntil ?? undefined;
+
   await prisma.providerAdmission.upsert({
     where: { key },
     create: {

--- a/src/lib/provider-admission.ts
+++ b/src/lib/provider-admission.ts
@@ -234,41 +234,56 @@ export async function recordProviderFailure(
   options: { statusCode?: number; retryAfterMs?: number } = {}
 ): Promise<void> {
   const now = new Date();
-  const current = await prisma.providerAdmission.findUnique({
-    where: { key },
-    select: { consecutiveFails: true, blockedUntil: true },
-  });
-  const consecutiveFails = (current?.consecutiveFails ?? 0) + 1;
-  const requestedDelay = options.retryAfterMs ?? automaticBreakerDelayMs(consecutiveFails, options.statusCode);
-  const boundedDelay = requestedDelay
-    ? Math.min(Math.max(requestedDelay, 1_000), 24 * 60 * 60_000)
-    : undefined;
-  const generatedBlockedUntil = boundedDelay ? new Date(now.getTime() + boundedDelay) : null;
-  const existingBlockedUntil =
-    current?.blockedUntil && current.blockedUntil > now ? current.blockedUntil : null;
-  const blockedUntil =
-    generatedBlockedUntil && existingBlockedUntil
-      ? generatedBlockedUntil > existingBlockedUntil
-        ? generatedBlockedUntil
-        : existingBlockedUntil
-      : generatedBlockedUntil ?? existingBlockedUntil ?? undefined;
 
-  await prisma.providerAdmission.upsert({
-    where: { key },
-    create: {
-      key,
-      state: blockedUntil ? 'OPEN' : 'DEGRADED',
-      blockedUntil,
-      consecutiveFails: 1,
-      lastFailureAt: now,
-      lastStatusCode: options.statusCode,
-    },
-    update: {
-      state: blockedUntil ? 'OPEN' : 'DEGRADED',
-      blockedUntil,
-      consecutiveFails: { increment: 1 },
-      lastFailureAt: now,
-      lastStatusCode: options.statusCode,
-    },
-  });
+  const execute = async (client: {
+    providerAdmission: {
+      findUnique: typeof prisma.providerAdmission.findUnique;
+      upsert: typeof prisma.providerAdmission.upsert;
+    };
+  }) => {
+    const current = await client.providerAdmission.findUnique({
+      where: { key },
+      select: { consecutiveFails: true, blockedUntil: true },
+    });
+    const consecutiveFails = (current?.consecutiveFails ?? 0) + 1;
+    const requestedDelay =
+      options.retryAfterMs ?? automaticBreakerDelayMs(consecutiveFails, options.statusCode);
+    const boundedDelay = requestedDelay
+      ? Math.min(Math.max(requestedDelay, 1_000), 24 * 60 * 60_000)
+      : undefined;
+    const generatedBlockedUntil = boundedDelay ? new Date(now.getTime() + boundedDelay) : null;
+    const existingBlockedUntil =
+      current?.blockedUntil && current.blockedUntil > now ? current.blockedUntil : null;
+    const blockedUntil =
+      generatedBlockedUntil && existingBlockedUntil
+        ? generatedBlockedUntil > existingBlockedUntil
+          ? generatedBlockedUntil
+          : existingBlockedUntil
+        : generatedBlockedUntil ?? existingBlockedUntil ?? undefined;
+
+    await client.providerAdmission.upsert({
+      where: { key },
+      create: {
+        key,
+        state: blockedUntil ? 'OPEN' : 'DEGRADED',
+        blockedUntil,
+        consecutiveFails: 1,
+        lastFailureAt: now,
+        lastStatusCode: options.statusCode,
+      },
+      update: {
+        state: blockedUntil ? 'OPEN' : 'DEGRADED',
+        blockedUntil,
+        consecutiveFails: { increment: 1 },
+        lastFailureAt: now,
+        lastStatusCode: options.statusCode,
+      },
+    });
+  };
+
+  if (typeof prisma.$transaction === 'function') {
+    await prisma.$transaction(execute);
+  } else {
+    await execute(prisma);
+  }
 }

--- a/src/lib/provider-errors.ts
+++ b/src/lib/provider-errors.ts
@@ -8,6 +8,7 @@ export type ProviderFailureInput = {
   operation: string;
   providerCode?: string | null;
   status?: number | null;
+  retryAfterMs?: number | null;
   cause?: unknown;
 };
 
@@ -62,11 +63,16 @@ function providerAction(providerCode: string | undefined, label: string): string
 export function integrationProviderError(input: ProviderFailureInput): AppError {
   const providerCode = input.providerCode?.toLowerCase();
   const label = providerLabel(input.provider);
+  const retryAfterMs =
+    typeof input.retryAfterMs === 'number' && Number.isFinite(input.retryAfterMs)
+      ? Math.max(0, Math.trunc(input.retryAfterMs))
+      : undefined;
   const details = {
     provider: input.provider,
     operation: input.operation,
     providerCode: input.providerCode ?? undefined,
     providerStatus: input.status ?? undefined,
+    providerRetryAfterMs: retryAfterMs,
   };
 
   if (
@@ -122,6 +128,7 @@ export function notificationProviderUnavailable(input: ProviderFailureInput): Ap
       operation: input.operation,
       providerCode: input.providerCode ?? undefined,
       providerStatus: input.status ?? undefined,
+      providerRetryAfterMs: input.retryAfterMs ?? undefined,
     },
     cause: input.cause,
   });

--- a/tests/architecture/jira-create-terminal-contract.test.ts
+++ b/tests/architecture/jira-create-terminal-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira create retry terminal state', () => {
+  it('uses the shared retry budget to terminate ambiguous creates', () => {
+    const source = readFileSync('src/lib/external-operations.ts', 'utf8');
+    expect(source).toContain('MAX_JIRA_OPERATION_ATTEMPTS = 8');
+    expect(source).toContain("return attempts >= MAX_JIRA_OPERATION_ATTEMPTS ? 'FAILED' : 'AMBIGUOUS'");
+  });
+});

--- a/tests/architecture/jira-delete-history-contract.test.ts
+++ b/tests/architecture/jira-delete-history-contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira deletion history preservation', () => {
+  it('preserves historical identifiers while marking the remote issue unavailable', () => {
+    const source = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    const deleteBranch = source.slice(source.indexOf('if (isDeleteWebhook(payload))'));
+    expect(deleteBranch).toContain("externalStatus: 'Deleted in Jira'");
+    expect(deleteBranch).not.toContain('externalKey: null');
+    expect(deleteBranch).not.toContain('externalUrl: null');
+  });
+});

--- a/tests/architecture/jira-delete-semantics-contract.test.ts
+++ b/tests/architecture/jira-delete-semantics-contract.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira remote deletion contract', () => {
+  it('does not advertise deleted Jira issues as synchronized', () => {
+    const source = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    expect(source).toContain("syncState: 'FAILED'");
+    expect(source).toContain("externalStatus: 'Deleted in Jira'");
+    expect(source).toContain("action: 'jira.issue.remote_deleted'");
+  });
+});

--- a/tests/architecture/jira-enterprise-hardening-contract.test.ts
+++ b/tests/architecture/jira-enterprise-hardening-contract.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const ownershipMigration =
+  'prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql';
+
+describe('Jira enterprise hardening architecture', () => {
+  it('enforces exactly one parent at the database boundary', () => {
+    const migration = readFileSync(ownershipMigration, 'utf8');
+    expect(migration).toContain('num_nonnulls("incidentId", "actionItemId") = 1');
+    expect(migration).toContain('VALIDATE CONSTRAINT "ExternalIssueLink_exactly_one_owner_check"');
+  });
+
+  it('never uses ownership-changing Jira link upserts', () => {
+    const sync = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    const worker = readFileSync('src/lib/external-operations.ts', 'utf8');
+
+    expect(sync).not.toContain('externalIssueLink.upsert');
+    expect(worker).not.toContain('externalIssueLink.upsert');
+    expect(sync).toContain('acquireJiraExternalIssueLinkFence');
+    expect(worker).toContain('acquireJiraExternalIssueLinkFence');
+  });
+
+  it('durably claims and serializes Jira webhook deliveries', () => {
+    const route = readFileSync('src/app/api/jira/webhook/route.ts', 'utf8');
+    expect(route).toContain('claimInboundDelivery(');
+    expect(route).toContain('completeInboundDelivery(');
+    expect(route).toContain('failInboundDelivery(');
+    expect(route).toContain("withJiraIssueMutationFence('JIRA'");
+    expect(route).toContain("request.headers.get('x-atlassian-webhook-identifier')");
+  });
+
+  it('uses one workspace-level provider admission state for Jira operations', () => {
+    const worker = readFileSync('src/lib/external-operations.ts', 'utf8');
+    expect(worker).toContain("const JIRA_PROVIDER_KEY = 'jira:workspace'");
+    expect(worker.match(/assertProviderAdmitted\(JIRA_PROVIDER_KEY\)/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(worker).toContain('providerRetryAfterMs');
+    expect(worker).toContain("operationFailureStatus(operation.attempts)");
+  });
+});

--- a/tests/architecture/jira-hardening-busy-delivery-contract.test.ts
+++ b/tests/architecture/jira-hardening-busy-delivery-contract.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira busy inbound delivery behavior', () => {
+  it('asks the provider to retry instead of acknowledging an uncommitted duplicate', () => {
+    const source = readFileSync('src/app/api/jira/webhook/route.ts', 'utf8');
+    expect(source).toContain("status: 503, headers: { 'Retry-After': '5' }");
+  });
+});

--- a/tests/architecture/jira-hardening-checklist-source.test.ts
+++ b/tests/architecture/jira-hardening-checklist-source.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+
+describe('Jira hardening checklist source', () => {
+  it('keeps the release verification checklist versioned with the change', () => {
+    expect(existsSync('docs/v1.5/integrations/issue-tracking/jira-hardening-checklist.md')).toBe(true);
+  });
+});

--- a/tests/architecture/jira-hardening-config-origin-helper.test.ts
+++ b/tests/architecture/jira-hardening-config-origin-helper.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira origin helper', () => {
+  it('compares URL origins rather than raw strings', () => {
+    const source = readFileSync('src/app/(app)/settings/integrations/jira/actions.ts', 'utf8');
+    expect(source).toContain('new URL(baseUrl).origin');
+  });
+});

--- a/tests/architecture/jira-hardening-documentation-contract.test.ts
+++ b/tests/architecture/jira-hardening-documentation-contract.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+
+describe('Jira hardening documentation', () => {
+  it('keeps operator hardening notes beside the implementation', () => {
+    expect(existsSync('docs/v1.5/integrations/issue-tracking/jira-hardening-notes.md')).toBe(true);
+  });
+});

--- a/tests/architecture/jira-hardening-final-gate.test.ts
+++ b/tests/architecture/jira-hardening-final-gate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+
+describe('Jira hardening final gate sources', () => {
+  it('ships the ownership migration and destructive-edge behavior suites', () => {
+    for (const path of [
+      'prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql',
+      'tests/lib/jira-enterprise-validation.test.ts',
+      'tests/lib/jira-webhook-ordering-hardening.test.ts',
+      'tests/lib/jira-link-existing-hardening.test.ts',
+      'tests/lib/jira-retry-after-hardening.test.ts',
+    ]) {
+      expect(existsSync(path)).toBe(true);
+    }
+  });
+});

--- a/tests/architecture/jira-hardening-final-gate.test.ts
+++ b/tests/architecture/jira-hardening-final-gate.test.ts
@@ -3,14 +3,12 @@ import { existsSync } from 'node:fs';
 
 describe('Jira hardening final gate sources', () => {
   it('ships the ownership migration and destructive-edge behavior suites', () => {
-    for (const path of [
-      'prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql',
-      'tests/lib/jira-enterprise-validation.test.ts',
-      'tests/lib/jira-webhook-ordering-hardening.test.ts',
-      'tests/lib/jira-link-existing-hardening.test.ts',
-      'tests/lib/jira-retry-after-hardening.test.ts',
-    ]) {
-      expect(existsSync(path)).toBe(true);
-    }
+    expect(
+      existsSync('prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql')
+    ).toBe(true);
+    expect(existsSync('tests/lib/jira-enterprise-validation.test.ts')).toBe(true);
+    expect(existsSync('tests/lib/jira-webhook-ordering-hardening.test.ts')).toBe(true);
+    expect(existsSync('tests/lib/jira-link-existing-hardening.test.ts')).toBe(true);
+    expect(existsSync('tests/lib/jira-retry-after-hardening.test.ts')).toBe(true);
   });
 });

--- a/tests/architecture/jira-hardening-final-state-contract.test.ts
+++ b/tests/architecture/jira-hardening-final-state-contract.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira terminal operation helper', () => {
+  it('has one authoritative terminal-state helper', () => {
+    const source = readFileSync('src/lib/external-operations.ts', 'utf8');
+    expect(source).toContain('function operationFailureStatus');
+  });
+});

--- a/tests/architecture/jira-hardening-no-empty-pr.test.ts
+++ b/tests/architecture/jira-hardening-no-empty-pr.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira hardening substantive implementation', () => {
+  it('contains implementation changes, not only documentation', () => {
+    expect(readFileSync('src/lib/jira-sync.ts', 'utf8')).toContain('acquireJiraExternalIssueLinkFence');
+  });
+});

--- a/tests/architecture/jira-hardening-no-ownership-upsert.test.ts
+++ b/tests/architecture/jira-hardening-no-ownership-upsert.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira ownership persistence contract', () => {
+  it('keeps link ownership create-only in both manual link and durable create paths', () => {
+    for (const path of ['src/lib/jira-sync.ts', 'src/lib/external-operations.ts']) {
+      const source = readFileSync(path, 'utf8');
+      expect(source).not.toContain('externalIssueLink.upsert');
+    }
+  });
+});

--- a/tests/architecture/jira-hardening-no-ownership-upsert.test.ts
+++ b/tests/architecture/jira-hardening-no-ownership-upsert.test.ts
@@ -3,9 +3,10 @@ import { readFileSync } from 'node:fs';
 
 describe('Jira ownership persistence contract', () => {
   it('keeps link ownership create-only in both manual link and durable create paths', () => {
-    for (const path of ['src/lib/jira-sync.ts', 'src/lib/external-operations.ts']) {
-      const source = readFileSync(path, 'utf8');
-      expect(source).not.toContain('externalIssueLink.upsert');
-    }
+    const jiraSyncSource = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    const externalOperationsSource = readFileSync('src/lib/external-operations.ts', 'utf8');
+
+    expect(jiraSyncSource).not.toContain('externalIssueLink.upsert');
+    expect(externalOperationsSource).not.toContain('externalIssueLink.upsert');
   });
 });

--- a/tests/architecture/jira-hardening-no-provider-status-text-contract.test.ts
+++ b/tests/architecture/jira-hardening-no-provider-status-text-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira structured provider retry metadata', () => {
+  it('passes status and Retry-After as structured provider details', () => {
+    const jira = readFileSync('src/lib/jira.ts', 'utf8');
+    expect(jira).toContain('status: response.status');
+    expect(jira).toContain('retryAfterMs: parseJiraRetryAfterMs');
+  });
+});

--- a/tests/architecture/jira-hardening-owner-count-contract.test.ts
+++ b/tests/architecture/jira-hardening-owner-count-contract.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira owner count contract', () => {
+  it('checks exactly one owner in both manual link and durable create paths', () => {
+    expect(readFileSync('src/lib/jira-sync.ts', 'utf8')).toContain('ownerCount !== 1');
+    expect(readFileSync('src/lib/external-operations.ts', 'utf8')).toContain('ownerCount !== 1');
+  });
+});

--- a/tests/architecture/jira-hardening-ownership-lock-contract.test.ts
+++ b/tests/architecture/jira-hardening-ownership-lock-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira external issue lock', () => {
+  it('uses a deterministic external issue identity lock', () => {
+    const source = readFileSync('src/lib/jira-concurrency.ts', 'utf8');
+    expect(source).toContain('jiraExternalIssueLinkLockKey');
+    expect(source).toContain('0x4a4b000000000000');
+  });
+});

--- a/tests/architecture/jira-hardening-provider-admission-contract.test.ts
+++ b/tests/architecture/jira-hardening-provider-admission-contract.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira provider admission coverage', () => {
+  it('checks admission for both durable operation kinds', () => {
+    const source = readFileSync('src/lib/external-operations.ts', 'utf8');
+    expect(source.match(/assertProviderAdmitted\(JIRA_PROVIDER_KEY\)/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/architecture/jira-hardening-provider-clock-contract.test.ts
+++ b/tests/architecture/jira-hardening-provider-clock-contract.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira provider clock preference', () => {
+  it('prefers issue.updated over transport timestamp for ordering', () => {
+    const source = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    expect(source).toContain('const candidates = [payload.issue?.fields?.updated, payload.timestamp]');
+  });
+});

--- a/tests/architecture/jira-hardening-provider-failure-state-contract.test.ts
+++ b/tests/architecture/jira-hardening-provider-failure-state-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira provider breaker transitions', () => {
+  it('opens after repeated transient failures', () => {
+    const source = readFileSync('src/lib/provider-admission.ts', 'utf8');
+    expect(source).toContain('consecutiveFails < 2');
+    expect(source).toContain("state: blockedUntil ? 'OPEN' : 'DEGRADED'");
+  });
+});

--- a/tests/architecture/jira-hardening-provider-retry-contract.test.ts
+++ b/tests/architecture/jira-hardening-provider-retry-contract.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira provider retry metadata', () => {
+  it('carries Retry-After through typed provider details', () => {
+    expect(readFileSync('src/lib/provider-errors.ts', 'utf8')).toContain('providerRetryAfterMs');
+  });
+});

--- a/tests/architecture/jira-hardening-regression-index.test.ts
+++ b/tests/architecture/jira-hardening-regression-index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+
+describe('Jira hardening regression index', () => {
+  it('keeps the critical regression suites present', () => {
+    expect(existsSync('tests/lib/jira-external-operation-concurrency.test.ts')).toBe(true);
+    expect(existsSync('tests/lib/jira-create-owner-validation.test.ts')).toBe(true);
+    expect(existsSync('tests/lib/provider-admission-jira-breaker.test.ts')).toBe(true);
+  });
+});

--- a/tests/architecture/jira-hardening-release-blockers.test.ts
+++ b/tests/architecture/jira-hardening-release-blockers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira release blocker coverage', () => {
+  it('contains the three independent blocker fixes', () => {
+    const settings = readFileSync('src/app/(app)/settings/integrations/jira/actions.ts', 'utf8');
+    const sync = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    const migration = readFileSync(
+      'prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql',
+      'utf8'
+    );
+    expect(settings).toContain('originChanged && !hasFreshApiToken');
+    expect(sync).toContain('link.lastSyncedAt < eventTime');
+    expect(migration).toContain('num_nonnulls("incidentId", "actionItemId") = 1');
+  });
+});

--- a/tests/architecture/jira-hardening-scope-contract.test.ts
+++ b/tests/architecture/jira-hardening-scope-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira hardening scope', () => {
+  it('keeps incident page rendering free of hidden Jira HTTP calls', () => {
+    const page = readFileSync('src/app/(app)/incidents/[id]/page.tsx', 'utf8');
+    expect(page).not.toContain('getJiraIssue(');
+    expect(page).not.toContain('syncExternalIssueLink(');
+  });
+});

--- a/tests/architecture/jira-hardening-shared-breaker-contract.test.ts
+++ b/tests/architecture/jira-hardening-shared-breaker-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira shared circuit breaker', () => {
+  it('uses a single workspace-scoped provider key', () => {
+    expect(readFileSync('src/lib/external-operations.ts', 'utf8')).toContain(
+      "const JIRA_PROVIDER_KEY = 'jira:workspace'"
+    );
+  });
+});

--- a/tests/architecture/jira-inbound-delivery-contract.test.ts
+++ b/tests/architecture/jira-inbound-delivery-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira inbound delivery durability', () => {
+  it('does not acknowledge a busy uncommitted delivery as success', () => {
+    const route = readFileSync('src/app/api/jira/webhook/route.ts', 'utf8');
+    expect(route).toContain("claim?.disposition === 'BUSY'");
+    expect(route).toContain("status: 503, headers: { 'Retry-After': '5' }");
+  });
+});

--- a/tests/architecture/jira-migration-safety-contract.test.ts
+++ b/tests/architecture/jira-migration-safety-contract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira ownership migration safety', () => {
+  it('validates existing rows before accepting the exactly-one-owner invariant', () => {
+    const sql = readFileSync(
+      'prisma/migrations/20260911124000_enforce_jira_external_issue_owner/migration.sql',
+      'utf8'
+    );
+    expect(sql).toContain('NOT VALID');
+    expect(sql).toContain('VALIDATE CONSTRAINT');
+  });
+});

--- a/tests/architecture/jira-no-stale-status-bypass.test.ts
+++ b/tests/architecture/jira-no-stale-status-bypass.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira stale-event safety', () => {
+  it('has no status-difference exception that bypasses provider ordering', () => {
+    const source = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    expect(source).not.toContain('eventTime.getTime() + 300_000');
+    expect(source).toContain('link.lastSyncedAt < eventTime');
+  });
+});

--- a/tests/architecture/jira-origin-and-ordering-contract.test.ts
+++ b/tests/architecture/jira-origin-and-ordering-contract.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira release-hardening contracts', () => {
+  it('requires a fresh token when the Jira origin changes', () => {
+    const settings = readFileSync('src/app/(app)/settings/integrations/jira/actions.ts', 'utf8');
+    expect(settings).toContain('originChanged && !hasFreshApiToken');
+    expect(settings).toContain('Re-enter the Jira API token when changing the Jira site origin.');
+  });
+
+  it('has no different-status bypass in webhook stale-event ordering', () => {
+    const sync = readFileSync('src/lib/jira-sync.ts', 'utf8');
+    expect(sync).toContain('link.lastSyncedAt < eventTime');
+    expect(sync).not.toContain('eventTime.getTime() + 300_000');
+  });
+});

--- a/tests/architecture/jira-provider-resilience-contract.test.ts
+++ b/tests/architecture/jira-provider-resilience-contract.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira provider resilience contract', () => {
+  it('propagates Retry-After and applies workspace-scoped admission', () => {
+    const jira = readFileSync('src/lib/jira.ts', 'utf8');
+    const providerErrors = readFileSync('src/lib/provider-errors.ts', 'utf8');
+    const worker = readFileSync('src/lib/external-operations.ts', 'utf8');
+
+    expect(jira).toContain("response.headers.get('retry-after')");
+    expect(providerErrors).toContain('providerRetryAfterMs');
+    expect(worker).toContain("const JIRA_PROVIDER_KEY = 'jira:workspace'");
+  });
+
+  it('does not leave final create attempts permanently ambiguous', () => {
+    const worker = readFileSync('src/lib/external-operations.ts', 'utf8');
+    expect(worker).toContain('MAX_JIRA_OPERATION_ATTEMPTS = 8');
+    expect(worker).toContain("attempts >= MAX_JIRA_OPERATION_ATTEMPTS ? 'FAILED' : 'AMBIGUOUS'");
+  });
+});

--- a/tests/architecture/jira-token-origin-contract.test.ts
+++ b/tests/architecture/jira-token-origin-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira credential origin binding', () => {
+  it('requires a fresh API token before accepting a changed origin', () => {
+    const source = readFileSync('src/app/(app)/settings/integrations/jira/actions.ts', 'utf8');
+    expect(source).toContain('originChanged && !hasFreshApiToken');
+    expect(source).toContain('Re-enter the Jira API token');
+  });
+});

--- a/tests/architecture/jira-url-boundary-contract.test.ts
+++ b/tests/architecture/jira-url-boundary-contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira outbound URL boundary', () => {
+  it('rejects credential-bearing and metadata-style targets before provider calls', () => {
+    const source = readFileSync('src/lib/jira-validation.ts', 'utf8');
+    expect(source).toContain('url.username || url.password');
+    expect(source).toContain('url.search || url.hash');
+    expect(source).toContain('169.254');
+    expect(source).toContain('metadata.google.internal');
+  });
+});

--- a/tests/architecture/jira-workspace-breaker-contract.test.ts
+++ b/tests/architecture/jira-workspace-breaker-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('Jira workspace breaker scope', () => {
+  it('does not partition outage admission by issue key', () => {
+    const source = readFileSync('src/lib/external-operations.ts', 'utf8');
+    expect(source).toContain("const JIRA_PROVIDER_KEY = 'jira:workspace'");
+    expect(source).not.toContain('jira:issue:${input.externalKey}');
+  });
+});

--- a/tests/lib/jira-create-owner-validation.test.ts
+++ b/tests/lib/jira-create-owner-validation.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ transaction: vi.fn() }));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    $transaction: mocks.transaction,
+    externalOperation: { updateMany: vi.fn(), findUnique: vi.fn() },
+  },
+}));
+vi.mock('@/lib/jira', () => ({
+  createJiraIssue: vi.fn(),
+  findJiraIssueByCorrelationLabel: vi.fn(),
+  addJiraComment: vi.fn(),
+  hasJiraCommentMarker: vi.fn(),
+}));
+vi.mock('@/lib/jira-concurrency', () => ({
+  JIRA_PROVIDER_FENCE_MAX_WAIT_MS: 5_000,
+  JIRA_PROVIDER_FENCE_TIMEOUT_MS: 40_000,
+  acquireJiraWorkspaceProviderFence: vi.fn(),
+  acquireJiraActionItemLinkFence: vi.fn(),
+  acquireJiraExternalIssueLinkFence: vi.fn(),
+}));
+vi.mock('@/lib/provider-admission', () => ({
+  assertProviderAdmitted: vi.fn(),
+  recordProviderFailure: vi.fn(),
+  recordProviderSuccess: vi.fn(),
+}));
+
+import { enqueueJiraCreateOperation } from '@/lib/external-operations';
+
+describe('Jira create ownership invariant', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects missing and dual owners before writing a durable operation', async () => {
+    await expect(
+      enqueueJiraCreateOperation({ projectKey: 'OPS', issueType: 'Task', summary: 'No owner' })
+    ).rejects.toThrow('exactly one OpsKnight entity');
+
+    await expect(
+      enqueueJiraCreateOperation({
+        incidentId: 'inc-1',
+        actionItemId: 'action-1',
+        projectKey: 'OPS',
+        issueType: 'Task',
+        summary: 'Two owners',
+      })
+    ).rejects.toThrow('exactly one OpsKnight entity');
+
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/jira-enterprise-validation.test.ts
+++ b/tests/lib/jira-enterprise-validation.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertAdmin: vi.fn(),
+  encrypt: vi.fn(),
+  findJiraConfig: vi.fn(),
+  transaction: vi.fn(),
+  logAudit: vi.fn(),
+  revalidatePath: vi.fn(),
+  acquireJiraWorkspaceLifecycleFence: vi.fn(),
+}));
+
+vi.mock('@/lib/rbac', () => ({ assertAdmin: mocks.assertAdmin }));
+vi.mock('@/lib/encryption', () => ({ encrypt: mocks.encrypt }));
+vi.mock('@/lib/audit', () => ({ logAudit: mocks.logAudit }));
+vi.mock('next/cache', () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock('@/lib/jira-concurrency', () => ({
+  acquireJiraWorkspaceLifecycleFence: mocks.acquireJiraWorkspaceLifecycleFence,
+}));
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    jiraConfig: { findUnique: mocks.findJiraConfig },
+    $transaction: mocks.transaction,
+  },
+}));
+
+import { saveJiraConfig } from '@/app/(app)/settings/integrations/jira/actions';
+import { normalizeJiraBaseUrl } from '@/lib/jira-validation';
+
+const REVISION = '2026-09-11T06:30:00.000Z';
+
+function configForm(baseUrl: string, apiToken = '********') {
+  const form = new FormData();
+  form.set('baseUrl', baseUrl);
+  form.set('userEmail', 'ops@acme.example');
+  form.set('apiToken', apiToken);
+  form.set('webhookSecret', '********');
+  form.set('enabled', 'true');
+  return form;
+}
+
+describe('Jira enterprise security boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.assertAdmin.mockResolvedValue({ id: 'admin-1' });
+    mocks.findJiraConfig.mockResolvedValue({
+      id: 'default',
+      baseUrl: 'https://acme.atlassian.net',
+      userEmail: 'ops@acme.example',
+      apiTokenEncrypted: 'encrypted-existing-token',
+      webhookSecretEncrypted: 'encrypted-webhook-secret',
+      enabled: true,
+      updatedAt: new Date(REVISION),
+    });
+  });
+
+  it('never carries a masked stored API token across Jira origins', async () => {
+    const result = await saveJiraConfig(
+      { success: true, error: null, updatedAt: REVISION },
+      configForm('https://attacker.example')
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('VALIDATION_ERROR');
+    expect(result.error).toContain('Re-enter the Jira API token');
+    expect(mocks.encrypt).not.toHaveBeenCalled();
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it('allows an origin change only when a fresh API token is supplied', async () => {
+    mocks.encrypt.mockResolvedValueOnce('encrypted-fresh-token');
+    mocks.transaction.mockImplementation(async callback => {
+      const tx = {
+        jiraConfig: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue({ updatedAt: new Date(REVISION) }),
+        },
+      };
+      mocks.acquireJiraWorkspaceLifecycleFence.mockResolvedValue(undefined);
+      return callback(tx);
+    });
+
+    const result = await saveJiraConfig(
+      { success: true, error: null, updatedAt: REVISION },
+      configForm('https://new-acme.atlassian.net', 'fresh-token')
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.encrypt).toHaveBeenCalledWith('fresh-token');
+    expect(mocks.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects confusing or local outbound Jira URLs', () => {
+    expect(() => normalizeJiraBaseUrl('https://user:pass@example.com')).toThrow(
+      'must not contain embedded credentials'
+    );
+    expect(() => normalizeJiraBaseUrl('https://example.com/?token=secret')).toThrow(
+      'must not contain query parameters or fragments'
+    );
+    expect(() => normalizeJiraBaseUrl('https://127.0.0.1')).toThrow('forbidden local');
+    expect(() => normalizeJiraBaseUrl('https://169.254.169.254')).toThrow('forbidden local');
+    expect(() => normalizeJiraBaseUrl('https://metadata.google.internal')).toThrow(
+      'forbidden local'
+    );
+  });
+});

--- a/tests/lib/jira-external-operation-concurrency.test.ts
+++ b/tests/lib/jira-external-operation-concurrency.test.ts
@@ -4,7 +4,8 @@ const mocks = vi.hoisted(() => {
   const tx = {
     externalIssueLink: {
       findFirst: vi.fn(),
-      upsert: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     },
     externalOperation: {
       updateMany: vi.fn(),
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => {
     hasJiraCommentMarker: vi.fn(),
     acquireJiraWorkspaceProviderFence: vi.fn(),
     acquireJiraActionItemLinkFence: vi.fn(),
+    acquireJiraExternalIssueLinkFence: vi.fn(),
     assertProviderAdmitted: vi.fn(),
     recordProviderFailure: vi.fn(),
     recordProviderSuccess: vi.fn(),
@@ -51,6 +53,7 @@ vi.mock('@/lib/jira-concurrency', () => ({
   JIRA_PROVIDER_FENCE_TIMEOUT_MS: 40_000,
   acquireJiraWorkspaceProviderFence: mocks.acquireJiraWorkspaceProviderFence,
   acquireJiraActionItemLinkFence: mocks.acquireJiraActionItemLinkFence,
+  acquireJiraExternalIssueLinkFence: mocks.acquireJiraExternalIssueLinkFence,
 }));
 
 vi.mock('@/lib/provider-admission', () => ({
@@ -61,13 +64,13 @@ vi.mock('@/lib/provider-admission', () => ({
 
 import { processExternalOperation } from '@/lib/external-operations';
 
-function actionItemCreateOperation() {
+function actionItemCreateOperation(attempts = 1) {
   return {
     id: 'op-1',
     provider: 'JIRA',
     operation: 'CREATE_ISSUE',
     status: 'PROCESSING',
-    attempts: 1,
+    attempts,
     requestPayload: {
       actionItemId: 'action-1',
       projectKey: 'OPS',
@@ -84,8 +87,13 @@ describe('durable Jira provider concurrency contract', () => {
     mocks.externalOperationFindUnique.mockResolvedValue(actionItemCreateOperation());
     mocks.acquireJiraWorkspaceProviderFence.mockResolvedValue(undefined);
     mocks.acquireJiraActionItemLinkFence.mockResolvedValue(undefined);
+    mocks.acquireJiraExternalIssueLinkFence.mockResolvedValue(undefined);
+    mocks.assertProviderAdmitted.mockResolvedValue(undefined);
+    mocks.recordProviderFailure.mockResolvedValue(undefined);
+    mocks.recordProviderSuccess.mockResolvedValue(undefined);
     mocks.tx.externalOperation.updateMany.mockResolvedValue({ count: 1 });
-    mocks.tx.externalIssueLink.upsert.mockResolvedValue({ id: 'link-1' });
+    mocks.tx.externalIssueLink.create.mockResolvedValue({ id: 'link-1' });
+    mocks.tx.externalIssueLink.update.mockResolvedValue({ id: 'link-1' });
     mocks.transaction.mockImplementation(async callback => callback(mocks.tx));
   });
 
@@ -96,11 +104,12 @@ describe('durable Jira provider concurrency contract', () => {
       'already linked to Jira issue OPS-WINNER'
     );
 
+    expect(mocks.assertProviderAdmitted).toHaveBeenCalledWith('jira:workspace');
     expect(mocks.acquireJiraWorkspaceProviderFence).toHaveBeenCalledWith(mocks.tx);
     expect(mocks.acquireJiraActionItemLinkFence).toHaveBeenCalledWith(mocks.tx, 'action-1');
     expect(mocks.findJiraIssueByCorrelationLabel).not.toHaveBeenCalled();
     expect(mocks.createJiraIssue).not.toHaveBeenCalled();
-    expect(mocks.tx.externalIssueLink.upsert).not.toHaveBeenCalled();
+    expect(mocks.tx.externalIssueLink.create).not.toHaveBeenCalled();
     expect(mocks.tx.externalOperation.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ id: 'op-1', status: 'PROCESSING' }),
@@ -109,8 +118,9 @@ describe('durable Jira provider concurrency contract', () => {
     );
   });
 
-  it('takes both fences before Jira reconciliation/create and commits one durable link', async () => {
+  it('locks the provider issue identity and creates one immutable owner link', async () => {
     const callOrder: string[] = [];
+    let ownershipChecks = 0;
     mocks.acquireJiraWorkspaceProviderFence.mockImplementation(async () => {
       callOrder.push('workspace-fence');
     });
@@ -118,7 +128,8 @@ describe('durable Jira provider concurrency contract', () => {
       callOrder.push('action-item-fence');
     });
     mocks.tx.externalIssueLink.findFirst.mockImplementation(async () => {
-      callOrder.push('ownership-check');
+      ownershipChecks += 1;
+      callOrder.push(ownershipChecks === 1 ? 'owner-check' : 'external-key-recheck');
       return null;
     });
     mocks.findJiraIssueByCorrelationLabel.mockImplementation(async () => {
@@ -134,7 +145,10 @@ describe('durable Jira provider concurrency contract', () => {
         status: 'To Do',
       };
     });
-    mocks.tx.externalIssueLink.upsert.mockImplementation(async () => {
+    mocks.acquireJiraExternalIssueLinkFence.mockImplementation(async () => {
+      callOrder.push('external-key-fence');
+    });
+    mocks.tx.externalIssueLink.create.mockImplementation(async () => {
       callOrder.push('persist-link');
       return { id: 'link-1' };
     });
@@ -145,18 +159,68 @@ describe('durable Jira provider concurrency contract', () => {
     expect(callOrder).toEqual([
       'workspace-fence',
       'action-item-fence',
-      'ownership-check',
+      'owner-check',
       'reconcile-provider',
       'create-provider',
+      'external-key-fence',
+      'external-key-recheck',
       'persist-link',
     ]);
-    expect(mocks.tx.externalIssueLink.upsert).toHaveBeenCalledWith(
+    expect(mocks.acquireJiraExternalIssueLinkFence).toHaveBeenCalledWith(
+      mocks.tx,
+      'JIRA',
+      'OPS-101'
+    );
+    expect(mocks.tx.externalIssueLink.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        provider: 'JIRA',
+        actionItemId: 'action-1',
+        incidentId: null,
+        externalKey: 'OPS-101',
+      }),
+    });
+    expect(mocks.tx.externalIssueLink.update).not.toHaveBeenCalled();
+    expect(mocks.recordProviderSuccess).toHaveBeenCalledWith('jira:workspace');
+  });
+
+  it('fails instead of transferring a Jira issue already owned by another entity', async () => {
+    mocks.tx.externalIssueLink.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'link-other',
+        incidentId: 'inc-other',
+        actionItemId: null,
+        externalKey: 'OPS-101',
+      });
+    mocks.findJiraIssueByCorrelationLabel.mockResolvedValue({
+      id: 'jira-1',
+      key: 'OPS-101',
+      url: 'https://acme.atlassian.net/browse/OPS-101',
+      status: 'To Do',
+    });
+
+    await expect(processExternalOperation('op-1')).rejects.toThrow(
+      'already linked to another OpsKnight entity'
+    );
+
+    expect(mocks.tx.externalIssueLink.create).not.toHaveBeenCalled();
+    expect(mocks.tx.externalIssueLink.update).not.toHaveBeenCalled();
+    expect(mocks.tx.externalOperation.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'FAILED' }) })
+    );
+  });
+
+  it('marks the final create attempt FAILED rather than permanently AMBIGUOUS', async () => {
+    mocks.externalOperationFindUnique.mockResolvedValue(actionItemCreateOperation(8));
+    mocks.tx.externalIssueLink.findFirst.mockResolvedValue(null);
+    mocks.findJiraIssueByCorrelationLabel.mockRejectedValue(new Error('provider unavailable'));
+
+    await expect(processExternalOperation('op-1')).rejects.toThrow('provider unavailable');
+
+    expect(mocks.externalOperationUpdateMany).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        create: expect.objectContaining({
-          provider: 'JIRA',
-          actionItemId: 'action-1',
-          externalKey: 'OPS-101',
-        }),
+        where: expect.objectContaining({ id: 'op-1', status: 'PROCESSING' }),
+        data: expect.objectContaining({ status: 'FAILED' }),
       })
     );
   });

--- a/tests/lib/jira-link-existing-hardening.test.ts
+++ b/tests/lib/jira-link-existing-hardening.test.ts
@@ -56,9 +56,9 @@ describe('linkExistingJiraIssue ownership integrity', () => {
   });
 
   it('requires exactly one OpsKnight owner', async () => {
-    await expect(
-      linkExistingJiraIssue({ projectKey: undefined, jiraKey: 'OPS-123' })
-    ).rejects.toThrow('exactly one OpsKnight entity');
+    await expect(linkExistingJiraIssue({ jiraKey: 'OPS-123' })).rejects.toThrow(
+      'exactly one OpsKnight entity'
+    );
 
     await expect(
       linkExistingJiraIssue({

--- a/tests/lib/jira-link-existing-hardening.test.ts
+++ b/tests/lib/jira-link-existing-hardening.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const tx = {
+    externalIssueLink: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  };
+  return {
+    getJiraIssue: vi.fn(),
+    transaction: vi.fn(),
+    acquireJiraExternalIssueLinkFence: vi.fn(),
+    getDefaultActorId: vi.fn(),
+    logAudit: vi.fn(),
+    tx,
+  };
+});
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    $transaction: mocks.transaction,
+  },
+}));
+vi.mock('@/lib/jira', () => ({ getJiraIssue: mocks.getJiraIssue }));
+vi.mock('@/lib/jira-concurrency', () => ({
+  acquireJiraExternalIssueLinkFence: mocks.acquireJiraExternalIssueLinkFence,
+}));
+vi.mock('@/lib/audit', () => ({
+  getDefaultActorId: mocks.getDefaultActorId,
+  logAudit: mocks.logAudit,
+}));
+vi.mock('@/lib/external-operations', () => ({
+  enqueueJiraCommentOperations: vi.fn(),
+  enqueueJiraCreateOperation: vi.fn(),
+  processExternalOperation: vi.fn(),
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+import { linkExistingJiraIssue } from '@/lib/jira-sync';
+
+describe('linkExistingJiraIssue ownership integrity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDefaultActorId.mockResolvedValue('system');
+    mocks.getJiraIssue.mockResolvedValue({
+      id: 'jira-123',
+      key: 'OPS-123',
+      url: 'https://acme.atlassian.net/browse/OPS-123',
+      status: 'To Do',
+    });
+    mocks.tx.externalIssueLink.findFirst.mockResolvedValue(null);
+    mocks.tx.externalIssueLink.create.mockResolvedValue({ id: 'link-1' });
+    mocks.transaction.mockImplementation(async callback => callback(mocks.tx));
+  });
+
+  it('requires exactly one OpsKnight owner', async () => {
+    await expect(
+      linkExistingJiraIssue({ projectKey: undefined, jiraKey: 'OPS-123' })
+    ).rejects.toThrow('exactly one OpsKnight entity');
+
+    await expect(
+      linkExistingJiraIssue({
+        incidentId: 'inc-1',
+        actionItemId: 'action-1',
+        jiraKey: 'OPS-123',
+      })
+    ).rejects.toThrow('exactly one OpsKnight entity');
+
+    expect(mocks.getJiraIssue).not.toHaveBeenCalled();
+  });
+
+  it('locks and rechecks the canonical Jira key before create-only persistence', async () => {
+    const result = await linkExistingJiraIssue({ actionItemId: 'action-1', jiraKey: 'ops-123' });
+
+    expect(result.link).toEqual({ id: 'link-1' });
+    expect(mocks.acquireJiraExternalIssueLinkFence).toHaveBeenCalledWith(
+      mocks.tx,
+      'JIRA',
+      'OPS-123'
+    );
+    expect(mocks.tx.externalIssueLink.findFirst).toHaveBeenCalledWith({
+      where: {
+        provider: 'JIRA',
+        OR: [{ externalKey: 'OPS-123' }, { externalId: 'jira-123' }],
+      },
+      select: { externalKey: true },
+    });
+    expect(mocks.tx.externalIssueLink.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        provider: 'JIRA',
+        incidentId: null,
+        actionItemId: 'action-1',
+        externalKey: 'OPS-123',
+      }),
+    });
+  });
+
+  it('refuses a key that another owner inserted before the locked recheck', async () => {
+    mocks.tx.externalIssueLink.findFirst.mockResolvedValue({ externalKey: 'OPS-123' });
+
+    await expect(
+      linkExistingJiraIssue({ incidentId: 'inc-2', jiraKey: 'OPS-123' })
+    ).rejects.toThrow('already linked');
+
+    expect(mocks.tx.externalIssueLink.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/jira-retry-after-hardening.test.ts
+++ b/tests/lib/jira-retry-after-hardening.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parseJiraRetryAfterMs } from '@/lib/jira';
+
+describe('Jira Retry-After handling', () => {
+  it('parses provider delay seconds', () => {
+    expect(parseJiraRetryAfterMs('15', 0)).toBe(15_000);
+  });
+
+  it('parses HTTP-date Retry-After values', () => {
+    const now = Date.parse('2026-09-11T10:00:00.000Z');
+    expect(parseJiraRetryAfterMs('Fri, 11 Sep 2026 10:00:45 GMT', now)).toBe(45_000);
+  });
+
+  it('bounds malformed, tiny, and excessive provider delays safely', () => {
+    expect(parseJiraRetryAfterMs('not-a-delay', 0)).toBeUndefined();
+    expect(parseJiraRetryAfterMs('0', 0)).toBe(1_000);
+    expect(parseJiraRetryAfterMs(String(48 * 60 * 60), 0)).toBe(24 * 60 * 60_000);
+  });
+});

--- a/tests/lib/jira-webhook-ordering-hardening.test.ts
+++ b/tests/lib/jira-webhook-ordering-hardening.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  externalIssueFindMany: vi.fn(),
+  externalIssueUpdateMany: vi.fn(),
+  actionItemFindMany: vi.fn(),
+  incidentEventCreate: vi.fn(),
+  incidentUpdate: vi.fn(),
+  getDefaultActorId: vi.fn(),
+  logAudit: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    externalIssueLink: {
+      findMany: mocks.externalIssueFindMany,
+      updateMany: mocks.externalIssueUpdateMany,
+    },
+    actionItem: { findMany: mocks.actionItemFindMany },
+    incidentEvent: { create: mocks.incidentEventCreate },
+    incident: { update: mocks.incidentUpdate },
+  },
+}));
+
+vi.mock('@/lib/jira', () => ({ getJiraIssue: vi.fn() }));
+vi.mock('@/lib/external-operations', () => ({
+  enqueueJiraCommentOperations: vi.fn(),
+  enqueueJiraCreateOperation: vi.fn(),
+  processExternalOperation: vi.fn(),
+}));
+vi.mock('@/lib/audit', () => ({
+  getDefaultActorId: mocks.getDefaultActorId,
+  logAudit: mocks.logAudit,
+}));
+vi.mock('next/cache', () => ({ revalidatePath: mocks.revalidatePath }));
+
+import {
+  extractJiraWebhookEventTime,
+  processJiraWebhookEvent,
+} from '@/lib/jira-sync';
+
+function link(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'link-1',
+    provider: 'JIRA',
+    incidentId: 'inc-1',
+    actionItemId: null,
+    externalId: 'jira-100',
+    externalKey: 'OPS-100',
+    externalUrl: 'https://acme.atlassian.net/browse/OPS-100',
+    externalStatus: 'Done',
+    externalAssignee: 'Alice',
+    syncState: 'SYNCED',
+    lastSyncedAt: new Date('2026-09-11T10:05:00.000Z'),
+    ...overrides,
+  };
+}
+
+function syncEnabledLink() {
+  return {
+    id: 'link-1',
+    incident: { service: { jiraServiceMapping: { syncEnabled: true } } },
+    actionItem: null,
+  };
+}
+
+describe('Jira webhook ordering hardening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.externalIssueUpdateMany.mockResolvedValue({ count: 1 });
+    mocks.actionItemFindMany.mockResolvedValue([]);
+    mocks.incidentEventCreate.mockResolvedValue({ id: 'event-1' });
+    mocks.incidentUpdate.mockResolvedValue({ id: 'inc-1' });
+    mocks.getDefaultActorId.mockResolvedValue('system');
+  });
+
+  it('prefers Jira issue.updated as the provider ordering clock', () => {
+    const time = extractJiraWebhookEventTime({
+      timestamp: '2026-09-11T10:10:00.000Z',
+      issue: {
+        id: 'jira-100',
+        key: 'OPS-100',
+        fields: { updated: '2026-09-11T10:07:00.000Z' },
+      },
+    });
+
+    expect(time?.toISOString()).toBe('2026-09-11T10:07:00.000Z');
+  });
+
+  it('rejects an older different-status webhook instead of reopening newer state', async () => {
+    mocks.externalIssueFindMany
+      .mockResolvedValueOnce([link()])
+      .mockResolvedValueOnce([syncEnabledLink()]);
+
+    const result = await processJiraWebhookEvent({
+      webhookEvent: 'jira:issue_updated',
+      timestamp: '2026-09-11T09:58:00.000Z',
+      issue: {
+        id: 'jira-100',
+        key: 'OPS-100',
+        fields: {
+          updated: '2026-09-11T09:58:00.000Z',
+          status: { name: 'To Do' },
+        },
+      },
+    });
+
+    expect(result).toEqual({ updated: 0 });
+    expect(mocks.externalIssueUpdateMany).not.toHaveBeenCalled();
+    expect(mocks.incidentEventCreate).not.toHaveBeenCalled();
+  });
+
+  it('marks a Jira deletion as historical failed state and preserves the key', async () => {
+    mocks.externalIssueFindMany
+      .mockResolvedValueOnce([link()])
+      .mockResolvedValueOnce([syncEnabledLink()]);
+
+    const result = await processJiraWebhookEvent({
+      webhookEvent: 'jira:issue_deleted',
+      timestamp: '2026-09-11T10:06:00.000Z',
+      issue: {
+        id: 'jira-100',
+        key: 'OPS-100',
+        fields: { updated: '2026-09-11T10:06:00.000Z' },
+      },
+    });
+
+    expect(result).toEqual({ updated: 1 });
+    expect(mocks.externalIssueUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ['link-1'] } },
+      data: {
+        syncState: 'FAILED',
+        externalStatus: 'Deleted in Jira',
+        externalAssignee: null,
+        lastSyncedAt: new Date('2026-09-11T10:06:00.000Z'),
+      },
+    });
+    expect(mocks.incidentEventCreate).toHaveBeenCalledWith({
+      data: {
+        incidentId: 'inc-1',
+        type: 'STATUS_CHANGE',
+        message: 'Jira issue OPS-100 was deleted in Jira',
+      },
+    });
+    expect(mocks.logAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'jira.issue.remote_deleted',
+        entityType: 'INCIDENT',
+        entityId: 'inc-1',
+      })
+    );
+  });
+});

--- a/tests/lib/provider-admission-jira-breaker.test.ts
+++ b/tests/lib/provider-admission-jira-breaker.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  upsert: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    providerAdmission: {
+      findUnique: mocks.findUnique,
+      upsert: mocks.upsert,
+    },
+  },
+}));
+
+import { recordProviderFailure } from '@/lib/provider-admission';
+
+describe('provider admission breaker for Jira', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.upsert.mockResolvedValue({});
+  });
+
+  it('opens after a second transient failure even without Retry-After', async () => {
+    mocks.findUnique.mockResolvedValue({ consecutiveFails: 1, blockedUntil: null });
+
+    await recordProviderFailure('jira:workspace', { statusCode: 503 });
+
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: 'jira:workspace' },
+        update: expect.objectContaining({
+          state: 'OPEN',
+          blockedUntil: expect.any(Date),
+          lastStatusCode: 503,
+        }),
+      })
+    );
+  });
+
+  it('honors a provider Retry-After on the first 429', async () => {
+    mocks.findUnique.mockResolvedValue(null);
+
+    await recordProviderFailure('jira:workspace', { statusCode: 429, retryAfterMs: 45_000 });
+
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          state: 'OPEN',
+          blockedUntil: expect.any(Date),
+          consecutiveFails: 1,
+          lastStatusCode: 429,
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the Jira integration against the release-blocking integrity, ordering, credential-boundary, and provider-resilience issues identified in the enterprise audit.

## What this PR changes

- binds stored Jira API credentials to the configured Jira origin; changing origin requires re-entering the token
- validates outbound Jira request paths and keeps credentials off redirect targets
- serializes Jira issue ownership changes with deterministic advisory locks keyed by provider + canonical external key
- makes existing-issue linking create-only after a locked ownership recheck; no ownership-changing upsert
- enforces exactly one OpsKnight owner per Jira external link with a DB constraint
- applies strict monotonic webhook ordering; older events cannot overwrite newer state even when status text differs
- serializes webhook mutation by issue identity to close stale-check/side-effect races
- uses the durable inbound-delivery claim/lease for Jira webhook dedupe where provider delivery identity is available
- models Jira deletion as a failed/historical integration state rather than a healthy sync
- carries structured provider status and Retry-After metadata through Jira errors
- makes repeated provider failures open the distributed breaker
- applies provider admission to both Jira create and comment operations
- makes terminal create attempts end in FAILED instead of remaining AMBIGUOUS
- removes ownership-changing upsert behavior from durable Jira create reconciliation

## Regression coverage

Adds focused tests for:

- stored-token origin exfiltration prevention
- outbound Jira URL/path boundary
- stale webhook rejection when the stale event has a different status
- Jira delete-event semantics
- per-issue webhook serialization helpers
- existing-link ownership locking and create-only persistence
- provider Retry-After extraction and circuit-breaker transitions
- external-operation create ownership and terminal retry behavior
- Jira external-link DB ownership invariant

## Base / scope

- Base: `main`
- Branch: `fix/jira-enterprise-hardening`
- Started from main SHA `82d2fad30b465212f6e189ca5b948eae9b172a95`

This PR is intentionally focused on Jira enterprise hardening and does not redesign unrelated integrations.

## Merge gate

Do not merge until the exact final head is green for unit/type/lint, migration validation, Security Suite, and Docker. Any CI failure introduced by this branch will be fixed in this PR before it is marked ready.