### PR TITLE
feat(ui): toast visual hierarchy redesign — neutral surface, semantic badges & layered elevation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,25 +11,25 @@
   --toast-muted: #64748b;
   --toast-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 18px rgba(0, 0, 0, 0.08), 0 16px 40px rgba(0, 0, 0, 0.06);
 
-  --toast-success-accent: #10b981;
-  --toast-success-icon-bg: #ecfdf5;
+  --toast-success-accent: #059669;
+  --toast-success-icon-bg: #f0fdf4;
   --toast-success-icon-border: #a7f3d0;
   --toast-success-icon-fg: #059669;
 
-  --toast-error-accent: #f43f5e;
-  --toast-error-icon-bg: #fff1f2;
+  --toast-error-accent: #e11d48;
+  --toast-error-icon-bg: #fef2f2;
   --toast-error-icon-border: #fecdd3;
   --toast-error-icon-fg: #e11d48;
 
-  --toast-warning-accent: #f59e0b;
+  --toast-warning-accent: #d97706;
   --toast-warning-icon-bg: #fffbeb;
   --toast-warning-icon-border: #fde68a;
   --toast-warning-icon-fg: #d97706;
 
-  --toast-info-accent: #0284c7;
-  --toast-info-icon-bg: #f0f9ff;
-  --toast-info-icon-border: #bae6fd;
-  --toast-info-icon-fg: #0284c7;
+  --toast-info-accent: #2563eb;
+  --toast-info-icon-bg: #eff6ff;
+  --toast-info-icon-border: #bfdbfe;
+  --toast-info-icon-fg: #2563eb;
 
   /* Backward-compatible fallbacks */
   --toast-success-bg: var(--toast-bg);
@@ -320,25 +320,25 @@
   --toast-muted: #9ca3af;
   --toast-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5), 0 20px 48px rgba(0, 0, 0, 0.6);
 
-  --toast-success-accent: #10b981;
+  --toast-success-accent: #059669;
   --toast-success-icon-bg: #064e3b;
   --toast-success-icon-border: #047857;
   --toast-success-icon-fg: #6ee7b7;
 
-  --toast-error-accent: #f43f5e;
+  --toast-error-accent: #e11d48;
   --toast-error-icon-bg: #4c0519;
   --toast-error-icon-border: #9f1239;
   --toast-error-icon-fg: #fda4af;
 
-  --toast-warning-accent: #f59e0b;
+  --toast-warning-accent: #d97706;
   --toast-warning-icon-bg: #451a03;
   --toast-warning-icon-border: #92400e;
   --toast-warning-icon-fg: #fcd34d;
 
-  --toast-info-accent: #0284c7;
-  --toast-info-icon-bg: #082f49;
-  --toast-info-icon-border: #0369a1;
-  --toast-info-icon-fg: #7dd3fc;
+  --toast-info-accent: #2563eb;
+  --toast-info-icon-bg: #1e3a8a33;
+  --toast-info-icon-border: #1d4ed8;
+  --toast-info-icon-fg: #93c5fd;
 
   /* Backward-compatible fallbacks */
   --toast-success-bg: var(--toast-bg);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,19 +4,46 @@
   /* Primary & Modern Palette: Muted Executive Slate */
   color-scheme: light;
 
