### PR TITLE
fix(ui): toast browser dark/light mode support and high-contrast visible close cross

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -355,6 +355,145 @@
   --toast-info-fg: var(--toast-fg);
 }
 
+/* Explicit Sonner toast theme scopes — guarantees full support for browser dark and light mode */
+[data-sonner-toaster][data-sonner-theme='light'],
+[data-sonner-toaster][data-sonner-theme='light'] [data-sonner-toast] {
+  --toast-bg: #ffffff;
+  --toast-border: #e2e8f0;
+  --toast-fg: #0f172a;
+  --toast-muted: #64748b;
+  --toast-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 18px rgba(0, 0, 0, 0.08), 0 16px 40px rgba(0, 0, 0, 0.06);
+
+  --toast-success-accent: #059669;
+  --toast-success-icon-bg: #f0fdf4;
+  --toast-success-icon-border: #a7f3d0;
+  --toast-success-icon-fg: #059669;
+
+  --toast-error-accent: #e11d48;
+  --toast-error-icon-bg: #fef2f2;
+  --toast-error-icon-border: #fecdd3;
+  --toast-error-icon-fg: #e11d48;
+
+  --toast-warning-accent: #d97706;
+  --toast-warning-icon-bg: #fffbeb;
+  --toast-warning-icon-border: #fde68a;
+  --toast-warning-icon-fg: #d97706;
+
+  --toast-info-accent: #2563eb;
+  --toast-info-icon-bg: #eff6ff;
+  --toast-info-icon-border: #bfdbfe;
+  --toast-info-icon-fg: #2563eb;
+
+  --toast-success-bg: var(--toast-bg);
+  --toast-success-border: var(--toast-border);
+  --toast-success-fg: var(--toast-fg);
+  --toast-error-bg: var(--toast-bg);
+  --toast-error-border: var(--toast-border);
+  --toast-error-fg: var(--toast-fg);
+  --toast-warning-bg: var(--toast-bg);
+  --toast-warning-border: var(--toast-border);
+  --toast-warning-fg: var(--toast-fg);
+  --toast-info-bg: var(--toast-bg);
+  --toast-info-border: var(--toast-border);
+  --toast-info-fg: var(--toast-fg);
+}
+
+[data-theme='dark'],
+[data-sonner-toaster][data-sonner-theme='dark'],
+[data-sonner-toaster][data-sonner-theme='dark'] [data-sonner-toast] {
+  --toast-bg: #111827;
+  --toast-border: #1f2937;
+  --toast-fg: #f9fafb;
+  --toast-muted: #9ca3af;
+  --toast-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5), 0 20px 48px rgba(0, 0, 0, 0.6);
+
+  --toast-success-accent: #059669;
+  --toast-success-icon-bg: #064e3b;
+  --toast-success-icon-border: #047857;
+  --toast-success-icon-fg: #6ee7b7;
+
+  --toast-error-accent: #e11d48;
+  --toast-error-icon-bg: #4c0519;
+  --toast-error-icon-border: #9f1239;
+  --toast-error-icon-fg: #fda4af;
+
+  --toast-warning-accent: #d97706;
+  --toast-warning-icon-bg: #451a03;
+  --toast-warning-icon-border: #92400e;
+  --toast-warning-icon-fg: #fcd34d;
+
+  --toast-info-accent: #2563eb;
+  --toast-info-icon-bg: #1e3a8a33;
+  --toast-info-icon-border: #1d4ed8;
+  --toast-info-icon-fg: #93c5fd;
+
+  --toast-success-bg: var(--toast-bg);
+  --toast-success-border: var(--toast-border);
+  --toast-success-fg: var(--toast-fg);
+  --toast-error-bg: var(--toast-bg);
+  --toast-error-border: var(--toast-border);
+  --toast-error-fg: var(--toast-fg);
+  --toast-warning-bg: var(--toast-bg);
+  --toast-warning-border: var(--toast-border);
+  --toast-warning-fg: var(--toast-fg);
+  --toast-info-bg: var(--toast-bg);
+  --toast-info-border: var(--toast-border);
+  --toast-info-fg: var(--toast-fg);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) [data-sonner-toaster]:not([data-sonner-theme='light']),
+  :root:not([data-theme='light']) [data-sonner-toaster]:not([data-sonner-theme='light']) [data-sonner-toast] {
+    --toast-bg: #111827;
+    --toast-border: #1f2937;
+    --toast-fg: #f9fafb;
+    --toast-muted: #9ca3af;
+    --toast-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5), 0 20px 48px rgba(0, 0, 0, 0.6);
+
+    --toast-success-accent: #059669;
+    --toast-success-icon-bg: #064e3b;
+    --toast-success-icon-border: #047857;
+    --toast-success-icon-fg: #6ee7b7;
+
+    --toast-error-accent: #e11d48;
+    --toast-error-icon-bg: #4c0519;
+    --toast-error-icon-border: #9f1239;
+    --toast-error-icon-fg: #fda4af;
+
+    --toast-warning-accent: #d97706;
+    --toast-warning-icon-bg: #451a03;
+    --toast-warning-icon-border: #92400e;
+    --toast-warning-icon-fg: #fcd34d;
+
+    --toast-info-accent: #2563eb;
+    --toast-info-icon-bg: #1e3a8a33;
+    --toast-info-icon-border: #1d4ed8;
+    --toast-info-icon-fg: #93c5fd;
+
+    --toast-success-bg: var(--toast-bg);
+    --toast-success-border: var(--toast-border);
+    --toast-success-fg: var(--toast-fg);
+    --toast-error-bg: var(--toast-bg);
+    --toast-error-border: var(--toast-border);
+    --toast-error-fg: var(--toast-fg);
+    --toast-warning-bg: var(--toast-bg);
+    --toast-warning-border: var(--toast-border);
+    --toast-warning-fg: var(--toast-fg);
+    --toast-info-bg: var(--toast-bg);
+    --toast-info-border: var(--toast-border);
+    --toast-info-fg: var(--toast-fg);
+  }
+}
+
+/* Ensure toast close button icon is always visible with crisp stroke and contrast */
+[data-sonner-toast] [data-close-button] svg {
+  display: block;
+  stroke: currentColor;
+  stroke-width: 2.25px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 
 .focus-border:focus,
 .focus-border:focus-visible {

--- a/src/components/ui/shadcn/sonner.tsx
+++ b/src/components/ui/shadcn/sonner.tsx
@@ -1,17 +1,25 @@
 'use client';
 
-import { CircleCheck, Info, LoaderCircle, OctagonX, TriangleAlert } from 'lucide-react';
+import { CircleCheck, Info, LoaderCircle, OctagonX, TriangleAlert, X } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Toaster as Sonner } from 'sonner';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
-const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'system' } = useTheme();
+const Toaster = ({ theme: propTheme, ...props }: ToasterProps) => {
+  const { theme: contextTheme } = useTheme();
+
+  // Support browser dark and light mode dynamically:
+  // - If propTheme is explicitly provided, respect it.
+  // - If contextTheme is 'dark', respect the explicit dark context.
+  // - Otherwise default to 'system' so Sonner queries window.matchMedia('(prefers-color-scheme: dark)')
+  //   and dynamically adapts to browser dark or light mode.
+  const resolvedTheme: ToasterProps['theme'] =
+    propTheme ?? (contextTheme === 'dark' ? 'dark' : 'system');
 
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      theme={resolvedTheme}
       className="toaster group"
       position="top-right"
       visibleToasts={3}
@@ -20,6 +28,13 @@ const Toaster = ({ ...props }: ToasterProps) => {
       mobileOffset="12px"
       closeButton
       icons={{
+        close: (
+          <X
+            data-testid="toast-close-icon"
+            className="h-3.5 w-3.5 stroke-[2.25] text-current"
+            aria-hidden="true"
+          />
+        ),
         success: (
           <div
             data-testid="toast-icon-badge"
@@ -83,11 +98,15 @@ const Toaster = ({ ...props }: ToasterProps) => {
           icon: '!self-start !mt-0',
           closeButton:
             '!right-2.5 !top-2.5 !left-auto !translate-x-0 !translate-y-0 ' +
-            '!h-7 !w-7 !rounded-md !border-0 !bg-transparent ' +
-            '!text-[var(--toast-muted)] !opacity-60 hover:!opacity-100 hover:!bg-muted/70 hover:!text-[var(--toast-fg)] ' +
+            '!h-7 !w-7 !rounded-lg !border !border-slate-200/80 dark:!border-slate-700/80 ' +
+            '!bg-slate-100/80 dark:!bg-slate-800/80 ' +
+            '!text-slate-600 dark:!text-slate-300 ' +
+            'hover:!bg-slate-200 dark:hover:!bg-slate-700 ' +
+            'hover:!text-slate-950 dark:hover:!text-white ' +
+            '!opacity-90 hover:!opacity-100 ' +
             '!pointer-events-auto flex items-center justify-center cursor-pointer ' +
             'after:absolute after:-inset-1.5 after:content-[\'\'] after:pointer-events-auto ' +
-            'transition-opacity transition-colors motion-reduce:transition-none',
+            'transition-all duration-150 motion-reduce:transition-none focus-visible:!ring-2 focus-visible:!ring-ring focus-visible:!ring-offset-1',
           actionButton:
             '!rounded-md !text-xs !font-medium !h-7 !px-2.5 !bg-primary !text-primary-foreground hover:!bg-primary/90',
           cancelButton:

--- a/tests/components/ui/ToastIntegration.test.tsx
+++ b/tests/components/ui/ToastIntegration.test.tsx
@@ -110,4 +110,31 @@ describe('Toast and Toaster Component Contract', () => {
       expect(screen.queryByText('Dismiss me')).toBeNull();
     });
   });
+
+  it('renders a visible cross icon inside the close button with high-contrast stroke', async () => {
+    render(<Toaster />);
+
+    notify.success('Visible cross test', { id: 'cross:1' });
+    await screen.findByText('Visible cross test');
+
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    expect(closeBtn).toBeDefined();
+
+    const closeIcon = screen.getByTestId('toast-close-icon');
+    expect(closeIcon).toBeDefined();
+    expect(closeIcon.getAttribute('class')).toContain('stroke-[2.25]');
+    expect(closeBtn.contains(closeIcon)).toBe(true);
+  });
+
+  it('supports dark mode theme configuration on the toaster', async () => {
+    render(<Toaster theme="dark" />);
+
+    notify.info('Dark mode toast', { id: 'dark:1' });
+    await screen.findByText('Dark mode toast');
+
+    const toaster = document.querySelector('[data-sonner-toaster]');
+    expect(toaster).toBeDefined();
+    expect(toaster?.getAttribute('data-sonner-theme')).toBe('dark');
+  });
 });
+


### PR DESCRIPTION
### Summary
This PR fixes two visual issues with the toast notifications:
1. **Visible Close Cross**: The close button previously rendered with low contrast / missing SVG stroke when relying on Sonner's default icon, causing the `X` to appear invisible or washed out against the card surface. We now explicitly provide a crisp Lucide `X` icon with `stroke-[2.25]`, along with dedicated SVG rules in CSS and high-contrast button styling across both light and dark themes.
2. **Browser Dark and Light Mode Support**: The toast card now automatically detects and adapts to browser / system theme preferences (`@media (prefers-color-scheme: dark)` and `theme="system"`), setting proper elevated neutral card surfaces and semantic badge colors for both modes even when the parent dashboard surface is in forced light mode.

### Changes
- `src/components/ui/shadcn/sonner.tsx`:
  - Added explicit Lucide `X` icon to `icons.close` with `stroke-[2.25]`.
  - Added dynamic theme resolution defaulting to `'system'` so Sonner queries `matchMedia('(prefers-color-scheme: dark)')` to support browser dark and light mode.
  - Refined `closeButton` styling to render a subtle border, balanced background (`!bg-slate-100/80 dark:!bg-slate-800/80`), and high-contrast text color with hover states.
- `src/app/globals.css`:
  - Added explicit token scopes for `[data-sonner-toaster][data-sonner-theme='light']`, `[data-sonner-toaster][data-sonner-theme='dark']`, and `@media (prefers-color-scheme: dark)`.
  - Added SVG stroke sizing rules (`stroke-width: 2.25px`) for `[data-sonner-toast] [data-close-button] svg` to prevent washed-out strokes.
- `tests/components/ui/ToastIntegration.test.tsx`:
  - Added tests asserting that the visible `X` cross icon is rendered with proper stroke attributes inside the close button.
  - Added tests verifying dark mode theme configuration on the toaster.

### Verification
- `npx vitest run tests/components/ui/ToastIntegration.test.tsx`: 8/8 passed.
- `npx tsc --noEmit`: 0 errors.
- `npx eslint src/components/ui/shadcn/sonner.tsx tests/components/ui/ToastIntegration.test.tsx`: 0 errors.