### PR TITLE
docs(jira): align v1.5 documentation with hardened implementation

### DIFF
--- a/docs/v1.5/core-concepts/action-items.md
+++ b/docs/v1.5/core-concepts/action-items.md
@@ -6,7 +6,7 @@ order: 10
 
 # Action Items
 
-Action items turn a postmortem into owned follow-up work. Each item belongs to a postmortem and its incident, and can carry an owner, due date, priority, status, description, and external ticket link (Jira / GitHub).
+Action items turn a postmortem into owned follow-up work. Each item belongs to a postmortem and its incident, and can carry an owner, due date, priority, status, description, and optional Jira issue link.
 
 ## Action-item fields
 
@@ -19,7 +19,7 @@ Action items turn a postmortem into owned follow-up work. Each item belongs to a
 | Priority      | High, Medium, or Low with color-coded badges                                         |
 | Status        | Open, In Progress, Completed, or Blocked with one-click transitions                  |
 | Source        | Postmortem for items created in the incident learning workflow                       |
-| External link | Optional linked Jira or GitHub issue with live sync state                            |
+| External link | Optional linked Jira issue with stored key, status, assignee, and sync state         |
 
 ## Add action items to a postmortem
 
@@ -49,9 +49,17 @@ Open **Action Items** from the main navigation. The page combines action items f
 
 Responders and administrators can manage action items. Update the status instantly using the card quick-action menu or change owner, due date, priority, and description from the postmortem.
 
-## Ticket integrations (Jira & GitHub)
+## Jira integration
 
-When the workspace Jira or GitHub integration is configured, an item can link to an external issue, display the issue key and status, and open the external issue with one click.
+When the workspace Jira integration is enabled, a persisted action item can create a Jira issue from its incident service mapping or link an existing Jira issue. OpsKnight displays the stored Jira key and supported metadata and can open the provider issue directly.
+
+A Jira issue can belong to only one OpsKnight incident or action item. Competing attempts to link the same Jira issue are rejected rather than merging two OpsKnight owners into one external link.
+
+Jira status synchronization mirrors only completion state for action items: a Jira status categorized as Done marks a non-completed item `COMPLETED`; if the Jira issue later leaves Done, a currently `COMPLETED` item is reopened to `OPEN`. Existing `IN_PROGRESS` and `BLOCKED` action items are not replaced by other non-Done Jira statuses.
+
+Jira metadata shown in OpsKnight is stored state refreshed by authenticated webhooks or an explicit Sync action; rendering the action item does not require a live Jira request.
+
+GitHub Issues do not have an equivalent native action-item issue-sync workflow in v1.5.
 
 ## Troubleshooting
 
@@ -62,6 +70,8 @@ When the workspace Jira or GitHub integration is configured, an item can link to
 | **Create Jira** fails                         | Configure workspace Jira, then configure the incident service's Jira project and action-item issue type. |
 | Jira reports an invalid project or issue type | Verify the project key, API-token permissions, and issue type in **Service Settings → Jira Mapping**.    |
 | A Jira issue cannot be linked                 | Confirm the key exists and is not already linked to another incident or action item.                     |
+| Jira status appears stale                     | Use Sync if permitted, confirm service sync is enabled, and verify Jira webhook delivery.                |
+| Jira link shows `Deleted in Jira`             | The provider issue was deleted; OpsKnight preserves the historical reference instead of deleting it.    |
 
 ## Related guides
 

--- a/docs/v1.5/integrations/README.md
+++ b/docs/v1.5/integrations/README.md
@@ -14,7 +14,7 @@ OpsKnight integrations have three distinct directions:
 | Outbound notification | Deliver incident and escalation messages to responders or external endpoints.               | Email, SMS, push, WhatsApp, Slack, service webhooks.  |
 | Workflow              | Connect incident response to another working surface.                                       | Slack ChatOps war rooms and Jira issues/action items. |
 
-There is no native voice/PSTN notification channel in v1.4. PagerDuty support is inbound Events API v2 compatibility, not a full PagerDuty product or bidirectional synchronization.
+There is no native voice/PSTN notification channel in v1.5. PagerDuty support is inbound Events API v2 compatibility, not a full PagerDuty product or bidirectional synchronization.
 
 ## Start here
 
@@ -27,7 +27,7 @@ There is no native voice/PSTN notification channel in v1.4. PagerDuty support is
 
 ## Inbound integration catalog
 
