### PR TITLE
fix: idempotent war-room archival, postgres migration regex, and standalone worker state sharing

### DIFF
--- a/prisma/migrations/20260913140000_canonicalize_oidc_issuer_authority/migration.sql
+++ b/prisma/migrations/20260913140000_canonicalize_oidc_issuer_authority/migration.sql
@@ -17,18 +17,21 @@ BEGIN
 
   trimmed := rtrim(raw_issuer, '/');
 
-  -- Extract scheme (e.g. https://)
-  IF trimmed ~* '^https?://' THEN
-    scheme := LOWER(SUBSTRING(trimmed FROM '^(?i)(https?://)'));
-    after_scheme := SUBSTRING(trimmed FROM '^(?i)[a-zA-Z0-9]+://(.*)$');
+  -- Extract scheme (e.g. https:// or http://)
+  IF lower(trimmed) ~ '^https://' THEN
+    scheme := 'https://';
+    after_scheme := substr(trimmed, 9);
+  ELSIF lower(trimmed) ~ '^http://' THEN
+    scheme := 'http://';
+    after_scheme := substr(trimmed, 8);
   ELSE
     RETURN trimmed;
   END IF;
 
   -- Separate authority from path
   IF position('/' IN after_scheme) > 0 THEN
-    authority := SUBSTRING(after_scheme FROM '^([^/]+)');
-    path_part := SUBSTRING(after_scheme FROM position('/' IN after_scheme));
+    authority := substr(after_scheme, 1, position('/' IN after_scheme) - 1);
+    path_part := substr(after_scheme, position('/' IN after_scheme));
   ELSE
     authority := after_scheme;
     path_part := '';
@@ -37,9 +40,9 @@ BEGIN
   -- Authority: lowercase hostname and strip default port 443 for HTTPS (or 80 for HTTP)
   canon_authority := LOWER(authority);
   IF scheme = 'https://' AND canon_authority ~ ':443$' THEN
-    canon_authority := SUBSTRING(canon_authority FROM '^(.+):443$');
+    canon_authority := substr(canon_authority, 1, length(canon_authority) - 4);
   ELSIF scheme = 'http://' AND canon_authority ~ ':80$' THEN
-    canon_authority := SUBSTRING(canon_authority FROM '^(.+):80$');
+    canon_authority := substr(canon_authority, 1, length(canon_authority) - 3);
   END IF;
 
   RETURN scheme || canon_authority || path_part;

--- a/src/lib/chatops/war-room.ts
+++ b/src/lib/chatops/war-room.ts
@@ -710,9 +710,22 @@ export async function archiveWarRoomChannel(
       channel: incident.slackChannelId,
     });
 
-    if (!archiveResult.ok && archiveResult.error !== 'already_archived') {
+    const isIdempotentSuccess =
+      archiveResult.ok ||
+      archiveResult.error === 'already_archived' ||
+      archiveResult.error === 'channel_not_found';
+
+    if (!isIdempotentSuccess) {
       logger.warn('[ChatOps] Failed to archive channel', { error: archiveResult.error });
       return { success: false, error: archiveResult.error || 'Failed to archive Slack channel' };
+    }
+
+    if (archiveResult.error === 'already_archived' || archiveResult.error === 'channel_not_found') {
+      logger.info('[ChatOps] Channel already archived or not found in Slack; treating as archived', {
+        incidentId,
+        channelId: incident.slackChannelId,
+        slackError: archiveResult.error,
+      });
     }
 
     // Mark the war-room as archived. The channel id is kept so the incident

--- a/src/lib/event-side-effects.ts
+++ b/src/lib/event-side-effects.ts
@@ -44,6 +44,8 @@ const EXPECTED_WAR_ROOM_SKIPS = [
   'Archive on resolve is disabled',
   'No Slack bot token',
   'not configured',
+  'already_archived',
+  'channel_not_found',
 ];
 function requireWarRoomDelivery(result: { success: boolean; error?: string }, label: string): void {
   if (result.success || EXPECTED_WAR_ROOM_SKIPS.some(reason => result.error?.includes(reason)))

--- a/src/lib/job-worker.ts
+++ b/src/lib/job-worker.ts
@@ -27,16 +27,41 @@ export interface JobWorkerConfig {
   busyPollMs: number;
 }
 
-let timer: NodeJS.Timeout | null = null;
-let initialized = false;
-let activeRun: Promise<void> | null = null;
-let workerConfig: JobWorkerConfig | null = null;
-let lastRunAt: Date | null = null;
-let lastSuccessAt: Date | null = null;
-let startedAt: Date | null = null;
-let lastError: string | null = null;
 export type JobWorkerLane = 'all' | 'critical' | 'bulk' | 'projector';
-let workerLane: JobWorkerLane = 'all';
+
+interface JobWorkerSharedState {
+  timer: NodeJS.Timeout | null;
+  initialized: boolean;
+  activeRun: Promise<void> | null;
+  workerConfig: JobWorkerConfig | null;
+  lastRunAt: Date | null;
+  lastSuccessAt: Date | null;
+  startedAt: Date | null;
+  lastError: string | null;
+  workerLane: JobWorkerLane;
+}
+
+declare global {
+  var jobWorkerGlobalState: JobWorkerSharedState | undefined;
+}
+
+const workerState: JobWorkerSharedState = globalThis.jobWorkerGlobalState ?? {
+  timer: null,
+  initialized: false,
+  activeRun: null,
+  workerConfig: null,
+  lastRunAt: null,
+  lastSuccessAt: null,
+  startedAt: null,
+  lastError: null,
+  workerLane: 'all',
+};
+
+// Next.js standalone webpack builds isolate module scopes between
+// instrumentation.ts and app/api/health/route.ts. Attaching worker lifecycle
+// state to globalThis ensures /api/health?mode=readiness accurately reflects
+// the running in-process worker started by instrumentation.
+globalThis.jobWorkerGlobalState = workerState;
 
 function readBoundedInteger(
   rawValue: string | undefined,
@@ -109,75 +134,83 @@ function withIdleJitter(delayMs: number): number {
 }
 
 function scheduleNextRun(delayMs: number): void {
-  if (!initialized) return;
+  if (!workerState.initialized) return;
 
-  if (timer) clearTimeout(timer);
-  timer = setTimeout(() => {
-    timer = null;
-    activeRun = runOnce().finally(() => {
-      activeRun = null;
+  if (workerState.timer) clearTimeout(workerState.timer);
+  workerState.timer = setTimeout(() => {
+    workerState.timer = null;
+    workerState.activeRun = runOnce().finally(() => {
+      workerState.activeRun = null;
     });
-    void activeRun;
+    void workerState.activeRun;
   }, delayMs);
 }
 
 async function runOnce(): Promise<void> {
-  if (!initialized || !workerConfig) return;
+  if (!workerState.initialized || !workerState.workerConfig) return;
 
-  lastRunAt = new Date();
-  const startedAt = Date.now();
+  workerState.lastRunAt = new Date();
+  const batchStartedAt = Date.now();
 
   try {
-    if (workerLane === 'projector') {
+    if (workerState.workerLane === 'projector') {
       const { reconcileStatusPageSnapshots } = await import('./status-pages/snapshot');
-      const projection = await reconcileStatusPageSnapshots(workerConfig.batchSize);
-      lastSuccessAt = new Date();
-      lastError = null;
-      scheduleNextRun(projection.attempted > 0 ? workerConfig.busyPollMs : workerConfig.idlePollMs);
+      const projection = await reconcileStatusPageSnapshots(workerState.workerConfig.batchSize);
+      workerState.lastSuccessAt = new Date();
+      workerState.lastError = null;
+      scheduleNextRun(
+        projection.attempted > 0
+          ? workerState.workerConfig.busyPollMs
+          : workerState.workerConfig.idlePollMs
+      );
       return;
     }
 
-    if (workerLane === 'bulk') {
+    if (workerState.workerLane === 'bulk') {
       const { isBulkNotificationDeliveryPaused } = await import('./notification-capacity-control');
       if (await isBulkNotificationDeliveryPaused()) {
-        lastSuccessAt = new Date();
-        lastError = null;
-        scheduleNextRun(withIdleJitter(workerConfig.idlePollMs));
+        workerState.lastSuccessAt = new Date();
+        workerState.lastError = null;
+        scheduleNextRun(withIdleJitter(workerState.workerConfig.idlePollMs));
         return;
       }
       const { processCentralNotificationQueue } = await import('./notification-control-plane');
       const notifications = await processCentralNotificationQueue({
         trafficClasses: ['PUBLIC_INCIDENT', 'BULK'],
-        batchSize: workerConfig.batchSize,
-        concurrency: workerConfig.concurrency,
+        batchSize: workerState.workerConfig.batchSize,
+        concurrency: workerState.workerConfig.concurrency,
       });
       const incidentFanout = await processPendingJobsByType(
         'STATUS_PAGE_NOTIFICATION',
-        workerConfig.batchSize,
-        workerConfig.concurrency
+        workerState.workerConfig.batchSize,
+        workerState.workerConfig.concurrency
       );
       const announcementFanout = await processPendingJobsByType(
         'STATUS_PAGE_ANNOUNCEMENT_FANOUT',
-        workerConfig.batchSize,
-        workerConfig.concurrency
+        workerState.workerConfig.batchSize,
+        workerState.workerConfig.concurrency
       );
       const failed = notifications.failed + incidentFanout.failed + announcementFanout.failed;
       if (failed > 0) {
-        lastError = `${failed} bulk delivery job(s) failed`;
+        workerState.lastError = `${failed} bulk delivery job(s) failed`;
         logger.warn('[JobWorker] Bulk lane degraded', { failed });
       } else {
-        lastSuccessAt = new Date();
-        lastError = null;
+        workerState.lastSuccessAt = new Date();
+        workerState.lastError = null;
       }
       const busy = notifications.processed + incidentFanout.total + announcementFanout.total > 0;
-      scheduleNextRun(busy ? workerConfig.busyPollMs : withIdleJitter(workerConfig.idlePollMs));
+      scheduleNextRun(
+        busy
+          ? workerState.workerConfig.busyPollMs
+          : withIdleJitter(workerState.workerConfig.idlePollMs)
+      );
       return;
     }
 
-    if (workerLane === 'critical') {
+    if (workerState.workerLane === 'critical') {
       const escalation = await runCriticalEscalationCycle({
-        batchSize: Math.min(workerConfig.batchSize, 50),
-        concurrency: Math.min(workerConfig.concurrency, 10),
+        batchSize: Math.min(workerState.workerConfig.batchSize, 50),
+        concurrency: Math.min(workerState.workerConfig.concurrency, 10),
       });
       const notifications = await runCriticalNotificationCycle();
       const laneErrors = [...escalation.errors, ...notifications.errors];
@@ -186,16 +219,20 @@ async function runOnce(): Promise<void> {
       if (notifications.centralFailed > 0)
         laneErrors.push(`${notifications.centralFailed} central notification(s) failed`);
       if (laneErrors.length > 0) {
-        lastError = laneErrors.join('; ');
+        workerState.lastError = laneErrors.join('; ');
         logger.warn('[JobWorker] Critical lane degraded', { errors: laneErrors });
       } else {
-        lastSuccessAt = new Date();
-        lastError = null;
+        workerState.lastSuccessAt = new Date();
+        workerState.lastError = null;
       }
       const busy =
         criticalEscalationCycleWasBusy(escalation) ||
         criticalNotificationCycleWasBusy(notifications);
-      scheduleNextRun(busy ? workerConfig.busyPollMs : withIdleJitter(workerConfig.idlePollMs));
+      scheduleNextRun(
+        busy
+          ? workerState.workerConfig.busyPollMs
+          : withIdleJitter(workerState.workerConfig.idlePollMs)
+      );
       return;
     }
 
@@ -203,8 +240,8 @@ async function runOnce(): Promise<void> {
     // a backlog of webhooks or status-page notifications, and this lane owns
     // escalation's recovery so it does not depend on the scheduler lease.
     const escalation = await runCriticalEscalationCycle({
-      batchSize: Math.min(workerConfig.batchSize, 50),
-      concurrency: Math.min(workerConfig.concurrency, 10),
+      batchSize: Math.min(workerState.workerConfig.batchSize, 50),
+      concurrency: Math.min(workerState.workerConfig.concurrency, 10),
     });
 
     // Then the pages escalation already made durable. A page committed in about
@@ -212,7 +249,10 @@ async function runOnce(): Promise<void> {
     // recovery runs on every replica too.
     const notifications = await runCriticalNotificationCycle();
 
-    const result = await processPendingJobs(workerConfig.batchSize, workerConfig.concurrency);
+    const result = await processPendingJobs(
+      workerState.workerConfig.batchSize,
+      workerState.workerConfig.concurrency
+    );
     const laneErrors = [...escalation.errors, ...notifications.errors];
     if (escalation.jobsFailed > 0) {
       laneErrors.push(`${escalation.jobsFailed} escalation job(s) failed`);
@@ -221,10 +261,10 @@ async function runOnce(): Promise<void> {
       laneErrors.push(`${notifications.centralFailed} central notification(s) failed`);
     }
     if (laneErrors.length === 0) {
-      lastSuccessAt = new Date();
-      lastError = null;
+      workerState.lastSuccessAt = new Date();
+      workerState.lastError = null;
     } else {
-      lastError = laneErrors.join('; ');
+      workerState.lastError = laneErrors.join('; ');
       logger.warn('[JobWorker] Critical lane degraded', { errors: laneErrors });
     }
 
@@ -234,7 +274,7 @@ async function runOnce(): Promise<void> {
       claimed: result.total,
       escalation,
       notifications,
-      durationMs: Date.now() - startedAt,
+      durationMs: Date.now() - batchStartedAt,
     });
 
     const busy =
@@ -242,17 +282,19 @@ async function runOnce(): Promise<void> {
       criticalEscalationCycleWasBusy(escalation) ||
       criticalNotificationCycleWasBusy(notifications) ||
       consumeEscalationWakeRequest();
-    const delay = busy ? workerConfig.busyPollMs : withIdleJitter(workerConfig.idlePollMs);
+    const delay = busy
+      ? workerState.workerConfig.busyPollMs
+      : withIdleJitter(workerState.workerConfig.idlePollMs);
     scheduleNextRun(delay);
   } catch (error) {
-    lastError = error instanceof Error ? error.message : String(error);
+    workerState.lastError = error instanceof Error ? error.message : String(error);
     logger.error('[JobWorker] Batch failed', {
-      error: lastError,
-      durationMs: Date.now() - startedAt,
+      error: workerState.lastError,
+      durationMs: Date.now() - batchStartedAt,
     });
 
     // A queue/database failure must not create a hot retry loop.
-    scheduleNextRun(withIdleJitter(workerConfig.idlePollMs));
+    scheduleNextRun(withIdleJitter(workerState.workerConfig.idlePollMs));
   }
 }
 
@@ -262,25 +304,25 @@ async function runOnce(): Promise<void> {
  * call this loop against the same database.
  */
 export function startJobWorker(lane: JobWorkerLane = 'all'): void {
-  if (initialized) {
+  if (workerState.initialized) {
     logger.debug('[JobWorker] Already initialized, skipping');
     return;
   }
 
-  workerConfig = getJobWorkerConfig();
-  workerLane = lane;
-  initialized = true;
-  lastRunAt = null;
-  lastSuccessAt = null;
-  startedAt = new Date();
-  lastError = null;
+  workerState.workerConfig = getJobWorkerConfig();
+  workerState.workerLane = lane;
+  workerState.initialized = true;
+  workerState.lastRunAt = null;
+  workerState.lastSuccessAt = null;
+  workerState.startedAt = new Date();
+  workerState.lastError = null;
 
   logger.info('[JobWorker] Starting', {
-    batchSize: workerConfig.batchSize,
-    concurrency: workerConfig.concurrency,
-    idlePollMs: workerConfig.idlePollMs,
-    busyPollMs: workerConfig.busyPollMs,
-    lane: workerLane,
+    batchSize: workerState.workerConfig.batchSize,
+    concurrency: workerState.workerConfig.concurrency,
+    idlePollMs: workerState.workerConfig.idlePollMs,
+    busyPollMs: workerState.workerConfig.busyPollMs,
+    lane: workerState.workerLane,
   });
 
   // Start immediately. Subsequent iterations are paced based on queue activity.
@@ -294,21 +336,22 @@ export function startJobWorker(lane: JobWorkerLane = 'all'): void {
  * process kill.
  */
 export async function stopJobWorker(): Promise<void> {
-  const wasRunning = initialized || timer !== null || activeRun !== null;
-  initialized = false;
+  const wasRunning =
+    workerState.initialized || workerState.timer !== null || workerState.activeRun !== null;
+  workerState.initialized = false;
 
-  if (timer) {
-    clearTimeout(timer);
-    timer = null;
+  if (workerState.timer) {
+    clearTimeout(workerState.timer);
+    workerState.timer = null;
   }
 
-  const inFlight = activeRun;
+  const inFlight = workerState.activeRun;
   if (inFlight) {
     await inFlight;
   }
 
-  workerConfig = null;
-  startedAt = null;
+  workerState.workerConfig = null;
+  workerState.startedAt = null;
 
   if (wasRunning) {
     logger.info('[JobWorker] Stopped');
@@ -317,13 +360,13 @@ export async function stopJobWorker(): Promise<void> {
 
 export function getJobWorkerStatus() {
   return {
-    running: initialized,
-    inFlight: activeRun !== null,
-    lastRunAt,
-    lastSuccessAt,
-    startedAt,
-    lastError,
-    config: workerConfig ? { ...workerConfig } : null,
-    lane: workerLane,
+    running: workerState.initialized,
+    inFlight: workerState.activeRun !== null,
+    lastRunAt: workerState.lastRunAt,
+    lastSuccessAt: workerState.lastSuccessAt,
+    startedAt: workerState.startedAt,
+    lastError: workerState.lastError,
+    config: workerState.workerConfig ? { ...workerState.workerConfig } : null,
+    lane: workerState.workerLane,
   };
 }

--- a/tests/lib/chatops-war-room.test.ts
+++ b/tests/lib/chatops-war-room.test.ts
@@ -564,6 +564,56 @@ describe('ChatOps War-Room Engine', () => {
       const result = await archiveWarRoomChannel('inc-104', { force: true });
       expect(result.success).toBe(true);
     });
+
+    it('should treat already_archived as idempotent success and stamp warRoomArchivedAt', async () => {
+      vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+        slackChannelId: 'C123',
+        slackChannelName: 'inc-104-payments',
+        serviceId: 'srv-1',
+      } as any);
+      vi.mocked(prisma.chatOpsConfig.findUnique).mockResolvedValue({
+        archiveOnResolve: true,
+      } as any);
+      vi.mocked(prisma.incident.update).mockResolvedValue({} as any);
+      vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
+      vi.spyOn(retryModule, 'retryFetch').mockResolvedValue({
+        json: async () => ({ ok: false, error: 'already_archived' }),
+      } as any);
+
+      const result = await archiveWarRoomChannel('inc-104');
+      expect(result.success).toBe(true);
+      expect(prisma.incident.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'inc-104' },
+          data: expect.objectContaining({ warRoomArchivedAt: expect.any(Date) }),
+        })
+      );
+    });
+
+    it('should treat channel_not_found as idempotent success and stamp warRoomArchivedAt', async () => {
+      vi.mocked(prisma.incident.findUnique).mockResolvedValue({
+        slackChannelId: 'C123',
+        slackChannelName: 'inc-104-payments',
+        serviceId: 'srv-1',
+      } as any);
+      vi.mocked(prisma.chatOpsConfig.findUnique).mockResolvedValue({
+        archiveOnResolve: true,
+      } as any);
+      vi.mocked(prisma.incident.update).mockResolvedValue({} as any);
+      vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
+      vi.spyOn(retryModule, 'retryFetch').mockResolvedValue({
+        json: async () => ({ ok: false, error: 'channel_not_found' }),
+      } as any);
+
+      const result = await archiveWarRoomChannel('inc-104');
+      expect(result.success).toBe(true);
+      expect(prisma.incident.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'inc-104' },
+          data: expect.objectContaining({ warRoomArchivedAt: expect.any(Date) }),
+        })
+      );
+    });
   });
 
   describe('archived war-room guards', () => {

--- a/tests/lib/chatops-war-room.test.ts
+++ b/tests/lib/chatops-war-room.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   generateBridgeUrl,
@@ -570,15 +571,15 @@ describe('ChatOps War-Room Engine', () => {
         slackChannelId: 'C123',
         slackChannelName: 'inc-104-payments',
         serviceId: 'srv-1',
-      } as any);
+      } as never);
       vi.mocked(prisma.chatOpsConfig.findUnique).mockResolvedValue({
         archiveOnResolve: true,
-      } as any);
-      vi.mocked(prisma.incident.update).mockResolvedValue({} as any);
-      vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
+      } as never);
+      vi.mocked(prisma.incident.update).mockResolvedValue({} as never);
+      vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as never);
       vi.spyOn(retryModule, 'retryFetch').mockResolvedValue({
         json: async () => ({ ok: false, error: 'already_archived' }),
-      } as any);
+      } as never);
 
       const result = await archiveWarRoomChannel('inc-104');
       expect(result.success).toBe(true);
@@ -595,15 +596,15 @@ describe('ChatOps War-Room Engine', () => {
         slackChannelId: 'C123',
         slackChannelName: 'inc-104-payments',
         serviceId: 'srv-1',
-      } as any);
+      } as never);
       vi.mocked(prisma.chatOpsConfig.findUnique).mockResolvedValue({
         archiveOnResolve: true,
-      } as any);
-      vi.mocked(prisma.incident.update).mockResolvedValue({} as any);
-      vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as any);
+      } as never);
+      vi.mocked(prisma.incident.update).mockResolvedValue({} as never);
+      vi.mocked(prisma.incidentEvent.create).mockResolvedValue({} as never);
       vi.spyOn(retryModule, 'retryFetch').mockResolvedValue({
         json: async () => ({ ok: false, error: 'channel_not_found' }),
-      } as any);
+      } as never);
 
       const result = await archiveWarRoomChannel('inc-104');
       expect(result.success).toBe(true);

--- a/tests/lib/job-worker.test.ts
+++ b/tests/lib/job-worker.test.ts
@@ -308,4 +308,20 @@ describe('dedicated job worker', () => {
     expect(processPendingJobs).toHaveBeenCalledTimes(1);
     expect(getJobWorkerStatus().running).toBe(false);
   });
+
+  it('shares worker lifecycle state via globalThis for isolated standalone webpack chunks', async () => {
+    expect(globalThis.jobWorkerGlobalState).toBeDefined();
+
+    startJobWorker('critical');
+    expect(globalThis.jobWorkerGlobalState?.initialized).toBe(true);
+    expect(globalThis.jobWorkerGlobalState?.workerLane).toBe('critical');
+    expect(globalThis.jobWorkerGlobalState?.startedAt).toBeInstanceOf(Date);
+    expect(getJobWorkerStatus().running).toBe(true);
+    expect(getJobWorkerStatus().lane).toBe('critical');
+
+    await stopJobWorker();
+    expect(globalThis.jobWorkerGlobalState?.initialized).toBe(false);
+    expect(globalThis.jobWorkerGlobalState?.startedAt).toBeNull();
+    expect(getJobWorkerStatus().running).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

This PR addresses three runtime and deployment operational issues discovered during EC2 host verification:

### 1. Slack War Room Channel Archival Idempotency (`src/lib/chatops/war-room.ts`, `src/lib/event-side-effects.ts`)
- **Problem**: When incidents resolve, the background lifecycle task archives the associated Slack war-room channel. If channels were deleted or archived prior to the archival job running, Slack's API returns `channel_not_found` or `already_archived`, causing background jobs to fail and enter retry/fail loops.
- **Fix**: Treat `channel_not_found` and `already_archived` as successful terminal states (idempotent no-ops with an informative log). The incident is stamped with `warRoomArchivedAt = new Date()`, preventing further dead channel queries and avoiding background job rejections. Added `'channel_not_found'` and `'already_archived'` to `EXPECTED_WAR_ROOM_SKIPS` in `event-side-effects.ts`.
- **Tests**: Added tests to `tests/lib/chatops-war-room.test.ts` verifying both error responses succeed and stamp `warRoomArchivedAt`.

### 2. PostgreSQL Migration Regex Compatibility (`prisma/migrations/20260913140000_canonicalize_oidc_issuer_authority/migration.sql`)
- **Problem**: PostgreSQL POSIX regular expressions do not support PCRE inline flags such as `(?i)` in `SUBSTRING(trimmed FROM '^(?i)(https?://)')`, resulting in `ERROR: 2201B: invalid regular expression: quantifier operand invalid` during startup migrations on fresh databases.
- **Fix**: Replaced POSIX PCRE regex patterns with standard SQL string functions (`lower(trimmed) ~ '^https://'`, `substr()`), completely avoiding non-POSIX regex operators across all PostgreSQL versions.

### 3. Standalone Worker State Sharing via `globalThis` (`src/lib/job-worker.ts`)
- **Problem**: Next.js standalone webpack builds isolate module scopes between `instrumentation.ts` and `app/api/health/route.ts`. The in-process job worker started by instrumentation at process startup operated in a separate module closure from the health check endpoint, causing `/api/health?mode=readiness` to report an uninitialized or stale worker status.
- **Fix**: Attached worker lifecycle state (`timer`, `initialized`, `activeRun`, `workerConfig`, `lastRunAt`, `lastSuccessAt`, `startedAt`, `lastError`, `workerLane`) to `globalThis.jobWorkerGlobalState` (identical to the pattern used in `prisma.ts`). Both instrumentation and `/api/health` now access the exact same shared worker lifecycle instance.
- **Tests**: Added test to `tests/lib/job-worker.test.ts` verifying `globalThis.jobWorkerGlobalState` tracking.

---

### Verification
- **Unit Tests**: `npm run test:unit` passed (**452 test files, 3,186 tests passed**).
- **TypeScript**: `npx tsc --noEmit` passed with **0 errors**.
- **ESLint**: Passed with **0 errors**.