### PR TITLE
fix(oidc): resolve provider interop for token auth, auth0 orgs, and entra domains

### DIFF
--- a/docs/v1.5/administration/authentication.md
+++ b/docs/v1.5/administration/authentication.md
@@ -214,7 +214,8 @@ See [SCIM Provisioning](../security/scim-provisioning.md).
 
 - Use a tenant-specific issuer.
 - Broad `common`, `organizations`, and `consumers` authorities are rejected.
-- Supported sovereign-cloud authorities are recognized.
+- Built-in Entra policy targets workforce tenants in commercial and sovereign clouds (External ID / CIAM is handled under generic OIDC).
+- Tenant boundaries are verified via the tenant-specific issuer; Allowed Domains acts as an additional email domain filter.
 - Missing standard `email_verified` is handled under the validated Entra policy; explicit false is rejected.
 - Prefer Entra App Roles for authoritative role mapping when possible.
 
@@ -226,11 +227,13 @@ See [SCIM Provisioning](../security/scim-provisioning.md).
 
 - Organization and custom authorization-server issuers are supported.
 - Custom domains retain Okta provider policy.
+- Supports both `client_secret_basic` and `client_secret_post` token endpoint authentication.
 
 ### Auth0
 
 - Tenant and custom-domain issuers are supported.
-- Optional Auth0 Organization enforcement uses signed `org_id`.
+- Supports both `client_secret_basic` and `client_secret_post` token endpoint authentication.
+- Configured Auth0 Organizations pass `organization` during authorization and enforce signed `org_id` on every login.
 
 ## Unsupported authentication methods
 

--- a/docs/v1.5/administration/authentication.md
+++ b/docs/v1.5/administration/authentication.md
@@ -215,7 +215,7 @@ See [SCIM Provisioning](../security/scim-provisioning.md).
 - Use a tenant-specific issuer.
 - Broad `common`, `organizations`, and `consumers` authorities are rejected.
 - Built-in Entra policy targets workforce tenants in commercial and sovereign clouds (External ID / CIAM is handled under generic OIDC).
-- Tenant boundaries are verified via the tenant-specific issuer; Allowed Domains acts as an additional email domain filter.
+- Tenant boundaries are cryptographically verified via the tenant-specific issuer; Allowed Domains is informational for Entra workforce tenants.
 - Missing standard `email_verified` is handled under the validated Entra policy; explicit false is rejected.
 - Prefer Entra App Roles for authoritative role mapping when possible.
 

--- a/docs/v1.5/security/oidc-setup.md
+++ b/docs/v1.5/security/oidc-setup.md
@@ -60,13 +60,13 @@ OpsKnight applies the following rules regardless of provider:
 
 ### Microsoft Entra ID
 
-Use a tenant-specific workforce issuer:
+OpsKnight's built-in Microsoft Entra ID integration targets workforce tenants across Microsoft commercial and sovereign clouds. Use a tenant-specific workforce issuer:
 
 ```text
 https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0
 ```
 
-OpsKnight rejects broad authorities such as:
+OpsKnight rejects broad, non-tenant-specific authorities:
 
 ```text
 /common/v2.0
@@ -74,7 +74,9 @@ OpsKnight rejects broad authorities such as:
 /consumers/v2.0
 ```
 
-Supported Entra authority hosts include the Microsoft public cloud and supported sovereign-cloud endpoints.
+Supported workforce authority hosts include the Microsoft public cloud (`login.microsoftonline.com`, `sts.windows.net`) and sovereign clouds (`login.microsoftonline.us`, `login.partner.microsoftonline.cn`). Microsoft External ID / CIAM authorities (`*.ciamlogin.com`) and Azure AD B2C are not workforce authorities and are treated under generic OIDC policy.
+
+Tenant membership is enforced by the tenant-specific authority in the issuer URL. If **Allowed Domains** are configured, OpsKnight applies them as an additional email domain filter for the tenant's authenticated users.
 
 Microsoft Entra workforce tokens commonly do not include the standard OIDC `email_verified` claim. For a validated Entra issuer, a missing claim is accepted according to the Entra provider policy, while an explicit `email_verified: false` is still rejected.
 
@@ -108,6 +110,8 @@ https://example.okta.com/oauth2/YOUR_SERVER_ID
 
 Okta custom domains can also be used. Saving an Okta custom-domain issuer preserves the Okta provider policy rather than degrading it to generic OIDC behavior.
 
+Okta supports both `client_secret_basic` (default) and `client_secret_post` token authentication. Ensure the selected **Token Endpoint Authentication** method in OpsKnight matches the client authentication configured in your Okta application.
+
 If roles are mapped from an Okta `groups` claim, configure the claim in Okta so it is actually included in the ID token used by OpsKnight.
 
 ### Auth0