-  /* Semantic toast tokens — light theme (restrained green + neutral surface) */
-  --toast-success-bg: #ecfdf5;
-  --toast-success-border: #a7f3d0;
-  --toast-success-fg: #022c22;
-  --toast-error-bg: #fff1f2;
-  --toast-error-border: #fecdd3;
-  --toast-error-fg: #4c0519;
-  --toast-warning-bg: #fffbeb;
-  --toast-warning-border: #fde68a;
-  --toast-warning-fg: #451a03;
-  --toast-info-bg: #f0f9ff;
-  --toast-info-border: #bae6fd;
-  --toast-info-fg: #0c4a6e;
+  /* Enterprise notification toast tokens — neutral elevated card with semantic accents */
+  --toast-bg: #ffffff;
+  --toast-border: #e2e8f0;
+  --toast-fg: #0f172a;
+  --toast-muted: #64748b;
+  --toast-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 18px rgba(0, 0, 0, 0.08), 0 16px 40px rgba(0, 0, 0, 0.06);
+
+  --toast-success-accent: #10b981;
+  --toast-success-icon-bg: #ecfdf5;
+  --toast-success-icon-border: #a7f3d0;
+  --toast-success-icon-fg: #059669;
+
+  --toast-error-accent: #f43f5e;
+  --toast-error-icon-bg: #fff1f2;
+  --toast-error-icon-border: #fecdd3;
+  --toast-error-icon-fg: #e11d48;
+
+  --toast-warning-accent: #f59e0b;
+  --toast-warning-icon-bg: #fffbeb;
+  --toast-warning-icon-border: #fde68a;
+  --toast-warning-icon-fg: #d97706;
+
+  --toast-info-accent: #0284c7;
+  --toast-info-icon-bg: #f0f9ff;
+  --toast-info-icon-border: #bae6fd;
+  --toast-info-icon-fg: #0284c7;
+
+  /* Backward-compatible fallbacks */
+  --toast-success-bg: var(--toast-bg);
+  --toast-success-border: var(--toast-border);
+  --toast-success-fg: var(--toast-fg);
+  --toast-error-bg: var(--toast-bg);
+  --toast-error-border: var(--toast-border);
+  --toast-error-fg: var(--toast-fg);
+  --toast-warning-bg: var(--toast-bg);
+  --toast-warning-border: var(--toast-border);
+  --toast-warning-fg: var(--toast-fg);
+  --toast-info-bg: var(--toast-bg);
+  --toast-info-border: var(--toast-border);
+  --toast-info-fg: var(--toast-fg);
   /* Tailwind expects HSL numbers (no unit, no hsl wrapper) - shadcn format */
   /* Note: shadcn tokens at line 131 define --primary: 30 41 59 */
   /* This is overridden by shadcn tokens below, so we don't define it here */
@@ -286,19 +313,46 @@
   --text-secondary: #94a3b8;
   --text-muted: #64748b;
 
-  /* Toast tokens — dark theme (dark neutral + emerald accent, not pale green flash) */
-  --toast-success-bg: #0f2a1f;
-  --toast-success-border: #065f46;
-  --toast-success-fg: #d1fae5;
-  --toast-error-bg: #2a0f1a;
-  --toast-error-border: #9f1239;
-  --toast-error-fg: #ffe4e6;
-  --toast-warning-bg: #2a1f0f;
-  --toast-warning-border: #92400e;
-  --toast-warning-fg: #fef3c7;
-  --toast-info-bg: #0f253a;
-  --toast-info-border: #075985;
-  --toast-info-fg: #e0f2fe;
+  /* Enterprise notification toast tokens — dark theme (neutral elevated card with semantic accents) */
+  --toast-bg: #111827;
+  --toast-border: #1f2937;
+  --toast-fg: #f9fafb;
+  --toast-muted: #9ca3af;
+  --toast-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5), 0 20px 48px rgba(0, 0, 0, 0.6);
+
+  --toast-success-accent: #10b981;
+  --toast-success-icon-bg: #064e3b;
+  --toast-success-icon-border: #047857;
+  --toast-success-icon-fg: #6ee7b7;
+
+  --toast-error-accent: #f43f5e;
+  --toast-error-icon-bg: #4c0519;
+  --toast-error-icon-border: #9f1239;
+  --toast-error-icon-fg: #fda4af;
+
+  --toast-warning-accent: #f59e0b;
+  --toast-warning-icon-bg: #451a03;
+  --toast-warning-icon-border: #92400e;
+  --toast-warning-icon-fg: #fcd34d;
+
+  --toast-info-accent: #0284c7;
+  --toast-info-icon-bg: #082f49;
+  --toast-info-icon-border: #0369a1;
+  --toast-info-icon-fg: #7dd3fc;
+
+  /* Backward-compatible fallbacks */
+  --toast-success-bg: var(--toast-bg);
+  --toast-success-border: var(--toast-border);
+  --toast-success-fg: var(--toast-fg);
+  --toast-error-bg: var(--toast-bg);
+  --toast-error-border: var(--toast-border);
+  --toast-error-fg: var(--toast-fg);
+  --toast-warning-bg: var(--toast-bg);
+  --toast-warning-border: var(--toast-border);
+  --toast-warning-fg: var(--toast-fg);
+  --toast-info-bg: var(--toast-bg);
+  --toast-info-border: var(--toast-border);
+  --toast-info-fg: var(--toast-fg);
 }
 
 

