### PR TITLE
docs(auth): document enterprise OIDC, SSO-only, sessions, and SCIM

### DIFF
--- a/docs/v1.5/administration/authentication.md
+++ b/docs/v1.5/administration/authentication.md
@@ -1,112 +1,149 @@
 ---
 order: 1
 title: Authentication
-description: Operate local credentials, OIDC, password recovery, and JWT session revocation safely.
+description: Operate local credentials, enterprise OIDC, sessions, recovery, linking, and SCIM safely.
 ---
 
 # Authentication
 
-OpsKnight v1.4 supports local email/password authentication and one workspace OIDC provider. Both can be available on the login page. Authentication proves identity; [authorization](../security/authorization.md) determines what the signed-in user may do.
+OpsKnight v1.5 supports local email/password authentication and one workspace OIDC provider. Either method can be enabled independently. Authentication proves identity; [authorization](../security/authorization.md) determines what the signed-in user may do.
 
 ## Production prerequisites
 
-Set a stable public HTTPS origin and preserve the authentication secrets:
+Use a stable public HTTPS origin and preserve authentication secrets:
 
-| Setting               | Purpose                                                                                          |
-| --------------------- | ------------------------------------------------------------------------------------------------ |
-| `NEXTAUTH_URL`        | Exact public origin used for callbacks and secure-cookie selection.                              |
-| `NEXTAUTH_SECRET`     | Signs/encrypts session tokens; changing it invalidates existing sessions.                        |
-| `ENCRYPTION_KEY`      | Stable 64-hex-character key used to encrypt the OIDC client secret and other stored credentials. |
-| `NEXT_PUBLIC_APP_URL` | Public origin used in user-facing links; normally matches `NEXTAUTH_URL`.                        |
+| Setting | Purpose |
+| --- | --- |
+| `NEXTAUTH_URL` | Exact public authentication origin used for callbacks and secure-cookie selection. |
+| `NEXTAUTH_SECRET` | Signs/encrypts session tokens; changing it invalidates existing sessions. |
+| `ENCRYPTION_KEYS` / `ENCRYPTION_KEY` | Encrypt stored OIDC and other protected credentials. |
+| `NEXT_PUBLIC_APP_URL` | Public origin used in user-facing links; normally matches `NEXTAUTH_URL`. |
 
-The reverse proxy must forward the original host and scheme. Back up secrets outside PostgreSQL; restoring the database without the matching encryption key does not restore usable OIDC credentials.
+The reverse proxy must forward the original host and scheme. Back up authentication/encryption secrets outside PostgreSQL.
 
 ## Bootstrap the first Admin
 
-When no user exists, open `/setup`, enter the Admin name and email, and create the account. OpsKnight displays a generated password once. Store it securely, sign in, change it immediately, and create a second Admin. Setup stops accepting another bootstrap after a user exists.
+When no user exists, open `/setup`, create the first Admin, store the generated password securely, sign in, change it, and create a second Admin. Setup stops accepting another bootstrap after a user exists.
 
-## Local accounts
+## Local credentials
 
-Admins invite subsequent users from **Users**. An invitation is valid for seven days and earlier unused invite tokens are invalidated when a replacement is generated. Treat the link as a credential.
+Admins can invite users from **Users**. Invitation and reset links are credentials and should only be shared through approved channels.
 
-Passwords must be 10–128 characters and contain lowercase, uppercase, numeric, and special characters. These rules are fixed in v1.4; there is no configurable expiry, history, or complexity policy.
+Credential sessions retain the existing local-session policy:
 
-After five failed local logins for one normalized email/client-IP key, v1.4 applies progressive process-local lockouts of approximately 1, 5, 15, then 60 minutes for repeated groups. The state is not shared across application replicas and is cleared by a process restart. Configure trusted proxy forwarding and an independent edge/identity-provider throttle for internet-facing deployments.
+- normal credential session: up to seven days;
+- **Remember me** credential session: up to one year.
 
-### Password recovery
+Password reset increments the user's token version so existing sessions are invalidated.
 
-The login page's **Forgot password** flow returns the same message for registered and unknown addresses. A reset token:
+## SSO-only mode
 
-- expires after one hour;
-- invalidates earlier unused reset tokens for the address;
-- is delivered by configured email, with SMS fallback only when the user and provider permit it;
-- increments the user's token version after use, revoking existing sessions.
+Local credential login can be disabled without disabling OIDC:
 
-If no delivery provider is available, an Admin can generate a reset link from the supported user-management workflow. Share any reset link only through an approved secret channel.
+```text
+AUTH_LOCAL_LOGIN_ENABLED=false
+```
+
+In SSO-only mode:
+
+- the OIDC button remains available on desktop and mobile login;
+- the local email/password form is hidden;
+- password-recovery entry points do not provide a bypass around SSO-only policy.
+
+If neither OIDC nor local authentication is available, the login page shows an explicit configuration error instead of silently presenting a broken form.
+
+## Break-glass access
+
+A dedicated emergency local account can be allowed even when normal local login is disabled:
+
+```text
+AUTH_BREAK_GLASS_ENABLED=true
+AUTH_BREAK_GLASS_EMAIL=admin@example.com
+```
+
+Use a dedicated Admin identity, store its password outside the normal SSO dependency, audit its use, and disable emergency access again after recovery.
 
 ## Configure OIDC
 
-You need `ADMIN` and a working `ENCRYPTION_KEY`.
-
 1. Register a confidential OIDC web application at the identity provider.
-2. Add this exact callback URL:
+2. Register this callback:
 
    ```text
    https://YOUR_OPSKNIGHT_URL/api/auth/callback/oidc
    ```
 
-3. Go to **Settings** → **System** → **Single Sign-On (OIDC)**.
-4. Enter the HTTPS issuer, client ID, client secret, and optional provider label/scopes.
-5. Select **Test connection** to validate issuer discovery.
-6. Configure provisioning restrictions and mappings before enabling OIDC.
-7. Save, then test with a non-Admin account in a private browser session while retaining a working local Admin session.
+3. Open **Settings → System → Single Sign-On (OIDC)**.
+4. Enter the HTTPS issuer, client ID, client secret, and provider-specific settings.
+5. Select **Test connection** to validate discovery, issuer consistency, endpoints, JWKS, and signing configuration.
+6. Configure provisioning, organization/domain restrictions, roles, and profile mappings.
+7. Save and test with a non-Admin account before relying on SSO for administrators.
 
-Default scopes are `openid email profile`; custom scopes are appended. The provider's claims—not its brand—determine whether domain, role, and profile rules work. See [OIDC setup](../security/oidc-setup.md) for registration examples.
+See [OIDC SSO Setup](../security/oidc-setup.md) for provider-specific Entra, Google, Okta, Auth0, and generic OIDC behavior.
 
-### Email and identity safety
+## Stable identity and email safety
 
-OpsKnight requires an email. An explicit `email_verified: false` is rejected. Set `OIDC_REQUIRE_EMAIL_VERIFIED_STRICT=true` to also reject a missing claim for all OIDC sign-ins.
+OpsKnight treats the normalized OIDC issuer plus provider subject (`sub`) as the permanent external identity.
 
-An OIDC identity is bound to the normalized issuer plus the provider subject (`sub`). OpsKnight does not treat an email address by itself as a stable external identity. This prevents an unrelated OIDC identity that happens to present the same email from silently taking over an existing OpsKnight account.
+```text
+issuer + sub -> OpsKnight user
+```
 
-For an existing account that does not yet have an OIDC identity, first-time linking requires all of the following:
+Email, UPN, username, and display name are not permanent identity keys.
 
-- the configured OIDC provider returns a stable subject;
-- the provider explicitly returns `email_verified: true`;
-- the OpsKnight account has administrator-provisioning evidence from the invite flow or from an Admin allowing OIDC linking;
-- the issuer-plus-subject identity is not already linked to another OpsKnight user.
+This means:
 
-After the first successful link, later sign-ins use the stored issuer-plus-subject identity rather than email-only matching.
+- changing a user's email does not silently create or move an existing identity;
+- an already-linked identity can continue to authenticate without an email claim;
+- email is required when OpsKnight must first-link or create an account;
+- an explicit `email_verified: false` is rejected;
+- provider-specific handling applies when a provider legitimately omits `email_verified`.
 
-### Manage OIDC linking for an existing user
+Microsoft Entra is the important example: validated Entra workforce issuers can legitimately omit the standard `email_verified` claim, so missing-claim handling differs from strict generic OIDC while an explicit false claim is still rejected.
 
-Use this workflow for an existing **Active** account that needs to establish its first OIDC identity link.
+## First-time OIDC linking
+
+OpsKnight does not silently attach an unrecognized OIDC subject to an existing user just because the email matches.
+
+For an existing **Active** or supported **Invited** account that has not linked OIDC yet:
 
 1. Sign in as an Admin and open **Users**.
-2. Open the user's **⋯** actions menu.
+2. Open the user's actions.
 3. Select **Allow OIDC linking**.
-4. Review the confirmation and select **Allow linking**.
-5. Ask the user to sign in through the configured OIDC provider.
+4. Review and confirm the approval.
+5. Ask the user to sign in through OIDC.
 
-The approval does not change the user's role, status, password, or existing sessions. The next first-time OIDC link is still accepted only when the provider returns the same account email, a stable subject, and `email_verified: true`, and the external identity is not linked elsewhere.
+Linking approvals are time-limited, renewable, revocable, scoped to the OIDC provider/configuration and issuer trust boundary, tied to the expected email, and consumed atomically when the link succeeds.
 
-Until an OIDC identity is established, the same **⋯** menu shows **Revoke OIDC linking approval**. Revoking removes the stored first-link provisioning evidence for that Active user. It does not disable the account or affect password authentication.
+Once linked, later logins use `(issuer, sub)` rather than email matching.
 
-Once an OIDC identity has been established, the menu shows **OIDC linked**. Approval revocation is intentionally not used as an unlink operation; removing an established external identity is a separate security-sensitive lifecycle operation.
+Do not use approval to bypass a wrong issuer, wrong tenant/organization, explicit unverified-email claim, missing subject, or an external identity already owned by another user.
 
-Users still in **Invited** status already have administrator-provisioning evidence from the supported invite workflow. The explicit allow/revoke control is therefore limited to Active accounts.
+## Automatic provisioning
 
-Do not use approval to work around an email mismatch, an unverified email claim, a missing subject, or an identity already linked to another user. Correct the identity-provider configuration instead.
+When auto-provisioning is enabled, an eligible first OIDC login can create a new active user. User creation and external-identity creation are committed atomically.
 
-### Auto-provisioning and domains
+When auto-provisioning is disabled, unknown external identities are denied.
 
-When auto-provisioning is disabled, an unknown OIDC user is denied. When enabled, an eligible first login creates an active `USER` account. A non-empty allowed-domain list requires an exact lower-case email-domain match.
+Provider-specific organization controls still apply to both new and already-linked identities. For example:
 
-OIDC sign-in can reactivate an existing linked disabled user. If deactivation must remain authoritative, remove or block the identity at the IdP as part of offboarding.
+- Entra must remain inside the configured tenant trust boundary;
+- Google Workspace uses the signed `hd` claim;
+- Auth0 can enforce a signed `org_id`.
 
-### Role mapping
+## Role ownership and mapping
 
-Rules are evaluated in order; the first exact scalar or array-value match wins:
+OpsKnight tracks role ownership so manually managed roles can be distinguished from roles managed by OIDC or SCIM.
+
+OIDC role rules support:
+
+```text
+USER
+AUDITOR
+RESPONDER
+ADMIN
+```
+
+Example:
 
 ```json
 [
@@ -115,50 +152,120 @@ Rules are evaluated in order; the first exact scalar or array-value match wins:
 ]
 ```
 
-Valid targets are `USER`, `AUDITOR`, `RESPONDER`, and `ADMIN`. A newly provisioned user begins as `USER`; if no rule matches, an existing user's current role is retained. Mapping can both promote and demote on later login, so use dedicated, tightly governed Auditor and Admin groups.
+When OIDC is authoritative for a user's role, removing the matching IdP claim can de-provision the corresponding OpsKnight privilege on a later login. Missing/over-limit group claims are not silently treated as a normal empty-group result where that would be unsafe.
 
-### Profile mapping
+## Profile mapping
 