-These entries are backed by v1.4 route handlers. The provider guide is authoritative for payload and recovery behavior.
+These entries are backed by v1.5 route handlers. The provider guide is authoritative for payload and recovery behavior.
 
 | Category              | Provider                | Webhook path                                                               | Guide                                                          |
 | --------------------- | ----------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------- |
@@ -72,7 +72,7 @@ The application also has `/api/integrations/health` for authenticated integratio
 | Jira Cloud                                              | [Jira](issue-tracking/jira.md)                          | Workspace configuration, service mapping, incident/action-item links. |
 | Service webhooks                                        | [Custom webhooks](custom/webhooks.md)                   | Outbound lifecycle webhook configuration and signing.                 |
 
-Microsoft Teams and Google Chat do not have dedicated native notification providers in the v1.4 provider model. A compatible incoming-webhook endpoint may accept a generic outbound webhook payload, but test its format explicitly and do not describe it as a native integration.
+Microsoft Teams and Google Chat do not have dedicated native notification providers in the v1.5 provider model. A compatible incoming-webhook endpoint may accept a generic outbound webhook payload, but test its format explicitly and do not describe it as a native integration.
 
 ## Credential vocabulary
 

--- a/docs/v1.5/integrations/issue-tracking/jira.md
+++ b/docs/v1.5/integrations/issue-tracking/jira.md
@@ -119,7 +119,7 @@ Incident notes are durably queued to every linked Jira issue in this form:
 NOTE_TEXT
 ```
 
-The OpsKnight note and its Jira delivery intent are committed together. A Jira outage therefore does not roll back the incident note; the external operation is retried independently. If provider delivery ultimately fails, inspect the Jira link/application operational state and Jira permissions before retrying operationally.
+The OpsKnight note and its Jira delivery intent are committed together. A Jira outage therefore does not roll back the incident note; Jira delivery is handled separately from the source incident mutation. Monitor operations after a prolonged provider outage or rate-limit window and retry/reconcile operationally if delivery remains ambiguous or failed.
 
 OpsKnight incident lifecycle transitions are **not** Jira workflow transitions and are not documented as automatically posting lifecycle comments in v1.5.
 
@@ -133,9 +133,9 @@ An action item without an incident/service mapping cannot create a correctly rou
 
 ## Reliability behavior
 
-Jira provider calls use bounded request timeouts and do not follow HTTP redirects with credentials. Durable Jira create/comment operations reconcile ambiguous provider outcomes before retrying so a lost response does not automatically create a duplicate Jira issue or comment.
+Jira provider calls use bounded request timeouts and do not follow HTTP redirects with credentials. Durable Jira create/comment operations use provider correlation/idempotency markers to reconcile ambiguous outcomes before another provider mutation, reducing duplicate Jira issues or comments after lost responses.
 
-When Jira returns `Retry-After`, OpsKnight carries that provider cooldown into durable retry scheduling. Repeated transient Jira failures can open a shared workspace-level cooldown so workers do not continuously hammer an unhealthy Jira workspace. Durable create operations become terminally `FAILED` after their retry/reconciliation budget is exhausted instead of remaining indefinitely ambiguous.
+Jira `Retry-After` values and transient provider failures are recorded in the external-operation/provider-admission state and can delay subsequent Jira work. Delivery remains asynchronous, so operators should monitor operations after long rate-limit or outage windows and explicitly retry/reconcile work that remains `AMBIGUOUS` or reaches `FAILED`. The v1.5 documentation does not guarantee that every deferred operation will automatically run until terminal completion across an arbitrarily long provider cooldown.
 
 Normal incident page rendering uses stored Jira metadata and does not perform hidden live Jira HTTP requests.
 

--- a/docs/v1.5/integrations/issue-tracking/jira.md
+++ b/docs/v1.5/integrations/issue-tracking/jira.md
@@ -6,22 +6,22 @@ description: Connect one Jira Cloud workspace, map services, create or link issu
 
 # Jira Cloud
 
-OpsKnight connects one Jira Cloud workspace to incident and action-item workflows. It can create or link Jira issues, post OpsKnight incident notes and lifecycle updates as Jira comments, and receive Jira status/assignee metadata by webhook.
+OpsKnight connects one Jira Cloud workspace to incident and action-item workflows. It can create or link Jira issues, durably queue OpsKnight incident notes as Jira comments, and receive Jira status/assignee metadata by webhook.
 
 This is not full two-way workflow mirroring: Jira transitions do not change an OpsKnight incident's lifecycle, and OpsKnight does not transition Jira workflows. Treat OpsKnight as the incident system of record and Jira as linked engineering-work tracking.
 
 ## What is supported
 
-| Workflow                       | Direction                  | Result                                                                       |
-| ------------------------------ | -------------------------- | ---------------------------------------------------------------------------- |
-| Create issue for incident      | OpsKnight → Jira           | Creates the configured issue type and stores a link.                         |
-| Link existing issue            | Jira → OpsKnight reference | Fetches and stores key, URL, status, and assignee.                           |
-| Create issue for action item   | OpsKnight → Jira           | Creates the service-mapped action-item issue type.                           |
-| Incident note/lifecycle update | OpsKnight → Jira           | Adds a best-effort formatted Jira comment to linked issues.                  |
-| Jira issue update webhook      | Jira → OpsKnight           | Refreshes stored Jira metadata and mirrors action-item completion state.     |
-| Jira issue delete webhook      | Jira → OpsKnight           | Event is accepted; it does not delete the OpsKnight incident or action item. |
+| Workflow                     | Direction                  | Result                                                                                           |
+| ---------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------ |
+| Create issue for incident    | OpsKnight → Jira           | Creates the configured issue type and stores one owned Jira link.                               |
+| Link existing issue          | Jira → OpsKnight reference | Fetches and stores key, URL, status, and assignee; the same Jira issue cannot have two owners. |
+| Create issue for action item | OpsKnight → Jira           | Creates the service-mapped action-item issue type.                                               |
+| Incident note                | OpsKnight → Jira           | Durably queues a formatted Jira comment without blocking the OpsKnight note on provider failure. |
+| Jira issue update webhook    | Jira → OpsKnight           | Refreshes stored Jira metadata and mirrors action-item completion state.                         |
+| Jira issue delete webhook    | Jira → OpsKnight           | Preserves the historical link, marks it failed/deleted, and leaves the OpsKnight entity intact. |
 
-GitHub Issues, Linear, and Asana do not have equivalent native issue-sync workflows in v1.4.
+GitHub Issues, Linear, and Asana do not have equivalent native issue-sync workflows in v1.5.
 
 ## Prerequisites and permissions
 
@@ -30,7 +30,7 @@ GitHub Issues, Linear, and Asana do not have equivalent native issue-sync workfl
 - Permission to create the configured issue types, read issues, and add comments.
 - An OpsKnight **Admin** for the workspace connection and service mappings.
 - A public HTTPS OpsKnight URL for Jira webhooks.
-- `ENCRYPTION_KEY` configured in production so API tokens and webhook secrets remain decryptable after restarts.
+- `ENCRYPTION_KEY` or `ENCRYPTION_KEYS` configured in production so API tokens and webhook secrets remain decryptable after restarts.
 
 Use a dedicated least-privilege Jira service account where possible. Changes to that account's projects or permissions affect every mapped OpsKnight service.
 
@@ -43,17 +43,23 @@ Use a dedicated least-privilege Jira service account where possible. Changes to 
 5. Select **Test Connection** and confirm the connected Jira identity.
 6. Turn on **Jira Workspace → Enabled** and save the configuration.
 
-OpsKnight normalizes a bare `example.atlassian.net` site value to HTTPS. Use the exact Cloud site, not a project or board URL. On later edits, leaving the masked token/secret unchanged preserves the stored encrypted values.
+OpsKnight normalizes a bare `example.atlassian.net` site value to HTTPS. Use the exact Cloud site, not a project or board URL.
+
+On later edits, leaving a masked API token unchanged reuses the stored encrypted token **only for the same Jira origin**. Changing the Jira site origin requires re-entering a fresh API token before the configuration can be saved. A masked webhook secret can be left unchanged when the workspace origin is unchanged.
+
+**Test Connection validates the Jira credentials and identity only.** It does not validate service project keys, issue types, components, or create permissions for every mapped service; verify those mappings separately.
 
 ## Configure the Jira webhook
 
-The Jira settings page displays the exact callback URL:
+The Jira settings page displays the callback URL:
 
 ```text
 https://ops.example.com/api/jira/webhook
 ```
 
-Create a Jira webhook for `jira:issue_updated` and `jira:issue_deleted`. Send the configured secret as either:
+Configure Jira to deliver at least `jira:issue_updated` and `jira:issue_deleted`. OpsKnight also accepts Jira issue-created/generic issue event names, but only supported status/assignee/deletion data is applied.
+
+Send the configured webhook secret using one of the supported mechanisms:
 
 ```http
 x-jira-webhook-secret: YOUR_SECRET
