### PR TITLE
feat(schedules): add dependency-safe admin-only schedule deletion

### DIFF
--- a/docs/v1.4/core-concepts/schedules.md
+++ b/docs/v1.4/core-concepts/schedules.md
@@ -10,7 +10,7 @@ A schedule answers “who is on call now?” for an escalation-policy step. Each
 
 ## Permissions
 
-Signed-in users can view schedules they are allowed to see. Application **Responders** and **Admins** can create and edit schedules, layers, participants, and overrides.
+Signed-in users can view schedules they are allowed to see. Application **Responders** and **Admins** can create and edit schedules, layers, participants, and overrides. Deleting a schedule requires **Admin** privileges.
 
 ## Scheduling model
 
@@ -112,6 +112,24 @@ Confirm the IANA timezone and inspect the date for a daylight-saving transition.
 ### An override has no effect
 
 Confirm its schedule, start/end range, replacement user, optional replaced user, and overlap with the effective layer. Reload the timeline after saving.
+
+## Delete a schedule
+
+Deleting a schedule is an **Admin-only** operation located in the **Settings** tab under the **Danger Zone**.
+
+### Dependency safety enforcement
+
+OpsKnight strictly prohibits deleting any schedule currently assigned as an escalation target in an active escalation policy. When a schedule is linked to escalation rules:
+- Deletion is blocked with code `SCHEDULE_IN_USE` (HTTP 409 Conflict).
+- OpsKnight displays the list of dependent policies and attached services with direct links.
+- Admins must remove or reassign the schedule in those escalation policies before deletion can proceed.
+
+### Deletion lifecycle & cleanup
+
+When an unreferenced schedule is deleted:
+1. **Confirmation**: Admins must type the exact schedule name to confirm deletion in the confirmation modal.
+2. **Transactional cleanup**: All schedule-owned layers, layer user assignments, schedule overrides, and shift records are removed in an atomic transaction.
+3. **Audit trail**: A `schedule.deleted` audit record is recorded atomically within the transaction, capturing a snapshot of the deleted schedule's name, timezone, and child resource counts. If audit logging fails, the entire deletion transaction rolls back.
 
 ## Related topics
 

--- a/docs/v1.5/core-concepts/schedules.md
+++ b/docs/v1.5/core-concepts/schedules.md
@@ -10,7 +10,7 @@ A schedule answers “who is on call now?” for an escalation-policy step. Each
 
 ## Permissions
 
-Signed-in users can view schedules they are allowed to see. Application **Responders** and **Admins** can create and edit schedules, layers, participants, and overrides.
+Signed-in users can view schedules they are allowed to see. Application **Responders** and **Admins** can create and edit schedules, layers, participants, and overrides. Deleting a schedule requires **Admin** privileges.
 
 ## Scheduling model
 
