### PR TITLE
fix(ui): eliminate close button background block and enforce high-contrast X icon contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -486,12 +486,27 @@
 }
 
 /* Ensure toast close button icon is always visible with crisp stroke and contrast */
+[data-sonner-toast] [data-close-button] {
+  border: none !important;
+  background: transparent !important;
+  color: var(--toast-muted) !important;
+  opacity: 0.85 !important;
+}
+
+[data-sonner-toast] [data-close-button]:hover {
+  background: rgba(128, 128, 128, 0.15) !important;
+  color: var(--toast-fg) !important;
+  opacity: 1 !important;
+}
+
 [data-sonner-toast] [data-close-button] svg {
-  display: block;
-  stroke: currentColor;
-  stroke-width: 2.25px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  display: block !important;
+  width: 14px !important;
+  height: 14px !important;
+  stroke: currentColor !important;
+  stroke-width: 2.25px !important;
+  stroke-linecap: round !important;
+  stroke-linejoin: round !important;
 }
 
 

--- a/src/components/ui/shadcn/sonner.tsx
+++ b/src/components/ui/shadcn/sonner.tsx
@@ -98,12 +98,10 @@ const Toaster = ({ theme: propTheme, ...props }: ToasterProps) => {
           icon: '!self-start !mt-0',
           closeButton:
             '!right-2.5 !top-2.5 !left-auto !translate-x-0 !translate-y-0 ' +
-            '!h-7 !w-7 !rounded-lg !border !border-slate-200/80 dark:!border-slate-700/80 ' +
-            '!bg-slate-100/80 dark:!bg-slate-800/80 ' +
-            '!text-slate-600 dark:!text-slate-300 ' +
-            'hover:!bg-slate-200 dark:hover:!bg-slate-700 ' +
-            'hover:!text-slate-950 dark:hover:!text-white ' +
-            '!opacity-90 hover:!opacity-100 ' +
+            '!h-7 !w-7 !rounded-md !border-0 !bg-transparent ' +
+            '!text-[var(--toast-muted)] hover:!text-[var(--toast-fg)] ' +
+            'hover:!bg-black/10 dark:hover:!bg-white/15 ' +
+            '!opacity-85 hover:!opacity-100 ' +
             '!pointer-events-auto flex items-center justify-center cursor-pointer ' +
             'after:absolute after:-inset-1.5 after:content-[\'\'] after:pointer-events-auto ' +
             'transition-all duration-150 motion-reduce:transition-none focus-visible:!ring-2 focus-visible:!ring-ring focus-visible:!ring-offset-1',


### PR DESCRIPTION
### Summary
This PR eliminates the solid white/light-gray box that could obscure the toast notification close button and ensures the `X` cross icon is always crisp, high-contrast, and clearly visible.

### Root Cause
1. In desktop views where `forcedTheme="light"` is active on the application context, Tailwind's `dark:` classes (`dark:!bg-slate-800/80`) did not activate even when the browser or sonner was in dark mode, causing a light gray background (`!bg-slate-100/80`) to render behind the close button.
2. Sonner's default CSS also sets `background: var(--normal-bg)` and `border: 1px solid var(--gray4)`, resulting in an opaque white/gray pill that could cover or wash out the close cross icon.

### Solution
- **Transparent Base**: The close button now has `background: transparent !important; border: none !important;` so there is never an opaque background square.
- **High-Contrast `X` Icon**: Styled with `color: var(--toast-muted) !important;` (which resolves to `#9ca3af` in dark mode with 7.5:1 contrast, and `#64748b` in light mode with 4.6:1 contrast) and hover state `color: var(--toast-fg) !important;` (`#f9fafb` in dark mode, `#0f172a` in light mode).
- **Subtle Hover Effect**: On hover, a translucent highlight (`background: rgba(128, 128, 128, 0.15) !important;`) provides smooth interactive feedback without any color clash in either light or dark mode.
- **Enforced SVG Dimensions & Stroke**: Set `width: 14px !important; height: 14px !important; stroke: currentColor !important; stroke-width: 2.25px !important;` to ensure sharp rendering.

### Verification
- `npx vitest run tests/components/ui/ToastIntegration.test.tsx`: 8/8 passed.
- `npx tsc --noEmit`: 0 errors.
- `npx eslint src/components/ui/shadcn/sonner.tsx`: 0 errors.