-Map IdP claim names to `department`, `jobTitle`, and `avatarUrl`. Non-empty values synchronize on login. An avatar uploaded locally under `/uploads/` is not overwritten by OIDC profile synchronization.
+OIDC can synchronize bounded claims to:
 
-## Sessions
+- `department`
+- `jobTitle`
+- `avatarUrl`
 
-Sessions are JWT based. Web login without **Remember me** has a seven-day ceiling; remembered web sessions and mobile sessions have a one-year ceiling. Activity refreshes session state at most hourly, but there is no separate configurable idle-timeout control in v1.4.
+Invalid claim types are not converted from arbitrary objects into profile strings.
 
-Cookies are HTTP-only where appropriate and use `SameSite=Lax`. `NEXTAUTH_URL` beginning with `https://` enables Secure cookies and secure name prefixes; an origin mismatch commonly causes login loops.
+## Issuer changes
 
-**Settings** → **Security** offers **Revoke all sessions**. It increments the user's token version; v1.4 does not list or revoke individual devices. Role/status changes may take effect after the authentication user-cache refresh, so use session revocation for urgent access removal and remove access at the IdP too.
+Changing the OIDC issuer crosses an identity trust boundary. OpsKnight requires explicit migration confirmation and revokes affected sessions and outstanding first-link approvals when the issuer changes.
+
+Treat Okta/Auth0 custom-domain migrations as issuer migrations, not cosmetic URL edits.
+
+## OIDC sessions
+
+OIDC sessions use an enterprise policy separate from local credential Remember Me behavior.
+
+Default OIDC values are:
+
+| Control | Default |
+| --- | ---: |
+| Maximum session age | 12 hours |
+| Session update age | 1 hour |
+| Idle timeout | 4 hours |
+| OpsKnight OIDC renewal boundary | 12 hours |
+
+Configuration variables:
+
+```text
+AUTH_SSO_SESSION_MAX_AGE_SECONDS
+AUTH_SSO_SESSION_UPDATE_AGE_SECONDS
+AUTH_SSO_SESSION_IDLE_TIMEOUT_SECONDS
+AUTH_SSO_REAUTH_AFTER_SECONDS
+```
+
+OpsKnight refreshes security-sensitive user state during server-side session evaluation so account disablement, token-version changes, SCIM deprovisioning, and trust/config-version changes can invalidate access without waiting for the original JWT lifetime.
+
+The `AUTH_SSO_REAUTH_AFTER_SECONDS` control requires a new OpsKnight OIDC session; it does not guarantee that the upstream IdP prompts the user for credentials instead of reusing its own SSO session.
+
+## Session revocation
+
+**Settings → Security → Revoke all sessions** increments the user's token version and invalidates sessions. Password reset, account disablement, SCIM deprovisioning, and relevant OIDC trust changes also revoke or invalidate active access.
+
+## SCIM provisioning
+
+OIDC authenticates users who are signing in. SCIM provides lifecycle provisioning/deprovisioning from an identity platform.
+
+OpsKnight v1.5 supports SCIM 2.0 Users operations with bearer authentication. Deprovisioning disables the internal user and invalidates sessions; DELETE also removes the resource from the SCIM namespace while preserving the internal disabled account for history/audit.
+
+See [SCIM Provisioning](../security/scim-provisioning.md).
+
+## Provider-specific notes
+
+### Microsoft Entra ID
+
+- Use a tenant-specific issuer.
+- Broad `common`, `organizations`, and `consumers` authorities are rejected.
+- Supported sovereign-cloud authorities are recognized.
+- Missing standard `email_verified` is handled under the validated Entra policy; explicit false is rejected.
+- Prefer Entra App Roles for authoritative role mapping when possible.
+
+### Google Workspace
+
+- Workspace membership is enforced using the signed `hd` claim, not email suffix alone.
+
+### Okta
+
+- Organization and custom authorization-server issuers are supported.
+- Custom domains retain Okta provider policy.
+
+### Auth0
+
+- Tenant and custom-domain issuers are supported.
+- Optional Auth0 Organization enforcement uses signed `org_id`.
 
 ## Unsupported authentication methods
 
-v1.4 does not provide native MFA, passkey/WebAuthn login, SAML, or email magic-link authentication. Enforce MFA at the OIDC provider or a trusted access proxy when required. The optional mobile platform-authenticator prompt is a client-side privacy overlay, not server authentication or a second factor.
+OpsKnight v1.5 does not provide native SAML, passkey/WebAuthn login, email magic-link login, or a native second factor. Enforce MFA at the OIDC provider or a trusted access proxy when required.
+
+OpsKnight v1.5 also supports one OIDC provider configuration per workspace; multi-IdP selection is outside this release.
 
 ## Failure-safe rollout
 
-- Keep a tested local break-glass Admin while introducing OIDC.
-- Restrict auto-provision domains before enabling it.
-- Test normal, denied-domain, missing-claim, disabled-user, and Admin-group cases.
-- Confirm role mapping cannot grant Admin through a user-controlled claim.
-- Verify allow, revoke, and first-link behavior with a non-Admin test account before migrating production accounts.
-- Verify revoke-all and IdP disable behavior.
-- Record the rollback: disable OIDC using the retained local Admin session.
+- Keep a tested break-glass recovery path while introducing SSO-only mode.
+- Use a tenant-/organization-specific provider boundary.
+- Test normal login, denied organization/domain, disabled user, role de-provisioning, and first-link approval.
+- Test issuer migration before changing a production issuer/custom domain.
+- Verify session revocation and SCIM deprovisioning.
+- Test a non-Admin account before migrating Admin access.
 
 ## Troubleshooting
 
-| Symptom                       | Check                                                                                                               |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Redirect/cookie loop          | Exact HTTPS `NEXTAUTH_URL`, forwarded host/scheme, and browser cookie policy.                                       |
-| Discovery test fails          | Issuer is HTTPS and exposes valid OIDC discovery metadata from the app network.                                     |
-| Existing local user is denied | Approval/invite evidence, verified email, stable subject, allowed domain, and whether the identity is already used. |
-| Approval shows OIDC linked    | The user already has a stored issuer-plus-subject identity; approval revoke is not an unlink operation.             |
-| New user is denied            | Auto-provision setting, exact allowed domain, email and verification claims.                                        |
-| Role does not update          | Requested custom scope, actual ID-token/profile claim, JSON rule order and exact value.                             |
-| Secret cannot decrypt         | Restore the matching `ENCRYPTION_KEY` or enter a new client secret.                                                 |
+| Symptom | Check |
+| --- | --- |
+| SSO-only page has no password form | Expected when `AUTH_LOCAL_LOGIN_ENABLED=false`; use the OIDC button or configured break-glass account. |
+| Redirect/cookie loop | `NEXTAUTH_URL`, reverse-proxy host/scheme forwarding, callback URI, and cookie policy. |
+| Discovery test fails | HTTPS issuer, exact discovery issuer, public endpoints, JWKS, and signing metadata. |
+| Existing user cannot first-link | Approval state/expiry, expected email, provider/config scope, stable subject, and provider assurance policy. |
+| Existing linked user is denied | Account status plus current provider organization/tenant policy. |
+| Google Workspace user denied | Signed `hd` claim. |
+| Auth0 organization user denied | Signed `org_id`. |
+| Role does not update | Claim presence, mapping rule, role ownership/source, and provider group-overage behavior. |
+| Session ends earlier than local Remember Me | OIDC uses the separate enterprise session limits by design. |
 
 ## Related topics
 
+- [OIDC SSO Setup](../security/oidc-setup.md)
+- [SCIM Provisioning](../security/scim-provisioning.md)
 - [Authorization](../security/authorization.md)
-- [OIDC setup](../security/oidc-setup.md)
 - [Users](../core-concepts/users.md)
-- [Configuration](../getting-started/configuration.md)
+- [Configuration Reference](../getting-started/configuration.md)
 - [Troubleshooting](../troubleshooting.md)

--- a/docs/v1.5/core-concepts/users.md
+++ b/docs/v1.5/core-concepts/users.md
@@ -6,30 +6,32 @@ order: 7
 
 # Users
 
-User accounts identify responders, administrators, observers, schedule participants, incident owners, and notification recipients. Application roles, account status, team roles, and notification preferences are independent controls.
+User accounts identify responders, administrators, observers, schedule participants, incident owners, and notification recipients. Application roles, account status, team roles, notification preferences, and identity-management source are independent controls.
 
 ## Application roles
 
-| Role          | Intended access                                                                                                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **User**      | Standard signed-in access to permitted dashboards and operational records. Some server-side resource checks also allow assigned users or owning-team members, but the v1.4 incident interface reserves management controls for Responders and Admins. |
-| **Auditor**   | Read-only organization-wide access to incidents, services, schedules, reports, metrics, and audit evidence. Cannot change operational resources or workspace settings.                                                                                |
-| **Responder** | Create and manage incidents, services, teams, schedules, integrations, and other response workflows. Cannot perform Admin-only workspace governance.                                                                                                  |
-| **Admin**     | Full workspace administration, including users, policy administration, providers, security configuration, and destructive account/service operations.                                                                                                 |
+| Role | Intended access |
+| --- | --- |
+| **User** | Standard signed-in access to permitted dashboards and operational records. Some server-side resource checks also allow assigned users or owning-team members, but incident management controls are reserved for appropriate responder/admin roles. |
+| **Auditor** | Read-only organization-wide access to incidents, services, schedules, reports, metrics, and audit evidence. Cannot change operational resources or workspace settings. |
+| **Responder** | Create and manage incidents, services, teams, schedules, integrations, and other response workflows. Cannot perform Admin-only workspace governance. |
+| **Admin** | Full workspace administration, including users, policy administration, providers, security configuration, and destructive account/service operations. |
 
 Team **Owner**, **Admin**, and **Member** are separate team-scoped roles. See [Teams](teams.md).
 
 Use least privilege. Prefer Auditor over Admin for compliance reviewers, keep at least two active application Admins, and review Responder access regularly.
 
+OpsKnight v1.5 also tracks the source of an application role so manually managed roles can be distinguished from OIDC- or SCIM-managed roles. This allows authoritative external role de-provisioning without treating every role change as manual administration.
+
 ## Account statuses
 
-| Status       | Meaning                                                                            |
-| ------------ | ---------------------------------------------------------------------------------- |
-| **Invited**  | The account exists and needs an invitation/password setup or a new invite.         |
-| **Active**   | The account can authenticate through its configured credential or linked identity. |
-| **Disabled** | Sign-in and response participation should be treated as unavailable.               |
+| Status | Meaning |
+| --- | --- |
+| **Invited** | The account exists and needs invitation/password setup or a supported external-identity activation flow. |
+| **Active** | The account can authenticate through its permitted credential or linked identity. |
+| **Disabled** | Sign-in and response participation are unavailable until the account is reactivated through an allowed lifecycle path. |
 
-An Admin can reactivate a disabled user or generate a fresh invite. OIDC deployments may create, link, synchronize, reactivate, or map a user according to the configured identity-provider policy; review [Authentication and security](authentication-security.md) before enabling automatic provisioning.
+An Admin can reactivate a disabled user or generate a fresh invite. OIDC can create/link users according to the configured provider policy, and SCIM can provision/deprovision lifecycle-managed users. Review [Authentication](../administration/authentication.md) and [SCIM Provisioning](../security/scim-provisioning.md) before enabling automatic identity management.
 
 ## Invite a user
 
@@ -40,7 +42,7 @@ Only an Admin can invite users.
 3. Select **Invite User**.
 4. Copy the generated one-time invitation link immediately.
 5. If workspace email is configured, confirm the invitation email was accepted by the provider. Otherwise share the link through a secure channel.
-6. Ask the user to set a password and sign in before the link expires.
+6. Ask the user to complete setup before the link expires.
 
 The invite link is a credential. Do not place it in tickets, public chat, screenshots, or documentation. Generating another invitation invalidates earlier outstanding invite tokens for that user.
 
@@ -48,36 +50,65 @@ If email delivery fails, the account and copyable link can still be created. Con
 
 ## Manage first-time OIDC linking
 
-For an existing **Active** account that has not linked OIDC yet:
+OpsKnight does not silently bind a new OIDC subject to an existing account merely because the email matches.
+
+For an existing **Active** or supported **Invited** account that has not linked OIDC yet:
 
 1. Open **Users** as an Admin.