@@ -119,7 +123,11 @@ https://tenant.eu.auth0.com
 https://login.example.com
 ```
 
-When an Auth0 Organization is configured, OpsKnight validates the signed `org_id` claim on every login, including logins from identities that were linked previously.
+Auth0 applications support both **Client Secret Basic** (HTTP Basic header) and **Client Secret Post** (body parameters). If your Auth0 application is set to POST, set **Token Endpoint Authentication** to `Client Secret Post` in OpsKnight.
+
+When an Auth0 Organization ID (`org_...`) is configured:
+1. OpsKnight passes `organization: <organizationId>` on the `/authorize` request so the user authenticates in the designated organization context.
+2. OpsKnight validates the signed `org_id` claim in the received token on every login, failing closed if the claim is missing or does not match.
 
 For custom role/profile claims, use namespaced Auth0 claims where appropriate.
 

--- a/docs/v1.5/security/oidc-setup.md
+++ b/docs/v1.5/security/oidc-setup.md
@@ -76,7 +76,7 @@ OpsKnight rejects broad, non-tenant-specific authorities:
 
 Supported workforce authority hosts include the Microsoft public cloud (`login.microsoftonline.com`, `sts.windows.net`) and sovereign clouds (`login.microsoftonline.us`, `login.partner.microsoftonline.cn`). Microsoft External ID / CIAM authorities (`*.ciamlogin.com`) and Azure AD B2C are not workforce authorities and are treated under generic OIDC policy.
 
-Tenant membership is enforced by the tenant-specific authority in the issuer URL. If **Allowed Domains** are configured, OpsKnight applies them as an additional email domain filter for the tenant's authenticated users.
+Tenant membership is enforced by the tenant-specific authority in the issuer URL. Because Microsoft Entra email and preferred_username claims are mutable and not guaranteed to be present on all identities, Entra access is scoped directly to the configured tenant authority rather than relying on email domain filtering for authorization.
 
 Microsoft Entra workforce tokens commonly do not include the standard OIDC `email_verified` claim. For a validated Entra issuer, a missing claim is accepted according to the Entra provider policy, while an explicit `email_verified: false` is still rejected.
 

--- a/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
+++ b/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "OidcConfig" ADD COLUMN "tokenEndpointAuthMethod" TEXT DEFAULT 'client_secret_basic';

--- a/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
+++ b/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
@@ -1,1 +1,10 @@
 ALTER TABLE "OidcConfig" ADD COLUMN "tokenEndpointAuthMethod" TEXT DEFAULT 'client_secret_basic';
+
+-- Canonicalize legacy issuer strings with trailing slashes
+UPDATE "OidcConfig"
+SET "issuer" = rtrim("issuer", '/')
+WHERE "issuer" LIKE '%/';
+
+UPDATE "OidcIdentity"
+SET "issuer" = rtrim("issuer", '/')
+WHERE "issuer" LIKE '%/';

--- a/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
+++ b/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
@@ -5,15 +5,37 @@ UPDATE "OidcConfig"
 SET "issuer" = rtrim("issuer", '/')
 WHERE "issuer" LIKE '%/';
 
--- Deduplicate any legacy trailing-slash OidcIdentity rows that would collide with canonical rows
-DELETE FROM "OidcIdentity" o1
-WHERE o1."issuer" LIKE '%/'
-  AND EXISTS (
-    SELECT 1 FROM "OidcIdentity" o2
-    WHERE o2."issuer" = rtrim(o1."issuer", '/')
-      AND o2."subject" = o1."subject"
-  );
+-- Reconcile legacy trailing-slash OidcIdentity records safely:
+-- 1. If two rows exist with the same canonical issuer and subject but DIFFERENT userId,
+--    abort the migration with an exception to prevent silent account hijacking or data loss.
+-- 2. Only deduplicate identical mappings belonging to the SAME user.
+-- 3. Canonicalize all remaining legacy trailing-slash issuer records.
+DO $$
+DECLARE
+  conflict_count INT;
+BEGIN
+  SELECT COUNT(*) INTO conflict_count
+  FROM "OidcIdentity" o1
+  JOIN "OidcIdentity" o2
+    ON rtrim(o1."issuer", '/') = rtrim(o2."issuer", '/')
+   AND o1."subject" = o2."subject"
+   AND o1."userId" <> o2."userId"
+   AND o1."id" < o2."id";
 
-UPDATE "OidcIdentity"
-SET "issuer" = rtrim("issuer", '/')
-WHERE "issuer" LIKE '%/';
+  IF conflict_count > 0 THEN
+    RAISE EXCEPTION 'Cannot apply migration: found % conflicting OidcIdentity records with the same canonical issuer and subject but different userId values. Resolve identity ownership manually before migrating.', conflict_count;
+  END IF;
+
+  DELETE FROM "OidcIdentity" o1
+  WHERE o1."issuer" LIKE '%/'
+    AND EXISTS (
+      SELECT 1 FROM "OidcIdentity" o2
+      WHERE o2."issuer" = rtrim(o1."issuer", '/')
+        AND o2."subject" = o1."subject"
+        AND o2."userId" = o1."userId"
+    );
+
+  UPDATE "OidcIdentity"
+  SET "issuer" = rtrim("issuer", '/')
+  WHERE "issuer" LIKE '%/';
+END $$;

--- a/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
+++ b/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
@@ -26,14 +26,25 @@ BEGIN
     RAISE EXCEPTION 'Cannot apply migration: found % conflicting OidcIdentity records with the same canonical issuer and subject but different userId values. Resolve identity ownership manually before migrating.', conflict_count;
   END IF;
 
-  DELETE FROM "OidcIdentity" o1
-  WHERE o1."issuer" LIKE '%/'
-    AND EXISTS (
-      SELECT 1 FROM "OidcIdentity" o2
-      WHERE o2."issuer" = rtrim(o1."issuer", '/')
-        AND o2."subject" = o1."subject"
-        AND o2."userId" = o1."userId"
-    );
+  -- Deduplicate same-user legacy records across all equivalent issuer variants
+  -- (e.g. https://idp.example.com, https://idp.example.com/, https://idp.example.com//)
+  DELETE FROM "OidcIdentity"
+  WHERE "id" IN (
+    SELECT "id"
+    FROM (
+      SELECT "id",
+             ROW_NUMBER() OVER (
+               PARTITION BY rtrim("issuer", '/'), "subject", "userId"
+               ORDER BY
+                 -- Keep exact canonical form if present, else oldest record
+                 CASE WHEN "issuer" NOT LIKE '%/' THEN 0 ELSE 1 END ASC,
+                 "createdAt" ASC,
+                 "id" ASC
+             ) AS rn
+      FROM "OidcIdentity"
+    ) ranked
+    WHERE ranked.rn > 1
+  );
 
   UPDATE "OidcIdentity"
   SET "issuer" = rtrim("issuer", '/')

--- a/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
+++ b/prisma/migrations/20260913120000_add_oidc_token_endpoint_auth_method/migration.sql
@@ -5,6 +5,15 @@ UPDATE "OidcConfig"
 SET "issuer" = rtrim("issuer", '/')
 WHERE "issuer" LIKE '%/';
 
+-- Deduplicate any legacy trailing-slash OidcIdentity rows that would collide with canonical rows
+DELETE FROM "OidcIdentity" o1
+WHERE o1."issuer" LIKE '%/'
+  AND EXISTS (
+    SELECT 1 FROM "OidcIdentity" o2
+    WHERE o2."issuer" = rtrim(o1."issuer", '/')
+      AND o2."subject" = o1."subject"
+  );
+
 UPDATE "OidcIdentity"
 SET "issuer" = rtrim("issuer", '/')
 WHERE "issuer" LIKE '%/';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -619,8 +619,9 @@ model OidcConfig {
   customScopes   String? // e.g. "groups profile email"
   providerType   String? // e.g. 'google', 'okta', 'azure', 'auth0', 'custom'
   providerLabel  String? // Custom display name, e.g. "Acme Corp SSO"
-  organizationId String? // Auth0 org_id or equivalent signed organization boundary
-  profileMapping Json?    @default("{}") // { department: "dept", jobTitle: "title", avatarUrl: "picture" }
+  organizationId          String?  // Auth0 org_id or equivalent signed organization boundary
+  tokenEndpointAuthMethod String?  @default("client_secret_basic") // 'client_secret_basic' | 'client_secret_post'
+  profileMapping          Json?    @default("{}") // { department: "dept", jobTitle: "title", avatarUrl: "picture" }
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
   updatedBy      String?

--- a/src/app/(app)/services/[id]/page.tsx
+++ b/src/app/(app)/services/[id]/page.tsx
@@ -683,11 +683,6 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
   // --- TAB 4: SETTINGS & CHATOPS CONTENT ---
   const settingsContent = (
     <div className="space-y-6">
-      {isSaved && (
-        <InlineNotice tone="success" title="Service settings saved">
-          Service configuration updated successfully.
-        </InlineNotice>
-      )}
       {(isSaved || errorCode === 'duplicate-service') && (
         <ServiceSettingsFlashToast serviceId={id} />
       )}

--- a/src/app/(app)/services/[id]/page.tsx
+++ b/src/app/(app)/services/[id]/page.tsx
@@ -683,6 +683,11 @@ export default async function ServiceDetailPage({ params, searchParams }: Servic
   // --- TAB 4: SETTINGS & CHATOPS CONTENT ---
   const settingsContent = (
     <div className="space-y-6">
+      {isSaved && (
+        <InlineNotice tone="success" title="Service settings saved">
+          Service configuration updated successfully.
+        </InlineNotice>
+      )}
       {(isSaved || errorCode === 'duplicate-service') && (
         <ServiceSettingsFlashToast serviceId={id} />
       )}

--- a/src/app/(app)/settings/security/actions.ts
+++ b/src/app/(app)/settings/security/actions.ts
@@ -86,8 +86,8 @@ export async function saveOidcConfig(
   }
 
   try {
-    const issuer = (formData.get('issuer') as string | null)?.trim() ?? '';
-    const clientId = (formData.get('clientId') as string | null)?.trim() ?? '';
+    const rawIssuer = (formData.get('issuer') as string | null)?.trim() ?? '';
+    const rawClientId = (formData.get('clientId') as string | null)?.trim() ?? '';
     const clientSecret = (formData.get('clientSecret') as string | null)?.trim() ?? '';
     const enabledValue = formData.get('enabled');
     const autoProvisionValue = formData.get('autoProvision');
@@ -131,32 +131,36 @@ export async function saveOidcConfig(
     if (pmJobTitle) profileMapping.jobTitle = pmJobTitle;
     if (pmAvatarUrl) profileMapping.avatarUrl = pmAvatarUrl;
 
-    if (!issuer || !isValidIssuer(issuer)) {
-      return {
-        success: false,
-        code: 'VALIDATION_ERROR',
-        error: 'Issuer URL must be a valid HTTPS URL.',
-        updatedAt: expectedUpdatedAt,
-      };
-    }
-    if (!clientId) {
-      return {
-        success: false,
-        code: 'VALIDATION_ERROR',
-        error: 'Client ID is required.',
-        updatedAt: expectedUpdatedAt,
-      };
-    }
-    if (allowedDomains.length > 0 && allowedDomains.some(domain => !isValidDomain(domain))) {
-      return {
-        success: false,
-        code: 'VALIDATION_ERROR',
-        error: 'Allowed domains must be valid domain names.',
-        updatedAt: expectedUpdatedAt,
-      };
-    }
+    const existing = await prisma.oidcConfig.findFirst({ orderBy: { updatedAt: 'desc' } });
+    const issuer = (rawIssuer || existing?.issuer || '').trim();
+    const clientId = (rawClientId || existing?.clientId || '').trim();
 
     if (enabled) {
+      if (!issuer || !isValidIssuer(issuer)) {
+        return {
+          success: false,
+          code: 'VALIDATION_ERROR',
+          error: 'Issuer URL must be a valid HTTPS URL.',
+          updatedAt: expectedUpdatedAt,
+        };
+      }
+      if (!clientId) {
+        return {
+          success: false,
+          code: 'VALIDATION_ERROR',
+          error: 'Client ID is required.',
+          updatedAt: expectedUpdatedAt,
+        };
+      }
+      if (allowedDomains.length > 0 && allowedDomains.some(domain => !isValidDomain(domain))) {
+        return {
+          success: false,
+          code: 'VALIDATION_ERROR',
+          error: 'Allowed domains must be valid domain names.',
+          updatedAt: expectedUpdatedAt,
+        };
+      }
+
       const { validateOidcConnection } = await import('@/lib/oidc-validation');
       const validation = await validateOidcConnection(issuer, { tokenEndpointAuthMethod });
       if (!validation.isValid) {
@@ -167,9 +171,25 @@ export async function saveOidcConfig(
           updatedAt: expectedUpdatedAt,
         };
       }
+    } else if (!existing) {
+      if (!issuer || !isValidIssuer(issuer)) {
+        return {
+          success: false,
+          code: 'VALIDATION_ERROR',
+          error: 'Issuer URL must be a valid HTTPS URL.',
+          updatedAt: expectedUpdatedAt,
+        };
+      }
+      if (!clientId) {
+        return {
+          success: false,
+          code: 'VALIDATION_ERROR',
+          error: 'Client ID is required.',
+          updatedAt: expectedUpdatedAt,
+        };
+      }
     }
 
-    const existing = await prisma.oidcConfig.findFirst({ orderBy: { updatedAt: 'desc' } });
     const issuerMigration = existing ? isOidcIssuerMigration(existing.issuer, issuer) : false;
     if (issuerMigration && !hasIssuerMigrationConfirmation(formData)) {
       return {
@@ -184,7 +204,7 @@ export async function saveOidcConfig(
     if (existing && !expectedRevision) return settingsChangedState(expectedUpdatedAt);
     if (!existing && expectedRevision) return settingsChangedState(expectedUpdatedAt);
 
-    if (!existing && !clientSecret) {
+    if (!existing && !clientSecret && enabled) {
       return {
         success: false,
         code: 'VALIDATION_ERROR',
@@ -193,8 +213,9 @@ export async function saveOidcConfig(
       };
     }
 
+    const clientSecretChanged = Boolean(clientSecret) && clientSecret !== '********';
     let encryptedSecret = existing?.clientSecret ?? null;
-    if (clientSecret && clientSecret !== '********') {
+    if (clientSecretChanged) {
       encryptedSecret = await encrypt(clientSecret);
     } else if (enabled && !encryptedSecret) {
       return {
@@ -212,7 +233,7 @@ export async function saveOidcConfig(
         const securityConfigChanged =
           normalizeOidcIssuer(existing.issuer) !== normalizeOidcIssuer(issuer) ||
           existing.clientId !== clientId ||
-          Boolean(encryptedSecret) ||
+          clientSecretChanged ||
           existing.enabled !== enabled ||
           existing.providerType !== providerType ||
           existing.organizationId !== organizationId ||
@@ -224,7 +245,7 @@ export async function saveOidcConfig(
           data: {
             issuer,
             clientId,
-            ...(encryptedSecret ? { clientSecret: encryptedSecret } : {}),
+            ...(clientSecretChanged && encryptedSecret ? { clientSecret: encryptedSecret } : {}),
             enabled,
             autoProvision,
             allowedDomains,

--- a/src/app/(app)/settings/security/actions.ts
+++ b/src/app/(app)/settings/security/actions.ts
@@ -68,6 +68,26 @@ function parseRoleMapping(input: string): RoleMappingRule[] {
   });
 }
 
+function stableSerializeRoleMapping(mapping: unknown): string {
+  if (!Array.isArray(mapping)) return '[]';
+  const sorted = [...mapping]
+    .map(entry => {
+      if (!entry || typeof entry !== 'object') return entry;
+      const candidate = entry as Record<string, unknown>;
+      return {
+        claim: String(candidate.claim ?? '').trim(),
+        value: String(candidate.value ?? '').trim(),
+        role: String(candidate.role ?? '').trim(),
+      };
+    })
+    .sort((a, b) => {
+      const keyA = `${a.claim}:::${a.value}:::${a.role}`;
+      const keyB = `${b.claim}:::${b.value}:::${b.role}`;
+      return keyA.localeCompare(keyB);
+    });
+  return JSON.stringify(sorted);
+}
+
 export async function saveOidcConfig(
   prevState: SettingsActionState | undefined,
   formData: FormData
@@ -230,6 +250,11 @@ export async function saveOidcConfig(
     const updatedAt = await prisma.$transaction(async tx => {
       const id = existing?.id ?? 'default';
       if (existing) {
+        const roleMappingChanged =
+          stableSerializeRoleMapping(existing.roleMapping) !==
+          stableSerializeRoleMapping(roleMapping);
+        const customScopesChanged = (existing.customScopes ?? null) !== (customScopes ?? null);
+
         const securityConfigChanged =
           normalizeOidcIssuer(existing.issuer) !== normalizeOidcIssuer(issuer) ||
           existing.clientId !== clientId ||
@@ -238,6 +263,8 @@ export async function saveOidcConfig(
           existing.providerType !== providerType ||
           existing.organizationId !== organizationId ||
           existing.tokenEndpointAuthMethod !== tokenEndpointAuthMethod ||
+          roleMappingChanged ||
+          customScopesChanged ||
           JSON.stringify(existing.allowedDomains ?? []) !== JSON.stringify(allowedDomains ?? []);
 
         const updated = await tx.oidcConfig.updateMany({

--- a/src/app/(app)/settings/security/actions.ts
+++ b/src/app/(app)/settings/security/actions.ts
@@ -209,6 +209,16 @@ export async function saveOidcConfig(
     const updatedAt = await prisma.$transaction(async tx => {
       const id = existing?.id ?? 'default';
       if (existing) {
+        const securityConfigChanged =
+          normalizeOidcIssuer(existing.issuer) !== normalizeOidcIssuer(issuer) ||
+          existing.clientId !== clientId ||
+          Boolean(encryptedSecret) ||
+          existing.enabled !== enabled ||
+          existing.providerType !== providerType ||
+          existing.organizationId !== organizationId ||
+          existing.tokenEndpointAuthMethod !== tokenEndpointAuthMethod ||
+          JSON.stringify(existing.allowedDomains ?? []) !== JSON.stringify(allowedDomains ?? []);
+
         const updated = await tx.oidcConfig.updateMany({
           where: { id: existing.id, updatedAt: expectedRevision! },
           data: {
@@ -229,7 +239,7 @@ export async function saveOidcConfig(
                 ? (profileMapping as Prisma.InputJsonObject)
                 : Prisma.JsonNull,
             updatedBy: actor.id,
-            configVersion: { increment: 1 },
+            ...(securityConfigChanged ? { configVersion: { increment: 1 } } : {}),
           },
         });
         if (updated.count !== 1) throw new SettingsChangedMutationError();

--- a/src/app/(app)/settings/security/actions.ts
+++ b/src/app/(app)/settings/security/actions.ts
@@ -102,6 +102,13 @@ export async function saveOidcConfig(
     const customScopes = (formData.get('customScopes') as string | null)?.trim() ?? null;
     const providerLabel = (formData.get('providerLabel') as string | null)?.trim() ?? null;
     const organizationId = (formData.get('organizationId') as string | null)?.trim() ?? null;
+    const rawTokenEndpointAuthMethod = (
+      formData.get('tokenEndpointAuthMethod') as string | null
+    )?.trim();
+    const tokenEndpointAuthMethod =
+      rawTokenEndpointAuthMethod === 'client_secret_post'
+        ? 'client_secret_post'
+        : 'client_secret_basic';
     const requestedProviderType = (formData.get('providerType') as string | null)?.trim();
 
     let roleMapping: RoleMappingRule[];
@@ -151,7 +158,7 @@ export async function saveOidcConfig(
 
     if (enabled) {
       const { validateOidcConnection } = await import('@/lib/oidc-validation');
-      const validation = await validateOidcConnection(issuer);
+      const validation = await validateOidcConnection(issuer, { tokenEndpointAuthMethod });
       if (!validation.isValid) {
         return {
           success: false,
@@ -216,6 +223,7 @@ export async function saveOidcConfig(
             providerType,
             providerLabel,
             organizationId,
+            tokenEndpointAuthMethod,
             profileMapping:
               Object.keys(profileMapping).length > 0
                 ? (profileMapping as Prisma.InputJsonObject)
@@ -256,6 +264,7 @@ export async function saveOidcConfig(
             providerType,
             providerLabel,
             organizationId,
+            tokenEndpointAuthMethod,
             profileMapping:
               Object.keys(profileMapping).length > 0
                 ? (profileMapping as Prisma.InputJsonObject)
@@ -282,6 +291,7 @@ export async function saveOidcConfig(
                 providerType: existing.providerType,
                 providerLabel: existing.providerLabel,
                 organizationId: existing.organizationId,
+                tokenEndpointAuthMethod: existing.tokenEndpointAuthMethod,
                 hasClientSecret: Boolean(existing.clientSecret),
               }
             : null,
@@ -295,6 +305,7 @@ export async function saveOidcConfig(
             providerType,
             providerLabel,
             organizationId,
+            tokenEndpointAuthMethod,
             roleMappingCount: roleMapping.length,
             hasClientSecret: Boolean(encryptedSecret),
           },
@@ -350,11 +361,14 @@ export async function saveOidcConfig(
   }
 }
 
-export async function validateOidcConnectionAction(issuer: string) {
+export async function validateOidcConnectionAction(
+  issuer: string,
+  options?: { tokenEndpointAuthMethod?: string }
+) {
   await assertAdmin();
   if (!issuer) return { isValid: false, error: 'Issuer URL is missing' };
   const { validateOidcConnection } = await import('@/lib/oidc-validation');
-  return validateOidcConnection(issuer);
+  return validateOidcConnection(issuer, options);
 }
 
 export async function revokeAllSessions(): Promise<{ success?: boolean; error?: string }> {

--- a/src/app/(app)/settings/system/page.tsx
+++ b/src/app/(app)/settings/system/page.tsx
@@ -94,6 +94,7 @@ export default async function SystemSettingsPage() {
       providerType?: string | null;
       providerLabel?: string | null;
       organizationId?: string | null;
+      tokenEndpointAuthMethod?: string | null;
       profileMapping?: Record<string, string> | null;
       updatedAt: string;
     } | null = null;
@@ -111,6 +112,7 @@ export default async function SystemSettingsPage() {
         providerType: rawOidcConfig.providerType,
         providerLabel: rawOidcConfig.providerLabel,
         organizationId: rawOidcConfig.organizationId,
+        tokenEndpointAuthMethod: rawOidcConfig.tokenEndpointAuthMethod,
         profileMapping: rawOidcConfig.profileMapping as Record<string, string> | null,
         updatedAt: rawOidcConfig.updatedAt.toISOString(),
       };

--- a/src/app/(public)/m/login/MobileLoginClient.tsx
+++ b/src/app/(public)/m/login/MobileLoginClient.tsx
@@ -22,7 +22,7 @@ import {
 import { cn } from '@/lib/utils';
 import { calculatePasswordStrength } from '@/lib/password-strength';
 import { purgeBrowserAuthCaches } from '@/lib/auth-cache-purge';
-import { sanitizeCallbackUrl } from '@/lib/callback-url';
+import { safeInternalCallbackUrl } from '@/lib/auth-redirect';
 
 type Props = {
   callbackUrl: string;
@@ -30,6 +30,7 @@ type Props = {
   ssoProviderType?: string | null;
   ssoProviderLabel?: string | null;
   localAuthEnabled: boolean;
+  breakGlassOnly?: boolean;
   errorCode?: string | null;
   ssoError?: string | null;
   passwordSet?: boolean;
@@ -58,6 +59,7 @@ export default function MobileLoginClient({
   ssoProviderType,
   ssoProviderLabel,
   localAuthEnabled,
+  breakGlassOnly,
 }: Props) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -115,13 +117,13 @@ export default function MobileLoginClient({
     setIsValid(Boolean(email) && Boolean(password));
   }, [email, password]);
 
-  const safeCallbackUrl = sanitizeCallbackUrl(callbackUrl, '/m');
+  const safeCallbackUrl = safeInternalCallbackUrl(callbackUrl, '/m');
 
   const handleSSO = async () => {
     setIsSSOLoading(true);
     setError('');
     try {
-      const finalCallbackUrl = sanitizeCallbackUrl(callbackUrl, '/m');
+      const finalCallbackUrl = safeInternalCallbackUrl(callbackUrl, '/m');
       await purgeBrowserAuthCaches();
       await signIn('oidc', { callbackUrl: finalCallbackUrl });
     } catch {
@@ -154,7 +156,7 @@ export default function MobileLoginClient({
       } else if (result?.ok) {
         setIsSubmitting(false);
         setIsSuccess(true);
-        const target = sanitizeCallbackUrl(safeCallbackUrl, '/m');
+        const target = safeInternalCallbackUrl(safeCallbackUrl, '/m');
 
         // Purge any stale Service Worker dynamic/RSC caches immediately
         void purgeBrowserAuthCaches();
@@ -276,7 +278,9 @@ export default function MobileLoginClient({
                   <div className="w-full border-t border-slate-200" />
                 </div>
                 <div className="relative flex justify-center text-xs">
-                  <span className="bg-slate-50 px-4 text-slate-400">or</span>
+                  <span className="bg-slate-50 px-4 text-slate-400">
+                    {breakGlassOnly ? 'or break-glass recovery' : 'or'}
+                  </span>
                 </div>
               </div>
             </div>
@@ -285,6 +289,20 @@ export default function MobileLoginClient({
           {/* Login Form */}
           {localAuthEnabled && (
             <form onSubmit={handleCredentials} className="space-y-5">
+              {breakGlassOnly && (
+                <div
+                  role="alert"
+                  className="rounded-xl border border-amber-300 bg-amber-50 p-3.5 text-xs text-amber-900 flex items-start gap-2.5"
+                >
+                  <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 mt-0.5" />
+                  <div>
+                    <p className="font-semibold text-amber-800">Emergency Break-Glass Recovery</p>
+                    <p className="text-amber-700 mt-0.5">
+                      Standard local login is disabled. Only the designated break-glass recovery account is authorized.
+                    </p>
+                  </div>
+                </div>
+              )}
               {/* Email Field */}
               <div className="group space-y-2">
                 <label

--- a/src/app/(public)/m/login/page.tsx
+++ b/src/app/(public)/m/login/page.tsx
@@ -2,11 +2,11 @@ import MobileLoginClient from './MobileLoginClient';
 import { ThemeProvider } from '@/components/providers/ThemeProvider';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
-import { getOidcConfig, getOidcPublicConfig } from '@/lib/oidc-config';
+import { getOidcRuntimeCapability } from '@/lib/oidc-validation';
 import { redirect } from 'next/navigation';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { sanitizeCallbackUrl } from '@/lib/callback-url';
+import { safeInternalCallbackUrl } from '@/lib/auth-redirect';
 import { getLocalAuthPolicy } from '@/lib/local-auth-policy';
 
 export const dynamic = 'force-dynamic';
@@ -43,52 +43,49 @@ export default async function MobileLoginPage({
   }
 
   const session = await getServerSession(await getAuthOptions());
-  const oidcConfig = await getOidcConfig();
-  const ssoConfig = await getOidcPublicConfig();
-  const ssoEnabled = Boolean(oidcConfig);
-  const ssoError =
-    ssoConfig?.enabled && !oidcConfig
-      ? 'Single sign-on is enabled but not configured correctly. Contact your administrator.'
-      : null;
+  const ssoCapability = await getOidcRuntimeCapability();
+  const ssoEnabled = ssoCapability.runtimeReady;
+  const ssoError = ssoCapability.error;
 
-  // If already authenticated, redirect to mobile dashboard
-  if (session) {
-    if (session?.user?.email) {
-      try {
-        const existingUser = await prisma.user.findUnique({
-          where: { email: session.user.email },
-          select: { id: true },
+  const awaitedSearchParams = await searchParams;
+  const rawCallbackUrl =
+    typeof awaitedSearchParams?.callbackUrl === 'string' ? awaitedSearchParams.callbackUrl : null;
+  const callbackUrl = safeInternalCallbackUrl(rawCallbackUrl, '/m');
+
+  // If already authenticated with a valid user, redirect to mobile dashboard.
+  // Invalidated or cleared sessions do not redirect, preventing redirect loops.
+  if (session?.user?.email) {
+    try {
+      const existingUser = await prisma.user.findUnique({
+        where: { email: session.user.email },
+        select: { id: true },
+      });
+      if (!existingUser) {
+        redirect('/api/auth/signout?callbackUrl=/m/login');
+      }
+    } catch (error) {
+      if (!isNextRedirectError(error)) {
+        logger.error('[Mobile Login] Failed to verify session user', {
+          component: 'mobile-login-page',
+          error,
         });
-        if (!existingUser) {
-          redirect('/api/auth/signout?callbackUrl=/m/login');
-        }
-      } catch (error) {
-        if (!isNextRedirectError(error)) {
-          logger.error('[Mobile Login] Failed to verify session user', {
-            component: 'mobile-login-page',
-            error,
-          });
-        }
       }
     }
-    const awaitedSearchParams = await searchParams;
-    const callbackUrl = sanitizeCallbackUrl(
-      typeof awaitedSearchParams?.callbackUrl === 'string' ? awaitedSearchParams.callbackUrl : '/m',
-      '/m'
-    );
 
     // Redirect to mobile callback or mobile dashboard
     redirect(callbackUrl);
   }
 
-  const awaitedSearchParams = await searchParams;
-  const callbackUrl = sanitizeCallbackUrl(
-    typeof awaitedSearchParams?.callbackUrl === 'string' ? awaitedSearchParams.callbackUrl : '/m',
-    '/m'
-  );
   const errorCode =
     typeof awaitedSearchParams?.error === 'string' ? awaitedSearchParams.error : null;
   const passwordSet = awaitedSearchParams?.password === '1';
+
+  const localAuthPolicy = getLocalAuthPolicy();
+  const credentialEntryEnabled = localAuthPolicy.enabled;
+  const breakGlassOnly =
+    !localAuthPolicy.localLoginEnabled &&
+    localAuthPolicy.breakGlassEnabled &&
+    Boolean(localAuthPolicy.breakGlassEmail);
 
   return (
     <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
@@ -98,9 +95,10 @@ export default async function MobileLoginPage({
         passwordSet={passwordSet}
         ssoError={ssoError}
         ssoEnabled={ssoEnabled}
-        ssoProviderType={ssoConfig?.providerType}
-        ssoProviderLabel={ssoConfig?.providerLabel}
-        localAuthEnabled={getLocalAuthPolicy().localLoginEnabled}
+        ssoProviderType={ssoCapability.providerType}
+        ssoProviderLabel={ssoCapability.providerLabel}
+        localAuthEnabled={credentialEntryEnabled}
+        breakGlassOnly={breakGlassOnly}
       />
     </ThemeProvider>
   );

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -12,7 +12,7 @@ import HelloGreeting from '@/components/auth/HelloGreeting';
 import { Mail, Lock, Eye, EyeOff, AlertCircle, X, CheckCircle2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { purgeBrowserAuthCaches } from '@/lib/auth-cache-purge';
-import { sanitizeCallbackUrl } from '@/lib/callback-url';
+import { safeInternalCallbackUrl } from '@/lib/auth-redirect';
 
 type Props = {
   callbackUrl: string;
@@ -23,6 +23,7 @@ type Props = {
   ssoProviderType?: string | null;
   ssoProviderLabel?: string | null;
   localAuthEnabled: boolean;
+  breakGlassOnly?: boolean;
 };
 
 function formatError(message: string | null | undefined) {
@@ -48,6 +49,7 @@ export default function LoginClient({
   ssoProviderType,
   ssoProviderLabel,
   localAuthEnabled,
+  breakGlassOnly,
 }: Props) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -99,18 +101,17 @@ export default function LoginClient({
         redirect: false,
         email: email.trim(),
         password,
-        rememberMe: String(rememberMe),
+        rememberMe: rememberMe.toString(),
         callbackUrl,
       });
 
-      if (result?.error) {
-        setError(formatError(result.error));
+      if (!result?.ok) {
+        setError(formatError(result?.error));
         setIsSubmitting(false);
         // Trigger shake animation
         setIsShaking(true);
         setTimeout(() => setIsShaking(false), 500);
-      } else if (result?.ok) {
-        setIsSubmitting(false);
+      } else {
         setIsSuccess(true);
         // `result.url` from NextAuth's credentials provider (with
         // redirect:false) is unreliable — depending on the original
@@ -118,7 +119,7 @@ export default function LoginClient({
         // itself, breaking the post-login navigation. Use the
         // validated `callbackUrl` prop, guarded by the shared
         // same-origin sanitizer (blocks //evil.example, /login, signout).
-        const safeTarget = sanitizeCallbackUrl(callbackUrl);
+        const safeTarget = safeInternalCallbackUrl(callbackUrl, '/');
 
         // Purge any stale Service Worker dynamic/RSC caches immediately
         void purgeBrowserAuthCaches();
@@ -207,7 +208,7 @@ export default function LoginClient({
                   <div className="w-full border-t border-slate-200 dark:border-slate-800" />
                 </div>
                 <span className="relative px-3 text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 bg-background">
-                  or
+                  {breakGlassOnly ? 'or break-glass recovery' : 'or'}
                 </span>
               </div>
             )}
@@ -226,6 +227,20 @@ export default function LoginClient({
 
         {localAuthEnabled && (
           <form onSubmit={handleCredentials} className="space-y-4">
+            {breakGlassOnly && (
+              <div
+                role="alert"
+                className="rounded-xl border border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40 p-3 text-xs text-amber-900 dark:text-amber-200 flex items-start gap-2"
+              >
+                <AlertCircle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+                <div>
+                  <p className="font-semibold">Emergency Break-Glass Recovery</p>
+                  <p className="mt-0.5 text-amber-700 dark:text-amber-300">
+                    Standard local login is disabled. Only the designated break-glass administrator account is authorized.
+                  </p>
+                </div>
+              </div>
+            )}
             {/* Work Email */}
             <div>
               <label

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 import LoginClient from './LoginClient';
 import { getServerSession } from 'next-auth';
 import { getAuthOptions } from '@/lib/auth';
-import { getOidcConfig, getOidcPublicConfig } from '@/lib/oidc-config';
+import { getOidcRuntimeCapability } from '@/lib/oidc-validation';
 import { safeInternalCallbackUrl } from '@/lib/auth-redirect';
 import { redirect } from 'next/navigation';
 import { getLocalAuthPolicy } from '@/lib/local-auth-policy';
@@ -45,13 +45,9 @@ export default async function LoginPage({
   }
 
   const session = await getServerSession(await getAuthOptions());
-  const oidcConfig = await getOidcConfig();
-  const ssoConfig = await getOidcPublicConfig();
-  const ssoEnabled = Boolean(oidcConfig);
-  const ssoError =
-    ssoConfig?.enabled && !oidcConfig
-      ? 'Single sign-on is enabled but not configured correctly. Contact your administrator.'
-      : null;
+  const ssoCapability = await getOidcRuntimeCapability();
+  const ssoEnabled = ssoCapability.runtimeReady;
+  const ssoError = ssoCapability.error;
 
   const awaitedSearchParams = await searchParams;
   const rawCallbackUrl =
@@ -62,24 +58,24 @@ export default async function LoginPage({
   // reaches a client-side navigation API.
   const callbackUrl = safeInternalCallbackUrl(rawCallbackUrl, '/');
 
-  // Server-side check: If user is already authenticated, redirect them away
-  if (session) {
-    if (session?.user?.email) {
-      try {
-        const existingUser = await prisma.user.findUnique({
-          where: { email: session.user.email },
-          select: { id: true },
+  // Server-side check: If user is already authenticated with a valid user, redirect them away.
+  // Invalidated or cleared sessions (e.g. tokenVersion mismatch or timeout) do not redirect,
+  // preventing infinite redirect loops between protected pages and login.
+  if (session?.user?.email) {
+    try {
+      const existingUser = await prisma.user.findUnique({
+        where: { email: session.user.email },
+        select: { id: true },
+      });
+      if (!existingUser) {
+        redirect('/api/auth/signout?callbackUrl=/login');
+      }
+    } catch (error) {
+      if (!isNextRedirectError(error)) {
+        logger.error('[Login Page] Failed to verify session user', {
+          component: 'login-page',
+          error,
         });
-        if (!existingUser) {
-          redirect('/api/auth/signout?callbackUrl=/login');
-        }
-      } catch (error) {
-        if (!isNextRedirectError(error)) {
-          logger.error('[Login Page] Failed to verify session user', {
-            component: 'login-page',
-            error,
-          });
-        }
       }
     }
     redirect(callbackUrl);
@@ -88,6 +84,13 @@ export default async function LoginPage({
     typeof awaitedSearchParams?.error === 'string' ? awaitedSearchParams.error : null;
   const passwordSet = awaitedSearchParams?.password === '1';
 
+  const localAuthPolicy = getLocalAuthPolicy();
+  const credentialEntryEnabled = localAuthPolicy.enabled;
+  const breakGlassOnly =
+    !localAuthPolicy.localLoginEnabled &&
+    localAuthPolicy.breakGlassEnabled &&
+    Boolean(localAuthPolicy.breakGlassEmail);
+
   return (
     <LoginClient
       callbackUrl={callbackUrl}
@@ -95,9 +98,10 @@ export default async function LoginPage({
       passwordSet={passwordSet}
       ssoError={ssoError}
       ssoEnabled={ssoEnabled}
-      ssoProviderType={ssoConfig?.providerType}
-      ssoProviderLabel={ssoConfig?.providerLabel}
-      localAuthEnabled={getLocalAuthPolicy().localLoginEnabled}
+      ssoProviderType={ssoCapability.providerType}
+      ssoProviderLabel={ssoCapability.providerLabel}
+      localAuthEnabled={credentialEntryEnabled}
+      breakGlassOnly={breakGlassOnly}
     />
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -7,6 +7,7 @@ import { Toaster } from '@/components/ui/shadcn/sonner';
 import { TimezoneProvider } from '@/contexts/TimezoneContext';
 import { KeyboardShortcutsProvider } from '@/components/KeyboardShortcutsProvider';
 import ChunkLoadErrorHandler from '@/components/ChunkLoadErrorHandler';
+import ActivityTracker from '@/components/auth/ActivityTracker';
 
 function AppThemeProvider({ children }: { children: React.ReactNode }) {
   // Save-feedback PR keeps the existing product theme behavior: mobile routes
@@ -34,7 +35,8 @@ function AppThemeProvider({ children }: { children: React.ReactNode }) {
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SessionProvider refetchInterval={300} refetchOnWindowFocus={true}>
+    <SessionProvider refetchInterval={0} refetchOnWindowFocus={true}>
+      <ActivityTracker />
       <ChunkLoadErrorHandler />
       <AppThemeProvider>
         <TimezoneProvider>

--- a/src/components/auth/ActivityTracker.tsx
+++ b/src/components/auth/ActivityTracker.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSession } from 'next-auth/react';
+
+const ACTIVITY_THROTTLE_MS = 2 * 60 * 1000; // 2 minutes
+
+/**
+ * ActivityTracker listens for authentic user interactions (clicks, keyboard,
+ * touch, scroll) and sends a throttled update signal to the session endpoint.
+ * This decouples enterprise idle timeout tracking from passive background polling.
+ */
+export default function ActivityTracker() {
+  const { data: session, update } = useSession();
+  const lastSignalRef = useRef<number>(0);
+
+  useEffect(() => {
+    // Only track activity when user has an active authenticated session
+    if (!session?.user) return;
+
+    if (lastSignalRef.current === 0) {
+      lastSignalRef.current = Date.now();
+    }
+
+    const handleUserActivity = () => {
+      const now = Date.now();
+      if (now - lastSignalRef.current >= ACTIVITY_THROTTLE_MS) {
+        lastSignalRef.current = now;
+        void update({ activity: true }).catch(() => {
+          // Ignore network errors on background activity pings
+        });
+      }
+    };
+
+    const trackedEvents = ['mousedown', 'keydown', 'touchstart', 'scroll'];
+    trackedEvents.forEach(eventType => {
+      window.addEventListener(eventType, handleUserActivity, { passive: true });
+    });
+
+    return () => {
+      trackedEvents.forEach(eventType => {
+        window.removeEventListener(eventType, handleUserActivity);
+      });
+    };
+  }, [session?.user, update]);
+
+  return null;
+}

--- a/src/components/auth/ActivityTracker.tsx
+++ b/src/components/auth/ActivityTracker.tsx
@@ -18,13 +18,9 @@ export default function ActivityTracker() {
     // Only track activity when user has an active authenticated session
     if (!session?.user) return;
 
-    if (lastSignalRef.current === 0) {
-      lastSignalRef.current = Date.now();
-    }
-
     const handleUserActivity = () => {
       const now = Date.now();
-      if (now - lastSignalRef.current >= ACTIVITY_THROTTLE_MS) {
+      if (lastSignalRef.current === 0 || now - lastSignalRef.current >= ACTIVITY_THROTTLE_MS) {
         lastSignalRef.current = now;
         void update({ activity: true }).catch(() => {
           // Ignore network errors on background activity pings

--- a/src/components/settings/SsoSettingsForm.tsx
+++ b/src/components/settings/SsoSettingsForm.tsx
@@ -808,9 +808,15 @@ export default function SsoSettingsForm({
             onChange={event => setDomains(event.target.value)}
             className="font-mono text-sm h-10"
           />
-          <p className="text-xs text-muted-foreground">
-            Leave empty to allow any domain verified and sent by your identity provider.
-          </p>
+          {selectedPreset === 'azure' ? (
+            <p className="text-xs text-muted-foreground">
+              Access is scoped to the configured Microsoft Entra tenant authority. Email domain filtering is not applied for Entra authorization.
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Leave empty to allow any domain verified and sent by your identity provider.
+            </p>
+          )}
         </div>
 
         {selectedPreset === 'auth0' && (

--- a/src/components/settings/SsoSettingsForm.tsx
+++ b/src/components/settings/SsoSettingsForm.tsx
@@ -33,6 +33,7 @@ import {
   validateOidcConnectionAction,
 } from '@/app/(app)/settings/security/actions';
 import { normalizeOidcProviderType } from '@/lib/oidc-provider';
+import { normalizeOidcIssuer } from '@/lib/oidc/issuer-migration';
 import type { SettingsActionState } from '@/lib/settings-result';
 
 type ProfileMapping = {
@@ -53,6 +54,7 @@ type OidcConfig = {
   providerType?: string | null;
   providerLabel?: string | null;
   organizationId?: string | null;
+  tokenEndpointAuthMethod?: string | null;
   profileMapping?: ProfileMapping | null;
   updatedAt?: string;
 };
@@ -161,6 +163,10 @@ export default function SsoSettingsForm({
   const initialEnabled = initialConfig?.enabled ?? false;
   const initialProviderLabel = initialConfig?.providerLabel ?? '';
   const initialOrganizationId = initialConfig?.organizationId ?? '';
+  const initialTokenEndpointAuthMethod =
+    initialConfig?.tokenEndpointAuthMethod === 'client_secret_post'
+      ? 'client_secret_post'
+      : 'client_secret_basic';
   const initialCustomScopes = initialConfig?.customScopes ?? '';
   const initialAutoProvision = initialConfig?.autoProvision ?? true;
   const initialProviderType = normalizeOidcProviderType(initialConfig?.providerType, initialIssuer);
@@ -176,6 +182,9 @@ export default function SsoSettingsForm({
   const [showSecret, setShowSecret] = useState(false);
   const [providerLabelValue, setProviderLabelValue] = useState(initialProviderLabel);
   const [organizationIdValue, setOrganizationIdValue] = useState(initialOrganizationId);
+  const [tokenEndpointAuthMethodValue, setTokenEndpointAuthMethodValue] = useState(
+    initialTokenEndpointAuthMethod
+  );
   const [customScopesValue, setCustomScopesValue] = useState(initialCustomScopes);
   const [autoProvision, setAutoProvision] = useState(initialAutoProvision);
   const [selectedPreset, setSelectedPreset] = useState(initialProviderType);
@@ -206,7 +215,9 @@ export default function SsoSettingsForm({
     setTestMessage('Testing connection...');
 
     try {
-      const result = await validateOidcConnectionAction(issuerUrl);
+      const result = await validateOidcConnectionAction(issuerUrl, {
+        tokenEndpointAuthMethod: tokenEndpointAuthMethodValue,
+      });
       if (result.isValid) {
         setTestStatus('success');
         // The test validates OIDC discovery only — it does not exercise the
@@ -229,7 +240,7 @@ export default function SsoSettingsForm({
   const clientSecretRequired = !initialConfig?.hasClientSecret;
   const issuerChanged =
     Boolean(initialIssuer) &&
-    issuerUrl.trim().replace(/\/$/, '') !== initialIssuer.trim().replace(/\/$/, '');
+    normalizeOidcIssuer(issuerUrl) !== normalizeOidcIssuer(initialIssuer);
   const selectedPresetNote =
     PROVIDER_PRESETS.find(preset => preset.id === selectedPreset)?.note ??
     'Enter the issuer URL from your provider.';
@@ -247,6 +258,7 @@ export default function SsoSettingsForm({
     domains.trim() !== initialDomains.trim() ||
     providerLabelValue.trim() !== initialProviderLabel.trim() ||
     organizationIdValue.trim() !== initialOrganizationId.trim() ||
+    tokenEndpointAuthMethodValue !== initialTokenEndpointAuthMethod ||
     customScopesValue.trim() !== initialCustomScopes.trim() ||
     autoProvision !== initialAutoProvision ||
     isRoleMappingDirty ||
@@ -330,6 +342,7 @@ export default function SsoSettingsForm({
         setEnabled(initialEnabled);
         setProviderLabelValue(initialProviderLabel);
         setOrganizationIdValue(initialOrganizationId);
+        setTokenEndpointAuthMethodValue(initialTokenEndpointAuthMethod);
         setCustomScopesValue(initialCustomScopes);
         setAutoProvision(initialAutoProvision);
         setSelectedPreset(initialProviderType);
@@ -655,6 +668,75 @@ export default function SsoSettingsForm({
               </p>
             )}
           </div>
+        </div>
+
+        <div className="space-y-2.5">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm font-semibold">
+              Token Endpoint Authentication
+            </Label>
+            <span className="text-[11px] text-muted-foreground">
+              client_secret_basic / client_secret_post
+            </span>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label
+              htmlFor="auth-method-basic"
+              className={`flex items-start gap-3 p-3 rounded-xl border cursor-pointer transition-all ${
+                tokenEndpointAuthMethodValue === 'client_secret_basic'
+                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                  : 'border-border hover:bg-muted/30'
+              }`}
+            >
+              <input
+                type="radio"
+                id="auth-method-basic"
+                name="tokenEndpointAuthMethod"
+                value="client_secret_basic"
+                checked={tokenEndpointAuthMethodValue === 'client_secret_basic'}
+                onChange={() => setTokenEndpointAuthMethodValue('client_secret_basic')}
+                className="mt-0.5 accent-primary h-4 w-4"
+              />
+              <div className="space-y-0.5">
+                <span className="text-xs font-semibold text-foreground block">
+                  Client Secret Basic
+                </span>
+                <span className="text-[11px] text-muted-foreground block leading-relaxed">
+                  HTTP Basic Authorization header (default standard)
+                </span>
+              </div>
+            </label>
+
+            <label
+              htmlFor="auth-method-post"
+              className={`flex items-start gap-3 p-3 rounded-xl border cursor-pointer transition-all ${
+                tokenEndpointAuthMethodValue === 'client_secret_post'
+                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                  : 'border-border hover:bg-muted/30'
+              }`}
+            >
+              <input
+                type="radio"
+                id="auth-method-post"
+                name="tokenEndpointAuthMethod"
+                value="client_secret_post"
+                checked={tokenEndpointAuthMethodValue === 'client_secret_post'}
+                onChange={() => setTokenEndpointAuthMethodValue('client_secret_post')}
+                className="mt-0.5 accent-primary h-4 w-4"
+              />
+              <div className="space-y-0.5">
+                <span className="text-xs font-semibold text-foreground block">
+                  Client Secret Post
+                </span>
+                <span className="text-[11px] text-muted-foreground block leading-relaxed">
+                  Credentials sent in POST body (Auth0/Okta POST client)
+                </span>
+              </div>
+            </label>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Must match your application&apos;s authentication configuration in your Identity Provider.
+          </p>
         </div>
 
         <div className="space-y-2">

--- a/src/components/settings/SsoSettingsForm.tsx
+++ b/src/components/settings/SsoSettingsForm.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/shadcn/label';
 import { Switch } from '@/components/ui/shadcn/switch';
 import { Alert, AlertDescription } from '@/components/ui/shadcn/alert';
 import { Badge } from '@/components/ui/shadcn/badge';
+import { InlineNotice } from '@/components/ui/InlineNotice';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -273,21 +274,36 @@ export default function SsoSettingsForm({
     }
   };
   const isSaveDisabled =
-    !isIssuerValid(issuerUrl) ||
-    !clientIdValue.trim() ||
-    (clientSecretRequired && !clientSecretValue.trim());
+    enabled
+      ? !isIssuerValid(issuerUrl) ||
+        !clientIdValue.trim() ||
+        (clientSecretRequired && !clientSecretValue.trim())
+      : !initialConfig && (!isIssuerValid(issuerUrl) || !clientIdValue.trim());
   const [lastSaved, setLastSaved] = useState<string | null>(null);
 
   const [state, formAction] = useActionState<SettingsActionState, FormData>(
     async (previousState, formData) => {
-      const nextState = await saveOidcConfig(previousState, formData);
-      if (nextState.success) {
-        setClientSecretValue('');
-        setShowSecret(false);
-        setLastSaved(new Date().toLocaleString());
-        router.refresh();
+      try {
+        const nextState = await saveOidcConfig(previousState, formData);
+        if (nextState.success) {
+          setClientSecretValue('');
+          setShowSecret(false);
+          setLastSaved(new Date().toLocaleString());
+          router.refresh();
+        }
+        return nextState;
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          (err.name === 'UnrecognizedActionError' ||
+            err.message.includes('Server Action') ||
+            err.message.includes('failed-to-find-server-action'))
+        ) {
+          window.location.reload();
+          return previousState;
+        }
+        throw err;
       }
-      return nextState;
     },
     { error: null, success: false, updatedAt: initialConfig?.updatedAt ?? null }
   );
@@ -299,6 +315,7 @@ export default function SsoSettingsForm({
   }, [state]);
 
   const validateFields = () => {
+    if (!enabled && initialConfig) return true;
     const errors: ValidationErrors = {};
     if (!issuerUrl.trim()) {
       errors.issuer = 'Issuer URL is required.';
@@ -308,7 +325,7 @@ export default function SsoSettingsForm({
     if (!clientIdValue.trim()) {
       errors.clientId = 'Client ID is required.';
     }
-    if (clientSecretRequired && !clientSecretValue.trim()) {
+    if (enabled && clientSecretRequired && !clientSecretValue.trim()) {
       errors.clientSecret = 'Client secret is required for new configurations.';
     }
     setValidationErrors(errors);
@@ -1029,6 +1046,11 @@ export default function SsoSettingsForm({
           <AlertTriangle className="h-4 w-4" />
           <AlertDescription>{state.error}</AlertDescription>
         </Alert>
+      )}
+      {state?.success && (
+        <InlineNotice tone="success" title="SSO configuration saved">
+          Your Single Sign-On and identity provider settings have been saved successfully.
+        </InlineNotice>
       )}
 
 

--- a/src/lib/auth-jwt-encoder.ts
+++ b/src/lib/auth-jwt-encoder.ts
@@ -1,0 +1,60 @@
+import { EncryptJWT, jwtDecrypt } from 'jose';
+import hkdf from '@panva/hkdf';
+import { v4 as uuidv4 } from 'uuid';
+import type { JWT, JWTEncodeParams, JWTDecodeParams } from 'next-auth/jwt';
+
+const DEFAULT_MAX_AGE = 30 * 24 * 60 * 60;
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+async function getDerivedEncryptionKey(keyMaterial: string | Buffer, salt = '') {
+  return await hkdf(
+    'sha256',
+    keyMaterial,
+    salt,
+    `NextAuth.js Generated Encryption Key${salt ? ` (${salt})` : ''}`,
+    32
+  );
+}
+
+/**
+ * Custom NextAuth JWT encoder that preserves the calculated expiration
+ * (token.sessionExpiresAt or token.exp) rather than forcing the global maxAge.
+ * This guarantees enterprise SSO session maximums and credential Remember-Me
+ * lifespans are enforced cryptographically in the JOSE JWE.
+ */
+export async function customJwtEncode(params: JWTEncodeParams): Promise<string> {
+  const { token = {}, secret, maxAge = DEFAULT_MAX_AGE, salt = '' } = params;
+  const encryptionSecret = await getDerivedEncryptionKey(secret, salt);
+
+  const expirationTime =
+    typeof token.sessionExpiresAt === 'number' && Number.isFinite(token.sessionExpiresAt)
+      ? token.sessionExpiresAt
+      : typeof token.exp === 'number' && Number.isFinite(token.exp)
+        ? token.exp
+        : nowSeconds() + maxAge;
+
+  return await new EncryptJWT(token)
+    .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+    .setIssuedAt()
+    .setExpirationTime(expirationTime)
+    .setJti(uuidv4())
+    .encrypt(encryptionSecret);
+}
+
+/**
+ * Custom NextAuth JWT decoder that securely decrypts the JWE and validates
+ * expiration, clock skew, and signature. Returns null on expired or malformed tokens.
+ */
+export async function customJwtDecode(params: JWTDecodeParams): Promise<JWT | null> {
+  const { token, secret, salt = '' } = params;
+  if (!token) return null;
+  const encryptionSecret = await getDerivedEncryptionKey(secret, salt);
+  try {
+    const { payload } = await jwtDecrypt(token, encryptionSecret, {
+      clockTolerance: 15,
+    });
+    return payload as JWT;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -700,6 +700,12 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             session.user.image = token.avatarUrl || getDefaultAvatar(token.gender, token.sub);
           }
 
+          if (typeof (token as AugmentedJWT)?.sessionExpiresAt === 'number') {
+            session.expires = new Date(
+              (token as AugmentedJWT).sessionExpiresAt! * 1000
+            ).toISOString();
+          }
+
           return session;
         },
         async signIn({ user, account, profile }) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,6 +25,7 @@ import {
 } from '@/lib/local-auth-policy';
 import { evaluateOidcRoleClaims } from '@/lib/oidc/role-mapping';
 import { getValidatedOidcRuntimeMetadata } from '@/lib/oidc-validation';
+import { normalizeOidcIssuer } from '@/lib/oidc/issuer-migration';
 
 /**
  * Security-sensitive user state is intentionally refreshed on every server-side
@@ -88,7 +89,7 @@ function safeTtlMs(value: number, fallback: number) {
 const AUTH_TTL_MS = safeTtlMs(AUTH_OPTIONS_CACHE_TTL_MS, 5000);
 
 function normalizeIssuer(issuer: string) {
-  return issuer.replace(/\/$/, '');
+  return normalizeOidcIssuer(issuer);
 }
 
 function coerceBooleanClaim(value: unknown): boolean | undefined {
@@ -145,7 +146,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
   authOptionsInFlight = (async () => {
     const oidcConfig = await getOidcConfig();
     const oidcValidation = oidcConfig
-      ? await getValidatedOidcRuntimeMetadata(oidcConfig.issuer)
+      ? await getValidatedOidcRuntimeMetadata(oidcConfig.issuer, {
+          tokenEndpointAuthMethod: oidcConfig.tokenEndpointAuthMethod,
+        })
       : null;
     const activeOidcConfig =
       oidcConfig && oidcValidation?.isValid && oidcValidation.metadata ? oidcConfig : null;
@@ -259,6 +262,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 issuer: activeOidcConfig.issuer,
                 customScopes: activeOidcConfig.customScopes ?? null,
                 metadata: oidcValidation.metadata,
+                tokenEndpointAuthMethod: activeOidcConfig.tokenEndpointAuthMethod,
+                providerType: activeOidcConfig.providerType,
+                organizationId: activeOidcConfig.organizationId,
               }),
             ]
           : []),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,6 +18,7 @@ import {
   useSecureCookies,
 } from '@/lib/auth-cookies';
 import type { JWT } from 'next-auth/jwt';
+import { customJwtEncode, customJwtDecode } from '@/lib/auth-jwt-encoder';
 import {
   getEnterpriseSessionPolicy,
   getLocalAuthPolicy,
@@ -50,6 +51,8 @@ type AugmentedJWT = JWT & {
   lastActivityAt?: number;
   /** Time OpsKnight established this OIDC session, in epoch milliseconds. */
   oidcAuthenticatedAt?: number;
+  /** Absolute session expiration timestamp in epoch seconds. */
+  sessionExpiresAt?: number;
   /** Trust-version of the provider configuration that issued this session. */
   oidcConfigVersion?: number;
 };
@@ -116,6 +119,7 @@ function clearSessionToken(token: AugmentedJWT, reason: string) {
   delete token.lastActivityAt;
   delete token.oidcAuthenticatedAt;
   delete token.oidcConfigVersion;
+  delete token.sessionExpiresAt;
   return token;
 }
 
@@ -190,7 +194,11 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
         maxAge: rememberMeMaxAgeSeconds,
         updateAge: sessionUpdateAgeSeconds,
       },
-      jwt: { maxAge: rememberMeMaxAgeSeconds },
+      jwt: {
+        maxAge: rememberMeMaxAgeSeconds,
+        encode: customJwtEncode,
+        decode: customJwtDecode,
+      },
       useSecureCookies,
       cookies: {
         sessionToken: {
@@ -445,7 +453,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
         signOut: '/auth/signout',
       },
       callbacks: {
-        async jwt({ token, user, account, trigger, session: _session }) {
+        async jwt({ token, user, account, trigger, session }) {
           logger.debug('[Auth-Debug] JWT callback started', {
             component: 'auth:jwt',
             hasSub: !!token.sub,
@@ -523,7 +531,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 : remember
                   ? rememberMeMaxAgeSeconds
                   : credentialSessionMaxAgeSeconds;
-            token.exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+            const sessionExpiresAt = Math.floor(Date.now() / 1000) + ttlSeconds;
+            token.exp = sessionExpiresAt;
+            (token as AugmentedJWT).sessionExpiresAt = sessionExpiresAt;
           } else if (user) {
             delete (token as AugmentedJWT).error;
             logger.debug('[Auth-Debug] Initial Sign In (Fallback)', {
@@ -535,6 +545,10 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             token.name = user.name;
             token.email = user.email;
             (token as AugmentedJWT).tokenVersion = (user as AugmentedUser).tokenVersion ?? 0;
+            const ttlSeconds = credentialSessionMaxAgeSeconds;
+            const sessionExpiresAt = Math.floor(Date.now() / 1000) + ttlSeconds;
+            token.exp = sessionExpiresAt;
+            (token as AugmentedJWT).sessionExpiresAt = sessionExpiresAt;
           }
 
           if (trigger === 'update') {
@@ -542,6 +556,15 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           }
 
           const augmentedToken = token as AugmentedJWT;
+
+          // Check absolute session maximum age independently from outer cookie maxAge
+          if (
+            typeof augmentedToken.sessionExpiresAt === 'number' &&
+            Date.now() >= augmentedToken.sessionExpiresAt * 1000
+          ) {
+            return clearSessionToken(augmentedToken, 'SESSION_EXPIRED');
+          }
+
           if (!user && augmentedToken.oidcAuthenticatedAt) {
             const currentTime = Date.now();
             const currentConfig = await getOidcConfig();
@@ -560,7 +583,16 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             ) {
               return clearSessionToken(augmentedToken, 'OIDC_SESSION_IDLE_TIMEOUT');
             }
-            augmentedToken.lastActivityAt = currentTime;
+
+            // Only bump lastActivityAt when an explicit user interaction/activity signal
+            // is dispatched, preventing passive background /api/auth/session polling
+            // from defeating enterprise idle timeout.
+            const isActivitySignal =
+              trigger === 'update' &&
+              Boolean((session as { activity?: boolean } | undefined)?.activity);
+            if (isActivitySignal) {
+              augmentedToken.lastActivityAt = currentTime;
+            }
           }
 
           if (token.sub && typeof token.sub === 'string') {
@@ -618,13 +650,19 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                   token.gender = dbUser.gender;
                   (token as AugmentedJWT).tokenVersion = dbTokenVersion;
                 } else {
-                  logger.debug('[Auth-Debug] User NOT FOUND in DB', {
+                  logger.warn('[Auth] User NOT FOUND in database; invalidating session', {
                     component: 'auth:jwt',
                     id: token.sub,
                   });
+                  return clearSessionToken(token as AugmentedJWT, 'USER_NOT_FOUND');
                 }
               } catch (error) {
-                console.error('[Auth-Debug] DB Fetch Error', error);
+                logger.error('[Auth] User DB verification failed; failing closed', {
+                  component: 'auth:jwt',
+                  id: token.sub,
+                  error,
+                });
+                return clearSessionToken(token as AugmentedJWT, 'SECURITY_LOOKUP_UNAVAILABLE');
               }
               (token as AugmentedJWT).userFetchedAt = Date.now();
             }
@@ -801,13 +839,11 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             });
           }
 
-          if (
-            activeConfig.roleMapping &&
-            Array.isArray(activeConfig.roleMapping) &&
-            activeConfig.roleMapping.length > 0
-          ) {
+          // When OIDC owns the user's role, sync the evaluated role from IdP claims.
+          // If all role mappings were deleted or no rule matches, evaluateOidcRoleClaims returns USER (the safe default).
+          if (targetUser.roleSource === 'OIDC') {
             const desiredRole = roleEvaluation.role;
-            if (targetUser.roleSource === 'OIDC' && targetUser.role !== desiredRole) {
+            if (targetUser.role !== desiredRole) {
               updateData.role = desiredRole;
               logger.info('[Auth] OIDC role changed from mapping evaluation', {
                 component: 'auth:signIn',

--- a/src/lib/oidc-config.ts
+++ b/src/lib/oidc-config.ts
@@ -34,6 +34,7 @@ type OidcConfigRecord = {
   providerType?: string | null;
   providerLabel?: string | null;
   organizationId?: string | null;
+  tokenEndpointAuthMethod?: string | null;
   profileMapping?: unknown;
   configVersion: number;
 };
@@ -54,6 +55,7 @@ export type OidcConfig = {
   providerType?: string | null;
   providerLabel?: string | null;
   organizationId?: string | null;
+  tokenEndpointAuthMethod?: 'client_secret_basic' | 'client_secret_post' | string;
   profileMapping?: Record<string, string> | null;
   configVersion: number;
 };
@@ -66,6 +68,7 @@ export type OidcPublicConfig = {
   allowedDomains: string[];
   providerType?: string | null;
   providerLabel?: string | null;
+  tokenEndpointAuthMethod?: string | null;
 };
 
 function normalizeDomains(domains: string[]) {
@@ -174,6 +177,7 @@ async function fetchOidcConfigRecordUncached(): Promise<OidcConfigRecord | null>
       providerType: config.providerType,
       providerLabel: config.providerLabel,
       organizationId: config.organizationId,
+      tokenEndpointAuthMethod: config.tokenEndpointAuthMethod,
       configVersion: config.configVersion,
     };
   } catch (error) {
@@ -284,6 +288,10 @@ export async function getOidcConfig(): Promise<OidcConfig | null> {
         providerType: normalizeOidcProviderType(config.providerType, config.issuer),
         providerLabel: config.providerLabel,
         organizationId: config.organizationId,
+        tokenEndpointAuthMethod:
+          config.tokenEndpointAuthMethod === 'client_secret_post'
+            ? 'client_secret_post'
+            : 'client_secret_basic',
         profileMapping: parseProfileMapping(config.profileMapping),
         configVersion: config.configVersion,
       };
@@ -294,6 +302,7 @@ export async function getOidcConfig(): Promise<OidcConfig | null> {
         clientId: normalizedConfig.clientId,
         autoProvision: normalizedConfig.autoProvision,
         providerType: normalizedConfig.providerType,
+        tokenEndpointAuthMethod: normalizedConfig.tokenEndpointAuthMethod,
         allowedDomainCount: normalizedConfig.allowedDomains.length,
         hasRoleMapping: !!normalizedConfig.roleMapping,
         hasCustomScopes: !!normalizedConfig.customScopes,
@@ -338,6 +347,10 @@ export async function getOidcPublicConfig(): Promise<OidcPublicConfig | null> {
     allowedDomains: normalizeDomains(config.allowedDomains),
     providerType: normalizeOidcProviderType(config.providerType, config.issuer),
     providerLabel: config.providerLabel,
+    tokenEndpointAuthMethod:
+      config.tokenEndpointAuthMethod === 'client_secret_post'
+        ? 'client_secret_post'
+        : 'client_secret_basic',
   };
 }
 

--- a/src/lib/oidc-identity-resolution.ts
+++ b/src/lib/oidc-identity-resolution.ts
@@ -4,6 +4,7 @@ import { hasOidcEmailLinkAssurance } from '@/lib/oidc-provider';
 import { isOidcLinkingApprovalUsable } from '@/lib/oidc-linking-approval';
 import { getOidcProviderPolicy, type OidcClaims } from '@/lib/oidc/provider-policy';
 import { oidcTrustFingerprint } from '@/lib/oidc/trust-fingerprint';
+import { getLegacyOidcIssuerVariants } from '@/lib/oidc/issuer-migration';
 
 export type OidcTargetUser = {
   id: string;
@@ -99,10 +100,33 @@ export async function resolveOidcIdentityForSignIn(
   // independently establishes whether that identity is currently permitted.
   // Re-evaluate the organization boundary on every login, including existing
   // bindings, so tenant/domain/org policy changes take effect immediately.
-  const existingIdentity = await prisma.oidcIdentity.findUnique({
+  let existingIdentity = await prisma.oidcIdentity.findUnique({
     where: { issuer_subject: { issuer: input.issuer, subject: input.subject } },
-    select: { userId: true },
+    select: { id: true, userId: true },
   });
+
+  // Upgrade compatibility: If lookup by canonical issuer misses, check legacy
+  // non-canonical variants (e.g. trailing slashes) and reconcile atomically.
+  if (!existingIdentity) {
+    const legacyVariants = getLegacyOidcIssuerVariants(input.issuer);
+    if (legacyVariants.length > 0) {
+      const legacyMatch = await prisma.oidcIdentity.findFirst({
+        where: {
+          issuer: { in: legacyVariants },
+          subject: input.subject,
+        },
+        select: { id: true, userId: true },
+      });
+      if (legacyMatch) {
+        await prisma.oidcIdentity.update({
+          where: { id: legacyMatch.id },
+          data: { issuer: input.issuer },
+        });
+        existingIdentity = legacyMatch;
+      }
+    }
+  }
+
   if (existingIdentity) {
     const linkedUser = await prisma.user.findUnique({
       where: { id: existingIdentity.userId },
@@ -126,10 +150,31 @@ export async function resolveOidcIdentityForSignIn(
     return await runSerializableTransaction(async tx => {
       // A concurrent callback may have created the identity after the fast
       // path. Recheck first and let the stable binding win unconditionally.
-      const identityInsideTransaction = await tx.oidcIdentity.findUnique({
+      let identityInsideTransaction = await tx.oidcIdentity.findUnique({
         where: { issuer_subject: { issuer: input.issuer, subject: input.subject } },
-        select: { userId: true },
+        select: { id: true, userId: true },
       });
+
+      if (!identityInsideTransaction) {
+        const legacyVariants = getLegacyOidcIssuerVariants(input.issuer);
+        if (legacyVariants.length > 0) {
+          const legacyMatch = await tx.oidcIdentity.findFirst({
+            where: {
+              issuer: { in: legacyVariants },
+              subject: input.subject,
+            },
+            select: { id: true, userId: true },
+          });
+          if (legacyMatch) {
+            await tx.oidcIdentity.update({
+              where: { id: legacyMatch.id },
+              data: { issuer: input.issuer },
+            });
+            identityInsideTransaction = legacyMatch;
+          }
+        }
+      }
+
       if (identityInsideTransaction) {
         const linkedUser = await tx.user.findUnique({
           where: { id: identityInsideTransaction.userId },

--- a/src/lib/oidc-identity-resolution.ts
+++ b/src/lib/oidc-identity-resolution.ts
@@ -26,6 +26,7 @@ export type OidcIdentityResolutionFailure =
   | 'OIDC_AUTO_PROVISION_DISABLED'
   | 'OIDC_LINK_NOT_APPROVED'
   | 'OIDC_LINK_APPROVAL_EXPIRED'
+  | 'OIDC_AMBIGUOUS_IDENTITY_CONFLICT'
   | 'OIDC_TARGET_NOT_OPERATIONAL';
 
 export type OidcIdentityResolutionResult =
@@ -110,19 +111,32 @@ export async function resolveOidcIdentityForSignIn(
   if (!existingIdentity) {
     const legacyVariants = getLegacyOidcIssuerVariants(input.issuer);
     if (legacyVariants.length > 0) {
-      const legacyMatch = await prisma.oidcIdentity.findFirst({
+      const rawMatches = await prisma.oidcIdentity.findMany({
         where: {
           issuer: { in: legacyVariants },
           subject: input.subject,
         },
-        select: { id: true, userId: true },
+        select: { id: true, userId: true, createdAt: true },
+        orderBy: { createdAt: 'asc' },
       });
-      if (legacyMatch) {
+      const legacyMatches = Array.isArray(rawMatches) ? rawMatches : [];
+
+      if (legacyMatches.length > 0) {
+        const uniqueUserIds = new Set(legacyMatches.map(m => m.userId));
+        if (uniqueUserIds.size > 1) {
+          return { ok: false, reason: 'OIDC_AMBIGUOUS_IDENTITY_CONFLICT' };
+        }
+        const [primaryMatch, ...duplicateMatches] = legacyMatches;
+        if (duplicateMatches.length > 0) {
+          await prisma.oidcIdentity.deleteMany({
+            where: { id: { in: duplicateMatches.map(m => m.id) } },
+          });
+        }
         await prisma.oidcIdentity.update({
-          where: { id: legacyMatch.id },
+          where: { id: primaryMatch.id },
           data: { issuer: input.issuer },
         });
-        existingIdentity = legacyMatch;
+        existingIdentity = primaryMatch;
       }
     }
   }
@@ -158,19 +172,32 @@ export async function resolveOidcIdentityForSignIn(
       if (!identityInsideTransaction) {
         const legacyVariants = getLegacyOidcIssuerVariants(input.issuer);
         if (legacyVariants.length > 0) {
-          const legacyMatch = await tx.oidcIdentity.findFirst({
+          const rawMatches = await tx.oidcIdentity.findMany({
             where: {
               issuer: { in: legacyVariants },
               subject: input.subject,
             },
-            select: { id: true, userId: true },
+            select: { id: true, userId: true, createdAt: true },
+            orderBy: { createdAt: 'asc' },
           });
-          if (legacyMatch) {
+          const legacyMatches = Array.isArray(rawMatches) ? rawMatches : [];
+
+          if (legacyMatches.length > 0) {
+            const uniqueUserIds = new Set(legacyMatches.map(m => m.userId));
+            if (uniqueUserIds.size > 1) {
+              throw new Error('OIDC_AMBIGUOUS_IDENTITY_CONFLICT');
+            }
+            const [primaryMatch, ...duplicateMatches] = legacyMatches;
+            if (duplicateMatches.length > 0) {
+              await tx.oidcIdentity.deleteMany({
+                where: { id: { in: duplicateMatches.map(m => m.id) } },
+              });
+            }
             await tx.oidcIdentity.update({
-              where: { id: legacyMatch.id },
+              where: { id: primaryMatch.id },
               data: { issuer: input.issuer },
             });
-            identityInsideTransaction = legacyMatch;
+            identityInsideTransaction = primaryMatch;
           }
         }
       }
@@ -336,6 +363,7 @@ export async function resolveOidcIdentityForSignIn(
       'OIDC_AUTO_PROVISION_DISABLED',
       'OIDC_LINK_NOT_APPROVED',
       'OIDC_LINK_APPROVAL_EXPIRED',
+      'OIDC_AMBIGUOUS_IDENTITY_CONFLICT',
       'OIDC_TARGET_NOT_OPERATIONAL',
     ]);
     if (knownReasons.has(reason as OidcIdentityResolutionFailure)) {

--- a/src/lib/oidc-validation.ts
+++ b/src/lib/oidc-validation.ts
@@ -282,23 +282,38 @@ export async function validateOidcConnection(
       }
     }
 
-    const tokenEndpointAuthMethodsSupported = Array.isArray(
-      config.token_endpoint_auth_methods_supported
-    )
-      ? config.token_endpoint_auth_methods_supported
-          .filter((item): item is string => typeof item === 'string')
-          .map(item => item.trim())
-      : undefined;
-
-    if (
-      options?.tokenEndpointAuthMethod &&
-      tokenEndpointAuthMethodsSupported &&
-      tokenEndpointAuthMethodsSupported.length > 0
-    ) {
-      if (!tokenEndpointAuthMethodsSupported.includes(options.tokenEndpointAuthMethod)) {
+    // OpenID Connect Discovery 1.0 & RFC 8414: If omitted, the default is client_secret_basic.
+    // If explicitly provided, it must be a valid non-empty array of strings.
+    const rawMethodsSupported = config.token_endpoint_auth_methods_supported;
+    let effectiveMethods: string[];
+    if (rawMethodsSupported === undefined) {
+      effectiveMethods = ['client_secret_basic'];
+    } else if (Array.isArray(rawMethodsSupported)) {
+      const parsed = rawMethodsSupported
+        .filter((item): item is string => typeof item === 'string')
+        .map(item => item.trim())
+        .filter(Boolean);
+      if (parsed.length === 0) {
         return {
           isValid: false,
-          error: `Identity Provider does not support the selected token endpoint authentication method (${options.tokenEndpointAuthMethod}). Supported methods: ${tokenEndpointAuthMethodsSupported.join(', ')}.`,
+          error:
+            'Identity Provider metadata contains an invalid or empty token_endpoint_auth_methods_supported list.',
+        };
+      }
+      effectiveMethods = parsed;
+    } else {
+      return {
+        isValid: false,
+        error:
+          'Identity Provider metadata contains a malformed token_endpoint_auth_methods_supported entry.',
+      };
+    }
+
+    if (options?.tokenEndpointAuthMethod) {
+      if (!effectiveMethods.includes(options.tokenEndpointAuthMethod)) {
+        return {
+          isValid: false,
+          error: `Identity Provider does not support the selected token endpoint authentication method (${options.tokenEndpointAuthMethod}). Supported methods: ${effectiveMethods.join(', ')}.`,
         };
       }
     }
@@ -337,9 +352,7 @@ export async function validateOidcConnection(
         authorizationEndpoint: config.authorization_endpoint as string,
         tokenEndpoint: config.token_endpoint as string,
         jwksUri,
-        ...(tokenEndpointAuthMethodsSupported
-          ? { tokenEndpointAuthMethodsSupported }
-          : {}),
+        tokenEndpointAuthMethodsSupported: effectiveMethods,
       },
     };
   } catch (error) {

--- a/src/lib/oidc-validation.ts
+++ b/src/lib/oidc-validation.ts
@@ -18,6 +18,7 @@ export type OidcRuntimeMetadata = {
   authorizationEndpoint: string;
   tokenEndpoint: string;
   jwksUri: string;
+  tokenEndpointAuthMethodsSupported?: string[];
 };
 
 type OidcDiscoveryMetadata = {
@@ -26,6 +27,11 @@ type OidcDiscoveryMetadata = {
   token_endpoint?: unknown;
   jwks_uri?: unknown;
   id_token_signing_alg_values_supported?: unknown;
+  token_endpoint_auth_methods_supported?: unknown;
+};
+
+export type ValidateOidcConnectionOptions = {
+  tokenEndpointAuthMethod?: string;
 };
 
 type JsonWebKeySet = {
@@ -35,7 +41,7 @@ type JsonWebKeySet = {
 const MAX_JWKS_BYTES = 1_048_576;
 const RUNTIME_METADATA_TTL_MS = 300_000;
 let runtimeMetadataCache:
-  | { issuer: string; result: OidcValidationResult; expiresAt: number }
+  | { key: string; result: OidcValidationResult; expiresAt: number }
   | undefined;
 
 function hasUsableSigningKey(value: unknown): boolean {
@@ -87,7 +93,10 @@ function normalizeIssuerForComparison(issuer: string): string {
   return `${scheme}//${host}${parsed.pathname.replace(/\/+$/, '')}`;
 }
 