--- a/src/components/ui/shadcn/sonner.tsx
+++ b/src/components/ui/shadcn/sonner.tsx
@@ -65,7 +65,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast:
             'group relative flex items-start gap-2.5 ' +
-            'data-[styled=true]:!w-[min(360px,calc(100vw-24px))] data-[styled=true]:!min-w-[320px] data-[styled=true]:!max-w-[380px] ' +
+            'data-[styled=true]:!w-[min(360px,calc(100vw-24px))] sm:data-[styled=true]:!min-w-[320px] data-[styled=true]:!max-w-[380px] ' +
             'data-[styled=true]:!rounded-xl data-[styled=true]:!border data-[styled=true]:!border-[var(--toast-border)] ' +
             'data-[styled=true]:!bg-[var(--toast-bg)] data-[styled=true]:!text-[var(--toast-fg)] ' +
             'data-[styled=true]:!p-3.5 data-[styled=true]:!pr-10 ' +

--- a/src/components/ui/shadcn/sonner.tsx
+++ b/src/components/ui/shadcn/sonner.tsx
@@ -14,37 +14,84 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme={theme as ToasterProps['theme']}
       className="toaster group"
       position="top-right"
-      visibleToasts={4}
-      gap={10}
+      visibleToasts={3}
+      gap={8}
       offset="20px"
       mobileOffset="12px"
       closeButton
       icons={{
-        success: <CircleCheck className="h-4 w-4" />,
-        info: <Info className="h-4 w-4" />,
-        warning: <TriangleAlert className="h-4 w-4" />,
-        error: <OctagonX className="h-4 w-4" />,
-        loading: <LoaderCircle className="h-4 w-4 animate-spin motion-reduce:animate-none" />,
+        success: (
+          <div
+            data-testid="toast-icon-badge"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--toast-success-icon-border)] bg-[var(--toast-success-icon-bg)] text-[var(--toast-success-icon-fg)]"
+          >
+            <CircleCheck className="h-4 w-4" />
+          </div>
+        ),
+        info: (
+          <div
+            data-testid="toast-icon-badge"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--toast-info-icon-border)] bg-[var(--toast-info-icon-bg)] text-[var(--toast-info-icon-fg)]"
+          >
+            <Info className="h-4 w-4" />
+          </div>
+        ),
+        warning: (
+          <div
+            data-testid="toast-icon-badge"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--toast-warning-icon-border)] bg-[var(--toast-warning-icon-bg)] text-[var(--toast-warning-icon-fg)]"
+          >
+            <TriangleAlert className="h-4 w-4" />
+          </div>
+        ),
+        error: (
+          <div
+            data-testid="toast-icon-badge"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--toast-error-icon-border)] bg-[var(--toast-error-icon-bg)] text-[var(--toast-error-icon-fg)]"
+          >
+            <OctagonX className="h-4 w-4" />
+          </div>
+        ),
+        loading: (
+          <div
+            data-testid="toast-icon-badge"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-border/80 bg-muted/60 text-muted-foreground"
+          >
+            <LoaderCircle className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+          </div>
+        ),
       }}
       toastOptions={{
         classNames: {
           toast:
-            'group relative data-[styled=true]:!w-[min(400px,calc(100vw-24px))] data-[styled=true]:!rounded-xl data-[styled=true]:!border data-[styled=true]:!pl-4 data-[styled=true]:!pr-10 data-[styled=true]:!py-3.5 data-[styled=true]:!shadow-[0_12px_32px_-12px_rgba(15,23,42,0.35)] data-[styled=true]:!backdrop-blur-xl data-[styled=false]:!p-0 data-[styled=false]:!border-0 data-[styled=false]:!bg-transparent data-[styled=false]:!shadow-none data-[styled=false]:!w-auto data-[styled=false]:!overflow-visible break-words motion-reduce:transition-none',
-          success:
-            '!border-[var(--toast-success-border)] !bg-[var(--toast-success-bg)] !text-[var(--toast-success-fg)]',
+            'group relative flex items-start gap-2.5 ' +
+            'data-[styled=true]:!w-[min(360px,calc(100vw-24px))] data-[styled=true]:!min-w-[320px] data-[styled=true]:!max-w-[380px] ' +
+            'data-[styled=true]:!rounded-xl data-[styled=true]:!border data-[styled=true]:!border-[var(--toast-border)] ' +
+            'data-[styled=true]:!bg-[var(--toast-bg)] data-[styled=true]:!text-[var(--toast-fg)] ' +
+            'data-[styled=true]:!p-3.5 data-[styled=true]:!pr-10 ' +
+            'data-[styled=true]:!shadow-[var(--toast-shadow)] data-[styled=true]:!backdrop-blur-xl ' +
+            'before:absolute before:left-0 before:top-2.5 before:bottom-2.5 before:w-[3px] before:rounded-r-full ' +
+            'data-[styled=false]:!p-0 data-[styled=false]:!border-0 data-[styled=false]:!bg-transparent data-[styled=false]:!shadow-none data-[styled=false]:!w-auto data-[styled=false]:!overflow-visible ' +
+            'break-words motion-reduce:transition-none',
+          success: 'before:!bg-[var(--toast-success-accent)]',
           error:
-            '!border-[var(--toast-error-border)] !bg-[var(--toast-error-bg)] !text-[var(--toast-error-fg)]',
-          warning:
-            '!border-[var(--toast-warning-border)] !bg-[var(--toast-warning-bg)] !text-[var(--toast-warning-fg)]',
-          info: '!border-[var(--toast-info-border)] !bg-[var(--toast-info-bg)] !text-[var(--toast-info-fg)]',
-          title: '!text-sm !font-semibold !leading-5',
-          description: '!mt-0.5 !text-sm !leading-5 !text-current !opacity-75',
-          icon: '!self-start !mt-0.5',
+            'before:!bg-[var(--toast-error-accent)] data-[styled=true]:!border-[var(--toast-error-icon-border)]/60',
+          warning: 'before:!bg-[var(--toast-warning-accent)]',
+          info: 'before:!bg-[var(--toast-info-accent)]',
+          title: '!text-sm !font-semibold !leading-5 !text-[var(--toast-fg)]',
+          description: '!mt-0.5 !text-[13px] !leading-[18px] !text-[var(--toast-muted)]',
+          icon: '!self-start !mt-0',
           closeButton:
-            '!right-2.5 !top-2.5 !left-auto !translate-x-0 !translate-y-0 !h-10 !w-10 !rounded-md !border !border-border/70 !bg-background/90 !text-muted-foreground !opacity-100 hover:!text-foreground hover:!bg-muted !pointer-events-auto flex items-center justify-center cursor-pointer shadow-2xs transition-opacity transition-colors motion-reduce:transition-none',
-          actionButton: '!rounded-md !bg-primary !text-primary-foreground hover:!bg-primary/90',
+            '!right-2.5 !top-2.5 !left-auto !translate-x-0 !translate-y-0 ' +
+            '!h-7 !w-7 !rounded-md !border-0 !bg-transparent ' +
+            '!text-[var(--toast-muted)] !opacity-60 hover:!opacity-100 hover:!bg-muted/70 hover:!text-[var(--toast-fg)] ' +
+            '!pointer-events-auto flex items-center justify-center cursor-pointer ' +
+            'after:absolute after:-inset-1.5 after:content-[\'\'] after:pointer-events-auto ' +
+            'transition-opacity transition-colors motion-reduce:transition-none',
+          actionButton:
+            '!rounded-md !text-xs !font-medium !h-7 !px-2.5 !bg-primary !text-primary-foreground hover:!bg-primary/90',
           cancelButton:
-            '!rounded-md !border !border-border !bg-card !text-foreground hover:!bg-muted',
+            '!rounded-md !text-xs !font-medium !h-7 !px-2.5 !border !border-border !bg-background !text-foreground hover:!bg-muted',
         },
       }}
       {...props}