-2. Open the user's **⋯** actions menu.
+2. Open the user's actions menu.
 3. Select **Allow OIDC linking**.
 4. Review the confirmation and select **Allow linking**.
 5. Ask the user to sign in through the configured OIDC provider.
 
-The approval does not change role, account status, password, or existing sessions. First-time linking still requires the configured provider to return the same email, a stable subject, and `email_verified: true`, and the external identity must not already belong to another OpsKnight account.
+A linking approval:
 
-Before the identity is established, reopen **⋯** and select **Revoke OIDC linking approval** to disallow the first-time link again. Revocation does not deactivate the user or remove password access.
+- does not itself change role, account status, password, or active sessions;
+- expires after the configured approval lifetime;
+- can be renewed or revoked;
+- is scoped to the provider/configuration and issuer trust boundary;
+- is tied to the expected account email; and
+- is consumed atomically by the successful first link.
 
-After the identity is established, the menu shows **OIDC linked**. The approval control intentionally does not unlink an established identity.
+The provider must still return a stable subject and satisfy its email-assurance and organization/tenant policy. Microsoft Entra is handled provider-specifically because validated Entra workforce issuers may legitimately omit the standard `email_verified` claim; an explicit `email_verified: false` remains a rejection.
 
-Users in **Invited** status already carry administrator-provisioning evidence from the invite workflow, so the explicit allow/revoke control is shown only for Active users. See [Authentication](../administration/authentication.md#manage-oidc-linking-for-an-existing-user).
+After the identity is established, sign-in resolves by normalized issuer plus subject (`iss` + `sub`), not by email. The approval control is not an unlink mechanism.
+
+See [Authentication](../administration/authentication.md#first-time-oidc-linking).
 
 ## Find and manage accounts
 
-The Users page shows 20 users per page and supports search by name/email, filters for status, application role, and team, plus sorting by creation date, name, email, or status. It also shows user/team audit activity.
+The Users page supports search by name/email, filters for status, application role, and team, sorting, and user/team audit activity.
 
 An Admin can:
 
-- change another user's application role;
+- change another user's application role when the role-management source permits it;
 - activate or deactivate accounts individually or in bulk;
 - generate a new invite;
-- allow or revoke first-time OIDC linking for an existing Active user;
+- allow, renew, or revoke first-time OIDC linking where applicable;
 - add users to teams;
 - delete accounts after safety checks.
 
 Admins cannot change their own role, deactivate themselves, or delete themselves through these actions. Deleting the last non-disabled Admin is blocked.
+
+## OIDC-managed users
+
+OIDC identity ownership is based on issuer plus subject. Email changes do not move the external identity to another OpsKnight account.
+
+When OIDC role mapping is authoritative for a user, removing the mapped IdP claim can remove the corresponding OpsKnight privilege on a later sign-in. Group-overage/missing-claim conditions are handled explicitly rather than always being interpreted as a normal empty set.
+
+Provider organization policy is evaluated even for previously linked identities. For example:
+
+- Entra identities remain constrained by the configured tenant trust boundary;
+- Google Workspace access uses the signed `hd` claim;
+- Auth0 can enforce the signed `org_id` claim.
+
+## SCIM-managed users
+
+SCIM can provision, update, deactivate, and remove users from the SCIM namespace.
+
+Deprovisioning disables the internal account and invalidates active access. SCIM DELETE removes the external SCIM identity while intentionally retaining the disabled OpsKnight user for history, audit evidence, and operational references.
+
+OpsKnight v1.5 supports SCIM **Users**, not a SCIM Groups endpoint. See [SCIM Provisioning](../security/scim-provisioning.md).
 
 ## User profile and timezone
 
@@ -85,7 +116,7 @@ Each user can open **Settings → Profile** to manage supported profile fields, 
 
 ### In-process vector avatar engine
 
-OpsKnight provides a zero-latency, local `@dicebear` vector avatar generator at `/api/avatar`. Users can select from 15 curated SVG style presets (including `bottts`, `shapes`, `initials`, `personas`, `identicon`, `avataaars`, `thumbs`, `lorelei`, `notionists`, `open-peeps`, `micah`, `miniavs`, `pixel-art`, `rings`, and `glass`) with gender-appropriate styling. Avatar SVGs are rendered locally without third-party network dependencies, cached immutably with `Cache-Control: public, max-age=31536000, immutable`, and served with strict SVG sandbox headers (`Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox`).
+OpsKnight provides a local `@dicebear` vector avatar generator at `/api/avatar`. Users can select from curated SVG style presets, with avatar SVGs rendered locally without third-party network dependencies, cached immutably, and served with strict SVG sandbox headers.
 
 Timezone affects how the application displays dates for that user. Schedule calculation remains authoritative in each schedule's timezone. Quiet Hours also evaluates its configured times in this profile timezone.
 
@@ -112,15 +143,17 @@ These switches express user preference; they do not configure workspace provider
 5. Quiet Hours does not intentionally suppress that LOW-urgency disruptive channel; and
 6. the provider accepts the message.
 
-Team paging also respects the membership's `Receive team notifications` setting. Test the full chain and review notification history rather than assuming a saved switch guarantees delivery. Quiet Hours suppression is an intentional policy decision and should not be interpreted as a provider delivery failure.
+Team paging also respects the membership's `Receive team notifications` setting. Test the full chain and review notification history rather than assuming a saved switch guarantees delivery.
 
 ## Passwords and sessions
 
-Credential users can change their password from **Settings → Security**. Accounts created only through OIDC may not have a local password until an appropriate setup/reset workflow is completed.
+Credential users can change their password from **Settings → Security**. OIDC-only accounts may not have a normal local password, especially when SSO-only policy is enabled.
 
-**Revoke all sessions** increments the account's session version and signs it out across devices. Password reset and account-disable operations also revoke or invalidate access as implemented. OpsKnight v1.4 does not present a per-device session list; the control revokes all sessions.
+Credential sessions retain the normal local policy, including the longer Remember Me lifetime. OIDC sessions use the separate enterprise maximum-age/idle/renewal policy described in [Authentication](../administration/authentication.md#oidc-sessions).
 
-Forgot-password responses do not reveal whether an email is registered. Treat reset and invite links as secrets.
+**Revoke all sessions** increments the account's token/security version and signs it out across devices. Password reset, account disablement, SCIM deprovisioning, and relevant OIDC trust changes also invalidate active access.
+
+Forgot-password responses do not reveal whether an email is registered. When local login is disabled, password recovery must not provide a bypass around the SSO-only policy.
 
 ## Deactivate, reactivate, or delete
 
@@ -135,19 +168,22 @@ Before deactivation:
 - transfer incident and action-item assignments;
 - transfer Team Lead and sole Team Owner responsibilities;
 - review API keys, devices, dashboards, templates, postmortems, and external issue ownership;
-- verify another Admin remains.
+- verify another Admin remains; and
+- disable/deprovision the identity at the authoritative IdP/SCIM source where applicable.
 
 Then deactivate and run test escalations for affected services.
 
 ### Reactivate
 
-An Admin can reactivate a disabled account. The user may need a new invitation or password reset before signing in. Re-enable response assignments only after authentication and notification channels are verified.
+An Admin can reactivate a disabled manually managed account. For OIDC/SCIM-managed users, coordinate reactivation with the authoritative external identity/provisioning policy so OpsKnight and the provider do not fight over lifecycle state.
 
 ### Delete
 
 Deletion is permanent and removes or disconnects related operational records according to application actions and database constraints. The current deletion workflow removes memberships, shifts, direct escalation rules, notes, notification records, watchers, and the account; other required references can block it.
 
 Deletion of a sole Team Owner or the last Admin is blocked. Prefer deactivation unless retention or privacy policy requires permanent removal. Export required evidence and take a verified backup first.
+
+SCIM DELETE is intentionally different from an OpsKnight Admin deleting the internal user: SCIM DELETE removes the SCIM resource and disables/retains the internal OpsKnight account for history.
 
 ## Offboarding verification
 
@@ -157,6 +193,8 @@ Deletion of a sole Team Owner or the last Admin is blocked. Prefer deactivation 
 - [ ] Active incidents and action items have new owners.
 - [ ] API keys and registered devices are revoked or reassigned.
 - [ ] Team Lead and dashboard/template ownership are handled.
+- [ ] Authoritative IdP/SCIM access is removed when externally managed.
+- [ ] Existing sessions are invalidated.
 - [ ] Affected service escalation tests succeed.
 - [ ] Audit evidence and required records are retained.
 
@@ -168,9 +206,13 @@ Use the copyable invite link, inspect the email provider and logs, verify sender
 
 ### An existing user still cannot sign in with OIDC
 
-For an Active user, open **⋯** and confirm the menu shows **Revoke OIDC linking approval**, which means first-time linking is currently allowed. Then verify the configured provider returns a stable subject, the same account email, and `email_verified: true`. Also check allowed-domain policy and whether the identity is already linked elsewhere.
+Confirm the user has a valid first-link approval when required. Check approval expiry and provider/config scope, stable subject, current account status, organization/tenant restriction, and whether the external `(issuer, sub)` identity is already linked elsewhere.
 
-If the menu shows **Allow OIDC linking**, approval is not currently present. If it shows **OIDC linked**, the external identity is already established and the problem is not first-link approval.
+For Entra, do not assume a missing standard `email_verified` claim is an error; validated Entra issuers use the provider-specific policy. An explicit false claim is still rejected.
+
+### A SCIM-deleted user still appears in OpsKnight
+
+Expected: SCIM DELETE removes the external SCIM identity and disables the account, but the internal OpsKnight user is retained for history/audit. It should no longer be exposed as the deleted SCIM resource.
 
 ### A user is targeted but receives no page
 
@@ -187,4 +229,6 @@ Check whether it is the current Admin, last Admin, a sole Team Owner, or still r
 - [Escalation policies](escalation-policies.md)
 - [Authentication and security](authentication-security.md)
 - [Authentication](../administration/authentication.md)
+- [OIDC SSO Setup](../security/oidc-setup.md)
+- [SCIM Provisioning](../security/scim-provisioning.md)
 - [Published API and CLI guides](../api/README.md)

--- a/docs/v1.5/getting-started/configuration.md
+++ b/docs/v1.5/getting-started/configuration.md
@@ -6,235 +6,258 @@ description: Runtime, deployment, security, integration, and advanced environmen
 
 # Configuration Reference
 
-This page documents the operator-facing environment variables supported by OpsKnight v1.5. Copy `env.example` to `.env`, then provide secrets through your platform's secret store in production.
+This page documents operator-facing environment variables supported by OpsKnight v1.5. Copy `env.example` to `.env`, then provide production secrets through your platform's secret store.
 
 ```bash
 cp env.example .env
 ```
 
----
+## Required variables
 
-## Required Variables
+| Variable | Description | Example / How to Generate |
+| --- | --- | --- |
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host:5432/db` |
+| `NEXTAUTH_URL` | Exact public authentication origin | `https://ops.yourcompany.com` |
+| `NEXTAUTH_SECRET` | Secret used to sign/encrypt session tokens | `openssl rand -base64 32` |
 
-These variables must be set for OpsKnight to start correctly in any environment.
+`NEXTAUTH_URL` must match the public URL users access, including `https://`. Callback/cookie mismatches commonly produce OAuth login loops.
 
-| Variable          | Description                                    | Example / How to Generate             |
-| ----------------- | ---------------------------------------------- | ------------------------------------- |
-| `DATABASE_URL`    | PostgreSQL connection string                   | `postgresql://user:pass@host:5432/db` |
-| `NEXTAUTH_URL`    | Public-facing URL of the application           | `https://ops.yourcompany.com`         |
-| `NEXTAUTH_SECRET` | Secret used to sign and encrypt session tokens | `openssl rand -base64 32`             |
+## Security and encryption
 
-> **`NEXTAUTH_URL`** must match the exact base URL your users will access, including the scheme (`https://`). Mismatches cause OAuth callback failures.
+| Variable | Required in Production | Description |
+| --- | :---: | --- |
+| `ENCRYPTION_KEYS` | Recommended | Rotation keyring using `key-id:64-hex-key` entries. The first key encrypts new values; the full ring decrypts supported older values. |
+| `ENCRYPTION_KEY` | Yes if no keyring | Single 64-hex-character key used as the compatibility/master encryption key. |
 
----
-
-## Security & Encryption
-
-| Variable                    | Required in Production | Description                                                                                                                                                                                                                    |
-| --------------------------- | :--------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ENCRYPTION_KEYS`           |      Recommended       | Rotation keyring in `key-id:64-hex-key` entries. The first key encrypts new values; remaining keys decrypt older v3/legacy values.                                                                                             |
-| `ENCRYPTION_KEY`            |   Yes if no keyring    | Single 32-byte hex key used for compatibility and as an optional legacy key alongside `ENCRYPTION_KEYS`. API keys are keyed hashes and are not encrypted with this key.                                                        |
-
-The notification control plane derives recipient identities from the existing `NEXTAUTH_SECRET`.
-It uses the active encryption key only for compatibility if no session secret is available. No
-separate notification-identity secret is required. Keep `NEXTAUTH_SECRET` stable in production,
-as required for session continuity.
-
-`NOTIFICATION_CONTROL_PLANE_PERSONAL=true` routes new personal incident deliveries through the
-encrypted durable control plane. Compose, Helm, and Kustomize leave it disabled by default for a
-staged rollout; enable it after every worker has been upgraded. Set it back to `false` only while
-legacy compatibility rows are being drained during a rollback.
-
-### Generating the Encryption Key
+Generate a key with:
 
 ```bash
 openssl rand -hex 32
 ```
 
-This produces a 64-character hex string. Set it in your environment:
+Example:
 
 ```bash
 ENCRYPTION_KEY=a3f1c2e4b5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2
 ```
 
-**Development note:** When `NODE_ENV=development` and `ENCRYPTION_KEY` is not set, OpsKnight uses a public, deterministic fallback key so local encryption-dependent flows can run. It provides no secrecy and is **not suitable for shared or production data**.
+When `NODE_ENV=development` and no encryption key is configured, the development fallback exists only to keep local encryption-dependent flows usable. It provides no production secrecy.
 
-See [Encryption](../security/encryption) for key rotation, migration guidance, and security considerations.
-
----
+See [Encryption](../security/encryption.md).
 
 ## Authentication
 
-| Variable          | Required | Description                                   | Generate With             |
-| ----------------- | :------: | --------------------------------------------- | ------------------------- |
-| `NEXTAUTH_SECRET` |   Yes    | Secret for signing session JWTs               | `openssl rand -base64 32` |
-| `NEXTAUTH_URL`    |   Yes    | Base URL for OAuth callbacks and redirects    | Your public domain        |
-| `ENCRYPTION_KEY`  |  Yes\*   | Master key for encrypting integration secrets | `openssl rand -hex 32`    |
+### Core authentication variables
 
-\*Required in production; auto-fallback available in development.
+| Variable | Default | Description |
+| --- | --- | --- |
+| `NEXTAUTH_SECRET` | required | Signs/encrypts session JWTs. Changing it invalidates sessions. |
+| `NEXTAUTH_URL` | required | Canonical public authentication origin and callback base. |
+| `AUTH_TRUST_HOST` | inferred from canonical auth configuration | Explicit Auth.js host-trust control. |
+| `TRUSTED_PROXY_HOPS` | `1` | Number of trusted proxy entries read from the right side of `X-Forwarded-For`. |
 
----
+### Local login and break-glass
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AUTH_LOCAL_LOGIN_ENABLED` | `true` | Enables normal local email/password authentication. Set `false` for SSO-only operation. |
+| `AUTH_BREAK_GLASS_ENABLED` | `false` | Enables the explicitly configured emergency local identity even when normal local login is disabled. |
+| `AUTH_BREAK_GLASS_EMAIL` | unset | Exact normalized email allowed through the break-glass local-auth path. |
+
+Example SSO-only configuration with an emergency Admin:
+
+```bash
+AUTH_LOCAL_LOGIN_ENABLED=false
+AUTH_BREAK_GLASS_ENABLED=true
+AUTH_BREAK_GLASS_EMAIL=security-admin@example.com
+```
+
+Keep break-glass credentials outside the ordinary OIDC dependency and audit each use.
+
+### OIDC session controls
+
+These limits apply to OIDC sessions and do not replace the normal credential Remember Me policy.
+
+| Variable | Default | Allowed runtime range | Description |
+| --- | ---: | ---: | --- |
+| `AUTH_SSO_SESSION_MAX_AGE_SECONDS` | `43200` (12h) | 900–2592000 | Absolute OpsKnight OIDC session lifetime. |
+| `AUTH_SSO_SESSION_UPDATE_AGE_SECONDS` | `3600` (1h) | 60–86400 | Session update/refresh cadence. |
+| `AUTH_SSO_SESSION_IDLE_TIMEOUT_SECONDS` | `14400` (4h) | 300–604800 | Idle-time boundary for OIDC sessions. |
+| `AUTH_SSO_REAUTH_AFTER_SECONDS` | `43200` (12h) | 900–2592000 | Requires a new OpsKnight OIDC session after this age. It does not guarantee the upstream IdP prompts for credentials. |
+
+Out-of-range or invalid values fall back to safe defaults.
+
+### OIDC compatibility and cache controls
+
+| Variable | Purpose |
+| --- | --- |
+| `OIDC_REQUIRE_EMAIL_VERIFIED_STRICT` | Generic OIDC verified-email policy. Provider-specific logic still applies to validated issuers such as Microsoft Entra, which may omit the standard claim. Explicit `email_verified=false` is rejected. |
+| `OIDC_CONFIG_CACHE_TTL_MS` | Advanced in-process OIDC config cache TTL. |
+| `OIDC_CONFIG_RECORD_CACHE_TTL_MS` | Advanced OIDC database-record cache TTL. |
+| `AUTH_OPTIONS_CACHE_TTL_MS` | Advanced Auth.js options cache TTL. |
+| `JWT_USER_REFRESH_TTL_MS` | Advanced session/user refresh timing. |
+
+Use the UI under **Settings → System → Single Sign-On (OIDC)** for issuer, client ID, encrypted client secret, provider policy, organization/domain restrictions, role mapping, and profile mapping. Do not add those secrets as ad-hoc environment variables.
+
+See [OIDC SSO Setup](../security/oidc-setup.md) and [Authentication](../administration/authentication.md).
+
+## SCIM provisioning
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SCIM_BEARER_TOKEN` | unset | Bearer secret for `/api/scim/v2`. Must be at least 32 characters. |
+
+Recommended generation:
+
+```bash
+openssl rand -hex 32
+```
+
+Example:
+
+```bash
+SCIM_BEARER_TOKEN=<64-hex-character-random-value>
+```
+
+Do not reuse the OIDC client secret as the SCIM token. See [SCIM Provisioning](../security/scim-provisioning.md).
 
 ## Database
 
-| Variable            | Required | Description                  | Default        |
-| ------------------- | :------: | ---------------------------- | -------------- |
-| `DATABASE_URL`      |   Yes    | PostgreSQL connection string | —              |
-| `POSTGRES_USER`     |    No    | Database username (Docker)   | `opsknight`    |
-| `POSTGRES_PASSWORD` |    No    | Database password (Docker)   | —              |
-| `POSTGRES_DB`       |    No    | Database name (Docker)       | `opsknight_db` |
+| Variable | Required | Description | Default |
+| --- | :---: | --- | --- |
+| `DATABASE_URL` | Yes | PostgreSQL connection string | — |
+| `POSTGRES_USER` | No | Database username for bundled Compose PostgreSQL | `opsknight` |
+| `POSTGRES_PASSWORD` | No | Bundled Compose PostgreSQL password | — |
+| `POSTGRES_DB` | No | Bundled Compose database name | `opsknight_db` |
+| `DATABASE_POOL_SIZE` | No | Adds a Prisma connection limit when `DATABASE_URL` has no `connection_limit` | `40` |
 
-`POSTGRES_*` variables are used by Docker Compose to initialise the database container. For Kubernetes or Helm deployments, configure your database separately and set `DATABASE_URL` directly.
+For Kubernetes or Helm deployments, configure the database independently and set `DATABASE_URL` directly.
 
-**Example encrypted connection:**
+Example encrypted connection:
 
 ```bash
 DATABASE_URL=postgresql://opsknight:password@host:5432/opsknight_db?sslmode=require
 ```
 
-Use the certificate-verification mode and trust configuration required by your PostgreSQL provider. Connection-pool size is deployment-specific: budget the per-process pool across all application replicas plus migration, backup, monitoring, and administrative reserve. Do not copy a fixed `connection_limit` or `pool_timeout` without load testing; see [Scalability and capacity planning](../core-concepts/scalability).
-
----
+Budget per-process pools across all application replicas plus migration, backup, monitoring, and administrative reserve. See [Scalability and capacity planning](../core-concepts/scalability.md).
 
 ## Application URL
 
-| Variable              | Required | Description                                                   |
-| --------------------- | :------: | ------------------------------------------------------------- |
-| `NEXT_PUBLIC_APP_URL` |   Yes    | Public URL used in emails, webhooks, RSS feeds, and client JS |
+| Variable | Required | Description |
+| --- | :---: | --- |
+| `NEXT_PUBLIC_APP_URL` | Yes | Public URL used in emails, webhooks, RSS feeds, and client-side links. |
 
-This should match `NEXTAUTH_URL` in most deployments. It is exposed to the browser (hence `NEXT_PUBLIC_`), so it must be the external URL, not an internal container address.
-
----
+This normally matches `NEXTAUTH_URL`. It is exposed to browser code and must not contain an internal-only container URL.
 
 ## Notification providers
 
-Configure Resend, SendGrid, SMTP, Amazon SES, Twilio, AWS SNS, WhatsApp, and Web Push in **Settings → Notification Providers**. v1.4 does not read `SMTP_*`, `TWILIO_*`, or AWS SNS credentials from environment variables. Configure a valid `ENCRYPTION_KEY` before entering provider credentials; see [Encryption](../security/encryption) for the protected-field and recovery boundaries.
+Configure Resend, SendGrid, SMTP, Amazon SES, Twilio, AWS SNS, WhatsApp, and Web Push from **Settings → Notification Providers**. Provider credentials are normally stored through the UI using encrypted protected fields.
 
-`AWS_ACCESS_KEY_ID` is only a fallback for the SES client after an enabled SES record supplies the remaining provider configuration. Prefer storing the full, dedicated SES credential set in the SES provider form so behavior is explicit.
+`AWS_ACCESS_KEY_ID` is only a fallback for the SES client after an enabled SES record supplies the remaining provider configuration. Prefer the complete dedicated SES configuration in the UI.
 
-See [Notifications](../administration/notifications) for fields, recipient requirements, test paths, and delivery semantics.
+See [Notifications](../administration/notifications.md).
 
----
+## Push notifications (Web Push / VAPID)
 
-## Push Notifications (Web Push / VAPID)
-
-VAPID keys for web push can be generated via **Settings → Notifications → Web Push** in the UI.
-
-| Variable                       | Description                                                                               |
-| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| Variable | Description |
+| --- | --- |
 | `NEXT_PUBLIC_VAPID_PUBLIC_KEY` | Public base64url VAPID key exposed to clients when no database provider key is available. |
-| `VAPID_PRIVATE_KEY`            | Matching private VAPID key used by the sender fallback.                                   |
-| `VAPID_SUBJECT`                | Contact URI, normally `mailto:admin@example.com`; defaults to `mailto:admin@localhost`.   |
+| `VAPID_PRIVATE_KEY` | Matching private VAPID fallback key. |
+| `VAPID_SUBJECT` | Contact URI, normally `mailto:admin@example.com`. |
 
-Set the public and private variables together. The database-backed Web Push provider is the normal production path.
-
----
+Set the public and private values together. The database-backed Web Push provider is the normal production path.
 
 ## Operations and observability
 
-| Variable                                  | Default                    | Description                                                                                                                                               |
-| ----------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LOG_LEVEL`                               | `info`                     | Minimum structured-log level: `debug`, `info`, `warn`, or `error`.                                                                                        |
-| `LOG_FORMAT`                              | Environment dependent      | Set to `json` for JSON output.                                                                                                                            |
-| `LOG_BUFFER_MAX`                          | `500`                      | Maximum in-memory log-buffer size.                                                                                                                        |
-| `SENTRY_DSN`                              | —                          | Requests optional Sentry initialization when a custom build includes `@sentry/nextjs`; the standard v1.4 dependency set does not.                         |
-| `SENTRY_ENVIRONMENT`                      | `NODE_ENV`                 | Optional Sentry environment label for such a custom build.                                                                                                |
-| `SENTRY_FORCE_ENABLE`                     | `false`                    | Enables that optional Sentry path outside production when `true`.                                                                                         |
-| `NEXT_PUBLIC_ENABLE_WEB_VITALS`           | `false` outside production | Enables browser Web Vitals reporting outside production.                                                                                                  |
-| `APP_VERSION` / `NEXT_PUBLIC_APP_VERSION` | Package version            | Server/public version label override.                                                                                                                     |
-| `PROMETHEUS_SCRAPE_TOKEN`                 | —                          | Bearer token for authenticated scraping of `/api/metrics`; use a high-entropy secret and follow the [Prometheus metrics guide](../deployment/prometheus). |
+| Variable | Default | Description |
+| --- | --- | --- |
+| `LOG_LEVEL` | `info` | Minimum structured-log level: `debug`, `info`, `warn`, or `error`. |
+| `LOG_FORMAT` | environment dependent | Set to `json` for JSON output. |
+| `LOG_BUFFER_MAX` | `500` | Maximum in-memory log buffer size. |
+| `SENTRY_DSN` | — | Optional Sentry DSN when the deployed build includes the supported Sentry integration. |
+| `SENTRY_ENVIRONMENT` | `NODE_ENV` | Optional Sentry environment label. |
+| `SENTRY_FORCE_ENABLE` | `false` | Enables optional Sentry initialization outside production where supported. |
+| `NEXT_PUBLIC_ENABLE_WEB_VITALS` | `false` outside production | Enables browser Web Vitals reporting outside production. |
+| `APP_VERSION` / `NEXT_PUBLIC_APP_VERSION` | package version | Server/public version label override. |
+| `PROMETHEUS_SCRAPE_TOKEN` | — | Bearer token for authenticated `/api/metrics` scraping. |
 
-OpenTelemetry variables are not consumed by the v1.4 application code and are therefore not part of this reference.
+See [Prometheus metrics](../deployment/prometheus.md) for the scrape contract.
 
 ## Runtime controls
 
-| Variable                         | Default      | Description                                                                                                                               |
-| -------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `DATABASE_POOL_SIZE`             | `40`         | Adds a Prisma connection limit when `DATABASE_URL` has no `connection_limit`.                                                             |
-| `ENABLE_INTERNAL_CRON`           | `true`       | Set to `false` when background jobs are run by another designated process.                                                                |
-| `INTEGRATION_RATE_LIMIT`         | `true`       | Set to `false` to disable standard-handler integration rate limiting. This is not recommended for internet-facing deployments.            |
-| `INTEGRATION_VERIFY_SIGNATURES`  | `true`       | Set to `false` to disable signature checks on handlers that honor this flag. Use only for controlled diagnosis.                           |
-| `CORS_ALLOWED_ORIGINS`           | empty        | Comma-separated origins allowed by middleware for cross-origin API requests.                                                              |
-| `STATUS_PAGE_DOMAIN_CACHE_TTL`   | `60`         | Custom-status-domain middleware cache TTL in seconds.                                                                                     |
-| `EVENT_TRANSACTION_MAX_ATTEMPTS` | code default | Advanced transaction retry limit; tune only after reviewing database contention.                                                          |
-| `ESCALATION_LOCK_TIMEOUT_MS`     | code default | Advanced escalation lock timeout in milliseconds.                                                                                         |
-| `SKIP_ENV_VALIDATION`            | unset        | Bypasses production environment validation. Use only for controlled build/diagnostic workflows.                                           |
-| `DISABLE_PWA`                    | `false`      | Set to `true` at build time to disable production service-worker generation, PWA installation, push, and supported offline behavior.      |
-| `EMAIL_FROM`                     | derived      | Fallback sender address when code paths do not receive a provider-specific From address; prefer an explicitly verified provider identity. |
-| `MIGRATION_RECOVERY_MODE`        | `safe`       | Startup recovery policy. Do not use `aggressive` without database-owner review of the failed migration and actual schema state.           |
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ENABLE_INTERNAL_CRON` | `true` | Set `false` when background jobs are run by another designated process. |
+| `INTEGRATION_RATE_LIMIT` | `true` | Controls standard-handler integration rate limiting. Disabling is not recommended for internet-facing deployments. |
+| `INTEGRATION_VERIFY_SIGNATURES` | `true` | Controls signature checks only for handlers that explicitly honor this flag. Use disablement only for controlled diagnosis. |
+| `CORS_ALLOWED_ORIGINS` | empty | Comma-separated origins allowed by middleware for cross-origin API requests. |
+| `STATUS_PAGE_DOMAIN_CACHE_TTL` | `60` | Custom status-domain middleware cache TTL in seconds. |
+| `EVENT_TRANSACTION_MAX_ATTEMPTS` | code default | Advanced transaction retry limit. |
+| `ESCALATION_LOCK_TIMEOUT_MS` | code default | Advanced escalation lock timeout. |
+| `SKIP_ENV_VALIDATION` | unset | Bypasses production environment validation; use only for controlled build/diagnostic workflows. |
+| `DISABLE_PWA` | `false` | Disables production service-worker generation/PWA behavior at build time when `true`. |
+| `EMAIL_FROM` | derived | Fallback sender address when a code path does not receive a provider-specific From address. |
+| `MIGRATION_RECOVERY_MODE` | `safe` | Startup migration recovery policy. Do not use aggressive recovery without database-owner review. |
 
-## Authentication and integration overrides
+## Integration overrides
 
-| Variable                                                       | Purpose                                                                                                           |
-| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `AUTH_TRUST_HOST`                                              | Explicitly enables Auth.js host trust; setting `NEXTAUTH_URL` also enables it.                                    |
-| `TRUSTED_PROXY_HOPS`                                           | Number of trusted proxy entries read from the right side of `X-Forwarded-For`; defaults to `1`.                   |
-| `OIDC_REQUIRE_EMAIL_VERIFIED_STRICT`                           | Requires a verified-email claim from OIDC; defaults to `true`. Set `false` only after IdP-specific risk review.   |
-| `OIDC_CONFIG_CACHE_TTL_MS`, `OIDC_CONFIG_RECORD_CACHE_TTL_MS`  | Advanced OIDC cache TTLs.                                                                                         |
-| `AUTH_OPTIONS_CACHE_TTL_MS`, `JWT_USER_REFRESH_TTL_MS`         | Advanced authentication/session cache timing.                                                                     |
-| `API_KEY_SECRET`                                               | Overrides the secret used to hash API keys; otherwise `NEXTAUTH_SECRET` is used. Back up and rotate deliberately. |
-| `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_REDIRECT_URI` | Slack OAuth fallback values when equivalent stored settings are absent.                                           |
-| `SLACK_SIGNING_SECRET`                                         | Slack request-signature fallback/override.                                                                        |
-| `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL`                         | Legacy Slack sender fallbacks; prefer the encrypted Slack configuration UI.                                       |
-| `SLA_ALERT_EMAIL`                                              | Fallback recipient for configured SLA-breach email alerts.                                                        |
+| Variable | Purpose |
+| --- | --- |
+| `API_KEY_SECRET` | Overrides the secret used to hash API keys; otherwise `NEXTAUTH_SECRET` is used. |
+| `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_REDIRECT_URI` | Slack OAuth fallback values when equivalent stored settings are absent. |
+| `SLACK_SIGNING_SECRET` | Slack request-signature fallback/override. |
+| `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL` | Legacy Slack sender fallbacks; prefer encrypted stored Slack configuration. |
+| `SLA_ALERT_EMAIL` | Fallback recipient for configured SLA-breach email alerts. |
 
----
-
-## Example `.env` (Production)
+## Example production `.env`
 
 ```bash
-# ============================================================
-# OpsKnight — Production Environment Configuration
-# ============================================================
-
-# --- Required ---
 DATABASE_URL=postgresql://opsknight:your_secure_password@db-host:5432/opsknight_db?sslmode=require
 NEXTAUTH_URL=https://ops.yourcompany.com
-NEXTAUTH_SECRET=<output of: openssl rand -base64 32>
-
-# --- Encryption (required in production) ---
-# Generate with: openssl rand -hex 32
-ENCRYPTION_KEY=<your-64-char-hex-key>
-
-# --- Application URL ---
+NEXTAUTH_SECRET=<output-of-openssl-rand-base64-32>
 NEXT_PUBLIC_APP_URL=https://ops.yourcompany.com
 
-# Configure notification-provider credentials in the application UI.
+ENCRYPTION_KEY=<output-of-openssl-rand-hex-32>
+
+# Enterprise SSO-only example
+AUTH_LOCAL_LOGIN_ENABLED=false
+AUTH_BREAK_GLASS_ENABLED=true
+AUTH_BREAK_GLASS_EMAIL=security-admin@example.com
+AUTH_SSO_SESSION_MAX_AGE_SECONDS=43200
+AUTH_SSO_SESSION_UPDATE_AGE_SECONDS=3600
+AUTH_SSO_SESSION_IDLE_TIMEOUT_SECONDS=14400
+AUTH_SSO_REAUTH_AFTER_SECONDS=43200
+
+# Optional SCIM provisioning
+SCIM_BEARER_TOKEN=<output-of-openssl-rand-hex-32>
 ```
 
----
-
-## Example `.env` (Local Development)
+## Example local-development `.env`
 
 ```bash
-# ============================================================
-# OpsKnight — Local Development
-# ============================================================
-
 DATABASE_URL=postgresql://opsknight:opsknight@localhost:5432/opsknight_db
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=dev-secret-not-for-production
 NEXT_PUBLIC_APP_URL=http://localhost:3000
-
-# ENCRYPTION_KEY is intentionally omitted in development.
-# A public deterministic fallback key is used when NODE_ENV=development.
+AUTH_LOCAL_LOGIN_ENABLED=true
 ```
 
----
+`ENCRYPTION_KEY` may be omitted only for local development where the documented non-secret fallback is acceptable.
 
-## Configuration Tips
+## Configuration tips
 
-- **Secrets management**: Use AWS Secrets Manager, HashiCorp Vault, or GCP Secret Manager in production. Never commit secrets to source control.
-- **Per-environment isolation**: Use distinct values for `NEXTAUTH_SECRET` and `ENCRYPTION_KEY` across dev, staging, and production.
-- **Rotation**: Rotate `NEXTAUTH_SECRET` (invalidates all sessions) and `ENCRYPTION_KEY` (requires data re-encryption) on a regular cadence or after a suspected compromise.
-- **Validation**: OpsKnight validates `ENCRYPTION_KEY` format on startup. If it is set but malformed (not a 64-char hex string), encryption is disabled and an error is logged.
+- Use AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, Kubernetes Secrets, or an equivalent production secret store.
+- Keep `NEXTAUTH_SECRET`, encryption keys, OIDC client secrets, break-glass credentials, and `SCIM_BEARER_TOKEN` out of source control.
+- Use distinct secrets for development, staging, and production.
+- Treat issuer changes and authentication-origin changes as security-sensitive changes and test them before production rollout.
+- For SSO-only deployments, document and periodically verify the break-glass recovery procedure.
 
----
+## Related topics
 
-## Related Topics
-
-- [Installation Guide](./installation) — Get OpsKnight running
-- [Encryption](../security/encryption) — Key management and rotation
-- [Authentication](../administration/authentication) — OIDC SSO configuration
-- [Deployment: Docker](../deployment/docker) — Docker-specific configuration
-- [Deployment: Kubernetes](../deployment/kubernetes) — Kubernetes secrets and ConfigMaps
+- [Installation Guide](./installation.md)
+- [Encryption](../security/encryption.md)
+- [Authentication](../administration/authentication.md)
+- [OIDC SSO Setup](../security/oidc-setup.md)
+- [SCIM Provisioning](../security/scim-provisioning.md)
+- [Deployment: Docker](../deployment/docker.md)
+- [Deployment: Kubernetes](../deployment/kubernetes.md)

--- a/docs/v1.5/security/README.md
+++ b/docs/v1.5/security/README.md
@@ -13,24 +13,32 @@ This section covers identity management, authorization, cryptographic data prote
 
 ## In This Section
 
-| Guide                                          | Description                                                           |
-| :--------------------------------------------- | :-------------------------------------------------------------------- |
-| [OIDC SSO Setup](./oidc-setup)                 | Configure single sign-on with Google, Okta, Azure AD, and Keycloak    |
-| [Authorization and Roles](./authorization)     | Apply workspace roles, team roles, and resource ownership safely      |
-| [Envelope Encryption](./encryption)            | Authenticated AES-256-GCM envelope encryption and keyring rotation    |
-| [Webhook Verification](./webhook-verification) | HMAC-SHA256 signature verification and timing-safe payload validation |
+| Guide | Description |
+| :--- | :--- |
+| [OIDC SSO Setup](./oidc-setup.md) | Configure enterprise OIDC with Microsoft Entra ID, Google Workspace, Okta, Auth0, and strict generic OIDC. |
+| [SCIM Provisioning](./scim-provisioning.md) | Provision, update, deactivate, and remove users from the SCIM namespace. |
+| [Authorization and Roles](./authorization.md) | Apply workspace roles, team roles, role ownership, and resource authorization safely. |
+| [Envelope Encryption](./encryption.md) | Authenticated AES-256-GCM envelope encryption and keyring rotation. |
+| [Webhook Verification](./webhook-verification.md) | HMAC-SHA256 signature verification and timing-safe payload validation. |
 
 ## Key Concepts
 
-- **Authentication** is handled by NextAuth.js with OIDC support. See [Authentication](../administration/authentication) for the full guide.
-- **Encryption at rest** uses authenticated AES-256-GCM envelope encryption for new protected values. Keys are supplied through `ENCRYPTION_KEYS` or the single-key `ENCRYPTION_KEY` compatibility setting.
-- **Signature verification** validates provider-specific tokens or raw-body HMACs when a signature secret is configured. Only modes that include and validate a timestamp provide an application-level replay-age check; use the exact [webhook contract](./webhook-verification).
+- **Authentication** uses local credentials and/or one workspace OIDC provider. Stable OIDC identity is based on issuer plus subject, not email. See [Authentication](../administration/authentication.md).
+- **Lifecycle provisioning** can use SCIM 2.0 Users operations. OIDC authenticates a user; SCIM manages account lifecycle.
+- **SSO-only mode** can disable ordinary local credential login while retaining OIDC and an explicitly configured break-glass account.
+- **Session revocation** uses user security/token versioning so password reset, account disablement, SCIM deprovisioning, and relevant trust changes can invalidate access.
+- **Encryption at rest** uses authenticated AES-256-GCM envelope encryption for protected values. Keys are supplied through `ENCRYPTION_KEYS` or the single-key `ENCRYPTION_KEY` compatibility setting.
+- **Signature verification** validates provider-specific tokens or raw-body HMACs when a signature secret is configured. Only modes that include and validate a timestamp provide an application-level replay-age check; use the exact [webhook contract](./webhook-verification.md).
 
 ## Authentication boundary
 
-v1.4 does not provide native MFA, passkey/WebAuthn login, SAML, or email magic-link authentication. Enforce MFA through the configured OIDC provider or a trusted access proxy when required. The mobile platform-authenticator prompt is only a privacy overlay.
+OpsKnight v1.5 does not provide native SAML, passkey/WebAuthn login, email magic-link login, or a native second factor. Enforce MFA through the configured OIDC provider or a trusted access proxy when required. The mobile platform-authenticator prompt is a privacy overlay rather than server authentication.
+
+OpsKnight v1.5 currently supports one OIDC provider configuration per workspace; multi-IdP selection is not part of this release.
 
 ## Related Administration Topics
 
-- [Authentication](../administration/authentication) — Local auth, SSO, sessions, and security settings
-- [Audit Logs](../administration/audit-logs) — Supported evidence, retention, and compliance boundaries
+- [Authentication](../administration/authentication.md) — Local auth, SSO-only mode, linking, sessions, and recovery
+- [Users](../core-concepts/users.md) — Account status, role ownership, provisioning, and offboarding
+- [Configuration Reference](../getting-started/configuration.md) — Authentication and SCIM environment settings
+- [Audit Logs](../administration/audit-logs.md) — Supported evidence, retention, and compliance boundaries

--- a/docs/v1.5/security/oidc-setup.md
+++ b/docs/v1.5/security/oidc-setup.md
@@ -1,281 +1,271 @@
 ---
 order: 1
 title: OIDC SSO Setup
-description: Configure OIDC Single Sign-On for common identity providers
+description: Configure and operate enterprise OIDC SSO with provider-specific security controls
 ---
 
 # OIDC Single Sign-On (SSO) Setup
 
-Configure OIDC SSO in OpsKnight for common identity providers.
-
----
+OpsKnight v1.5 supports one workspace OIDC provider at a time. The OIDC implementation uses the provider issuer plus the OIDC subject (`iss` + `sub`) as the stable external identity. Email, UPN, username, and display name are profile attributes and are never used as the permanent identity key.
 
 ## Prerequisites
 
-- OpsKnight admin access
-- An IdP OIDC app registration created
-- A stable base URL for OpsKnight (used for redirect/callback)
-- `ENCRYPTION_KEY` configured (required to store client secrets)
-
----
+- OpsKnight Admin access
+- A confidential OIDC web application at the identity provider
+- A stable public HTTPS OpsKnight URL
+- `NEXTAUTH_URL` set to that public origin
+- `ENCRYPTION_KEYS` or `ENCRYPTION_KEY` configured in production so the client secret can be stored securely
 
 ## Callback URL
 
-Configure this callback URL in your identity provider:
+Register this exact redirect URI with the identity provider:
 
-```
+```text
 https://YOUR_OPSKNIGHT_URL/api/auth/callback/oidc
 ```
 
-Replace `YOUR_OPSKNIGHT_URL` with your OpsKnight instance URL.
+The value shown in **Settings → System → Single Sign-On (OIDC)** should match the public authentication origin configured for OpsKnight.
 
----
+## Configure SSO
 
-## Configuration Fields
+1. Open **Settings → System → Single Sign-On (OIDC)**.
+2. Choose the provider family.
+3. Enter the HTTPS issuer URL, client ID, and client secret.
+4. Optionally configure custom scopes, automatic provisioning, organization/domain restrictions, role mapping, profile mapping, and the provider label.
+5. Select **Test connection**. This validates OIDC discovery, issuer consistency, provider endpoints, JWKS availability, and supported signing configuration. It does not perform a real user login.
+6. Save the configuration.
+7. Test sign-in with a non-Admin account before relying on SSO for administrators.
 
-| Field               | Required | Description                           |
-| ------------------- | :------: | ------------------------------------- |
-| **Issuer URL**      |   Yes    | The OIDC issuer URL for your provider |
-| **Client ID**       |   Yes    | From your IdP app                     |
-| **Client Secret**   |   Yes    | From your IdP app (stored encrypted)  |
-| **Custom Scopes**   |    No    | Additional scopes beyond default      |
-| **Auto-provision**  |    No    | Create users on first login           |
-| **Allowed Domains** |    No    | Email domain allowlist                |
-| **Role Mapping**    |    No    | Map IdP claims to roles               |
-| **Profile Mapping** |    No    | Map IdP claims to user fields         |
-| **Provider Label**  |    No    | Custom text for SSO button            |
+Default scopes are:
 
-**Default Scopes**: `openid email profile`
+```text
+openid email profile
+```
 
----
+## Security model
 
-## OpsKnight Setup Steps
+OpsKnight applies the following rules regardless of provider:
 
-1. Go to **Settings** → **System Settings** → **Single Sign-On (OIDC)**
-2. Enable SSO
-3. Enter Issuer URL, Client ID, Client Secret
-4. Configure optional settings:
-   - Custom scopes
-   - Allowed domains
-   - Auto-provision
-   - Role mapping
-   - Profile mapping
-5. Save
-6. Test with the SSO button on the login page
+- HTTPS-only issuer and discovery endpoints.
+- Exact discovery issuer matching.
+- Authorization, token, and JWKS endpoints are validated before use.
+- Discovery and JWKS access are protected against redirects, private-network access, and DNS-rebinding style endpoint changes.
+- ID tokens must use the allowed asymmetric signing algorithm policy.
+- Existing identities are resolved by normalized issuer plus `sub` before email is considered.
+- An explicit `email_verified: false` claim is rejected.
+- Email is required when OpsKnight must create or first-link a user, but an already-linked identity can continue to authenticate without an email claim.
+- Callback URLs are restricted to the local OpsKnight origin.
 
----
+## Provider-specific behavior
 
-## Supported Providers
+### Microsoft Entra ID
 
-OpsKnight auto-detects provider type from the issuer URL:
+Use a tenant-specific workforce issuer:
 
-| Provider      | Detection                             |
-| ------------- | ------------------------------------- |
-| **Google**    | `accounts.google.com` in issuer       |
-| **Microsoft** | `login.microsoftonline.com` in issuer |
-| **Okta**      | `okta` in issuer                      |
-| **Auth0**     | `auth0` in issuer                     |
-| **Custom**    | All other issuers                     |
+```text
+https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0
+```
 
----
+OpsKnight rejects broad authorities such as:
 
-## Provider Guides
+```text
+/common/v2.0
+/organizations/v2.0
+/consumers/v2.0
+```
+
+Supported Entra authority hosts include the Microsoft public cloud and supported sovereign-cloud endpoints.
+
+Microsoft Entra workforce tokens commonly do not include the standard OIDC `email_verified` claim. For a validated Entra issuer, a missing claim is accepted according to the Entra provider policy, while an explicit `email_verified: false` is still rejected.
+
+For authorization, prefer Entra App Roles when possible. If group claims are used, OpsKnight detects group-overage conditions instead of silently treating an omitted groups claim as an empty group list.
 
 ### Google Workspace
 
-1. Create an OAuth app in Google Cloud Console
-2. Configure OAuth consent screen
-3. Create OAuth client credentials (Web application)
-4. **Authorized redirect URI**: `https://YOUR_OPSKNIGHT_URL/api/auth/callback/oidc`
-5. **Issuer URL**: `https://accounts.google.com`
-6. **Scopes**: `openid email profile` (default)
+Use:
 
-**Profile mapping claims**:
+```text
+https://accounts.google.com
+```
 
-- `avatarUrl`: `picture`
-- `department`: Not provided by Google
-- `jobTitle`: Not provided by Google
+When restricting access to a Google Workspace domain, OpsKnight validates the signed `hd` claim. It does not treat the suffix of the email address as proof of Workspace membership.
 
-### Microsoft Entra ID (Azure AD)
+For example, a Workspace restriction to `example.com` requires the token to contain:
 
-1. Register an app in Azure Entra ID
-2. Add a Web platform redirect URI: `https://YOUR_OPSKNIGHT_URL/api/auth/callback/oidc`
-3. Create a client secret
-4. **Issuer URL**: `https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0`
-5. **Scopes**: `openid email profile` (default)
-6. Optional: Add email and profile claims if not present
-
-**Profile mapping claims**:
-
-- `department`: `department`
-- `jobTitle`: `jobTitle`
-- `avatarUrl`: `picture`
+```text
+hd = example.com
+```
 
 ### Okta
 
-1. Create an OIDC Web App integration
-2. **Sign-in redirect URI**: `https://YOUR_OPSKNIGHT_URL/api/auth/callback/oidc`
-3. **Issuer URL**: `https://YOUR_OKTA_DOMAIN/oauth2/default`
-4. **Scopes**: `openid email profile` (default)
+OpsKnight supports normal Okta issuers including organization and custom authorization-server forms, for example:
 
-**Profile mapping claims**:
+```text
+https://example.okta.com
+https://example.okta.com/oauth2/default
+https://example.okta.com/oauth2/YOUR_SERVER_ID
+```
 
-- `department`: `department`
-- `jobTitle`: `title`
-- `avatarUrl`: `picture`
+Okta custom domains can also be used. Saving an Okta custom-domain issuer preserves the Okta provider policy rather than degrading it to generic OIDC behavior.
+
+If roles are mapped from an Okta `groups` claim, configure the claim in Okta so it is actually included in the ID token used by OpsKnight.
 
 ### Auth0
 
-1. Create a Regular Web Application
-2. **Allowed Callback URLs**: `https://YOUR_OPSKNIGHT_URL/api/auth/callback/oidc`
-3. **Issuer URL**: `https://YOUR_AUTH0_DOMAIN`
-4. **Scopes**: `openid email profile` (default)
+Use the tenant issuer or a configured Auth0 custom domain, for example:
 
-**Profile mapping claims**:
+```text
+https://tenant.eu.auth0.com
+https://login.example.com
+```
 
-- `department`: Use custom claim, e.g., `https://example.com/department`
-- `jobTitle`: Use custom claim, e.g., `https://example.com/title`
-- `avatarUrl`: `picture`
+When an Auth0 Organization is configured, OpsKnight validates the signed `org_id` claim on every login, including logins from identities that were linked previously.
 
-### Keycloak
+For custom role/profile claims, use namespaced Auth0 claims where appropriate.
 
-1. Create a Realm and Client (OpenID Connect)
-2. Client Access Type: Confidential
-3. **Valid Redirect URIs**: `https://YOUR_OPSKNIGHT_URL/api/auth/callback/oidc`
-4. **Issuer URL**: `https://YOUR_KEYCLOAK_HOST/realms/YOUR_REALM`
-5. **Scopes**: `openid email profile` (default)
+### Generic OIDC / Keycloak
 
-**Profile mapping claims**:
+Generic OIDC is intentionally strict. The issuer must expose valid OIDC discovery metadata and satisfy the same HTTPS, issuer, endpoint, JWKS, signing, state, nonce, and PKCE protections used by the built-in provider policies.
 
-- `department`: `department`
-- `jobTitle`: `jobTitle`
-- `avatarUrl`: `picture`
+Typical Keycloak issuer:
 
----
+```text
+https://keycloak.example.com/realms/YOUR_REALM
+```
 
-## Role Mapping
+## First-time account linking
 
-Map IdP claims to OpsKnight roles automatically.
+OpsKnight never silently attaches a new OIDC subject to an existing account merely because the email matches.
 
-### Format
+For an existing account that has not yet linked OIDC, an Admin can authorize first-time linking from **Users**.
 
-JSON array of rules:
+Linking approvals are:
+
+- time limited;
+- renewable and revocable;
+- scoped to the provider configuration and issuer trust boundary;
+- tied to the expected account email;
+- consumed atomically when the first link succeeds.
+
+Approvals are available for supported **Active** and **Invited** account flows. The provider still has to pass its identity, email-assurance, organization, and domain checks.
+
+Once linked, future logins use the stored `(issuer, sub)` identity rather than email matching.
+
+## Automatic provisioning
+
+When **Auto-provision** is enabled, an eligible first OIDC login can create an OpsKnight account automatically.
+
+Creation and identity binding are committed atomically so OpsKnight does not leave a half-created user when identity linking fails or races with another login.
+
+When auto-provisioning is disabled, unknown external identities are denied.
+
+## Organization and domain restrictions
+
+Restrictions are provider-aware:
+
+- **Microsoft Entra ID** — tenant-specific issuer/trust policy.
+- **Google Workspace** — signed `hd` claim.
+- **Auth0** — optional signed `org_id` boundary.
+- **Okta / generic OIDC** — configured issuer plus any supported email/domain policy.
+
+Do not rely on an email suffix as the sole proof of organizational membership when the provider exposes a stronger signed organization claim.
+
+## Role mapping
+
+Role rules are evaluated from bounded OIDC claims and can map to:
+
+```text
+USER
+AUDITOR
+RESPONDER
+ADMIN
+```
+
+Example:
 
 ```json
 [
-  { "claim": "groups", "value": "admins", "role": "ADMIN" },
-  { "claim": "groups", "value": "oncall-team", "role": "RESPONDER" },
-  { "claim": "department", "value": "engineering", "role": "RESPONDER" }
+  { "claim": "groups", "value": "opsknight-admins", "role": "ADMIN" },
+  { "claim": "groups", "value": "on-call", "role": "RESPONDER" }
 ]
 ```
 
-### Rule Fields
+OpsKnight tracks whether a role is managed manually, by OIDC, or by SCIM. OIDC-managed access can therefore be de-provisioned when the authoritative mapped claim is removed, without confusing that state with a manually managed role.
 
-| Field   | Description                                     |
-| ------- | ----------------------------------------------- |
-| `claim` | The IdP claim name to check                     |
-| `value` | The value to match                              |
-| `role`  | OpsKnight role: `ADMIN`, `RESPONDER`, or `USER` |
+## Profile mapping
 
-### Evaluation
+The following profile fields can be synchronized from bounded claims:
 
-- Rules are evaluated in order
-- First match wins
-- Users not matching any rule get the default role (`USER`)
+- `department`
+- `jobTitle`
+- `avatarUrl`
 
----
+Wrong claim types are rejected/ignored according to the mapping policy rather than being coerced from arbitrary objects.
 
-## Profile Mapping
+## Issuer changes
 
-Sync user profile fields from IdP claims.
+Changing the issuer changes the external identity trust boundary. OpsKnight requires explicit confirmation for an issuer migration and invalidates affected sessions and outstanding first-link approvals as part of the change.
 
-### Supported Fields
+Do not change an Okta/Auth0 issuer to a custom domain without planning the identity migration first.
 
-| OpsKnight Field | Description         |
-| --------------- | ------------------- |
-| `department`    | User's department   |
-| `jobTitle`      | User's job title    |
-| `avatarUrl`     | Profile picture URL |
+## SSO-only and break-glass access
 
-### Format
+Local credential login can be disabled with:
 
-JSON object mapping OpsKnight fields to IdP claim names:
-
-```json
-{
-  "department": "department",
-  "jobTitle": "title",
-  "avatarUrl": "picture"
-}
+```text
+AUTH_LOCAL_LOGIN_ENABLED=false
 ```
 
-### Behavior
+When disabled, the SSO button remains available and local password login/recovery is not exposed as a bypass.
 
-- Profile fields update on each login
-- Empty claims don't overwrite existing values
+For emergency recovery, configure a dedicated break-glass account with:
 
----
+```text
+AUTH_BREAK_GLASS_ENABLED=true
+AUTH_BREAK_GLASS_EMAIL=admin@example.com
+```
 
-## Domain Restrictions
+Keep the break-glass credentials outside the normal SSO dependency and restrict use to documented recovery procedures.
 
-Limit which email domains can use SSO:
+## OIDC session policy
 
-1. In SSO settings, add **Allowed Domains**
-2. Enter domains (comma-separated): `example.com, subsidiary.com`
-3. Only users with matching email domains can sign in
+OIDC sessions have separate enterprise limits from local credential sessions. Defaults are:
 
-If empty, all email domains are allowed.
+```text
+Maximum OIDC session age: 12 hours
+Idle timeout:             4 hours
+OpsKnight SSO renewal:   12 hours
+Session update age:       1 hour
+```
 
----
+These values are controlled by the `AUTH_SSO_*` settings documented in [Configuration Reference](../getting-started/configuration.md).
 
-## Auto-Provisioning
+OpsKnight can require a new OpsKnight OIDC session after the configured period, but that is not the same as forcing the identity provider to prompt for credentials again; the IdP may reuse its own SSO session.
 
-**Enabled**: Users are created automatically on first SSO login.
+## Current scope
 
-**Disabled**: Only pre-existing users can sign in via SSO.
+OpsKnight v1.5 currently supports **one OIDC provider configuration per workspace**. Multi-IdP selection is not part of this release.
 
-When enabled:
-
-- New users get the role from role mapping (or default `USER`)
-- Profile fields populated from claims
-- Email domain must match allowed domains (if configured)
-
----
+For lifecycle provisioning and de-provisioning, see [SCIM Provisioning](./scim-provisioning.md).
 
 ## Troubleshooting
 
-### SSO Button Not Showing
+| Symptom | Check |
+| --- | --- |
+| SSO button missing | OIDC is enabled and its client secret can be decrypted. |
+| Discovery validation fails | HTTPS issuer, exact discovery issuer, reachable public endpoints, valid JWKS metadata. |
+| Entra login denied | Use a tenant-specific issuer; do not use `common`, `organizations`, or `consumers`. |
+| Google Workspace user denied | Verify the signed `hd` claim matches the configured Workspace domain. |
+| Auth0 user denied | Verify the configured `org_id` and the token's signed organization claim. |
+| Existing account cannot first-link | Review the Admin linking approval, expiry, provider/config scope, email, and provider assurance checks. |
+| Existing linked user changed email | Identity should still resolve by `(issuer, sub)`; investigate issuer/subject changes instead of relinking by email. |
+| Role does not update | Confirm the expected claim is present and the mapping value exactly matches. |
+| Login loops after URL change | Confirm `NEXTAUTH_URL`, reverse-proxy host/scheme forwarding, and the registered callback URI all match. |
 
-1. Verify SSO is enabled in settings
-2. Check `ENCRYPTION_KEY` environment variable is set
-3. Verify client secret can be decrypted
+## Related topics
 
-### Validation Fails
-
-1. Confirm issuer URL uses HTTPS
-2. Verify OIDC discovery document is reachable: `{issuer}/.well-known/openid-configuration`
-3. Check client ID and secret are correct
-
-### Access Denied
-
-1. Check allowed domains configuration
-2. Verify auto-provision is enabled (for new users)
-3. Ensure IdP sends the email claim
-
-### Profile Fields Not Syncing
-
-1. Confirm claim names in profile mapping match IdP claims
-2. Verify IdP includes the claims in the token
-3. Check IdP token/claims debugger
-
-### Missing Email Claim
-
-Ensure your IdP is configured to include the `email` claim in tokens. Some providers require explicit configuration.
-
----
-
-## Related Topics
-
-- [Authentication](../administration/authentication) — All authentication methods
-- [Users](../core-concepts/users) — User management
-- [Security Overview](.) — Security best practices
+- [Authentication](../administration/authentication.md)
+- [SCIM Provisioning](./scim-provisioning.md)
+- [Users](../core-concepts/users.md)
+- [Authorization and Roles](./authorization.md)
+- [Configuration Reference](../getting-started/configuration.md)

--- a/docs/v1.5/security/scim-provisioning.md
+++ b/docs/v1.5/security/scim-provisioning.md
@@ -1,0 +1,212 @@
+---
+order: 2
+title: SCIM Provisioning
+description: Provision, update, and deprovision OpsKnight users through SCIM 2.0
+---
+
+# SCIM Provisioning
+
+OpsKnight v1.5 exposes a SCIM 2.0 **Users** endpoint for identity-provider lifecycle management. Use OIDC for interactive authentication and SCIM for create/update/deactivate/delete lifecycle operations.
+
+## Endpoint
+
+Use this base URL:
+
+```text
+https://YOUR_OPSKNIGHT_URL/api/scim/v2
+```
+
+Users collection:
+
+```text
+https://YOUR_OPSKNIGHT_URL/api/scim/v2/Users
+```
+
+## Authentication
+
+Configure a high-entropy bearer token in the OpsKnight environment:
+
+```text
+SCIM_BEARER_TOKEN=<at-least-32-character-random-secret>
+```
+
+Identity providers must send:
+
+```http
+Authorization: Bearer <SCIM_BEARER_TOKEN>
+```
+
+OpsKnight rejects missing/short configured tokens and performs timing-safe comparison of the supplied bearer token.
+
+Generate a token with a cryptographically secure secret generator, for example:
+
+```bash
+openssl rand -hex 32
+```
+
+Store the token in the identity provider's SCIM connector and in your production secret manager. Do not commit it to source control.
+
+## Supported resource
+
+OpsKnight v1.5 supports the SCIM core User schema:
+
+```text
+urn:ietf:params:scim:schemas:core:2.0:User
+```
+
+Supported operations:
+
+| Method | Endpoint | Behavior |
+| --- | --- | --- |
+| `GET` | `/Users` | List/search SCIM-managed users. |
+| `POST` | `/Users` | Provision a user. |
+| `GET` | `/Users/{id}` | Read one SCIM resource. |
+| `PUT` | `/Users/{id}` | Replace supported user attributes. |
+| `PATCH` | `/Users/{id}` | Apply supported replace operations. |
+| `DELETE` | `/Users/{id}` | Deprovision the SCIM resource. |
+
+OpsKnight currently implements **Users**, not SCIM Groups. Group-to-role lifecycle should therefore be designed around your OIDC role mapping or provider-side user provisioning policy rather than assuming a `/Groups` endpoint exists.
+
+## Supported user attributes
+
+OpsKnight serializes the following main fields:
+
+| SCIM field | OpsKnight meaning |
+| --- | --- |
+| `id` | Stable OpsKnight user ID used as the SCIM resource ID. |
+| `externalId` | Stable external provisioning identifier. |
+| `userName` | User email address. |
+| `displayName` | User display name. |
+| `emails` | Primary work email representation. |
+| `active` | Whether the OpsKnight account is active. |
+
+`externalId` is immutable for an existing SCIM resource.
+
+## Filtering
+
+The Users collection supports equality filtering for:
+
+```text
+externalId eq "..."
+userName eq "..."
+```
+
+Unsupported filter forms return an error rather than being silently reinterpreted.
+
+## Provisioning behavior
+
+When the identity provider creates a SCIM user, OpsKnight records the external provisioning identity and marks the account role source as SCIM-managed where applicable.
+
+Use a stable `externalId` from the identity platform. Do not recycle one person's external ID for another person.
+
+## Updating a user
+
+`PUT` can update supported replacement fields such as email, display name, and active state.
+
+`PATCH` currently supports replace-style operations for supported paths such as:
+
+```text
+active
+displayName
+```
+
+Unsupported operations/paths fail explicitly.
+
+Security-sensitive state changes use the same administrative invariants as normal OpsKnight account management.
+
+## Deprovisioning and DELETE
+
+Setting `active=false` disables the OpsKnight account and invalidates active access according to the account/session security policy.
+
+`DELETE /Users/{id}` intentionally does **not** physically erase the underlying OpsKnight user record. Instead OpsKnight:
+
+1. disables the internal account;
+2. invalidates sessions by advancing the user's security/session version;
+3. clears the SCIM external identity so the resource disappears from the SCIM namespace; and
+4. retains the disabled internal account for audit/history and operational references.
+
+A later `GET /Users/{id}` therefore no longer exposes that account as the same SCIM-managed resource after successful SCIM deletion.
+
+## OIDC and SCIM together
+
+Recommended enterprise model:
+
+```text
+OIDC -> authentication
+SCIM -> provisioning/deprovisioning
+```
+
+OIDC identities remain based on `(issuer, sub)`. SCIM lifecycle identity uses the SCIM resource/external ID. Do not assume that matching email addresses alone are sufficient to rewrite OIDC identity ownership.
+
+When a user is deprovisioned through SCIM, session invalidation is intended to take effect without waiting for the previous OIDC JWT lifetime to expire.
+
+## Role ownership
+
+OpsKnight tracks whether a role is managed manually, by OIDC, or by SCIM. This avoids treating all role changes as equivalent.
+
+If OIDC role mapping is authoritative for a deployment, document how it interacts with SCIM provisioning so administrators know whether role changes should be made in the IdP token claims or through the provisioning system.
+
+## Microsoft Entra provisioning
+
+In Microsoft Entra ID:
+
+1. Configure the enterprise application's provisioning mode for SCIM.
+2. Set the tenant URL to:
+
+   ```text
+   https://YOUR_OPSKNIGHT_URL/api/scim/v2
+   ```
+
+3. Set the secret token to the value of `SCIM_BEARER_TOKEN`.
+4. Test the connection.
+5. Map a stable source identifier to `externalId`, email to `userName`, display name to `displayName`, and account enabled state to `active`.
+6. Start with a small assigned test group before broad rollout.
+
+OIDC and Entra provisioning are separate connections: the Entra OIDC client secret is not the SCIM bearer token.
+
+## Okta provisioning
+
+For an Okta SCIM integration:
+
+1. Use the same SCIM base URL:
+
+   ```text
+   https://YOUR_OPSKNIGHT_URL/api/scim/v2
+   ```
+
+2. Use HTTP Header/Bearer authentication with `SCIM_BEARER_TOKEN`.
+3. Enable the user lifecycle capabilities required by your deployment.
+4. Map a stable Okta identity to `externalId`.
+5. Verify create, update, deactivate, and delete behavior with test users before production rollout.
+
+## Operational checks
+
+Before enabling automatic provisioning broadly, verify:
+
+- bearer authentication rejects missing/wrong tokens;
+- create produces one SCIM resource;
+- repeated lookup by `externalId`/`userName` identifies the expected resource;
+- update changes only supported fields;
+- deactivation prevents access and invalidates sessions;
+- DELETE returns success, removes the resource from the SCIM namespace, and keeps the internal disabled account for history;
+- re-provisioning follows the intended account recovery/new-resource policy;
+- at least two non-SCIM-dependent Admin recovery paths are understood.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `401` from every request | `SCIM_BEARER_TOKEN` is set, at least 32 characters, and the IdP sends `Authorization: Bearer ...`. |
+| User lookup fails | Confirm the resource is still SCIM-managed and verify the `externalId` or `userName` filter. |
+| `409` on update | Check immutable `externalId`, duplicate email/external identity, and account invariants. |
+| DELETE succeeds but user still exists in OpsKnight | Expected: the internal account is retained disabled for history while the SCIM external identity is removed. |
+| User still has a browser session after offboarding | Verify the SCIM operation completed and inspect account/session audit events. |
+| Provider expects SCIM Groups | OpsKnight v1.5 does not expose a Groups resource; use OIDC role mapping or provider-side assignment policy. |
+
+## Related topics
+
+- [OIDC SSO Setup](./oidc-setup.md)
+- [Authentication](../administration/authentication.md)
+- [Users](../core-concepts/users.md)
+- [Authorization and Roles](./authorization.md)
+- [Configuration Reference](../getting-started/configuration.md)

--- a/env.example
+++ b/env.example
@@ -44,27 +44,45 @@ ENCRYPTION_KEY=
 # ----------------------------------------------
 POSTGRES_USER=opsknight
 POSTGRES_PASSWORD=devpassword
-
-# Enterprise authentication policy
-AUTH_LOCAL_LOGIN_ENABLED=true
-AUTH_BREAK_GLASS_ENABLED=false
-# AUTH_BREAK_GLASS_EMAIL=admin@example.com
-AUTH_SSO_SESSION_MAX_AGE_SECONDS=43200
-AUTH_SSO_SESSION_UPDATE_AGE_SECONDS=3600
 POSTGRES_DB=opsknight_db
 POSTGRES_PORT=5432
 APP_PORT=3000
 
-# Main Compose defaults to the patched v1.4 runtime. Override only with a tested tag or digest.
-# OPSKNIGHT_IMAGE=ghcr.io/opsknight-labs/opsknight:1.4.0-hotfix
+# ----------------------------------------------
+# 5. ENTERPRISE AUTHENTICATION POLICY
+# ----------------------------------------------
+# Disable normal local email/password login while keeping OIDC available.
+AUTH_LOCAL_LOGIN_ENABLED=true
+
+# Optional emergency local access when normal local login is disabled.
+AUTH_BREAK_GLASS_ENABLED=false
+# AUTH_BREAK_GLASS_EMAIL=admin@example.com
+
+# OIDC session controls. Values are seconds and are bounded by the runtime.
+AUTH_SSO_SESSION_MAX_AGE_SECONDS=43200
+AUTH_SSO_SESSION_UPDATE_AGE_SECONDS=3600
+AUTH_SSO_SESSION_IDLE_TIMEOUT_SECONDS=14400
+AUTH_SSO_REAUTH_AFTER_SECONDS=43200
+
+# Optional strict generic OIDC email-verification policy.
+# Validated Microsoft Entra issuers use provider-aware handling for a missing
+# standard email_verified claim; explicit email_verified=false is rejected.
+OIDC_REQUIRE_EMAIL_VERIFIED_STRICT=true
+
+# SCIM 2.0 Users API bearer secret. Generate a high-entropy value, for example:
+# openssl rand -hex 32
+# SCIM_BEARER_TOKEN=
+
+# Override only with a tested OpsKnight image tag or digest.
+# OPSKNIGHT_IMAGE=ghcr.io/opsknight-labs/opsknight:<version>
 
 # ----------------------------------------------
-# 5. SLACK (OPTIONAL DEVELOPMENT OVERRIDE)
+# 6. SLACK (OPTIONAL DEVELOPMENT OVERRIDE)
 # ----------------------------------------------
 # Slack is normally configured in the UI under Settings > Integrations > Slack.
 # SLACK_SIGNING_SECRET=
 
 # ----------------------------------------------
-# 6. MONITORING & METRICS (OPTIONAL)
+# 7. MONITORING & METRICS (OPTIONAL)
 # ----------------------------------------------
 # PROMETHEUS_SCRAPE_TOKEN=

--- a/tests/architecture/oidc-enterprise-documentation-contract.test.ts
+++ b/tests/architecture/oidc-enterprise-documentation-contract.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+describe('enterprise identity documentation', () => {
+  it('keeps the v1.5 OIDC and SCIM guides versioned with the implementation', () => {
+    expect(existsSync('docs/v1.5/security/oidc-setup.md')).toBe(true);
+    expect(existsSync('docs/v1.5/security/scim-provisioning.md')).toBe(true);
+  });
+
+  it('documents the provider-specific OIDC security boundaries', () => {
+    const oidc = readFileSync('docs/v1.5/security/oidc-setup.md', 'utf8');
+    expect(oidc).toContain('issuer plus the OIDC subject');
+    expect(oidc).toContain('Microsoft Entra ID');
+    expect(oidc).toContain('signed `hd` claim');
+    expect(oidc).toContain('signed `org_id`');
+    expect(oidc).toContain('one OIDC provider configuration per workspace');
+  });
+
+  it('documents SSO-only, break-glass, session, and SCIM operator controls', () => {
+    const auth = readFileSync('docs/v1.5/administration/authentication.md', 'utf8');
+    const config = readFileSync('docs/v1.5/getting-started/configuration.md', 'utf8');
+    const scim = readFileSync('docs/v1.5/security/scim-provisioning.md', 'utf8');
+
+    expect(auth).toContain('AUTH_LOCAL_LOGIN_ENABLED=false');
+    expect(auth).toContain('AUTH_BREAK_GLASS_EMAIL');
+    expect(config).toContain('AUTH_SSO_SESSION_IDLE_TIMEOUT_SECONDS');
+    expect(config).toContain('AUTH_SSO_REAUTH_AFTER_SECONDS');
+    expect(config).toContain('SCIM_BEARER_TOKEN');
+    expect(scim).toContain('SCIM 2.0 **Users**');
+    expect(scim).toContain('does **not** physically erase');
+  });
+});


### PR DESCRIPTION
## Summary

Documentation follow-up for the enterprise OIDC/SSO hardening merged in #612. This updates the v1.5 docs so operator guidance matches the actual authentication, provider, session, and SCIM behavior now on `main`.

## Updated

- Rewrote the v1.5 OIDC guide around immutable `(issuer, sub)` identity and provider-specific trust.
- Documented Microsoft Entra tenant-specific issuers, sovereign-cloud support, and provider-aware `email_verified` handling.
- Documented Google Workspace `hd`, Okta custom/authorization-server issuers, Auth0 custom domains and `org_id`, and strict generic OIDC behavior.
- Documented expiring/scoped OIDC linking approvals, atomic JIT provisioning, role ownership/de-provisioning, issuer migration, SSO-only mode, break-glass access, and enterprise OIDC session limits.
- Added a dedicated SCIM 2.0 Users provisioning/deprovisioning guide, including DELETE semantics and Entra/Okta setup guidance.
- Updated Users documentation for OIDC/SCIM-managed lifecycle and first-link behavior.
- Updated the v1.5 configuration reference with local-auth, break-glass, OIDC session, strict-provider, and `SCIM_BEARER_TOKEN` settings.
- Updated `env.example` with the complete authentication/session/SCIM operator settings and removed stale v1.4 wording.
- Updated Security navigation and v1.5 authentication boundaries.
- Added a documentation contract test so the enterprise identity docs cannot silently regress.

## Important documented boundaries

- OpsKnight v1.5 supports one OIDC provider configuration per workspace.
- `AUTH_SSO_REAUTH_AFTER_SECONDS` renews the OpsKnight OIDC session; it does not guarantee a fresh upstream IdP credential prompt.
- SCIM v1.5 exposes Users lifecycle operations, not a Groups resource.
- SCIM DELETE removes the external SCIM resource while retaining the disabled internal OpsKnight account for history/audit.

## Scope

Documentation/test changes only. No authentication runtime behavior is changed by this PR.