### PR TITLE
fix(oidc): use canonical metadata issuer for provider configuration

### DIFF
--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -31,11 +31,13 @@ export default function OIDCProvider(config: OIDCConfig): OAuthConfig<OIDCProfil
     hasCustomScopes: !!config.customScopes,
   });
 
+  const canonicalIssuer = config.metadata.issuer || issuer;
+
   return {
     id: 'oidc',
     name: 'SSO',
     type: 'oauth',
-    issuer,
+    issuer: canonicalIssuer,
     clientId: config.clientId,
     clientSecret: config.clientSecret,
     authorization: {

--- a/tests/lib/oidc-runtime-provider.test.ts
+++ b/tests/lib/oidc-runtime-provider.test.ts
@@ -29,4 +29,22 @@ describe('OIDC runtime provider networking', () => {
     );
     expect(provider.client?.id_token_signed_response_alg).toBe('RS256');
   });
+
+  it('uses canonical metadata issuer to match IdP ID token iss claim', () => {
+    const provider = OIDCProvider({
+      issuer: 'https://dev-example.us.auth0.com',
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      metadata: {
+        issuer: 'https://dev-example.us.auth0.com/',
+        authorizationEndpoint: 'https://dev-example.us.auth0.com/authorize',
+        tokenEndpoint: 'https://dev-example.us.auth0.com/oauth/token',
+        jwksUri: 'https://dev-example.us.auth0.com/.well-known/jwks.json',
+      },
+    });
+
+    // openid-client validateJWT matches payload.iss strictly against this.issuer.issuer.
+    // Auth0 (and other providers) advertise and sign with trailing slash in iss.
+    expect(provider.issuer).toBe('https://dev-example.us.auth0.com/');
+  });
 });


### PR DESCRIPTION
## Problem
When logging in via OIDC (e.g. Auth0), NextAuth/openid-client threw an `OAuthCallbackError`:
```
unexpected iss value, expected https://dev-o3jcz8s3tyji1ysl.us.auth0.com, got: https://dev-o3jcz8s3tyji1ysl.us.auth0.com/
```

## Cause
In `src/lib/oidc.ts`, the issuer passed to NextAuth/openid-client was unconditionally stripped of any trailing slash (`config.issuer.replace(/\/$/, '')`). However, openid-client's `validateJWT` checks the ID token's `iss` claim against `this.issuer.issuer` with strict string equality:
```js
if (payload.iss !== expectedIss) {
  throw new RPError({ printf: ['unexpected iss value, expected %s, got: %s', expectedIss, payload.iss] });
}
```
Providers like Auth0 advertise and issue tokens with the trailing slash in `.well-known/openid-configuration` (`iss: "https://...auth0.com/"`).

## Solution
Use the validated `config.metadata.issuer` as the provider's `issuer`, falling back to the stripped issuer if not present. This preserves the canonical issuer as signed by the identity provider and passes token validation.

Added regression test in `tests/lib/oidc-runtime-provider.test.ts`.