@@ -127,6 +127,24 @@ The selected local time is either nonexistent (spring-forward) or ambiguous (fal
 ### An override has no effect
 
 Confirm its schedule, start/end range, replacement user, optional replaced user, and overlap with the effective layer. Reload the timeline after saving.
+
+## Delete a schedule
+
+Deleting a schedule is an **Admin-only** operation located in the **Settings** tab under the **Danger Zone**.
+
+### Dependency safety enforcement
+
+OpsKnight strictly prohibits deleting any schedule currently assigned as an escalation target in an active escalation policy. When a schedule is linked to escalation rules:
+- Deletion is blocked with code `SCHEDULE_IN_USE` (HTTP 409 Conflict).
+- OpsKnight displays the list of dependent policies and attached services with direct links.
+- Admins must remove or reassign the schedule in those escalation policies before deletion can proceed.
+
+### Deletion lifecycle & cleanup
+
+When an unreferenced schedule is deleted:
+1. **Confirmation**: Admins must type the exact schedule name to confirm deletion in the confirmation modal.
+2. **Transactional cleanup**: All schedule-owned layers, layer user assignments, schedule overrides, and shift records are removed in an atomic transaction.
+3. **Audit trail**: A `schedule.deleted` audit record is recorded atomically within the transaction, capturing a snapshot of the deleted schedule's name, timezone, and child resource counts. If audit logging fails, the entire deletion transaction rolls back.
 
 ## Related topics
 

--- a/src/app/(app)/schedules/[id]/page.tsx
+++ b/src/app/(app)/schedules/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   createOverride,
   deleteLayer,
   deleteOverride,
+  deleteSchedule,
   moveLayerUser,
   moveLayerPrecedence,
   removeLayerUser,
@@ -40,6 +41,7 @@ import ScheduleHealthCheck from '@/components/ScheduleHealthCheck';
 import ScheduleLinkedPolicies, {
   type LinkedPolicy,
 } from '@/components/schedules/ScheduleLinkedPolicies';
+import DeleteScheduleCard from '@/components/schedules/DeleteScheduleCard';
 import DetailHeroBanner from '@/components/ui/DetailHeroBanner';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/shadcn/alert';
 import { Badge } from '@/components/ui/shadcn/badge';
@@ -679,22 +681,40 @@ export default async function ScheduleDetailPage({
     </>
   );
 
-  const settings = capabilities.canManageScheduleSettings ? (
-    <ScheduleEditForm
-      scheduleId={schedule.id}
-      currentName={schedule.name}
-      currentTimeZone={schedule.timeZone}
-      updateSchedule={updateSchedule}
-      canManageSchedules={capabilities.canManageScheduleSettings}
-    />
-  ) : (
-    <Alert>
-      <Info className="h-4 w-4" />
-      <AlertTitle>Schedule settings are read-only</AlertTitle>
-      <AlertDescription>
-        This schedule uses {schedule.timeZone}. Admins and responders can change schedule settings.
-      </AlertDescription>
-    </Alert>
+  const settings = (
+    <div className="space-y-6">
+      {capabilities.canManageScheduleSettings ? (
+        <ScheduleEditForm
+          scheduleId={schedule.id}
+          currentName={schedule.name}
+          currentTimeZone={schedule.timeZone}
+          updateSchedule={updateSchedule}
+          canManageSchedules={capabilities.canManageScheduleSettings}
+        />
+      ) : (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertTitle>Schedule settings are read-only</AlertTitle>
+          <AlertDescription>
+            This schedule uses {schedule.timeZone}. Admins and responders can change schedule settings.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {capabilities.canDeleteSchedule && (
+        <DeleteScheduleCard
+          scheduleId={schedule.id}
+          scheduleName={schedule.name}
+          stats={{
+            layerCount: schedule.layers.length,
+            participantCount: viewModel.participantCount,
+            overrideCount: currentAndFutureOverrides.length + historyCount,
+          }}
+          linkedRules={linkedRules}
+          deleteScheduleAction={deleteSchedule}
+        />
+      )}
+    </div>
   );
 
   return (

--- a/src/app/(app)/schedules/actions.ts
+++ b/src/app/(app)/schedules/actions.ts
@@ -2,7 +2,11 @@
 
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
-import { assertAdminOrResponder, assertCanCreateScheduleOverride } from '@/lib/rbac';
+import {
+  assertAdmin,
+  assertAdminOrResponder,
+  assertCanCreateScheduleOverride,
+} from '@/lib/rbac';
 import { logAudit } from '@/lib/audit';
 import { createInAppNotifications, getScheduleUserIds } from '@/lib/in-app-notifications';
 import { parseDateTimeInTimeZone, isValidTimeZone } from '@/lib/timezone';
@@ -16,8 +20,10 @@ import {
 import {
   addScheduleLayerUser,
   createScheduleOverrideMutation,
+  deleteScheduleMutation,
   moveScheduleLayerUser,
   removeScheduleLayerUser,
+  type ScheduleDependency,
 } from '@/lib/schedules/mutations';
 import { runSerializableTransaction } from '@/lib/db-utils';
 
@@ -845,3 +851,66 @@ export async function deleteOverride(
     return scheduleActionError(error, 'Failed to delete override.');
   }
 }
+
+export type DeleteScheduleResult = {
+  success?: boolean;
+  error?: string;
+  code?: string;
+  action?: string;
+  retryable?: boolean;
+  dependencies?: ScheduleDependency[];
+};
+
+export async function deleteSchedule(scheduleId: string): Promise<DeleteScheduleResult> {
+  let actorId: string;
+  try {
+    actorId = (await assertAdmin()).id;
+  } catch (error) {
+    if (error instanceof AppError) {
+      return {
+        success: false,
+        error: error.userMessage,
+        code: error.code,
+      };
+    }
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unauthorized. Admin access required.',
+      code: 'AUTHORIZATION_DENIED',
+    };
+  }
+
+  try {
+    await deleteScheduleMutation(scheduleId, actorId);
+
+    revalidatePath('/schedules');
+    revalidatePath('/audit');
+
+    return { success: true };
+  } catch (error) {
+    if (error instanceof AppError && error.code === 'SCHEDULE_IN_USE') {
+      return {
+        success: false,
+        error: error.userMessage,
+        code: error.code,
+        action: error.action,
+        dependencies: (error.details?.dependencies as ScheduleDependency[]) || [],
+      };
+    }
+
+    if (error instanceof AppError) {
+      return {
+        success: false,
+        error: error.userMessage,
+        code: error.code,
+        action: error.action,
+      };
+    }
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to delete schedule.',
+    };
+  }
+}
+

--- a/src/components/schedules/DeleteScheduleCard.tsx
+++ b/src/components/schedules/DeleteScheduleCard.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useToast } from '@/hooks/use-product-notification';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
+import { Button } from '@/components/ui/shadcn/button';
+import { Input } from '@/components/ui/shadcn/input';
+import { Badge } from '@/components/ui/shadcn/badge';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/shadcn/alert-dialog';
+import {
+  Trash2,
+  AlertTriangle,
+  Loader2,
+  ShieldAlert,
+  ArrowUpRight,
+  Server,
+  Layers,
+  Users,
+  Clock,
+  Shield,
+} from 'lucide-react';
+import type { LinkedPolicy } from '@/components/schedules/ScheduleLinkedPolicies';
+import type { DeleteScheduleResult } from '@/app/(app)/schedules/actions';
+
+type DeleteScheduleCardProps = {
+  scheduleId: string;
+  scheduleName: string;
+  stats: {
+    layerCount: number;
+    participantCount: number;
+    overrideCount: number;
+  };
+  linkedRules: LinkedPolicy[];
+  deleteScheduleAction: (scheduleId: string) => Promise<DeleteScheduleResult>;
+};
+
+export default function DeleteScheduleCard({
+  scheduleId,
+  scheduleName,
+  stats,
+  linkedRules,
+  deleteScheduleAction,
+}: DeleteScheduleCardProps) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [confirmName, setConfirmName] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // Deduplicate linked policies by ID
+  const uniquePoliciesMap = new Map<string, LinkedPolicy['policy']>();
+  linkedRules.forEach(rule => {
+    if (rule.policy && !uniquePoliciesMap.has(rule.policy.id)) {
+      uniquePoliciesMap.set(rule.policy.id, rule.policy);
+    }
+  });
+  const policies = Array.from(uniquePoliciesMap.values());
+  const hasDependencies = policies.length > 0;
+  const isConfirmed = confirmName.trim() === scheduleName.trim();
+
+  const handleDelete = () => {
+    if (!isConfirmed || isPending) return;
+    setErrorMessage(null);
+
+    startTransition(async () => {
+      try {
+        const res = await deleteScheduleAction(scheduleId);
+        if (!res.success) {
+          const msg = res.error || 'Failed to delete schedule.';
+          setErrorMessage(msg);
+          showToast(msg, 'error');
+        } else {
+          showToast(`Schedule "${scheduleName}" deleted successfully`, 'success');
+          setOpen(false);
+          router.push('/schedules');
+          router.refresh();
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Failed to delete schedule.';
+        setErrorMessage(msg);
+        showToast(msg, 'error');
+      }
+    });
+  };
+
+  return (
+    <Card className="overflow-hidden border-destructive/30 bg-destructive/5 shadow-xs">
+      <CardHeader className="border-b border-destructive/20 bg-destructive/10 px-4 py-3 sm:px-5">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <CardTitle className="text-sm font-semibold text-destructive">Danger Zone</CardTitle>
+          </div>
+          <Badge variant="destructive" size="xs" className="text-[10px] font-semibold">
+            Admin Only
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-4 sm:p-5 space-y-4">
+        {hasDependencies ? (
+          <div className="space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3.5 text-xs text-amber-900 dark:text-amber-200">
+            <div className="flex items-start gap-2.5">
+              <ShieldAlert className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+              <div className="space-y-1">
+                <p className="font-semibold text-sm text-foreground">
+                  Schedule In Use — Deletion Blocked
+                </p>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  This schedule is currently configured as an alert target in{' '}
+                  <strong>
+                    {policies.length} escalation {policies.length === 1 ? 'policy' : 'policies'}
+                  </strong>
+                  . To prevent silent notification failures, you must remove or reassign this schedule
+                  from all escalation steps before deleting it.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2 pt-1 border-t border-amber-500/20">
+              <p className="text-[11px] font-medium text-foreground">
+                Dependent Escalation Policies:
+              </p>
+              <div className="space-y-1.5">
+                {policies.map(policy => (
+                  <div
+                    key={policy.id}
+                    className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border/60 bg-background/80 px-2.5 py-1.5"
+                  >
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <Shield className="h-3.5 w-3.5 shrink-0 text-primary" />
+                      <Link
+                        href={`/policies/${policy.id}`}
+                        className="font-medium text-foreground hover:text-primary transition-colors flex items-center gap-1 truncate text-xs"
+                      >
+                        <span>{policy.name}</span>
+                        <ArrowUpRight className="h-3 w-3 opacity-60" />
+                      </Link>
+                    </div>
+
+                    {policy.services.length > 0 && (
+                      <div className="flex items-center gap-1 flex-wrap">
+                        <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
+                          <Server className="h-3 w-3" />
+                        </span>
+                        {policy.services.map(svc => (
+                          <Link
+                            key={svc.id}
+                            href={`/services/${svc.id}`}
+                            className="rounded border bg-muted/30 px-1.5 py-0.5 text-[10px] font-medium hover:border-primary/40 transition-colors"
+                          >
+                            {svc.name}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="pt-1 flex items-center justify-between">
+              <p className="text-[11px] text-muted-foreground">
+                Remove all references above to enable deletion.
+              </p>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled
+                className="gap-1.5 text-xs font-medium opacity-50 cursor-not-allowed"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete Schedule
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div className="space-y-1.5">
+              <p className="text-xs font-semibold text-foreground">Permanently delete this schedule</p>
+              <p className="text-[11px] text-muted-foreground max-w-lg leading-relaxed">
+                Permanently deletes <strong>{scheduleName}</strong>, including all rotation layers,
+                user assignments, and schedule overrides. This action is irreversible.
+              </p>
+              <div className="flex items-center gap-2 pt-1">
+                <Badge variant="outline" size="xs" className="text-[10px] gap-1">
+                  <Layers className="h-3 w-3 text-muted-foreground" />
+                  {stats.layerCount} {stats.layerCount === 1 ? 'layer' : 'layers'}
+                </Badge>
+                <Badge variant="outline" size="xs" className="text-[10px] gap-1">
+                  <Users className="h-3 w-3 text-muted-foreground" />
+                  {stats.participantCount} {stats.participantCount === 1 ? 'participant' : 'participants'}
+                </Badge>
+                <Badge variant="outline" size="xs" className="text-[10px] gap-1">
+                  <Clock className="h-3 w-3 text-muted-foreground" />
+                  {stats.overrideCount} {stats.overrideCount === 1 ? 'override' : 'overrides'}
+                </Badge>
+              </div>
+            </div>
+
+            <AlertDialog
+              open={open}
+              onOpenChange={isOpen => {
+                setOpen(isOpen);
+                if (!isOpen) {
+                  setConfirmName('');
+                  setErrorMessage(null);
+                }
+              }}
+            >
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="gap-1.5 text-xs font-medium shrink-0"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete Schedule
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent className="text-xs sm:text-sm max-w-md">
+                <AlertDialogHeader>
+                  <AlertDialogTitle className="flex items-center gap-2 text-destructive text-base">
+                    <Trash2 className="h-5 w-5" />
+                    Delete Schedule Permanently
+                  </AlertDialogTitle>
+                  <AlertDialogDescription className="space-y-3 pt-2 text-xs leading-relaxed text-muted-foreground">
+                    <span>
+                      Are you sure you want to delete <strong>{scheduleName}</strong>? This will
+                      permanently remove:
+                    </span>
+                    <ul className="list-disc pl-5 space-y-1 text-foreground font-medium">
+                      <li>
+                        {stats.layerCount} rotation {stats.layerCount === 1 ? 'layer' : 'layers'}
+                      </li>
+                      <li>
+                        {stats.participantCount} responder {stats.participantCount === 1 ? 'assignment' : 'assignments'}
+                      </li>
+                      <li>
+                        {stats.overrideCount} active and historical {stats.overrideCount === 1 ? 'override' : 'overrides'}
+                      </li>
+                    </ul>
+                    <span className="block text-destructive font-medium pt-1">
+                      This action cannot be undone.
+                    </span>
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+
+                <div className="space-y-2 py-2">
+                  <label htmlFor="confirm-schedule-name" className="text-xs text-muted-foreground">
+                    To confirm, please type <strong className="text-foreground">{scheduleName}</strong>:
+                  </label>
+                  <Input
+                    id="confirm-schedule-name"
+                    value={confirmName}
+                    onChange={e => setConfirmName(e.target.value)}
+                    placeholder={scheduleName}
+                    disabled={isPending}
+                    className="text-xs"
+                    autoComplete="off"
+                  />
+                  {errorMessage && (
+                    <p className="text-xs text-destructive font-medium">{errorMessage}</p>
+                  )}
+                </div>
+
+                <AlertDialogFooter className="gap-2 sm:gap-0">
+                  <AlertDialogCancel disabled={isPending} className="text-xs">
+                    Cancel
+                  </AlertDialogCancel>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={handleDelete}
+                    disabled={!isConfirmed || isPending}
+                    className="text-xs gap-1.5 bg-destructive hover:bg-destructive/90"
+                  >
+                    {isPending ? (
+                      <>
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        Deleting...
+                      </>
+                    ) : (
+                      <>
+                        <Trash2 className="h-3.5 w-3.5" />
+                        Permanently Delete
+                      </>
+                    )}
+                  </Button>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/errors/registry.ts
+++ b/src/lib/errors/registry.ts
@@ -367,6 +367,15 @@ export const ERROR_REGISTRY = {
     retryable: false,
     exposure: 'public',
   },
+  SCHEDULE_IN_USE: {
+    status: 409,
+    category: 'conflict',
+    userMessage:
+      'Cannot delete schedule because it is currently in use by one or more escalation policies.',
+    action: 'Remove this schedule from all escalation policy steps before deleting it.',
+    retryable: false,
+    exposure: 'public',
+  },
   STATUS_PAGE_WEBHOOK_NOT_FOUND: {
     status: 404,
     category: 'not_found',

--- a/src/lib/schedules/capabilities.ts
+++ b/src/lib/schedules/capabilities.ts
@@ -6,6 +6,7 @@ export type ScheduleUICapabilities = {
   canManageScheduleSettings: boolean;
   canCreateOverride: boolean;
   canDeleteOverride: boolean;
+  canDeleteSchedule: boolean;
 };
 
 type ScheduleCapabilityContext = {
@@ -33,5 +34,6 @@ export function deriveScheduleUICapabilities({
     canManageScheduleSettings: canManageRotation,
     canCreateOverride: canManageOverrides,
     canDeleteOverride: canManageOverrides,
+    canDeleteSchedule: isAdmin,
   };
 }

--- a/src/lib/schedules/mutations.ts
+++ b/src/lib/schedules/mutations.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { runSerializableTransaction } from '@/lib/db-utils';
 import { AppError } from '@/lib/errors';
+import { logAudit } from '@/lib/audit';
 
 type TransactionClient = Prisma.TransactionClient;
 
@@ -364,4 +365,140 @@ export async function createScheduleOverrideMutation(input: CreateScheduleOverri
     }
     throw error;
   }
+}
+
+export type ScheduleDeletionSnapshot = {
+  id: string;
+  name: string;
+  timeZone: string;
+  layerCount: number;
+  participantCount: number;
+  overrideCount: number;
+  shiftCount: number;
+};
+
+export type ScheduleDependency = {
+  policyId: string;
+  policyName: string;
+  stepOrder: number;
+  services: Array<{ id: string; name: string }>;
+};
+
+export async function deleteScheduleMutation(
+  scheduleId: string,
+  actorId: string
+): Promise<ScheduleDeletionSnapshot> {
+  return runSerializableTransaction(async tx => {
+    const schedule = await tx.onCallSchedule.findUnique({
+      where: { id: scheduleId },
+      select: {
+        id: true,
+        name: true,
+        timeZone: true,
+      },
+    });
+
+    if (!schedule) {
+      throw new AppError({
+        code: 'SCHEDULE_NOT_FOUND',
+        userMessage: 'The requested schedule could not be found.',
+        details: { scheduleId },
+      });
+    }
+
+    const referencingRules = await tx.escalationRule.findMany({
+      where: { targetScheduleId: scheduleId },
+      select: {
+        stepOrder: true,
+        policy: {
+          select: {
+            id: true,
+            name: true,
+            services: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (referencingRules.length > 0) {
+      const dependencies: ScheduleDependency[] = referencingRules.map(rule => ({
+        policyId: rule.policy.id,
+        policyName: rule.policy.name,
+        stepOrder: rule.stepOrder,
+        services: rule.policy.services,
+      }));
+
+      throw new AppError({
+        code: 'SCHEDULE_IN_USE',
+        userMessage: `Cannot delete schedule "${schedule.name}" because it is currently in use by ${dependencies.length} escalation policy step(s).`,
+        action: 'Remove this schedule from all escalation policy steps before deleting it.',
+        details: {
+          scheduleId,
+          dependencies,
+        },
+      });
+    }
+
+    const [layerCount, participantCount, overrideCount, shiftCount] = await Promise.all([
+      tx.onCallLayer.count({ where: { scheduleId } }),
+      tx.onCallLayerUser.count({ where: { layer: { scheduleId } } }),
+      tx.onCallOverride.count({ where: { scheduleId } }),
+      tx.onCallShift.count({ where: { scheduleId } }),
+    ]);
+
+    const snapshot: ScheduleDeletionSnapshot = {
+      id: schedule.id,
+      name: schedule.name,
+      timeZone: schedule.timeZone,
+      layerCount,
+      participantCount,
+      overrideCount,
+      shiftCount,
+    };
+
+    await tx.onCallLayerUser.deleteMany({
+      where: { layer: { scheduleId } },
+    });
+
+    await tx.onCallLayer.deleteMany({
+      where: { scheduleId },
+    });
+
+    await tx.onCallOverride.deleteMany({
+      where: { scheduleId },
+    });
+
+    await tx.onCallShift.deleteMany({
+      where: { scheduleId },
+    });
+
+    await tx.onCallSchedule.delete({
+      where: { id: scheduleId },
+    });
+
+    await logAudit(
+      {
+        action: 'schedule.deleted',
+        entityType: 'SCHEDULE',
+        entityId: scheduleId,
+        actorId,
+        details: {
+          name: snapshot.name,
+          timeZone: snapshot.timeZone,
+          layerCount: snapshot.layerCount,
+          participantCount: snapshot.participantCount,
+          overrideCount: snapshot.overrideCount,
+          shiftCount: snapshot.shiftCount,
+        },
+      },
+      tx
+    );
+
+    return snapshot;
+  });
 }

--- a/tests/actions/schedule-deletion.test.ts
+++ b/tests/actions/schedule-deletion.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '@/lib/errors';
+import { AuthorizationError, CAPABILITIES } from '@/lib/authorization';
+
+const mocks = vi.hoisted(() => ({
+  assertAdmin: vi.fn(),
+  logAudit: vi.fn(),
+  revalidatePath: vi.fn(),
+  tx: {
+    onCallSchedule: {
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+    escalationRule: {
+      findMany: vi.fn(),
+    },
+    onCallLayer: {
+      count: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    onCallLayerUser: {
+      count: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    onCallOverride: {
+      count: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    onCallShift: {
+      count: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  assertAdmin: mocks.assertAdmin,
+  assertAdminOrResponder: vi.fn(),
+  assertCanCreateScheduleOverride: vi.fn(),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  logAudit: mocks.logAudit,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock('@/lib/db-utils', () => ({
+  runSerializableTransaction: vi.fn(async callback => callback(mocks.tx)),
+}));
+
+import { deleteSchedule } from '@/app/(app)/schedules/actions';
+import { deleteScheduleMutation } from '@/lib/schedules/mutations';
+
+describe('Schedule Deletion Lifecycle & RBAC', () => {
+  const scheduleId = 'sched-123';
+  const adminActor = { id: 'admin-1', role: 'ADMIN' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.assertAdmin.mockResolvedValue(adminActor);
+    mocks.tx.onCallSchedule.findUnique.mockResolvedValue({
+      id: scheduleId,
+      name: 'Primary SRE Rotation',
+      timeZone: 'America/New_York',
+    });
+    mocks.tx.escalationRule.findMany.mockResolvedValue([]);
+    mocks.tx.onCallLayer.count.mockResolvedValue(2);
+    mocks.tx.onCallLayerUser.count.mockResolvedValue(4);
+    mocks.tx.onCallOverride.count.mockResolvedValue(3);
+    mocks.tx.onCallShift.count.mockResolvedValue(10);
+    mocks.tx.onCallLayerUser.deleteMany.mockResolvedValue({ count: 4 });
+    mocks.tx.onCallLayer.deleteMany.mockResolvedValue({ count: 2 });
+    mocks.tx.onCallOverride.deleteMany.mockResolvedValue({ count: 3 });
+    mocks.tx.onCallShift.deleteMany.mockResolvedValue({ count: 10 });
+    mocks.tx.onCallSchedule.delete.mockResolvedValue({ id: scheduleId });
+    mocks.logAudit.mockResolvedValue(undefined);
+  });
+
+  describe('Authorization Enforcement (Admin Only)', () => {
+    it('allows an ADMIN user to successfully delete an unreferenced schedule', async () => {
+      const result = await deleteSchedule(scheduleId);
+
+      expect(result).toEqual({ success: true });
+      expect(mocks.assertAdmin).toHaveBeenCalledTimes(1);
+      expect(mocks.revalidatePath).toHaveBeenCalledWith('/schedules');
+      expect(mocks.revalidatePath).toHaveBeenCalledWith('/audit');
+    });
+
+    it('rejects RESPONDER access with AUTHORIZATION_DENIED', async () => {
+      mocks.assertAdmin.mockRejectedValue(
+        new AuthorizationError(
+          'Unauthorized. Admin access required.',
+          CAPABILITIES.ADMIN_MANAGE
+        )
+      );
+
+      const result = await deleteSchedule(scheduleId);
+
+      expect(result).toMatchObject({
+        success: false,
+        code: 'AUTHORIZATION_DENIED',
+        error: expect.stringContaining('Unauthorized. Admin access required.'),
+      });
+      expect(mocks.tx.onCallSchedule.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects standard USER access with AUTHORIZATION_DENIED', async () => {
+      mocks.assertAdmin.mockRejectedValue(
+        new AuthorizationError(
+          'Unauthorized. Admin access required.',
+          CAPABILITIES.ADMIN_MANAGE
+        )
+      );
+
+      const result = await deleteSchedule(scheduleId);
+
+      expect(result).toMatchObject({
+        success: false,
+        code: 'AUTHORIZATION_DENIED',
+      });
+      expect(mocks.tx.onCallSchedule.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Dependency Safety (P0: SCHEDULE_IN_USE 409 Conflict)', () => {
+    it('blocks deletion with SCHEDULE_IN_USE when linked to escalation policy steps', async () => {
+      mocks.tx.escalationRule.findMany.mockResolvedValue([
+        {
+          stepOrder: 0,
+          policy: {
+            id: 'policy-prod-core',
+            name: 'Production Core Policy',
+            services: [
+              { id: 'svc-auth', name: 'Auth Service' },
+              { id: 'svc-billing', name: 'Billing Service' },
+            ],
+          },
+        },
+        {
+          stepOrder: 1,
+          policy: {
+            id: 'policy-infra',
+            name: 'Infra Escalation',
+            services: [{ id: 'svc-db', name: 'Database Cluster' }],
+          },
+        },
+      ]);
+
+      const result = await deleteSchedule(scheduleId);
+
+      expect(result).toMatchObject({
+        success: false,
+        code: 'SCHEDULE_IN_USE',
+        error: expect.stringContaining('currently in use by 2 escalation policy step(s)'),
+        dependencies: [
+          {
+            policyId: 'policy-prod-core',
+            policyName: 'Production Core Policy',
+            stepOrder: 0,
+            services: [
+              { id: 'svc-auth', name: 'Auth Service' },
+              { id: 'svc-billing', name: 'Billing Service' },
+            ],
+          },
+          {
+            policyId: 'policy-infra',
+            policyName: 'Infra Escalation',
+            stepOrder: 1,
+            services: [{ id: 'svc-db', name: 'Database Cluster' }],
+          },
+        ],
+      });
+
+      // Assert that NO deletions occurred
+      expect(mocks.tx.onCallLayerUser.deleteMany).not.toHaveBeenCalled();
+      expect(mocks.tx.onCallLayer.deleteMany).not.toHaveBeenCalled();
+      expect(mocks.tx.onCallOverride.deleteMany).not.toHaveBeenCalled();
+      expect(mocks.tx.onCallShift.deleteMany).not.toHaveBeenCalled();
+      expect(mocks.tx.onCallSchedule.delete).not.toHaveBeenCalled();
+      expect(mocks.logAudit).not.toHaveBeenCalled();
+    });
+
+    it('returns SCHEDULE_NOT_FOUND when schedule does not exist', async () => {
+      mocks.tx.onCallSchedule.findUnique.mockResolvedValue(null);
+
+      const result = await deleteSchedule(scheduleId);
+
+      expect(result).toMatchObject({
+        success: false,
+        code: 'SCHEDULE_NOT_FOUND',
+      });
+      expect(mocks.tx.onCallSchedule.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Transactional Cleanup & Audit Atomicity (P0)', () => {
+    it('deletes child resources in correct foreign key order', async () => {
+      const deletionOrder: string[] = [];
+
+      mocks.tx.onCallLayerUser.deleteMany.mockImplementation(async () => {
+        deletionOrder.push('layerUsers');
+        return { count: 4 };
+      });
+      mocks.tx.onCallLayer.deleteMany.mockImplementation(async () => {
+        deletionOrder.push('layers');
+        return { count: 2 };
+      });
+      mocks.tx.onCallOverride.deleteMany.mockImplementation(async () => {
+        deletionOrder.push('overrides');
+        return { count: 3 };
+      });
+      mocks.tx.onCallShift.deleteMany.mockImplementation(async () => {
+        deletionOrder.push('shifts');
+        return { count: 10 };
+      });
+      mocks.tx.onCallSchedule.delete.mockImplementation(async () => {
+        deletionOrder.push('schedule');
+        return { id: scheduleId };
+      });
+
+      await deleteScheduleMutation(scheduleId, adminActor.id);
+
+      // Verify layer users deleted before layers, and all children before parent schedule
+      expect(deletionOrder.indexOf('layerUsers')).toBeLessThan(deletionOrder.indexOf('layers'));
+      expect(deletionOrder.indexOf('layers')).toBeLessThan(deletionOrder.indexOf('schedule'));
+      expect(deletionOrder.indexOf('overrides')).toBeLessThan(deletionOrder.indexOf('schedule'));
+      expect(deletionOrder.indexOf('shifts')).toBeLessThan(deletionOrder.indexOf('schedule'));
+    });
+
+    it('emits schedule.deleted audit event inside transaction with safe snapshot metadata', async () => {
+      await deleteScheduleMutation(scheduleId, adminActor.id);
+
+      expect(mocks.logAudit).toHaveBeenCalledTimes(1);
+      expect(mocks.logAudit).toHaveBeenCalledWith(
+        {
+          action: 'schedule.deleted',
+          entityType: 'SCHEDULE',
+          entityId: scheduleId,
+          actorId: adminActor.id,
+          details: {
+            name: 'Primary SRE Rotation',
+            timeZone: 'America/New_York',
+            layerCount: 2,
+            participantCount: 4,
+            overrideCount: 3,
+            shiftCount: 10,
+          },
+        },
+        mocks.tx
+      );
+    });
+
+    it('propagates error and aborts transaction if audit write fails', async () => {
+      mocks.logAudit.mockRejectedValue(new Error('Audit service unavailable'));
+
+      await expect(deleteScheduleMutation(scheduleId, adminActor.id)).rejects.toThrow(
+        'Audit service unavailable'
+      );
+    });
+  });
+});

--- a/tests/architecture/oidc-enterprise-documentation-contract.test.ts
+++ b/tests/architecture/oidc-enterprise-documentation-contract.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
 
 describe('enterprise identity documentation', () => {
   it('keeps the v1.5 OIDC and SCIM guides versioned with the implementation', () => {

--- a/tests/lib/schedule-action-errors.test.ts
+++ b/tests/lib/schedule-action-errors.test.ts
@@ -57,5 +57,11 @@ describe('schedule action error adapter', () => {
       code: 'SCHEDULE_OVERRIDE_CONFLICT',
       retryable: false,
     });
+    expect(
+      scheduleActionError(new AppError({ code: 'SCHEDULE_IN_USE' }), 'fallback')
+    ).toMatchObject({
+      code: 'SCHEDULE_IN_USE',
+      retryable: false,
+    });
   });
 });

--- a/tests/lib/schedules/capabilities.test.ts
+++ b/tests/lib/schedules/capabilities.test.ts
@@ -18,6 +18,7 @@ describe('schedule UI capability contract', () => {
       canManageScheduleSettings: true,
       canCreateOverride: true,
       canDeleteOverride: true,
+      canDeleteSchedule: true,
     });
   });
 
@@ -67,6 +68,7 @@ describe('schedule UI capability contract', () => {
       canManageScheduleSettings: false,
       canCreateOverride: false,
       canDeleteOverride: false,
+      canDeleteSchedule: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR closes the lifecycle gap in OpsKnight schedules by introducing an Admin-only, dependency-safe schedule deletion workflow.

### Key Architectural Enhancements
1. **Admin-Only RBAC**:
   - Deletion is guarded by `assertAdmin()` and exposed via `capabilities.canDeleteSchedule: isAdmin`. Responders and standard users are blocked (`AUTHORIZATION_DENIED` / 403).
2. **Strict Dependency Safety (P0)**:
   - When any escalation policy step references the schedule (`targetScheduleId`), deletion is **strictly rejected** with HTTP 409 (`SCHEDULE_IN_USE`) returning structured dependency details (policy ID, policy name, step order, and attached services).
   - No cascading or silent nullification of escalation steps occurs, preventing alert black holes.
3. **Transactional Cleanup (P0)**:
   - Schedule-owned child records (`OnCallLayerUser`, `OnCallLayer`, `OnCallOverride`, `OnCallShift`) are deleted transactionally alongside the parent `OnCallSchedule` in proper foreign key order.
4. **Atomic Audit Logging (P0)**:
   - Emits `schedule.deleted` audit event with a sanitized metadata snapshot (`name`, `timeZone`, `layerCount`, `participantCount`, `overrideCount`, `shiftCount`) directly within the database transaction. If audit logging fails, the deletion rolls back completely.
5. **UI Danger Zone & Confirmation**:
   - Added Danger Zone card in the Schedule Settings tab.
   - If active dependencies exist, a warning banner blocks deletion and displays links to dependent escalation policies.
   - If unreferenced, deletion requires typing the exact schedule name to confirm before triggering.
6. **Documentation & Tests**:
   - Updated `docs/v1.4/core-concepts/schedules.md` and `docs/v1.5/core-concepts/schedules.md`.
   - Added comprehensive integration/unit tests in `tests/actions/schedule-deletion.test.ts` and updated `tests/lib/schedule-action-errors.test.ts`.

### Test Coverage
- `tests/actions/schedule-deletion.test.ts` (8 tests passing)
- `tests/lib/schedule-action-errors.test.ts` (4 tests passing)
- `tests/architecture/audit-contract.test.ts` (1 test passing)
- TypeScript compiler verification (`tsc --noEmit`) passes cleanly with 0 errors.