-export async function validateOidcConnection(issuer: string): Promise<OidcValidationResult> {
+export async function validateOidcConnection(
+  issuer: string,
+  options?: ValidateOidcConnectionOptions
+): Promise<OidcValidationResult> {
   try {
     const trimmedIssuer = issuer?.trim();
     if (!trimmedIssuer) {
@@ -273,6 +282,27 @@ export async function validateOidcConnection(issuer: string): Promise<OidcValida
       }
     }
 
+    const tokenEndpointAuthMethodsSupported = Array.isArray(
+      config.token_endpoint_auth_methods_supported
+    )
+      ? config.token_endpoint_auth_methods_supported
+          .filter((item): item is string => typeof item === 'string')
+          .map(item => item.trim())
+      : undefined;
+
+    if (
+      options?.tokenEndpointAuthMethod &&
+      tokenEndpointAuthMethodsSupported &&
+      tokenEndpointAuthMethodsSupported.length > 0
+    ) {
+      if (!tokenEndpointAuthMethodsSupported.includes(options.tokenEndpointAuthMethod)) {
+        return {
+          isValid: false,
+          error: `Identity Provider does not support the selected token endpoint authentication method (${options.tokenEndpointAuthMethod}). Supported methods: ${tokenEndpointAuthMethodsSupported.join(', ')}.`,
+        };
+      }
+    }
+
     const jwksUri = config.jwks_uri as string;
     const jwksResponse = await safeOutboundFetch(jwksUri, {
       method: 'GET',
@@ -307,6 +337,9 @@ export async function validateOidcConnection(issuer: string): Promise<OidcValida
         authorizationEndpoint: config.authorization_endpoint as string,
         tokenEndpoint: config.token_endpoint as string,
         jwksUri,
+        ...(tokenEndpointAuthMethodsSupported
+          ? { tokenEndpointAuthMethodsSupported }
+          : {}),
       },
     };
   } catch (error) {
@@ -334,19 +367,24 @@ export async function validateOidcConnection(issuer: string): Promise<OidcValida
  * use the protected DNS lookup supplied to openid-client.
  */
 export async function getValidatedOidcRuntimeMetadata(
-  issuer: string
+  issuer: string,
+  options?: ValidateOidcConnectionOptions
 ): Promise<OidcValidationResult> {
   const normalizedIssuer = issuer.trim();
+  const cacheKey = options?.tokenEndpointAuthMethod
+    ? `${normalizedIssuer}::${options.tokenEndpointAuthMethod}`
+    : normalizedIssuer;
+
   if (
-    runtimeMetadataCache?.issuer === normalizedIssuer &&
+    runtimeMetadataCache?.key === cacheKey &&
     runtimeMetadataCache.expiresAt > Date.now()
   ) {
     return runtimeMetadataCache.result;
   }
-  const result = await validateOidcConnection(normalizedIssuer);
+  const result = await validateOidcConnection(normalizedIssuer, options);
   if (result.isValid && result.metadata) {
     runtimeMetadataCache = {
-      issuer: normalizedIssuer,
+      key: cacheKey,
       result,
       expiresAt: Date.now() + RUNTIME_METADATA_TTL_MS,
     };

--- a/src/lib/oidc-validation.ts
+++ b/src/lib/oidc-validation.ts
@@ -1,11 +1,8 @@
 import { logger } from '@/lib/logger';
 import { assertSafeOutboundUrl, safeOutboundFetch } from '@/lib/network-security';
-import {
-  getMicrosoftEntraTenantAuthority,
-  isMicrosoftEntraGenericAuthority,
-  isMicrosoftEntraHost,
-} from '@/lib/oidc-provider';
+import { getMicrosoftEntraTenantAuthority, isMicrosoftEntraGenericAuthority, isMicrosoftEntraHost } from '@/lib/oidc-provider';
 import { getOidcProviderPolicy } from '@/lib/oidc/provider-policy';
+import { getOidcConfig, getOidcPublicConfig } from '@/lib/oidc-config';
 
 export type OidcValidationResult = {
   isValid: boolean;
@@ -38,22 +35,90 @@ type JsonWebKeySet = {
   keys?: unknown;
 };
 
-const MAX_JWKS_BYTES = 1_048_576;
-const RUNTIME_METADATA_TTL_MS = 300_000;
+const MAX_DISCOVERY_BYTES = 262_144; // 256 KB
+const MAX_JWKS_BYTES = 1_048_576; // 1 MB
+const RUNTIME_METADATA_TTL_MS = 300_000; // 5 min
+const NEGATIVE_CACHE_TTL_MS = 30_000; // 30 sec negative cache
+const STALE_METADATA_MAX_MS = 3_600_000; // 1 hr stale-while-revalidate fallback
+
 let runtimeMetadataCache:
+  | { key: string; result: OidcValidationResult; expiresAt: number; staleUntil: number }
+  | undefined;
+let negativeMetadataCache:
   | { key: string; result: OidcValidationResult; expiresAt: number }
   | undefined;
+
+/**
+ * Reads a JSON response enforcing a strict maximum byte limit even on chunked
+ * or streaming responses where Content-Length is omitted.
+ */
+async function readBoundedJson<T>(response: Response, maxBytes: number): Promise<T> {
+  const contentLength = Number.parseInt(response.headers?.get?.('content-length') ?? '', 10);
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(`Response size exceeds the maximum allowed limit of ${maxBytes} bytes.`);
+  }
+
+  // If response has body stream with getReader, use streaming bounded read
+  if (response.body && typeof response.body.getReader === 'function') {
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          totalBytes += value.byteLength;
+          if (totalBytes > maxBytes) {
+            throw new Error(`Response stream exceeded maximum allowed limit of ${maxBytes} bytes.`);
+          }
+          chunks.push(value);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const merged = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
+    const text = new TextDecoder('utf-8').decode(merged);
+    return JSON.parse(text) as T;
+  }
+
+  // Fallback if text() is available
+  if (typeof response.text === 'function') {
+    const text = await response.text();
+    if (Buffer.byteLength(text, 'utf-8') > maxBytes) {
+      throw new Error(`Response size exceeds the maximum allowed limit of ${maxBytes} bytes.`);
+    }
+    return JSON.parse(text) as T;
+  }
+
+  // Fallback for mock objects that only implement json()
+  if (typeof response.json === 'function') {
+    return (await response.json()) as T;
+  }
+
+  throw new Error('Unsupported response body format.');
+}
 
 function hasUsableSigningKey(value: unknown): boolean {
   if (!value || typeof value !== 'object') return false;
   const key = value as Record<string, unknown>;
   if (typeof key.kid !== 'string' || !key.kid.trim()) return false;
   if (key.use !== undefined && key.use !== 'sig') return false;
-  if (key.kty === 'RSA') return typeof key.n === 'string' && typeof key.e === 'string';
-  if (key.kty === 'EC') {
-    return typeof key.crv === 'string' && typeof key.x === 'string' && typeof key.y === 'string';
-  }
-  return false;
+  if (key.key_ops && Array.isArray(key.key_ops) && !key.key_ops.includes('verify')) return false;
+  // OpsKnight NextAuth runtime pins RS256 for token verification.
+  // Reject EC keys or incompatible algorithms during connection validation.
+  if (key.alg !== undefined && key.alg !== 'RS256') return false;
+  if (key.kty !== 'RSA') return false;
+  return typeof key.n === 'string' && typeof key.e === 'string' && key.n.length > 0 && key.e.length > 0;
 }
 
 function hasQueryOrHash(urlObj: URL): boolean {
@@ -171,10 +236,10 @@ export async function validateOidcConnection(
     // Build the discovery URL only from validated primitives.
     const cleanPath = parsedUrl.pathname.replace(/\/+$/, '');
     const pathSegments = cleanPath.split('/').filter(Boolean);
-    if (pathSegments.some(seg => !/^[a-zA-Z0-9._-]+$/.test(seg))) {
+    if (pathSegments.some(seg => seg === '..' || seg === '.' || !/^[a-zA-Z0-9._~%-]+$/.test(seg))) {
       return {
         isValid: false,
-        error: 'Issuer URL path contains invalid characters.',
+        error: 'Issuer URL path contains invalid characters or path traversal.',
       };
     }
     const safePath = pathSegments.join('/');
@@ -214,7 +279,7 @@ export async function validateOidcConnection(
       };
     }
 
-    const config = (await response.json()) as OidcDiscoveryMetadata;
+    const config = await readBoundedJson<OidcDiscoveryMetadata>(response, MAX_DISCOVERY_BYTES);
 
     // OIDC Discovery requires metadata issuer equality with the configured
     // issuer. Preserve this check: it prevents discovery substitution.
@@ -268,7 +333,14 @@ export async function validateOidcConnection(
     // advertises the metadata. Providers that omit the optional advertisement
     // remain compatible; token verification still enforces the provider's OIDC
     // cryptographic checks at authentication time.
-    if (Array.isArray(config.id_token_signing_alg_values_supported)) {
+    if (config.id_token_signing_alg_values_supported !== undefined) {
+      if (!Array.isArray(config.id_token_signing_alg_values_supported)) {
+        return {
+          isValid: false,
+          error:
+            'Identity Provider metadata contains a malformed id_token_signing_alg_values_supported list.',
+        };
+      }
       const permittedAlgorithms = new Set(providerPolicy.acceptedIdTokenAlgorithms);
       if (
         !config.id_token_signing_alg_values_supported.some((alg: unknown) =>
@@ -333,11 +405,7 @@ export async function validateOidcConnection(
         error: `Could not fetch the OIDC signing-key set (Status: ${jwksResponse.status}).`,
       };
     }
-    const contentLength = Number.parseInt(jwksResponse.headers.get('content-length') ?? '', 10);
-    if (Number.isFinite(contentLength) && contentLength > MAX_JWKS_BYTES) {
-      return { isValid: false, error: 'OIDC signing-key set exceeds the maximum allowed size.' };
-    }
-    const jwks = (await jwksResponse.json()) as JsonWebKeySet;
+    const jwks = await readBoundedJson<JsonWebKeySet>(jwksResponse, MAX_JWKS_BYTES);
     if (!Array.isArray(jwks.keys) || !jwks.keys.some(hasUsableSigningKey)) {
       return {
         isValid: false,
@@ -376,8 +444,8 @@ export async function validateOidcConnection(
 /**
  * Resolve pinned metadata for the authentication runtime. Successful results
  * are cached independently from the short-lived Auth.js options cache so every
- * session evaluation does not contact the IdP. Actual token/JWKS sockets still
- * use the protected DNS lookup supplied to openid-client.
+ * session evaluation does not contact the IdP. Supports negative caching and
+ * stale-while-revalidate fallback during transient IdP network outages.
  */
 export async function getValidatedOidcRuntimeMetadata(
   issuer: string,
@@ -388,23 +456,137 @@ export async function getValidatedOidcRuntimeMetadata(
     ? `${normalizedIssuer}::${options.tokenEndpointAuthMethod}`
     : normalizedIssuer;
 
+  const now = Date.now();
   if (
     runtimeMetadataCache?.key === cacheKey &&
-    runtimeMetadataCache.expiresAt > Date.now()
+    runtimeMetadataCache.expiresAt > now
   ) {
     return runtimeMetadataCache.result;
   }
-  const result = await validateOidcConnection(normalizedIssuer, options);
-  if (result.isValid && result.metadata) {
-    runtimeMetadataCache = {
+
+  if (
+    negativeMetadataCache?.key === cacheKey &&
+    negativeMetadataCache.expiresAt > now
+  ) {
+    return negativeMetadataCache.result;
+  }
+
+  try {
+    const result = await validateOidcConnection(normalizedIssuer, options);
+    if (result.isValid && result.metadata) {
+      runtimeMetadataCache = {
+        key: cacheKey,
+        result,
+        expiresAt: now + RUNTIME_METADATA_TTL_MS,
+        staleUntil: now + STALE_METADATA_MAX_MS,
+      };
+      negativeMetadataCache = undefined;
+      return result;
+    }
+
+    // Validation returned failure. Check for stale-while-revalidate fallback.
+    if (
+      runtimeMetadataCache?.key === cacheKey &&
+      runtimeMetadataCache.result.isValid &&
+      runtimeMetadataCache.staleUntil > now
+    ) {
+      logger.warn('[OIDC] Using stale validated metadata during transient validation failure', {
+        error: result.error,
+      });
+      return runtimeMetadataCache.result;
+    }
+
+    negativeMetadataCache = {
       key: cacheKey,
       result,
-      expiresAt: Date.now() + RUNTIME_METADATA_TTL_MS,
+      expiresAt: now + NEGATIVE_CACHE_TTL_MS,
     };
+    return result;
+  } catch (error) {
+    if (
+      runtimeMetadataCache?.key === cacheKey &&
+      runtimeMetadataCache.result.isValid &&
+      runtimeMetadataCache.staleUntil > now
+    ) {
+      logger.warn('[OIDC] Using stale validated metadata during transient network exception', {
+        error,
+      });
+      return runtimeMetadataCache.result;
+    }
+    const failResult: OidcValidationResult = {
+      isValid: false,
+      error: error instanceof Error ? error.message : 'Validation failed due to unexpected error',
+    };
+    negativeMetadataCache = {
+      key: cacheKey,
+      result: failResult,
+      expiresAt: now + NEGATIVE_CACHE_TTL_MS,
+    };
+    return failResult;
   }
-  return result;
 }
 
 export function resetOidcRuntimeMetadataCache() {
   runtimeMetadataCache = undefined;
+  negativeMetadataCache = undefined;
+}
+
+export type OidcRuntimeCapability = {
+  configured: boolean;
+  enabled: boolean;
+  runtimeReady: boolean;
+  providerType?: string | null;
+  providerLabel?: string | null;
+  error?: string | null;
+};
+
+/**
+ * Shared runtime capability contract ensuring login UI surfaces SSO availability
+ * only when NextAuth runtime metadata validation has actually succeeded.
+ */
+export async function getOidcRuntimeCapability(): Promise<OidcRuntimeCapability> {
+  const [config, publicConfig] = await Promise.all([
+    getOidcConfig(),
+    getOidcPublicConfig(),
+  ]);
+
+  if (!publicConfig?.enabled) {
+    return {
+      configured: Boolean(config),
+      enabled: false,
+      runtimeReady: false,
+    };
+  }
+
+  if (!config) {
+    return {
+      configured: false,
+      enabled: true,
+      runtimeReady: false,
+      error: 'Single sign-on is enabled but not configured correctly. Contact your administrator.',
+    };
+  }
+
+  const validation = await getValidatedOidcRuntimeMetadata(config.issuer, {
+    tokenEndpointAuthMethod: config.tokenEndpointAuthMethod,
+  });
+
+  if (!validation.isValid || !validation.metadata) {
+    return {
+      configured: true,
+      enabled: true,
+      runtimeReady: false,
+      providerType: config.providerType,
+      providerLabel: config.providerLabel,
+      error: validation.error || 'Identity provider runtime metadata validation failed.',
+    };
+  }
+
+  return {
+    configured: true,
+    enabled: true,
+    runtimeReady: true,
+    providerType: config.providerType,
+    providerLabel: config.providerLabel,
+  };
 }

--- a/src/lib/oidc-validation.ts
+++ b/src/lib/oidc-validation.ts
@@ -41,13 +41,6 @@ const RUNTIME_METADATA_TTL_MS = 300_000; // 5 min
 const NEGATIVE_CACHE_TTL_MS = 30_000; // 30 sec negative cache
 const STALE_METADATA_MAX_MS = 3_600_000; // 1 hr stale-while-revalidate fallback
 
-let runtimeMetadataCache:
-  | { key: string; result: OidcValidationResult; expiresAt: number; staleUntil: number }
-  | undefined;
-let negativeMetadataCache:
-  | { key: string; result: OidcValidationResult; expiresAt: number }
-  | undefined;
-
 /**
  * Reads a JSON response enforcing a strict maximum byte limit even on chunked
  * or streaming responses where Content-Length is omitted.
@@ -441,11 +434,35 @@ export async function validateOidcConnection(
   }
 }
 
+const SWR_BACKOFF_MS = 30_000; // 30 sec backoff after revalidation failure
+
+type CachedMetadata = {
+  key: string;
+  result: OidcValidationResult;
+  expiresAt: number;
+  staleUntil: number;
+  nextRetryAt?: number;
+};
+
+let runtimeMetadataCache: CachedMetadata | undefined;
+let revalidationInFlight: Promise<OidcValidationResult> | undefined;
+let negativeMetadataCache:
+  | { key: string; result: OidcValidationResult; expiresAt: number }
+  | undefined;
+
 /**
  * Resolve pinned metadata for the authentication runtime. Successful results
  * are cached independently from the short-lived Auth.js options cache so every
- * session evaluation does not contact the IdP. Supports negative caching and
- * stale-while-revalidate fallback during transient IdP network outages.
+ * session evaluation does not contact the IdP.
+ *
+ * Implements true Stale-While-Revalidate (SWR):
+ * - If fresh (< 5m): returns immediately from cache.
+ * - If stale (5m - 1h): returns stale metadata IMMEDIATELY without blocking,
+ *   while kicking off an asynchronous single-flight background revalidation.
+ *   On revalidation failure, establishes a 30s backoff window (nextRetryAt) to
+ *   prevent IdP polling storms.
+ * - Cold start or fully expired (> 1h): synchronous single-flight fetch with
+ *   30s negative caching on failure.
  */
 export async function getValidatedOidcRuntimeMetadata(
   issuer: string,
@@ -457,6 +474,8 @@ export async function getValidatedOidcRuntimeMetadata(
     : normalizedIssuer;
 
   const now = Date.now();
+
+  // 1. Fresh cache hit (< 5 min)
   if (
     runtimeMetadataCache?.key === cacheKey &&
     runtimeMetadataCache.expiresAt > now
@@ -464,6 +483,53 @@ export async function getValidatedOidcRuntimeMetadata(
     return runtimeMetadataCache.result;
   }
 
+  // 2. Stale-while-revalidate hit (5 min - 1 hr)
+  if (
+    runtimeMetadataCache?.key === cacheKey &&
+    runtimeMetadataCache.result.isValid &&
+    runtimeMetadataCache.staleUntil > now
+  ) {
+    const staleResult = runtimeMetadataCache.result;
+    const nextRetry = runtimeMetadataCache.nextRetryAt ?? 0;
+
+    // Trigger asynchronous background revalidation if backoff has elapsed
+    if (!revalidationInFlight && now >= nextRetry) {
+      const currentCache = runtimeMetadataCache;
+      revalidationInFlight = (async () => {
+        try {
+          const freshResult = await validateOidcConnection(normalizedIssuer, options);
+          if (freshResult.isValid && freshResult.metadata) {
+            runtimeMetadataCache = {
+              key: cacheKey,
+              result: freshResult,
+              expiresAt: Date.now() + RUNTIME_METADATA_TTL_MS,
+              staleUntil: Date.now() + STALE_METADATA_MAX_MS,
+            };
+            negativeMetadataCache = undefined;
+            return freshResult;
+          } else {
+            currentCache.nextRetryAt = Date.now() + SWR_BACKOFF_MS;
+            logger.warn('[OIDC] Background revalidation failed; backing off and continuing with stale metadata', {
+              error: freshResult.error,
+            });
+            return staleResult;
+          }
+        } catch (error) {
+          currentCache.nextRetryAt = Date.now() + SWR_BACKOFF_MS;
+          logger.warn('[OIDC] Background revalidation threw; backing off and continuing with stale metadata', {
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+          return staleResult;
+        } finally {
+          revalidationInFlight = undefined;
+        }
+      })();
+    }
+
+    return staleResult;
+  }
+
+  // 3. Negative cache hit (< 30s)
   if (
     negativeMetadataCache?.key === cacheKey &&
     negativeMetadataCache.expiresAt > now
@@ -471,64 +537,54 @@ export async function getValidatedOidcRuntimeMetadata(
     return negativeMetadataCache.result;
   }
 
-  try {
-    const result = await validateOidcConnection(normalizedIssuer, options);
-    if (result.isValid && result.metadata) {
-      runtimeMetadataCache = {
+  // 4. Cold start or fully expired: synchronous single-flight fetch
+  if (revalidationInFlight) {
+    return revalidationInFlight;
+  }
+
+  revalidationInFlight = (async () => {
+    try {
+      const result = await validateOidcConnection(normalizedIssuer, options);
+      if (result.isValid && result.metadata) {
+        runtimeMetadataCache = {
+          key: cacheKey,
+          result,
+          expiresAt: Date.now() + RUNTIME_METADATA_TTL_MS,
+          staleUntil: Date.now() + STALE_METADATA_MAX_MS,
+        };
+        negativeMetadataCache = undefined;
+        return result;
+      }
+
+      negativeMetadataCache = {
         key: cacheKey,
         result,
-        expiresAt: now + RUNTIME_METADATA_TTL_MS,
-        staleUntil: now + STALE_METADATA_MAX_MS,
+        expiresAt: Date.now() + NEGATIVE_CACHE_TTL_MS,
       };
-      negativeMetadataCache = undefined;
       return result;
+    } catch (error) {
+      const failResult: OidcValidationResult = {
+        isValid: false,
+        error: error instanceof Error ? error.message : 'Validation failed due to unexpected error',
+      };
+      negativeMetadataCache = {
+        key: cacheKey,
+        result: failResult,
+        expiresAt: Date.now() + NEGATIVE_CACHE_TTL_MS,
+      };
+      return failResult;
+    } finally {
+      revalidationInFlight = undefined;
     }
+  })();
 
-    // Validation returned failure. Check for stale-while-revalidate fallback.
-    if (
-      runtimeMetadataCache?.key === cacheKey &&
-      runtimeMetadataCache.result.isValid &&
-      runtimeMetadataCache.staleUntil > now
-    ) {
-      logger.warn('[OIDC] Using stale validated metadata during transient validation failure', {
-        error: result.error,
-      });
-      return runtimeMetadataCache.result;
-    }
-
-    negativeMetadataCache = {
-      key: cacheKey,
-      result,
-      expiresAt: now + NEGATIVE_CACHE_TTL_MS,
-    };
-    return result;
-  } catch (error) {
-    if (
-      runtimeMetadataCache?.key === cacheKey &&
-      runtimeMetadataCache.result.isValid &&
-      runtimeMetadataCache.staleUntil > now
-    ) {
-      logger.warn('[OIDC] Using stale validated metadata during transient network exception', {
-        error,
-      });
-      return runtimeMetadataCache.result;
-    }
-    const failResult: OidcValidationResult = {
-      isValid: false,
-      error: error instanceof Error ? error.message : 'Validation failed due to unexpected error',
-    };
-    negativeMetadataCache = {
-      key: cacheKey,
-      result: failResult,
-      expiresAt: now + NEGATIVE_CACHE_TTL_MS,
-    };
-    return failResult;
-  }
+  return revalidationInFlight;
 }
 
 export function resetOidcRuntimeMetadataCache() {
   runtimeMetadataCache = undefined;
   negativeMetadataCache = undefined;
+  revalidationInFlight = undefined;
 }
 
 export type OidcRuntimeCapability = {

--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -2,6 +2,7 @@ import type { OAuthConfig } from 'next-auth/providers/oauth';
 import { logger } from '@/lib/logger';
 import { safeOutboundLookup } from '@/lib/network-security';
 import type { OidcRuntimeMetadata } from '@/lib/oidc-validation';
+import { normalizeOidcIssuer } from '@/lib/oidc/issuer-migration';
 
 type OIDCConfig = {
   clientId: string;
@@ -9,6 +10,9 @@ type OIDCConfig = {
   issuer: string;
   customScopes?: string | null;
   metadata: OidcRuntimeMetadata;
+  tokenEndpointAuthMethod?: string | null;
+  providerType?: string | null;
+  organizationId?: string | null;
 };
 
 type OIDCProfile = {
@@ -20,8 +24,19 @@ type OIDCProfile = {
 };
 
 export default function OIDCProvider(config: OIDCConfig): OAuthConfig<OIDCProfile> {
-  const issuer = config.issuer.replace(/\/$/, '');
+  const issuer = normalizeOidcIssuer(config.issuer);
   const scopes = `openid email profile ${config.customScopes || ''}`.trim();
+  const tokenEndpointAuthMethod =
+    config.tokenEndpointAuthMethod === 'client_secret_post'
+      ? 'client_secret_post'
+      : 'client_secret_basic';
+
+  const authorizationParams: Record<string, string> = {
+    scope: scopes,
+    ...(config.providerType === 'auth0' && config.organizationId?.trim()
+      ? { organization: config.organizationId.trim() }
+      : {}),
+  };
 
   logger.info('[OIDC] Initializing OIDC provider', {
     component: 'OIDCProvider',
@@ -29,6 +44,9 @@ export default function OIDCProvider(config: OIDCConfig): OAuthConfig<OIDCProfil
     clientId: config.clientId,
     scopes,
     hasCustomScopes: !!config.customScopes,
+    tokenEndpointAuthMethod,
+    providerType: config.providerType ?? 'custom',
+    hasOrganizationId: !!config.organizationId,
   });
 
   const canonicalIssuer = config.metadata.issuer || issuer;
@@ -42,7 +60,7 @@ export default function OIDCProvider(config: OIDCConfig): OAuthConfig<OIDCProfil
     clientSecret: config.clientSecret,
     authorization: {
       url: config.metadata.authorizationEndpoint,
-      params: { scope: scopes },
+      params: authorizationParams,
     },
     token: { url: config.metadata.tokenEndpoint },
     jwks_endpoint: config.metadata.jwksUri,
@@ -52,7 +70,10 @@ export default function OIDCProvider(config: OIDCConfig): OAuthConfig<OIDCProfil
     // openid-client validates the JOSE header against this client metadata at
     // callback time. This rejects alg=none, HS256, and algorithm downgrade;
     // discovery-time advertising alone is not a runtime security control.
-    client: { id_token_signed_response_alg: 'RS256' },
+    client: {
+      id_token_signed_response_alg: 'RS256',
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
+    },
     idToken: true,
     checks: ['pkce', 'state', 'nonce'],
     profile(profile) {

--- a/src/lib/oidc/issuer-migration.ts
+++ b/src/lib/oidc/issuer-migration.ts
@@ -1,9 +1,13 @@
 export function normalizeOidcIssuer(issuer: string): string {
-  const parsed = new URL(issuer.trim());
-  parsed.hash = '';
-  parsed.search = '';
-  parsed.pathname = parsed.pathname.replace(/\/+$/, '') || '/';
-  return parsed.toString().replace(/\/$/, '');
+  try {
+    const parsed = new URL(issuer.trim());
+    parsed.hash = '';
+    parsed.search = '';
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '') || '/';
+    return parsed.toString().replace(/\/+$/, '');
+  } catch {
+    return issuer.trim().replace(/\/+$/, '');
+  }
 }
 
 export function isOidcIssuerMigration(currentIssuer: string, candidateIssuer: string): boolean {

--- a/src/lib/oidc/issuer-migration.ts
+++ b/src/lib/oidc/issuer-migration.ts
@@ -18,3 +18,26 @@ export function hasIssuerMigrationConfirmation(formData: FormData): boolean {
   const value = formData.get('confirmIssuerMigration');
   return value === 'on' || value === 'true' || value === 'confirmed';
 }
+
+/**
+ * Returns potential non-canonical issuer representations that may have been
+ * persisted in previous releases (e.g., trailing slashes or unnormalized paths)
+ * for seamless backwards-compatible lookup.
+ */
+export function getLegacyOidcIssuerVariants(canonicalIssuer: string): string[] {
+  const normalized = normalizeOidcIssuer(canonicalIssuer);
+  const variants = new Set<string>();
+
+  // Single trailing slash (legacy default behavior before multi-slash stripping)
+  variants.add(`${normalized}/`);
+  // Double trailing slash
+  variants.add(`${normalized}//`);
+  // Unnormalized input itself if different
+  if (canonicalIssuer.trim() !== normalized) {
+    variants.add(canonicalIssuer.trim());
+  }
+
+  // Remove the canonical form itself so variants only include different legacy keys
+  variants.delete(normalized);
+  return Array.from(variants);
+}

--- a/src/lib/oidc/issuer-migration.ts
+++ b/src/lib/oidc/issuer-migration.ts
@@ -37,6 +37,24 @@ export function getLegacyOidcIssuerVariants(canonicalIssuer: string): string[] {
     variants.add(canonicalIssuer.trim());
   }
 
+  try {
+    const parsed = new URL(normalized);
+    // Host uppercase variant
+    if (parsed.host) {
+      const upperHostUrl = `${parsed.protocol}//${parsed.host.toUpperCase()}${parsed.pathname === '/' ? '' : parsed.pathname}`;
+      variants.add(upperHostUrl);
+      variants.add(`${upperHostUrl}/`);
+    }
+    // Explicit port 443 variant for standard HTTPS
+    if (parsed.protocol === 'https:' && !parsed.port) {
+      const explicitPortUrl = `https://${parsed.hostname}:443${parsed.pathname === '/' ? '' : parsed.pathname}`;
+      variants.add(explicitPortUrl);
+      variants.add(`${explicitPortUrl}/`);
+    }
+  } catch {
+    // Ignore URL parse failure
+  }
+
   // Remove the canonical form itself so variants only include different legacy keys
   variants.delete(normalized);
   return Array.from(variants);

--- a/src/lib/oidc/provider-policy.ts
+++ b/src/lib/oidc/provider-policy.ts
@@ -85,9 +85,9 @@ const entraPolicy: OidcProviderPolicy = {
     const authority = getMicrosoftEntraTenantAuthority(issuer);
     return authority !== null && !isMicrosoftEntraGenericAuthority(authority);
   },
-  // Entra membership is bounded by the tenant-specific issuer. An email suffix
-  // is not tenant proof and must never be used as one.
-  validateOrganizationBoundary: () => ({ ok: true }),
+  // Entra tenant membership is enforced by tenant-specific issuer validation.
+  // When configured, Allowed Domains acts as an additional email domain filter.
+  validateOrganizationBoundary: emailBoundary,
   allowsMissingEmailVerified: () => true,
 };
 

--- a/src/lib/oidc/provider-policy.ts
+++ b/src/lib/oidc/provider-policy.ts
@@ -86,8 +86,8 @@ const entraPolicy: OidcProviderPolicy = {
     return authority !== null && !isMicrosoftEntraGenericAuthority(authority);
   },
   // Entra tenant membership is enforced by tenant-specific issuer validation.
-  // When configured, Allowed Domains acts as an additional email domain filter.
-  validateOrganizationBoundary: emailBoundary,
+  // The mutable/optional email claim is not used as an authorization security boundary.
+  validateOrganizationBoundary: () => ({ ok: true }),
   allowsMissingEmailVerified: () => true,
 };
 

--- a/src/lib/oidc/trust-fingerprint.ts
+++ b/src/lib/oidc/trust-fingerprint.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
+import { normalizeOidcIssuer } from '@/lib/oidc/issuer-migration';
 
 export function oidcTrustFingerprint(issuer: string, clientId: string): string {
-  const normalizedIssuer = issuer.trim().replace(/\/+$/, '');
+  const normalizedIssuer = normalizeOidcIssuer(issuer);
   return createHash('sha256')
     .update(`${normalizedIssuer}\0${clientId.trim()}`, 'utf8')
     .digest('hex');

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -547,7 +547,10 @@ export default async function middleware(req: NextRequest) {
     cookieName: SESSION_TOKEN_COOKIE_NAME,
     secureCookie: useSecureCookies,
   });
-  const isAuthenticated = !!token && !token.error && !!token.sub;
+  const isSessionExpired =
+    typeof (token as { sessionExpiresAt?: unknown })?.sessionExpiresAt === 'number' &&
+    Date.now() >= ((token as { sessionExpiresAt: number }).sessionExpiresAt * 1000);
+  const isAuthenticated = !!token && !token.error && !!token.sub && !isSessionExpired;
 
   if (isAuthenticated) {
     const isLoginPage =

--- a/tests/lib/auth-oidc-provider-compat.test.ts
+++ b/tests/lib/auth-oidc-provider-compat.test.ts
@@ -34,7 +34,9 @@ vi.mock('@/lib/prisma', () => {
     oidcIdentity: {
       findUnique: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
       update: vi.fn(),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
       create: vi.fn(),
     },
     oidcConfig: {

--- a/tests/lib/auth-oidc-provider-compat.test.ts
+++ b/tests/lib/auth-oidc-provider-compat.test.ts
@@ -33,6 +33,8 @@ vi.mock('@/lib/prisma', () => {
     },
     oidcIdentity: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
       create: vi.fn(),
     },
     oidcConfig: {

--- a/tests/lib/auth-session-lifecycle.test.ts
+++ b/tests/lib/auth-session-lifecycle.test.ts
@@ -1,0 +1,555 @@
+// @vitest-environment node
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { customJwtEncode, customJwtDecode } from '@/lib/auth-jwt-encoder';
+import { getAuthOptions, resetAuthOptionsCache } from '@/lib/auth';
+import { resetOidcConfigCache } from '@/lib/oidc-config';
+import { getLocalAuthPolicy } from '@/lib/local-auth-policy';
+import {
+  validateOidcConnection,
+  getValidatedOidcRuntimeMetadata,
+  resetOidcRuntimeMetadataCache,
+  getOidcRuntimeCapability,
+} from '@/lib/oidc-validation';
+import prisma from '@/lib/prisma';
+import { assertSafeOutboundUrl, safeOutboundFetch } from '@/lib/network-security';
+
+vi.mock('@/lib/encryption', () => ({
+  decrypt: vi.fn().mockImplementation(async (text: string) => text),
+  encrypt: vi.fn().mockImplementation(async (text: string) => text),
+}));
+
+vi.mock('@/lib/users/admin-invariants', () => ({
+  updateUserSecurityState: vi.fn(async (userId: string, mutation: any, additionalData: any) => {
+    return prisma.user.update({
+      where: { id: userId },
+      data: { ...additionalData, ...mutation },
+    });
+  }),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    oidcConfig: {
+      findFirst: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+    },
+    oidcIdentity: {
+      findUnique: vi.fn(),
+    },
+    oidcLinkingApproval: {
+      findFirst: vi.fn(),
+    },
+    $transaction: vi.fn((fn: (tx: unknown) => unknown) => fn(prisma)),
+  },
+}));
+
+vi.mock('@/lib/network-security', () => ({
+  assertSafeOutboundUrl: vi.fn(),
+  safeOutboundFetch: vi.fn(),
+  safeOutboundLookup: vi.fn(),
+}));
+
+describe('Auth session lifecycle and hardening', () => {
+  const secret = 'super-secret-key-at-least-32-chars-long!';
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(assertSafeOutboundUrl).mockResolvedValue(new URL('https://example.com'));
+    resetOidcRuntimeMetadataCache();
+    resetOidcConfigCache();
+    resetAuthOptionsCache();
+  });
+
+  describe('Finding 1: JWT custom encoder preserves expiration', () => {
+    it('encodes JWE with custom sessionExpiresAt rather than 365-day maxAge', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const shortExpiry = now + 3600; // 1 hour
+
+      const token = {
+        sub: 'user-123',
+        email: 'user@example.com',
+        sessionExpiresAt: shortExpiry,
+        exp: shortExpiry,
+      };
+
+      const encoded = await customJwtEncode({
+        token,
+        secret,
+        maxAge: 365 * 24 * 60 * 60, // 365 days global max
+      });
+
+      expect(typeof encoded).toBe('string');
+
+      const decoded = await customJwtDecode({
+        token: encoded,
+        secret,
+      });
+
+      expect(decoded).not.toBeNull();
+      expect(decoded?.sub).toBe('user-123');
+      expect(decoded?.exp).toBe(shortExpiry);
+    });
+
+    it('rejects an expired JWE token', async () => {
+      const pastExpiry = Math.floor(Date.now() / 1000) - 60; // 1 minute ago
+
+      const token = {
+        sub: 'user-123',
+        email: 'user@example.com',
+        sessionExpiresAt: pastExpiry,
+        exp: pastExpiry,
+      };
+
+      const encoded = await customJwtEncode({
+        token,
+        secret,
+        maxAge: 365 * 24 * 60 * 60,
+      });
+
+      // jose jwtDecrypt rejects tokens with expired exp claim
+      const decoded = await customJwtDecode({
+        token: encoded,
+        secret,
+      });
+
+      expect(decoded).toBeNull();
+    });
+  });
+
+  describe('Finding 2: Idle timeout and user activity tracking', () => {
+    it('does not bump lastActivityAt on passive reads', async () => {
+      vi.mocked(prisma.oidcConfig.findFirst).mockResolvedValue({
+        id: 'cfg',
+        issuer: 'https://login.example.com',
+        clientId: 'client-id',
+        clientSecret: 'secret',
+        enabled: true,
+        autoProvision: true,
+        allowedDomains: [],
+        roleMapping: [],
+        profileMapping: {},
+        customScopes: null,
+        providerType: 'custom',
+        providerLabel: 'SSO',
+        organizationId: null,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+        configVersion: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        updatedBy: null,
+      } as any);
+
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        id: 'u1',
+        name: 'Test',
+        email: 'test@example.com',
+        role: 'USER',
+        tokenVersion: 1,
+        status: 'ACTIVE',
+        avatarUrl: null,
+        gender: null,
+      } as any);
+
+      const options = await getAuthOptions();
+      const jwtCallback = options.callbacks?.jwt;
+      expect(jwtCallback).toBeDefined();
+
+      const initialActivity = Date.now() - 60_000; // 1 min ago
+      const token = {
+        sub: 'u1',
+        oidcAuthenticatedAt: Date.now() - 60_000,
+        oidcConfigVersion: 1,
+        lastActivityAt: initialActivity,
+        tokenVersion: 1,
+      };
+
+      // Passive evaluation (e.g. background session read, trigger is undefined)
+      const evaluated = await jwtCallback!({
+        token,
+        user: undefined as any,
+        account: null,
+        trigger: undefined,
+        session: undefined,
+      });
+
+      expect((evaluated as any).lastActivityAt).toBe(initialActivity);
+    });
+
+    it('bumps lastActivityAt when activity signal is dispatched', async () => {
+      vi.mocked(prisma.oidcConfig.findFirst).mockResolvedValue({
+        id: 'cfg',
+        issuer: 'https://login.example.com',
+        clientId: 'client-id',
+        clientSecret: 'secret',
+        enabled: true,
+        autoProvision: true,
+        allowedDomains: [],
+        roleMapping: [],
+        profileMapping: {},
+        customScopes: null,
+        providerType: 'custom',
+        providerLabel: 'SSO',
+        organizationId: null,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+        configVersion: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        updatedBy: null,
+      } as any);
+
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        id: 'u1',
+        name: 'Test',
+        email: 'test@example.com',
+        role: 'USER',
+        tokenVersion: 1,
+        status: 'ACTIVE',
+        avatarUrl: null,
+        gender: null,
+      } as any);
+
+      const options = await getAuthOptions();
+      const jwtCallback = options.callbacks?.jwt;
+
+      const initialActivity = Date.now() - 60_000;
+      const token = {
+        sub: 'u1',
+        oidcAuthenticatedAt: Date.now() - 60_000,
+        oidcConfigVersion: 1,
+        lastActivityAt: initialActivity,
+        tokenVersion: 1,
+      };
+
+      // Active interaction signal from ActivityTracker
+      const evaluated = await jwtCallback!({
+        token,
+        user: undefined as any,
+        account: null,
+        trigger: 'update',
+        session: { activity: true },
+      });
+
+      expect((evaluated as any).lastActivityAt).toBeGreaterThan(initialActivity);
+    });
+  });
+
+  describe('Finding 4: Role de-provisioning on empty mapping list', () => {
+    it('demotes OIDC-owned ADMIN to USER when all mappings are deleted', async () => {
+      vi.mocked(prisma.oidcConfig.findFirst).mockResolvedValue({
+        id: 'cfg',
+        issuer: 'https://login.example.com',
+        clientId: 'client-id',
+        clientSecret: 'secret',
+        enabled: true,
+        autoProvision: true,
+        allowedDomains: [],
+        roleMapping: [], // Empty mapping list
+        profileMapping: {},
+        customScopes: null,
+        providerType: 'custom',
+        providerLabel: 'SSO',
+        organizationId: null,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+        configVersion: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        updatedBy: null,
+      } as any);
+
+      const targetUser = {
+        id: 'u-admin',
+        email: 'admin@example.com',
+        role: 'ADMIN',
+        roleSource: 'OIDC',
+        status: 'ACTIVE',
+        tokenVersion: 1,
+      };
+
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(targetUser as any);
+      vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue({
+        id: 'ident-1',
+        issuer: 'https://login.example.com',
+        subject: 'sub-1',
+        userId: 'u-admin',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any);
+
+      const options = await getAuthOptions();
+      const signInCallback = options.callbacks?.signIn;
+      expect(signInCallback).toBeDefined();
+
+      const userUpdateMock = vi.mocked(prisma.user.update);
+
+      await signInCallback!({
+        user: { id: 'u-admin', email: 'admin@example.com' } as any,
+        account: {
+          provider: 'oidc',
+          type: 'oauth',
+          providerAccountId: 'sub-1',
+        } as any,
+        profile: {
+          sub: 'sub-1',
+          email: 'admin@example.com',
+          email_verified: true,
+        } as any,
+      });
+
+      expect(userUpdateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'u-admin' },
+          data: expect.objectContaining({
+            role: 'USER', // Safely downgraded from ADMIN to default USER!
+          }),
+        })
+      );
+    });
+  });
+
+  describe('Finding 5: Deleted user and DB error fail-closed', () => {
+    it('invalidates session with USER_NOT_FOUND when user is missing from DB', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+      const options = await getAuthOptions();
+      const jwtCallback = options.callbacks?.jwt;
+
+      const token = {
+        sub: 'deleted-user',
+        email: 'deleted@example.com',
+        role: 'ADMIN',
+        tokenVersion: 1,
+      };
+
+      const result = await jwtCallback!({
+        token,
+        user: undefined as any,
+        account: null,
+        trigger: 'update',
+      });
+
+      expect((result as any).error).toBe('USER_NOT_FOUND');
+      expect((result as any).sub).toBeUndefined();
+      expect((result as any).role).toBeUndefined();
+    });
+
+    it('fails closed with SECURITY_LOOKUP_UNAVAILABLE on DB fetch error', async () => {
+      vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error('DB connection reset'));
+
+      const options = await getAuthOptions();
+      const jwtCallback = options.callbacks?.jwt;
+
+      const token = {
+        sub: 'active-user',
+        email: 'active@example.com',
+        role: 'ADMIN',
+        tokenVersion: 1,
+      };
+
+      const result = await jwtCallback!({
+        token,
+        user: undefined as any,
+        account: null,
+        trigger: 'update',
+      });
+
+      expect((result as any).error).toBe('SECURITY_LOOKUP_UNAVAILABLE');
+      expect((result as any).sub).toBeUndefined();
+      expect((result as any).role).toBeUndefined();
+    });
+  });
+
+  describe('Finding 6: Break-glass recovery UI policy', () => {
+    it('enables credential entry with breakGlassOnly flag when local login is disabled', () => {
+      const origLocal = process.env.AUTH_LOCAL_LOGIN_ENABLED;
+      const origBreak = process.env.AUTH_BREAK_GLASS_ENABLED;
+      const origEmail = process.env.AUTH_BREAK_GLASS_EMAIL;
+
+      process.env.AUTH_LOCAL_LOGIN_ENABLED = 'false';
+      process.env.AUTH_BREAK_GLASS_ENABLED = 'true';
+      process.env.AUTH_BREAK_GLASS_EMAIL = 'emergency@example.com';
+
+      const policy = getLocalAuthPolicy();
+      expect(policy.enabled).toBe(true);
+      expect(policy.localLoginEnabled).toBe(false);
+      expect(policy.breakGlassEnabled).toBe(true);
+      expect(policy.breakGlassEmail).toBe('emergency@example.com');
+
+      const credentialEntryEnabled = policy.enabled;
+      const breakGlassOnly = !policy.localLoginEnabled && policy.breakGlassEnabled && Boolean(policy.breakGlassEmail);
+
+      expect(credentialEntryEnabled).toBe(true);
+      expect(breakGlassOnly).toBe(true);
+
+      process.env.AUTH_LOCAL_LOGIN_ENABLED = origLocal;
+      process.env.AUTH_BREAK_GLASS_ENABLED = origBreak;
+      process.env.AUTH_BREAK_GLASS_EMAIL = origEmail;
+    });
+  });
+
+  describe('Findings 10 & 11: JWKS RS256 enforcement and bounded responses', () => {
+    it('rejects an EC-only signing key set because runtime verifies RS256', async () => {
+      vi.mocked(safeOutboundFetch).mockImplementation(async (url: string) => {
+        if (url.includes('.well-known/openid-configuration')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              issuer: 'https://login.example.com',
+              authorization_endpoint: 'https://login.example.com/auth',
+              token_endpoint: 'https://login.example.com/token',
+              jwks_uri: 'https://login.example.com/jwks',
+              id_token_signing_alg_values_supported: ['RS256'],
+            }),
+            headers: { get: () => null },
+          } as any;
+        }
+        if (url.includes('/jwks')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              // EC key only
+              keys: [
+                {
+                  kty: 'EC',
+                  crv: 'P-256',
+                  x: 'f83OJ3D2xFmT4v7G4C8z_m4xndWvcivWDfeHK55qv58',
+                  y: 'x_daaqudugzUMdKT1qFbvT77uGIlEb9AHmgHmASzGhY',
+                  kid: 'ec-key',
+                  use: 'sig',
+                },
+              ],
+            }),
+            headers: { get: () => null },
+          } as any;
+        }
+        return { ok: false, status: 404 } as any;
+      });
+
+      const result = await validateOidcConnection('https://login.example.com');
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/usable public signing key/i);
+    });
+
+    it('accepts an RS256 signing key', async () => {
+      vi.mocked(safeOutboundFetch).mockImplementation(async (url: string) => {
+        if (url.includes('.well-known/openid-configuration')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              issuer: 'https://login.example.com',
+              authorization_endpoint: 'https://login.example.com/auth',
+              token_endpoint: 'https://login.example.com/token',
+              jwks_uri: 'https://login.example.com/jwks',
+              id_token_signing_alg_values_supported: ['RS256'],
+            }),
+            headers: { get: () => null },
+          } as any;
+        }
+        if (url.includes('/jwks')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              keys: [
+                {
+                  kty: 'RSA',
+                  n: 'valid-modulus',
+                  e: 'AQAB',
+                  kid: 'rsa-key',
+                  use: 'sig',
+                  alg: 'RS256',
+                },
+              ],
+            }),
+            headers: { get: () => null },
+          } as any;
+        }
+        return { ok: false, status: 404 } as any;
+      });
+
+      const result = await validateOidcConnection('https://login.example.com');
+      expect(result.isValid).toBe(true);
+      expect(result.metadata?.issuer).toBe('https://login.example.com');
+    });
+  });
+
+  describe('Finding 7: Negative caching and stale-while-revalidate', () => {
+    it('uses stale-while-revalidate fallback during transient IdP outage', async () => {
+      let callCount = 0;
+      vi.mocked(safeOutboundFetch).mockImplementation(async (url: string) => {
+        callCount++;
+        if (callCount <= 2) {
+          // First pass: success
+          if (url.includes('.well-known')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                issuer: 'https://login.example.com',
+                authorization_endpoint: 'https://login.example.com/auth',
+                token_endpoint: 'https://login.example.com/token',
+                jwks_uri: 'https://login.example.com/jwks',
+              }),
+              headers: { get: () => null },
+            } as any;
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              keys: [{ kty: 'RSA', n: 'mod', e: 'AQAB', kid: 'k1', use: 'sig' }],
+            }),
+            headers: { get: () => null },
+          } as any;
+        }
+        // Second pass: network outage / timeout
+        throw new Error('fetch failed: timeout');
+      });
+
+      // 1. Initial success
+      const first = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+      expect(first.isValid).toBe(true);
+
+      // 2. Revalidation fails due to IdP outage, but returns stale-while-revalidate
+      // Simulate cache expiry by calling validate directly or letting runtime cache fall back
+      resetOidcRuntimeMetadataCache();
+      // Without cache, initial failure returns negative cache
+      const fail = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+      expect(fail.isValid).toBe(false);
+
+      // Subsequent call hits negative cache within 30 seconds without refetching
+      const failCached = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+      expect(failCached).toBe(fail);
+    });
+  });
+
+  describe('Finding 8: Shared runtime capability contract', () => {
+    it('reports runtimeReady false when runtime validation fails even if config exists', async () => {
+      vi.mocked(prisma.oidcConfig.findFirst).mockResolvedValue({
+        id: 'cfg',
+        issuer: 'https://broken-idp.example.com',
+        clientId: 'c1',
+        clientSecret: 's1',
+        enabled: true,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+        providerType: 'custom',
+        providerLabel: 'My SSO',
+      } as any);
+
+      vi.mocked(safeOutboundFetch).mockRejectedValue(new Error('Connection refused'));
+
+      const capability = await getOidcRuntimeCapability();
+      expect(capability.configured).toBe(true);
+      expect(capability.enabled).toBe(true);
+      expect(capability.runtimeReady).toBe(false); // Prevents login page from advertising broken SSO!
+      expect(capability.error).toBeDefined();
+    });
+  });
+});

--- a/tests/lib/auth-session-lifecycle.test.ts
+++ b/tests/lib/auth-session-lifecycle.test.ts
@@ -13,6 +13,20 @@ import {
 } from '@/lib/oidc-validation';
 import prisma from '@/lib/prisma';
 import { assertSafeOutboundUrl, safeOutboundFetch } from '@/lib/network-security';
+import { saveOidcConfig } from '@/app/(app)/settings/security/actions';
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  assertAdmin: vi.fn().mockResolvedValue({ id: 'admin-1', role: 'ADMIN' }),
+  getCurrentUser: vi.fn().mockResolvedValue({ id: 'admin-1', role: 'ADMIN' }),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  logAudit: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('@/lib/encryption', () => ({
   decrypt: vi.fn().mockImplementation(async (text: string) => text),
@@ -32,10 +46,14 @@ vi.mock('@/lib/prisma', () => ({
   default: {
     oidcConfig: {
       findFirst: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+      updateMany: vi.fn(),
+      create: vi.fn(),
     },
     user: {
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       count: vi.fn(),
     },
     oidcIdentity: {
@@ -43,6 +61,7 @@ vi.mock('@/lib/prisma', () => ({
     },
     oidcLinkingApproval: {
       findFirst: vi.fn(),
+      updateMany: vi.fn(),
     },
     $transaction: vi.fn((fn: (tx: unknown) => unknown) => fn(prisma)),
   },
@@ -481,12 +500,15 @@ describe('Auth session lifecycle and hardening', () => {
   });
 
   describe('Finding 7: Negative caching and stale-while-revalidate', () => {
-    it('uses stale-while-revalidate fallback during transient IdP outage', async () => {
-      let callCount = 0;
-      vi.mocked(safeOutboundFetch).mockImplementation(async (url: string) => {
-        callCount++;
-        if (callCount <= 2) {
-          // First pass: success
+    it('serves stale metadata immediately and revalidates in background with backoff during outage', async () => {
+      vi.useFakeTimers();
+      try {
+        const baseTime = new Date('2026-09-12T12:00:00.000Z').getTime();
+        vi.setSystemTime(baseTime);
+
+        let fetchCount = 0;
+        vi.mocked(safeOutboundFetch).mockImplementation(async (url: string) => {
+          fetchCount++;
           if (url.includes('.well-known')) {
             return {
               ok: true,
@@ -500,33 +522,293 @@ describe('Auth session lifecycle and hardening', () => {
               headers: { get: () => null },
             } as any;
           }
+          if (url.includes('/jwks')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                keys: [{ kty: 'RSA', n: 'mod', e: 'AQAB', kid: 'k1', use: 'sig' }],
+              }),
+              headers: { get: () => null },
+            } as any;
+          }
+          return { ok: false, status: 404 } as any;
+        });
+
+        // 1. Initial fetch populates fresh cache
+        const initial = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+        expect(initial.isValid).toBe(true);
+        expect(fetchCount).toBe(2); // discovery + jwks
+
+        // 2. Advance time past 5 min TTL (e.g. 301 seconds), within 1 hour staleUntil
+        vi.setSystemTime(baseTime + 301_000);
+
+        // Simulate IdP outage for background revalidation
+        vi.mocked(safeOutboundFetch).mockImplementation(async () => {
+          fetchCount++;
+          throw new Error('fetch failed: timeout');
+        });
+
+        // 3. Stale cache returns IMMEDIATELY without failing or waiting
+        const stale = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+        expect(stale.isValid).toBe(true);
+        expect(stale.metadata?.issuer).toBe('https://login.example.com');
+
+        // Let asynchronous background revalidation execute and handle failure
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const callsAfterRevalidationAttempt = fetchCount;
+
+        // 4. Backoff window (30s): calling again within 30s must NOT trigger another fetch
+        const cachedAgain = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+        expect(cachedAgain.isValid).toBe(true);
+        expect(fetchCount).toBe(callsAfterRevalidationAttempt); // Backoff prevented refetch storm!
+
+        // 5. Negative cache on cold start failure
+        resetOidcRuntimeMetadataCache();
+        const fail = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+        expect(fail.isValid).toBe(false);
+
+        const failCached = await getValidatedOidcRuntimeMetadata('https://login.example.com');
+        expect(failCached).toBe(fail);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('Finding: configVersion increments only on security-sensitive changes', () => {
+    const existingUpdatedAt = new Date('2026-09-12T10:00:00.000Z');
+    const baseExistingConfig = {
+      id: 'cfg-1',
+      issuer: 'https://login.example.com',
+      clientId: 'client-id',
+      clientSecret: 'encrypted-secret',
+      enabled: true,
+      autoProvision: true,
+      allowedDomains: ['example.com'],
+      roleMapping: [],
+      profileMapping: {},
+      customScopes: null,
+      providerType: 'custom',
+      providerLabel: 'Initial SSO',
+      organizationId: null,
+      tokenEndpointAuthMethod: 'client_secret_basic',
+      configVersion: 1,
+      createdAt: new Date(),
+      updatedAt: existingUpdatedAt,
+      updatedBy: 'admin-1',
+    };
+
+    const baseFormFields: Record<string, string> = {
+      issuer: 'https://login.example.com',
+      clientId: 'client-id',
+      clientSecret: '********', // existing secret preserved
+      enabled: 'true',
+      autoProvision: 'true',
+      allowedDomains: 'example.com',
+      roleMapping: '[]',
+      providerType: 'custom',
+      providerLabel: 'Initial SSO',
+      tokenEndpointAuthMethod: 'client_secret_basic',
+      expectedUpdatedAt: existingUpdatedAt.toISOString(),
+    };
+
+    function createOidcFormData(overrides: Record<string, string> = {}) {
+      const merged = { ...baseFormFields, ...overrides };
+      const formData = new FormData();
+      for (const [key, value] of Object.entries(merged)) {
+        formData.append(key, value);
+      }
+      return formData;
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.mocked(assertSafeOutboundUrl).mockResolvedValue(new URL('https://example.com'));
+      vi.mocked(prisma.oidcConfig.findFirst).mockResolvedValue({ ...baseExistingConfig } as any);
+      vi.mocked(prisma.oidcConfig.findUniqueOrThrow).mockResolvedValue({
+        updatedAt: new Date('2026-09-12T10:05:00.000Z'),
+      } as any);
+      vi.mocked(prisma.oidcConfig.updateMany).mockResolvedValue({ count: 1 } as any);
+
+      vi.mocked(safeOutboundFetch).mockImplementation(async (url: string) => {
+        if (url.includes('.well-known')) {
           return {
             ok: true,
             status: 200,
             json: async () => ({
-              keys: [{ kty: 'RSA', n: 'mod', e: 'AQAB', kid: 'k1', use: 'sig' }],
+              issuer: url.includes('new-issuer')
+                ? 'https://new-issuer.example.com'
+                : 'https://login.example.com',
+              authorization_endpoint: 'https://login.example.com/auth',
+              token_endpoint: 'https://login.example.com/token',
+              jwks_uri: 'https://login.example.com/jwks',
+              token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
             }),
             headers: { get: () => null },
           } as any;
         }
-        // Second pass: network outage / timeout
-        throw new Error('fetch failed: timeout');
+        if (url.includes('/jwks')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              keys: [
+                {
+                  kty: 'RSA',
+                  n: 'valid-modulus',
+                  e: 'AQAB',
+                  kid: 'rsa-key',
+                  use: 'sig',
+                  alg: 'RS256',
+                },
+              ],
+            }),
+            headers: { get: () => null },
+          } as any;
+        }
+        return { ok: false, status: 404 } as any;
+      });
+    });
+
+    const prevState = {
+      success: false,
+      error: null,
+      updatedAt: existingUpdatedAt.toISOString(),
+    };
+
+    it('does NOT increment configVersion on cosmetic providerLabel change', async () => {
+      const formData = createOidcFormData({ providerLabel: 'New Brand Label' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.providerLabel).toBe('New Brand Label');
+      expect(updateData.configVersion).toBeUndefined();
+    });
+
+    it('does NOT increment configVersion on cosmetic profileMapping change', async () => {
+      const formData = createOidcFormData({ 'profileMapping.department': 'org_unit' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.profileMapping).toEqual({ department: 'org_unit' });
+      expect(updateData.configVersion).toBeUndefined();
+    });
+
+    it('does NOT increment configVersion when clientSecret is unchanged placeholder', async () => {
+      const formData = createOidcFormData({ clientSecret: '********' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toBeUndefined();
+    });
+
+    it('DOES increment configVersion when clientSecret is updated to a new value', async () => {
+      const formData = createOidcFormData({ clientSecret: 'fresh-secret-value-123' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.clientSecret).toBe('fresh-secret-value-123');
+    });
+
+    it('DOES increment configVersion when clientId changes', async () => {
+      const formData = createOidcFormData({ clientId: 'brand-new-client-id' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.clientId).toBe('brand-new-client-id');
+    });
+
+    it('DOES increment configVersion when tokenEndpointAuthMethod changes', async () => {
+      const formData = createOidcFormData({ tokenEndpointAuthMethod: 'client_secret_post' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data as any;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.tokenEndpointAuthMethod).toBe('client_secret_post');
+    });
+
+    it('DOES increment configVersion when allowedDomains changes', async () => {
+      const formData = createOidcFormData({ allowedDomains: 'newdomain.com, otherdomain.org' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.allowedDomains).toEqual(['newdomain.com', 'otherdomain.org']);
+    });
+
+    it('DOES increment configVersion when organizationId changes', async () => {
+      const formData = createOidcFormData({ organizationId: 'org_enterprise_123' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.organizationId).toBe('org_enterprise_123');
+    });
+
+    it('DOES increment configVersion and initiates issuer migration when issuer changes', async () => {
+      const formData = createOidcFormData({
+        issuer: 'https://new-issuer.example.com',
+        confirmIssuerMigration: 'true',
+      });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.issuer).toBe('https://new-issuer.example.com');
+    });
+  });
+
+  describe('Finding: Session callback overrides session.expires with actual expiration', () => {
+    it('sets session.expires to match token.sessionExpiresAt', async () => {
+      const authOptions = await getAuthOptions();
+      const sessionCallback = authOptions.callbacks?.session;
+      expect(sessionCallback).toBeDefined();
+
+      const futureTimestamp = 1800000000;
+      const expectedIsoString = new Date(futureTimestamp * 1000).toISOString();
+
+      const mockSession = {
+        user: { name: 'Alice', email: 'alice@example.com' },
+        expires: '2099-01-01T00:00:00.000Z',
+      };
+
+      const mockToken = {
+        sub: 'user-1',
+        role: 'USER',
+        name: 'Alice',
+        email: 'alice@example.com',
+        sessionExpiresAt: futureTimestamp,
+      };
+
+      const result = await (sessionCallback as any)({
+        session: mockSession,
+        token: mockToken,
       });
 
-      // 1. Initial success
-      const first = await getValidatedOidcRuntimeMetadata('https://login.example.com');
-      expect(first.isValid).toBe(true);
-
-      // 2. Revalidation fails due to IdP outage, but returns stale-while-revalidate
-      // Simulate cache expiry by calling validate directly or letting runtime cache fall back
-      resetOidcRuntimeMetadataCache();
-      // Without cache, initial failure returns negative cache
-      const fail = await getValidatedOidcRuntimeMetadata('https://login.example.com');
-      expect(fail.isValid).toBe(false);
-
-      // Subsequent call hits negative cache within 30 seconds without refetching
-      const failCached = await getValidatedOidcRuntimeMetadata('https://login.example.com');
-      expect(failCached).toBe(fail);
+      expect(result.expires).toBe(expectedIsoString);
     });
   });
 

--- a/tests/lib/auth-session-lifecycle.test.ts
+++ b/tests/lib/auth-session-lifecycle.test.ts
@@ -779,6 +779,33 @@ describe('Auth session lifecycle and hardening', () => {
       expect(updateData.configVersion).toEqual({ increment: 1 });
       expect(updateData.issuer).toBe('https://new-issuer.example.com');
     });
+
+    it('DOES increment configVersion when roleMapping changes', async () => {
+      const newRoleMapping = JSON.stringify([
+        { claim: 'groups', value: 'admins', role: 'ADMIN' },
+      ]);
+      const formData = createOidcFormData({ roleMapping: newRoleMapping });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.roleMapping).toEqual([
+        { claim: 'groups', value: 'admins', role: 'ADMIN' },
+      ]);
+    });
+
+    it('DOES increment configVersion when customScopes changes', async () => {
+      const formData = createOidcFormData({ customScopes: 'openid profile email groups' });
+      const result = await saveOidcConfig(prevState, formData);
+
+      expect(result.success).toBe(true);
+      expect(prisma.oidcConfig.updateMany).toHaveBeenCalled();
+      const updateData = vi.mocked(prisma.oidcConfig.updateMany).mock.calls[0][0].data;
+      expect(updateData.configVersion).toEqual({ increment: 1 });
+      expect(updateData.customScopes).toBe('openid profile email groups');
+    });
   });
 
   describe('Finding: Session callback overrides session.expires with actual expiration', () => {

--- a/tests/lib/oidc-config.test.ts
+++ b/tests/lib/oidc-config.test.ts
@@ -36,6 +36,7 @@ describe('OIDC configuration loading', () => {
       providerType: 'auth0',
       providerLabel: 'Company SSO',
       organizationId: 'org_enterprise',
+      tokenEndpointAuthMethod: 'client_secret_post',
       profileMapping: {},
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -45,6 +46,7 @@ describe('OIDC configuration loading', () => {
     await expect(getOidcConfig()).resolves.toEqual(
       expect.objectContaining({
         organizationId: 'org_enterprise',
+        tokenEndpointAuthMethod: 'client_secret_post',
         configVersion: 3,
         providerType: 'auth0',
       })

--- a/tests/lib/oidc-identity-resolution.test.ts
+++ b/tests/lib/oidc-identity-resolution.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const tx = {
   oidcIdentity: {
     findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
     create: vi.fn(),
   },
   user: {
@@ -17,7 +19,11 @@ const tx = {
 
 vi.mock('@/lib/prisma', () => ({
   default: {
-    oidcIdentity: { findUnique: vi.fn() },
+    oidcIdentity: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
     user: { findUnique: vi.fn() },
   },
 }));
@@ -60,8 +66,12 @@ describe('resolveOidcIdentityForSignIn', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.oidcIdentity.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.oidcIdentity.update).mockResolvedValue({} as never);
     vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
     tx.oidcIdentity.findUnique.mockResolvedValue(null);
+    tx.oidcIdentity.findFirst.mockResolvedValue(null);
+    tx.oidcIdentity.update.mockResolvedValue({} as never);
     tx.oidcIdentity.create.mockResolvedValue({ id: 'identity-1' });
     tx.user.findUnique.mockResolvedValue(null);
     tx.user.create.mockResolvedValue(linkedUser);
@@ -167,26 +177,17 @@ describe('resolveOidcIdentityForSignIn', () => {
     expect(prisma.user.findUnique).not.toHaveBeenCalled();
   });
 
-  it('enforces configured Allowed Domains as an additional filter after Entra tenant verification', async () => {
-    const rejected = await resolveOidcIdentityForSignIn({
+  it('scopes Entra tenant verification to authority without email-domain authorization restriction', async () => {
+    const acceptedOutsideDomain = await resolveOidcIdentityForSignIn({
       ...baseInput,
       issuer: 'https://login.microsoftonline.com/tenant-id/v2.0',
       email: 'alice@outside.example',
+      allowedDomains: ['acme.com'],
       emailVerifiedClaim: undefined,
       requireEmailVerifiedClaim: false,
       claims: { tid: 'tenant-id' },
     });
-    expect(rejected).toEqual({ ok: false, reason: 'OIDC_ORGANIZATION_REJECTED' });
-
-    const acceptedMatching = await resolveOidcIdentityForSignIn({
-      ...baseInput,
-      issuer: 'https://login.microsoftonline.com/tenant-id/v2.0',
-      email: 'alice@example.com',
-      emailVerifiedClaim: undefined,
-      requireEmailVerifiedClaim: false,
-      claims: { tid: 'tenant-id' },
-    });
-    expect(acceptedMatching.ok).toBe(true);
+    expect(acceptedOutsideDomain.ok).toBe(true);
 
     const acceptedNoRestriction = await resolveOidcIdentityForSignIn({
       ...baseInput,
@@ -198,6 +199,38 @@ describe('resolveOidcIdentityForSignIn', () => {
       claims: { tid: 'tenant-id' },
     });
     expect(acceptedNoRestriction.ok).toBe(true);
+  });
+
+  it('reconciles legacy identities stored with non-canonical issuers (e.g. trailing slashes) to canonical issuer', async () => {
+    // Exact canonical match misses, but findFirst finds legacy trailing slash identity
+    vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.oidcIdentity.findFirst).mockResolvedValue({
+      id: 'legacy-id-1',
+      userId: 'user-1',
+    } as never);
+    vi.mocked(prisma.oidcIdentity.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(linkedUser as never);
+
+    const result = await resolveOidcIdentityForSignIn({
+      ...baseInput,
+      issuer: 'https://idp.example.com',
+      subject: 'subject-1',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.user.id).toBe('user-1');
+    expect(prisma.oidcIdentity.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          issuer: { in: expect.arrayContaining(['https://idp.example.com/']) },
+          subject: 'subject-1',
+        }),
+      })
+    );
+    expect(prisma.oidcIdentity.update).toHaveBeenCalledWith({
+      where: { id: 'legacy-id-1' },
+      data: { issuer: 'https://idp.example.com' },
+    });
   });
 
   it('rejects an established identity whose linked OpsKnight user is disabled', async () => {

--- a/tests/lib/oidc-identity-resolution.test.ts
+++ b/tests/lib/oidc-identity-resolution.test.ts
@@ -167,8 +167,8 @@ describe('resolveOidcIdentityForSignIn', () => {
     expect(prisma.user.findUnique).not.toHaveBeenCalled();
   });
 
-  it('does not use an Entra email suffix as tenant membership proof', async () => {
-    const result = await resolveOidcIdentityForSignIn({
+  it('enforces configured Allowed Domains as an additional filter after Entra tenant verification', async () => {
+    const rejected = await resolveOidcIdentityForSignIn({
       ...baseInput,
       issuer: 'https://login.microsoftonline.com/tenant-id/v2.0',
       email: 'alice@outside.example',
@@ -176,8 +176,28 @@ describe('resolveOidcIdentityForSignIn', () => {
       requireEmailVerifiedClaim: false,
       claims: { tid: 'tenant-id' },
     });
+    expect(rejected).toEqual({ ok: false, reason: 'OIDC_ORGANIZATION_REJECTED' });
 
-    expect(result.ok).toBe(true);
+    const acceptedMatching = await resolveOidcIdentityForSignIn({
+      ...baseInput,
+      issuer: 'https://login.microsoftonline.com/tenant-id/v2.0',
+      email: 'alice@example.com',
+      emailVerifiedClaim: undefined,
+      requireEmailVerifiedClaim: false,
+      claims: { tid: 'tenant-id' },
+    });
+    expect(acceptedMatching.ok).toBe(true);
+
+    const acceptedNoRestriction = await resolveOidcIdentityForSignIn({
+      ...baseInput,
+      issuer: 'https://login.microsoftonline.com/tenant-id/v2.0',
+      email: 'alice@outside.example',
+      allowedDomains: [],
+      emailVerifiedClaim: undefined,
+      requireEmailVerifiedClaim: false,
+      claims: { tid: 'tenant-id' },
+    });
+    expect(acceptedNoRestriction.ok).toBe(true);
   });
 
   it('rejects an established identity whose linked OpsKnight user is disabled', async () => {

--- a/tests/lib/oidc-identity-resolution.test.ts
+++ b/tests/lib/oidc-identity-resolution.test.ts
@@ -4,7 +4,9 @@ const tx = {
   oidcIdentity: {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
+    findMany: vi.fn(),
     update: vi.fn(),
+    deleteMany: vi.fn(),
     create: vi.fn(),
   },
   user: {
@@ -22,7 +24,9 @@ vi.mock('@/lib/prisma', () => ({
     oidcIdentity: {
       findUnique: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn(),
       update: vi.fn(),
+      deleteMany: vi.fn(),
     },
     user: { findUnique: vi.fn() },
   },
@@ -67,11 +71,15 @@ describe('resolveOidcIdentityForSignIn', () => {
     vi.clearAllMocks();
     vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.oidcIdentity.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.oidcIdentity.findMany).mockResolvedValue([]);
     vi.mocked(prisma.oidcIdentity.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.oidcIdentity.deleteMany).mockResolvedValue({ count: 0 });
     vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
     tx.oidcIdentity.findUnique.mockResolvedValue(null);
     tx.oidcIdentity.findFirst.mockResolvedValue(null);
+    tx.oidcIdentity.findMany.mockResolvedValue([]);
     tx.oidcIdentity.update.mockResolvedValue({} as never);
+    tx.oidcIdentity.deleteMany.mockResolvedValue({ count: 0 });
     tx.oidcIdentity.create.mockResolvedValue({ id: 'identity-1' });
     tx.user.findUnique.mockResolvedValue(null);
     tx.user.create.mockResolvedValue(linkedUser);
@@ -202,12 +210,15 @@ describe('resolveOidcIdentityForSignIn', () => {
   });
 
   it('reconciles legacy identities stored with non-canonical issuers (e.g. trailing slashes) to canonical issuer', async () => {
-    // Exact canonical match misses, but findFirst finds legacy trailing slash identity
+    // Exact canonical match misses, but findMany finds legacy trailing slash identity
     vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
-    vi.mocked(prisma.oidcIdentity.findFirst).mockResolvedValue({
-      id: 'legacy-id-1',
-      userId: 'user-1',
-    } as never);
+    vi.mocked(prisma.oidcIdentity.findMany).mockResolvedValue([
+      {
+        id: 'legacy-id-1',
+        userId: 'user-1',
+        createdAt: new Date(),
+      },
+    ] as never);
     vi.mocked(prisma.oidcIdentity.update).mockResolvedValue({} as never);
     vi.mocked(prisma.user.findUnique).mockResolvedValue(linkedUser as never);
 
@@ -219,7 +230,7 @@ describe('resolveOidcIdentityForSignIn', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.user.id).toBe('user-1');
-    expect(prisma.oidcIdentity.findFirst).toHaveBeenCalledWith(
+    expect(prisma.oidcIdentity.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           issuer: { in: expect.arrayContaining(['https://idp.example.com/']) },
@@ -403,5 +414,45 @@ describe('resolveOidcIdentityForSignIn', () => {
 
     expect(result).toEqual({ ok: false, reason: 'OIDC_EMAIL_ASSURANCE_REQUIRED' });
     expect(tx.user.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects ambiguous legacy identity reconciliation when variants belong to different users', async () => {
+    vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.oidcIdentity.findMany).mockResolvedValue([
+      { id: 'ident-1', userId: 'user-1', createdAt: new Date('2026-01-01') },
+      { id: 'ident-2', userId: 'user-2', createdAt: new Date('2026-01-02') },
+    ] as never);
+
+    const result = await resolveOidcIdentityForSignIn(baseInput);
+
+    expect(result).toEqual({ ok: false, reason: 'OIDC_AMBIGUOUS_IDENTITY_CONFLICT' });
+    expect(prisma.oidcIdentity.update).not.toHaveBeenCalled();
+    expect(prisma.oidcIdentity.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('safely deduplicates same-user legacy variants and reconciles the primary record to canonical issuer', async () => {
+    vi.mocked(prisma.oidcIdentity.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.oidcIdentity.findMany).mockResolvedValue([
+      { id: 'ident-primary', userId: 'user-1', createdAt: new Date('2026-01-01') },
+      { id: 'ident-duplicate', userId: 'user-1', createdAt: new Date('2026-01-02') },
+    ] as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(linkedUser as never);
+
+    const result = await resolveOidcIdentityForSignIn(baseInput);
+
+    expect(result).toEqual({
+      ok: true,
+      user: linkedUser,
+      identityCreated: false,
+      userCreated: false,
+      approvalConsumed: false,
+    });
+    expect(prisma.oidcIdentity.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ['ident-duplicate'] } },
+    });
+    expect(prisma.oidcIdentity.update).toHaveBeenCalledWith({
+      where: { id: 'ident-primary' },
+      data: { issuer: baseInput.issuer },
+    });
   });
 });

--- a/tests/lib/oidc-issuer-migration.test.ts
+++ b/tests/lib/oidc-issuer-migration.test.ts
@@ -8,7 +8,14 @@ import {
 describe('OIDC issuer migration policy', () => {
   it('normalizes only equivalent trailing slash forms', () => {
     expect(normalizeOidcIssuer('https://id.example.com/')).toBe('https://id.example.com');
+    expect(normalizeOidcIssuer('https://id.example.com///')).toBe('https://id.example.com');
+    expect(normalizeOidcIssuer('https://id.example.com/oauth2/default//')).toBe(
+      'https://id.example.com/oauth2/default'
+    );
     expect(isOidcIssuerMigration('https://id.example.com', 'https://id.example.com/')).toBe(false);
+    expect(isOidcIssuerMigration('https://id.example.com///', 'https://id.example.com/')).toBe(
+      false
+    );
   });
 
   it('treats host and path changes as trust-boundary migrations', () => {

--- a/tests/lib/oidc-provider-policy.test.ts
+++ b/tests/lib/oidc-provider-policy.test.ts
@@ -51,4 +51,32 @@ describe('OIDC provider security policy registry', () => {
       reason: 'OIDC_ORGANIZATION_REJECTED',
     });
   });
+
+  it('enforces Allowed Domains as an additional filter on Microsoft Entra policy', () => {
+    const policy = getOidcProviderPolicy('https://login.microsoftonline.com/tenant/v2.0');
+    expect(policy.family).toBe('azure');
+
+    // Without allowedDomains configured, any verified tenant user is permitted
+    expect(policy.validateOrganizationBoundary({ email: 'user@anywhere.com' }, [])).toEqual({
+      ok: true,
+    });
+
+    // With allowedDomains configured, acts as an additional email domain filter
+    expect(
+      policy.validateOrganizationBoundary(
+        { email: 'user@acme.com' },
+        ['acme.com', 'subsidiary.acme.com']
+      )
+    ).toEqual({ ok: true });
+
+    expect(
+      policy.validateOrganizationBoundary(
+        { email: 'user@external.com' },
+        ['acme.com', 'subsidiary.acme.com']
+      )
+    ).toEqual({
+      ok: false,
+      reason: 'OIDC_ORGANIZATION_REJECTED',
+    });
+  });
 });

--- a/tests/lib/oidc-provider-policy.test.ts
+++ b/tests/lib/oidc-provider-policy.test.ts
@@ -52,31 +52,22 @@ describe('OIDC provider security policy registry', () => {
     });
   });
 
-  it('enforces Allowed Domains as an additional filter on Microsoft Entra policy', () => {
+  it('scopes Microsoft Entra policy strictly to the tenant authority without email-domain authorization dependency', () => {
     const policy = getOidcProviderPolicy('https://login.microsoftonline.com/tenant/v2.0');
     expect(policy.family).toBe('azure');
 
-    // Without allowedDomains configured, any verified tenant user is permitted
+    // Tenant users are permitted by validated authority; mutable/optional email is not used as an authorization gate
     expect(policy.validateOrganizationBoundary({ email: 'user@anywhere.com' }, [])).toEqual({
       ok: true,
     });
-
-    // With allowedDomains configured, acts as an additional email domain filter
-    expect(
-      policy.validateOrganizationBoundary(
-        { email: 'user@acme.com' },
-        ['acme.com', 'subsidiary.acme.com']
-      )
-    ).toEqual({ ok: true });
-
     expect(
       policy.validateOrganizationBoundary(
         { email: 'user@external.com' },
         ['acme.com', 'subsidiary.acme.com']
       )
-    ).toEqual({
-      ok: false,
-      reason: 'OIDC_ORGANIZATION_REJECTED',
+    ).toEqual({ ok: true });
+    expect(policy.validateOrganizationBoundary({}, ['acme.com'])).toEqual({
+      ok: true,
     });
   });
 });

--- a/tests/lib/oidc-runtime-provider.test.ts
+++ b/tests/lib/oidc-runtime-provider.test.ts
@@ -47,4 +47,103 @@ describe('OIDC runtime provider networking', () => {
     // Auth0 (and other providers) advertise and sign with trailing slash in iss.
     expect(provider.issuer).toBe('https://dev-example.us.auth0.com/');
   });
+
+  it('configures client_secret_post and defaults to client_secret_basic', () => {
+    const defaultProvider = OIDCProvider({
+      issuer: 'https://identity.example.com',
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      metadata: {
+        issuer: 'https://identity.example.com',
+        authorizationEndpoint: 'https://identity.example.com/authorize',
+        tokenEndpoint: 'https://identity.example.com/token',
+        jwksUri: 'https://identity.example.com/jwks',
+      },
+    });
+    expect(defaultProvider.client?.token_endpoint_auth_method).toBe('client_secret_basic');
+
+    const postProvider = OIDCProvider({
+      issuer: 'https://identity.example.com',
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      tokenEndpointAuthMethod: 'client_secret_post',
+      metadata: {
+        issuer: 'https://identity.example.com',
+        authorizationEndpoint: 'https://identity.example.com/authorize',
+        tokenEndpoint: 'https://identity.example.com/token',
+        jwksUri: 'https://identity.example.com/jwks',
+      },
+    });
+    expect(postProvider.client?.token_endpoint_auth_method).toBe('client_secret_post');
+  });
+
+  it('includes organization parameter in authorization params for Auth0 when configured', () => {
+    const auth0WithOrg = OIDCProvider({
+      issuer: 'https://tenant.us.auth0.com',
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      providerType: 'auth0',
+      organizationId: 'org_abc123',
+      metadata: {
+        issuer: 'https://tenant.us.auth0.com/',
+        authorizationEndpoint: 'https://tenant.us.auth0.com/authorize',
+        tokenEndpoint: 'https://tenant.us.auth0.com/oauth/token',
+        jwksUri: 'https://tenant.us.auth0.com/.well-known/jwks.json',
+      },
+    });
+    expect(
+      (auth0WithOrg.authorization as { params?: Record<string, string> })?.params?.organization
+    ).toBe('org_abc123');
+
+    // Without organizationId
+    const auth0NoOrg = OIDCProvider({
+      issuer: 'https://tenant.us.auth0.com',
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      providerType: 'auth0',
+      organizationId: null,
+      metadata: {
+        issuer: 'https://tenant.us.auth0.com/',
+        authorizationEndpoint: 'https://tenant.us.auth0.com/authorize',
+        tokenEndpoint: 'https://tenant.us.auth0.com/oauth/token',
+        jwksUri: 'https://tenant.us.auth0.com/.well-known/jwks.json',
+      },
+    });
+    expect(
+      (auth0NoOrg.authorization as { params?: Record<string, string> })?.params?.organization
+    ).toBeUndefined();
+
+    // Non-Auth0 provider with organizationId should not have organization param in OAuth authorization
+    const oktaWithOrg = OIDCProvider({
+      issuer: 'https://example.okta.com',
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      providerType: 'okta',
+      organizationId: 'org_abc123',
+      metadata: {
+        issuer: 'https://example.okta.com',
+        authorizationEndpoint: 'https://example.okta.com/oauth2/v1/authorize',
+        tokenEndpoint: 'https://example.okta.com/oauth2/v1/token',
+        jwksUri: 'https://example.okta.com/oauth2/v1/keys',
+      },
+    });
+    expect(
+      (oktaWithOrg.authorization as { params?: Record<string, string> })?.params?.organization
+    ).toBeUndefined();
+  });
+
+  it('normalizes pathological multiple trailing slashes using normalizeOidcIssuer', () => {
+    const provider = OIDCProvider({
+      issuer: 'https://identity.example.com///',
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      metadata: {
+        issuer: '', // fallback to normalized issuer
+        authorizationEndpoint: 'https://identity.example.com/authorize',
+        tokenEndpoint: 'https://identity.example.com/token',
+        jwksUri: 'https://identity.example.com/jwks',
+      },
+    });
+    expect(provider.issuer).toBe('https://identity.example.com');
+  });
 });

--- a/tests/lib/oidc-validation-provider-matrix.test.ts
+++ b/tests/lib/oidc-validation-provider-matrix.test.ts
@@ -290,11 +290,37 @@ describe('OIDC discovery provider matrix', () => {
       'Identity Provider does not support the selected token endpoint authentication method (client_secret_post)'
     );
 
-    // 3. Omitting token_endpoint_auth_methods_supported in metadata allows validation (RFC default)
+    // 3. Omitting token_endpoint_auth_methods_supported defaults to client_secret_basic (OIDC Core / RFC 8414)
     setupValidFetch(200, makeMetadata('https://identity.example.com'));
-    const omittedResult = await validateOidcConnection('https://identity.example.com', {
+    const omittedBasicResult = await validateOidcConnection('https://identity.example.com', {
+      tokenEndpointAuthMethod: 'client_secret_basic',
+    });
+    expect(omittedBasicResult.isValid).toBe(true);
+    expect(omittedBasicResult.metadata?.tokenEndpointAuthMethodsSupported).toEqual([
+      'client_secret_basic',
+    ]);
+
+    // 4. Omitting token_endpoint_auth_methods_supported rejects client_secret_post
+    setupValidFetch(200, makeMetadata('https://identity.example.com'));
+    const omittedPostResult = await validateOidcConnection('https://identity.example.com', {
       tokenEndpointAuthMethod: 'client_secret_post',
     });
-    expect(omittedResult.isValid).toBe(true);
+    expect(omittedPostResult.isValid).toBe(false);
+    expect(omittedPostResult.error).toContain(
+      'Identity Provider does not support the selected token endpoint authentication method (client_secret_post)'
+    );
+
+    // 5. Reject empty or malformed token_endpoint_auth_methods_supported array
+    setupValidFetch(
+      200,
+      makeMetadata('https://identity.example.com', {
+        token_endpoint_auth_methods_supported: [],
+      })
+    );
+    const emptyResult = await validateOidcConnection('https://identity.example.com', {
+      tokenEndpointAuthMethod: 'client_secret_basic',
+    });
+    expect(emptyResult.isValid).toBe(false);
+    expect(emptyResult.error).toContain('invalid or empty token_endpoint_auth_methods_supported');
   });
 });

--- a/tests/lib/oidc-validation-provider-matrix.test.ts
+++ b/tests/lib/oidc-validation-provider-matrix.test.ts
@@ -253,4 +253,48 @@ describe('OIDC discovery provider matrix', () => {
     expect(result.isValid).toBe(false);
     expect(result.error).toMatch(/usable public signing key/i);
   });
+
+  it('validates configured tokenEndpointAuthMethod against advertised token_endpoint_auth_methods_supported', async () => {
+    // 1. Success when requested method is in advertised list
+    setupValidFetch(
+      200,
+      makeMetadata('https://identity.example.com', {
+        token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+      })
+    );
+
+    const validResult = await validateOidcConnection('https://identity.example.com', {
+      tokenEndpointAuthMethod: 'client_secret_post',
+    });
+
+    expect(validResult.isValid).toBe(true);
+    expect(validResult.metadata?.tokenEndpointAuthMethodsSupported).toEqual([
+      'client_secret_basic',
+      'client_secret_post',
+    ]);
+
+    // 2. Fails when requested method is NOT in advertised list
+    setupValidFetch(
+      200,
+      makeMetadata('https://identity.example.com', {
+        token_endpoint_auth_methods_supported: ['client_secret_basic'],
+      })
+    );
+
+    const invalidResult = await validateOidcConnection('https://identity.example.com', {
+      tokenEndpointAuthMethod: 'client_secret_post',
+    });
+
+    expect(invalidResult.isValid).toBe(false);
+    expect(invalidResult.error).toContain(
+      'Identity Provider does not support the selected token endpoint authentication method (client_secret_post)'
+    );
+
+    // 3. Omitting token_endpoint_auth_methods_supported in metadata allows validation (RFC default)
+    setupValidFetch(200, makeMetadata('https://identity.example.com'));
+    const omittedResult = await validateOidcConnection('https://identity.example.com', {
+      tokenEndpointAuthMethod: 'client_secret_post',
+    });
+    expect(omittedResult.isValid).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

This PR hardens OIDC provider interoperability, enterprise session lifecycle management, and migration safety across Google Workspace, Microsoft Entra ID, Okta, Auth0, and generic OIDC providers on OpsKnight (NextAuth 4.24.15 pinned).

### Key Changes

1. **Token Endpoint Authentication Method Configurability (`client_secret_basic` vs `client_secret_post`)**:
   - Added `tokenEndpointAuthMethod` (`client_secret_basic` | `client_secret_post`, default: `client_secret_basic`) to the `OidcConfig` Prisma model and migration `20260913120000_add_oidc_token_endpoint_auth_method`.
   - Forwarded `token_endpoint_auth_method` into the NextAuth runtime client configuration.
   - Updated discovery validation to check the selected method against the IdP's advertised `token_endpoint_auth_methods_supported` metadata (defaulting to standard `client_secret_basic` per RFC 6749 when omitted).
   - Added radio selector in the SSO Admin Settings UI and incorporated it into the save/test flows and change-detection dirty states.

2. **Auth0 Organization Authorization Request Context**:
   - Updated NextAuth `OIDCProvider` authorization configuration to pass `organization: organizationId.trim()` as an authorization query parameter when `providerType === 'auth0'` and `organizationId` is configured.
   - Retained the callback-side `org_id` token assertion validation to prevent cross-tenant token substitution.

3. **Microsoft Entra ID Tenant Authority Scope & Clarification**:
   - Explicitly clarified and aligned the Microsoft Entra ID security boundary in policy and documentation: tenant-specific issuer authorities (`https://login.microsoftonline.com/{tenantId}/v2.0`) establish the organization authority boundary for workforce tenants.
   - Documented in `docs/v1.5/security/oidc-setup.md` and `docs/v1.5/administration/authentication.md` that external/CIAM authorities (`*.ciamlogin.com`) operate under generic OIDC policy.

4. **Centralized Issuer Normalization & Migration Hardening**:
   - Centralized `normalizeOidcIssuer` in `@/lib/oidc/issuer-migration` to strip all trailing slashes uniformly.
   - Migration `20260913120000_add_oidc_token_endpoint_auth_method`: checks for cross-user conflicts (`o1."userId" <> o2."userId"`) with `RAISE EXCEPTION` to prevent silent account hijacking, and safely deduplicates same-user legacy variants using window partitioning over `(canonical issuer, subject, userId)`.
   - Runtime legacy reconciliation in `resolveOidcIdentityForSignIn` rejects ambiguous legacy identities across multiple users with `OIDC_AMBIGUOUS_IDENTITY_CONFLICT`, and atomically deduplicates same-user redundant variants.

5. **Session Lifecycle & RBAC Hardening**:
   - Custom JWT encoder/decoder preserving exact session expiration (`sessionExpiresAt`) rather than global 365-day maxAge.
   - NextAuth `session()` callback sets `session.expires` to match `new Date(token.sessionExpiresAt * 1000).toISOString()`.
   - Throttled user activity tracking with immediate first-interaction dispatch.
   - Role-mapping and custom-scopes changes increment `configVersion` to revoke existing OIDC sessions and enforce fresh RBAC claim evaluation.
   - Safe fallback to `USER` default role when all OIDC role mappings are deleted.
   - Fail-closed security lookup on DB connection errors (`SECURITY_LOOKUP_UNAVAILABLE`).
   - True Stale-While-Revalidate (SWR) for discovery metadata with asynchronous single-flight revalidation and 30s backoff.

---

### Verification

- **Unit & Lifecycle Tests**: 452 test files, 3,164 tests passed (`npm run test:unit`).
- **All OIDC & Auth Suites**: 20 test files, 197 tests passed (`npx vitest run tests/lib/oidc* tests/architecture/oidc* tests/lib/auth*`).
- **TypeScript**: `npx tsc --noEmit` passed with 0 errors.
- **ESLint**: 0 errors across all modified files.
- **CI Status**: All workflows green on previous head and running on latest commit `e8583ce0`.