--- a/tests/components/ui/ToastIntegration.test.tsx
+++ b/tests/components/ui/ToastIntegration.test.tsx
@@ -67,15 +67,35 @@ describe('Toast and Toaster Component Contract', () => {
     expect(await screen.findByText('Informational notice')).toBeDefined();
   });
 
-  it('provides close button with touch-friendly 40x40 dimension classes', async () => {
+  it('provides a 28x28 visual close button with expanded touch target', async () => {
     render(<Toaster />);
 
     notify.success('Touch target test', { id: 'touch:1' });
     await screen.findByText('Touch target test');
 
     const closeBtn = screen.getByRole('button', { name: /close/i });
-    expect(closeBtn.className).toContain('!h-10');
-    expect(closeBtn.className).toContain('!w-10');
+    expect(closeBtn.className).toContain('!h-7');
+    expect(closeBtn.className).toContain('!w-7');
+    expect(closeBtn.className).toContain('after:-inset-1.5');
+  });
+
+  it('renders semantic icon badge and neutral card surface with status rail', async () => {
+    render(<Toaster />);
+
+    notify.success('Card styling test', { id: 'style:1' });
+    const toastTitle = await screen.findByText('Card styling test');
+
+    // Semantic icon badge container is rendered
+    const badge = screen.getByTestId('toast-icon-badge');
+    expect(badge).toBeDefined();
+    expect(badge.className).toContain('h-7');
+    expect(badge.className).toContain('w-7');
+
+    // Toast container contains neutral surface and status rail classes
+    const toastCard = toastTitle.closest('li');
+    expect(toastCard).toBeDefined();
+    expect(toastCard?.className).toContain('data-[styled=true]:!bg-[var(--toast-bg)]');
+    expect(toastCard?.className).toContain('before:!bg-[var(--toast-success-accent)]');
   });
 
   it('allows programmatic dismiss via notify.dismiss', async () => {


### PR DESCRIPTION
## Summary
Redesigns OpsKnight's notification toast popup from full-surface colored alerts to a calm, Linear/Stripe-class enterprise notification card. Moves semantic color primarily to a dedicated 28×28px icon badge and a 2–3px vertical status rail, keeping the card surface elevated and neutral.

## Architecture & Visual Hierarchy
- **Neutral Elevated Surface**: Replaces full-surface emerald/rose/amber fills with neutral elevated cards (`--toast-bg`: `#ffffff` in light, `#111827` in dark; `--toast-border`: `#e2e8f0` / `#1f2937`).
- **Semantic Icon Containers**: 28×28px (`h-7 w-7`) rounded badge containers with subtle semantic tint, border, and center-aligned 16px Lucide icons (emerald `CircleCheck`, rose `OctagonX`, amber `TriangleAlert`, sky `Info`, muted `LoaderCircle`).
- **Semantic Status Rail**: 3px vertical accent strip on the left (`before:!bg-[var(--toast-*-accent)]`) for immediate status recognition without dominating the card surface.
- **Typography & Proportions**:
  - Title: 14px / font-weight 600 / line-height 20px (`text-[var(--toast-fg)]`)
  - Description: 13px / line-height 18px (`text-[var(--toast-muted)]`)
  - Desktop width: `min(360px, calc(100vw - 24px))` with max 380px and min 320px for a compact, non-intrusive footprint.
  - Mobile: `calc(100vw - 24px)` with safe-area spacing and centered layout.
- **Close Affordance (X)**:
  - 28×28px visual ghost button with 14px X icon, `opacity-60 hover:opacity-100 hover:bg-muted/70`.
  - Expanded 40×40px touch hit area via pseudo-element (`after:absolute after:-inset-1.5`) for accessible mobile/touch interaction without looking bulky on desktop.
  - Dedicated right padding (`pr-10`) prevents titles and descriptions from overlapping the close button.
- **Layered Elevation Shadow**: Multi-layer enterprise shadow (`0 1px 2px rgba(0,0,0,0.04), 0 6px 18px rgba(0,0,0,0.08), 0 16px 40px rgba(0,0,0,0.06)` in light mode, deeper calibration in dark mode).
- **Stacking Density**: Capped visible normal toasts at 3 (`visibleToasts={3}`, `gap={8}`).

## Verification
- Unit & Integration Tests:
  - `tests/components/ui/ToastIntegration.test.tsx` (6/6 passed — neutral card surface, semantic icon badge, 28px ghost close button with 40px hitbox, dedup by ID, programmatic dismiss)
  - `tests/components/service/ServiceSettingsFlashToast.test.tsx` (4/4 passed)
  - `tests/components/ui/InlineNotice.test.tsx` (6/6 passed)
  - `tests/components/StatusPageConfig.test.tsx` (7/7 passed)
- TypeScript Check: `npx tsc --noEmit` (0 errors)
- Lint Check: `npx eslint` on modified files (0 errors, 0 warnings)