@@ -65,11 +71,17 @@ or:
 Authorization: Bearer YOUR_SECRET
 ```
 
-In production, OpsKnight rejects Jira webhooks if no webhook secret is configured. The comparison is constant-time. Limit the Jira webhook with JQL to projects used by OpsKnight when practical.
+For Jira Cloud webhook configuration that cannot send a custom header, use the exact generated callback URL from the Jira settings page, which can include the secret as a query parameter. Treat that URL as a credential: do not publish it, paste it into tickets, or expose it in logs.
+
+In production, OpsKnight rejects Jira webhooks if no webhook secret is configured. Secret comparison is constant-time. Limit the Jira webhook with JQL to projects used by OpsKnight when practical.
 
 The inbound webhook updates only fields actually present in the Jira event, so an omitted assignee or status field does not erase previously synchronized metadata. Jira status changes do not transition the OpsKnight incident lifecycle.
 
-For linked **action items**, OpsKnight intentionally mirrors only completion state: a Jira status categorized as Done marks a non-completed action item `COMPLETED`; if that Jira issue later leaves Done, an action item that OpsKnight previously sees as completed is reopened to `OPEN`. Jira non-Done states do not overwrite an action item that is already `IN_PROGRESS` or `BLOCKED`.
+When Jira supplies a stable delivery identity (or OpsKnight can derive one from stable issue/changelog/comment/timestamp identifiers), webhook deliveries are durably claimed so completed duplicates are ignored. Same-issue webhook mutation chains are serialized across replicas. When Jira's issue `updated` timestamp is available, it is used as the ordering clock so an older event cannot overwrite newer accepted Jira metadata or roll an action item's completion state backward.
+
+For linked **action items**, OpsKnight intentionally mirrors only completion state: a Jira status categorized as Done marks a non-completed action item `COMPLETED`; if that Jira issue later leaves Done, a currently `COMPLETED` action item is reopened to `OPEN`. Jira non-Done states do not overwrite an action item that is already `IN_PROGRESS` or `BLOCKED`.
+
+For `jira:issue_deleted`, OpsKnight preserves the Jira key/URL as historical evidence, marks the link as failed with status `Deleted in Jira`, clears the synchronized assignee, and does not delete the OpsKnight incident or action item.
 
 ## Map each service
 
@@ -86,11 +98,11 @@ Open **Service → Settings → Jira Workflow Mapping** and configure:
 | Auto-create urgency        | High, Medium, and/or Low incidents eligible for auto-create.                |
 | Sync Jira status metadata  | Controls service-level metadata sync behavior.                              |
 
-The workspace connection can be configured before or after mappings, but auto-create requires an enabled workspace connection and a valid mapping. Verify project keys, issue-type names, and components against Jira; the free-text form cannot guarantee that they exist.
+The workspace connection can be configured before or after mappings, but auto-create requires an enabled workspace connection and a valid mapping. Verify project keys, issue-type names, and components against Jira; the free-text form validates their format but cannot guarantee that the Jira project metadata or permissions are correct.
 
 ## Incident workflow
 
-On an incident's Jira card, an authorized responder can:
+On an incident's Jira controls, an authorized responder can:
 
 - create a new issue using the service mapping;
 - link an existing Jira key or a URL containing a Jira key;
@@ -98,22 +110,34 @@ On an incident's Jira card, an authorized responder can:
 - open the issue in Jira;
 - unlink it from the incident without deleting the Jira issue.
 
-An external Jira issue can be linked only once in OpsKnight. Incident notes are posted to every linked Jira issue in this form:
+A Jira issue can be owned by only one OpsKnight incident or action item. Concurrent attempts to link the same Jira key are serialized and competing owners are rejected rather than merged into one link.
+
+Incident notes are durably queued to every linked Jira issue in this form:
 
 ```text
 [OpsKnight Note by RESPONDER_NAME]:
 NOTE_TEXT
 ```
 
-Lifecycle updates are posted as `[OpsKnight Update]: ...` comments. Comment sync is best-effort: a Jira failure does not block the OpsKnight incident action, so inspect the link's sync state and Jira when the comment matters.
+The OpsKnight note and its Jira delivery intent are committed together. A Jira outage therefore does not roll back the incident note; the external operation is retried independently. If provider delivery ultimately fails, inspect the Jira link/application operational state and Jira permissions before retrying operationally.
+
+OpsKnight incident lifecycle transitions are **not** Jira workflow transitions and are not documented as automatically posting lifecycle comments in v1.5.
 
 ## Action-item workflow
 
 From **Action Items** or the action-item section of its postmortem, create a Jira issue using the action item's incident service mapping, or link an existing Jira issue. The same persisted action item and Jira link are shown consistently across the global Action Items board, postmortem detail/edit views, and the incident postmortem tab.
 
-OpsKnight stores the external key, URL, status, assignee, sync state, and last-sync time. An action item with an existing Jira link must be refreshed rather than given a second active Jira link; stale Create/Link requests are rejected server-side.
+OpsKnight stores the external key, URL, status, assignee, sync state, and last accepted sync time. An action item with an existing Jira link must be refreshed rather than given a second active Jira link; stale Create/Link requests are rejected server-side.
 
 An action item without an incident/service mapping cannot create a correctly routed Jira issue. Fix the association or mapping first.
+
+## Reliability behavior
+
+Jira provider calls use bounded request timeouts and do not follow HTTP redirects with credentials. Durable Jira create/comment operations reconcile ambiguous provider outcomes before retrying so a lost response does not automatically create a duplicate Jira issue or comment.
+
+When Jira returns `Retry-After`, OpsKnight carries that provider cooldown into durable retry scheduling. Repeated transient Jira failures can open a shared workspace-level cooldown so workers do not continuously hammer an unhealthy Jira workspace. Durable create operations become terminally `FAILED` after their retry/reconciliation budget is exhausted instead of remaining indefinitely ambiguous.
+
+Normal incident page rendering uses stored Jira metadata and does not perform hidden live Jira HTTP requests.
 
 ## Disable, remove, or rotate credentials
 
@@ -126,6 +150,7 @@ Workspace removal does **not** delete Jira issues in Atlassian. OpsKnight also r
 For credential rotation:
 
 - Rotating the API token requires saving the new token and running **Test Connection**.
+- Changing the Jira site origin requires a freshly entered API token; OpsKnight does not reuse a masked stored token across origins.
 - Rotating the webhook secret requires updating Jira and OpsKnight together; otherwise inbound requests return 401.
 - Removing an individual OpsKnight link does not delete the Jira issue.
 
@@ -135,32 +160,41 @@ For credential rotation:
 - [ ] Enable/Disable hides and restores operational Jira controls as expected.
 - [ ] Each production service maps to an existing project, component, and issue type.
 - [ ] A manual incident issue is created with the expected labels and link.
-- [ ] An existing issue can be linked and duplicate linking is rejected.
-- [ ] An incident note appears as a Jira comment.
+- [ ] An existing issue can be linked and duplicate/cross-owner linking is rejected.
+- [ ] An incident note appears as a Jira comment even though the OpsKnight note itself does not depend on Jira availability.
 - [ ] A Jira status or assignee update refreshes the stored metadata.
+- [ ] A repeated webhook delivery does not duplicate supported side effects when it has a durable delivery identity.
+- [ ] An older Jira update does not overwrite a newer accepted status when provider ordering metadata is available.
+- [ ] A Jira delete event preserves the historical key while marking the link deleted/failed.
 - [ ] A linked action item shows the same Jira key on Action Items and postmortem surfaces.
-- [ ] Jira Done marks a linked action item complete and reopening Jira reopens a previously completed item.
+- [ ] Jira Done marks a linked action item complete and reopening Jira reopens a currently completed item.
 - [ ] A test action item creates or links the intended issue type.
 - [ ] Auto-create is tested for one selected and one excluded urgency.
 - [ ] Invalid webhook secrets return 401 without changing metadata.
+- [ ] Changing the Jira origin without a fresh API token is rejected.
 - [ ] Remove Jira Workspace clears OpsKnight Jira state without deleting the provider ticket.
 
 ## Troubleshooting
 
-| Symptom                                      | Check                                                                                 |
-| -------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Test Connection returns 401                  | Jira email/token pair, revoked token, and site URL.                                   |
-| Create returns 400/404                       | Project key, issue type, component, labels, and service-account permissions.          |
-| “already linked”                             | The Jira issue or action item already has an active OpsKnight Jira association.       |
-| Webhook returns 401                          | Stored webhook secret and the Jira header/Bearer value must match exactly.            |
-| Webhook returns 204                          | The event name is not one of the two handled names.                                   |
-| Webhook says `updated: 0`                    | No stored link matches the Jira issue ID or key, or Jira sync is disabled.             |
-| Jira changed but incident did not transition | Expected limitation: inbound Jira changes do not change incident lifecycle state.     |
-| OpsKnight note missing in Jira               | Comment permission, API token, linked issue, Jira availability, and application logs. |
+| Symptom                                      | Check                                                                                                    |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Test Connection returns 401                  | Jira email/token pair, revoked token, and site URL.                                                      |
+| Test Connection succeeds but Create fails    | Test Connection validates identity, not the service project/issue type/component/create permission.     |
+| Save asks for the API token again            | The Jira site origin changed; re-enter a token rather than reusing the masked stored credential.         |
+| Create returns 400/404                       | Project key, issue type, component, labels, and service-account permissions.                             |
+| “already linked”                             | The Jira issue or action item already has an active OpsKnight Jira association.                          |
+| Webhook returns 401                          | Stored webhook secret and the Jira header/Bearer/query-secret value must match exactly.                  |
+| Webhook returns 204                          | The webhook event name is not recognized as a supported Jira issue event.                                |
+| Webhook says `updated: 0`                    | No stored link matches, sync is disabled, the delivery is stale/duplicate, or no newer state was applied. |
+| Jira link shows `Deleted in Jira`            | The provider issue was deleted; OpsKnight intentionally preserves the historical reference.             |
+| Jira changed but incident did not transition | Expected limitation: inbound Jira changes do not change incident lifecycle state.                        |
+| OpsKnight note missing in Jira               | Comment permission, API token, linked issue, Jira availability, retry/cooldown state, and application logs. |
 
 ## Security notes
 
-Jira API tokens and webhook secrets are encrypted at rest with the application encryption layer. HTTPS is still required in transit. Do not put the API token in a Jira webhook or expose it in logs; the webhook uses its separate shared secret.
+Jira API tokens and webhook secrets are encrypted at rest with the application encryption layer. HTTPS is required in transit, provider redirects are not followed with Jira credentials, and stored API tokens are origin-bound so a masked credential cannot be silently redirected to a different Jira host.
+
+Configured Jira base URLs reject embedded credentials, query/fragment confusion, loopback/link-local destinations, and common metadata-service targets. Do not put the API token in a Jira webhook or expose it in logs; the webhook uses its separate shared secret.
 
 ## Related topics
 


### PR DESCRIPTION
## Summary

Align the public v1.5 Jira documentation with the current hardened Jira implementation.

## What changed

- document origin-bound Jira API-token reuse and fresh-token requirement when the Jira origin changes
- clarify that **Test Connection** validates Jira identity/credentials, not service mapping correctness
- document durable inbound delivery claims, same-issue serialization, and monotonic provider-event ordering
- document Jira remote-delete behavior (`Deleted in Jira` / failed historical link instead of deleting OpsKnight state)
- clarify one-owner Jira link semantics and cross-owner duplicate rejection
- accurately describe Jira timeout/idempotency/cooldown behavior without promising automatic terminal delivery across arbitrarily long provider cooldowns
- remove the unsupported claim that incident lifecycle transitions are automatically posted as Jira comments; v1.5 automatically queues incident notes
- fix webhook troubleshooting text that incorrectly described only two handled event names
- correct the Action Items guide to Jira-only native issue sync (the current external issue provider enum is Jira-only)
- fix stale `v1.4` references inside the v1.5 integrations index
- mention both `ENCRYPTION_KEY` and `ENCRYPTION_KEYS`

## Scope

Docs only. No application, schema, migration, or runtime behavior changes.

## Validation

Exactly three documentation files are changed. The Codex P1 about Retry-After/background-job scheduling was valid; this docs PR now states the current runtime guarantee conservatively. The underlying scheduler coordination defect is intentionally kept out of this docs-only change and should be fixed separately in runtime code.